### PR TITLE
Do not use GCC_MINOR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,8 @@ IF( MINGW OR UNIX )
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
     string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GCC_VERSION})
     list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
-    list(GET GCC_VERSION_COMPONENTS 1 GCC_MINOR)
 
-    message(STATUS Compiler: ${COMPILER} " Major:" ${GCC_MAJOR} " Minor:" ${GCC_MINOR})
+    message(STATUS Compiler: ${COMPILER} " Major:" ${GCC_MAJOR})
 
     IF ( CYGWIN OR ( ${GCC_MAJOR} GREATER 5 ))
         ADD_DEFINITIONS( -std=gnu++98 ) # to support snprintf


### PR DESCRIPTION
"gcc -dumpversion" with GCC >= 7 only prints "7", thus GCC_MINOR is not defined.
That results in:

```
CMake Error at CMakeLists.txt:86 (list):
list index: 1 out of range (-1, 0)
```

While there are definitely better options to check whether gnu++98 is supported, this should work fine for the time being.