### PR TITLE
Added support for 'Tamron SP 15-30mm f/2.8 Di VC USD A012' and 'Tamron SP 90mm f/2.8 Di VC USD MACRO1:1'

### DIFF
--- a/src/canonmn.cpp
+++ b/src/canonmn.cpp
@@ -828,7 +828,8 @@ namespace Exiv2 {
         { 132, "Canon EF 1200mm f/5.6L"                                     },
         { 134, "Canon EF 600mm f/4L IS"                                     },
         { 135, "Canon EF 200mm f/1.8L"                                      },
-        { 136, "Canon EF 300mm f/2.8L"                                      },
+        { 136, "Canon EF 300mm f/2.8L"                                      }, // 0
+        { 136, "Tamron SP 15-30mm f/2.8 Di VC USD A012"                     }, // 1
         { 137, "Canon EF 85mm f/1.2L"                                       }, // 0
         { 137, "Sigma 18-50mm f/2.8-4.5 DC OS HSM"                          }, // 1
         { 137, "Sigma 50-200mm f/4-5.6 DC OS HSM"                           }, // 2
@@ -1017,7 +1018,10 @@ namespace Exiv2 {
         { 251, "Canon EF 70-200mm f/2.8L IS II USM"                         },
         { 252, "Canon EF 70-200mm f/2.8L IS II USM + 1.4x"                  },
         { 253, "Canon EF 70-200mm f/2.8L IS II USM + 2x"                    },
-        { 254, "Canon EF 100mm f/2.8L Macro IS USM"                         },
+        { 254, "Canon EF 100mm f/2.8L Macro IS USM"                         }, // 0
+        { 254, "Tamron SP 90mm f/2.8 Di VC USD Macro 1:1"                   }, // 1
+      //{ 254, "Tamron SP 90mm f/2.8 Di VC USD Macro 1:1 F004"              }, // 1 older model
+      //{ 254, "Tamron SP 90mm f/2.8 Di VC USD Macro 1:1 F017"              }, // 2 model released in 2016
         { 255, "Sigma 24-105mm f/4 DG OS HSM | A"                           }, // 0
         { 255, "Sigma 180mm f/2.8 EX DG OS HSM APO Macro"                   }, // 1
         { 488, "Canon EF-S 15-85mm f/3.5-5.6 IS USM"                        },
@@ -1092,6 +1096,7 @@ namespace Exiv2 {
         {  42, printCsLensByFocalLength },
         {  47, printCsLensByFocalLength }, // not tested
         { 131, printCsLensByFocalLength },
+        { 136, printCsLensByFocalLength },
         { 137, printCsLensByFocalLength }, // not tested
         { 143, printCsLensByFocalLength },
         { 150, printCsLensByFocalLength },
@@ -1115,6 +1120,7 @@ namespace Exiv2 {
         { 234, printCsLensByFocalLength }, // not tested
         { 248, printCsLensByFocalLength }, // not tested
         { 250, printCsLensByFocalLength }, // not tested
+        { 254, printCsLensByFocalLength },
         { 255, printCsLensByFocalLength }, // not tested
         { 493, printCsLensByFocalLength }, // not tested
         { 747, printCsLensByFocalLength }, // not tested


### PR DESCRIPTION
Added support for 'Tamron SP 15-30mm f/2.8 Di VC USD A012' and 'Tamron SP 90mm f/2.8 Di VC USD MACRO1:1'. But there is no distinction between the F004 and the F017 Versions of the 90mm.

Fixed Bug #1306 and #1304 (partly)

Test results:

$ ./bin/exiv2 -pa ../TamronSP15-30mmF2.8DiVCUSDA012.JPG | grep -ai lens
Exif.CanonCs.LensType                        Short       1  Tamron SP 15-30mm f/2.8 Di VC USD A012
Exif.CanonCs.Lens                            Short       3  15.0 - 30.0 mm
Exif.Canon.LensModel                         Ascii      74  TAMRON SP 15-30mm F/2.8 Di VC USD A012
Exif.Photo.LensSpecification                 Rational    4  15/1 30/1 0/1 0/1
Exif.Photo.LensModel                         Ascii      39  TAMRON SP 15-30mm F/2.8 Di VC USD A012
Exif.Photo.LensSerialNumber                  Ascii      11  0000000000

$ ./bin/exiv2 -pa ../TamronSP90mmF2.8DiVCUSDMacroF004.JPG | grep -ai lens
Exif.CanonCs.LensType                        Short       1  Tamron SP 90mm f/2.8 Di VC USD MACRO1:1
Exif.CanonCs.Lens                            Short       3  90.0 mm
Exif.Canon.LensModel                         Ascii      70  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004

$ ./bin/exiv2 -pa ../TamronSP90mmF2.8DiVCUSDMacroF017.JPG | grep -ai lens
Exif.CanonCs.LensType                        Short       1  Tamron SP 90mm f/2.8 Di VC USD MACRO1:1
Exif.CanonCs.Lens                            Short       3  90.0 mm
Exif.Canon.LensModel                         Ascii      70  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F017
Exif.Photo.LensSpecification                 Rational    4  90/1 90/1 0/0 0/0
Exif.Photo.LensModel                         Ascii      70  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F017
Exif.Photo.LensSerialNumber                  Ascii      12  0000000000
