### PR TITLE
Add option to disable tools (currently exiv2 binary)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ ELSE()
     OPTION( EXIV2_ENABLE_SSH           "USE Libssh for SshIo"                              ON  )
     SET ( EXIV2_ENABLE_DYNAMIC_RUNTIME OFF )
 ENDIF()
+OPTION( EXIV2_ENABLE_TOOLS         "Build exiv2 executable"                                ON  )
 
 include(config/findDependencies.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -285,9 +285,11 @@ set( EXIV2_SRC  exiv2.cpp
                 utils.hpp
 )
 
-add_executable( exiv2 ${EXIV2_SRC} )
-target_link_libraries( exiv2 PRIVATE exiv2lib )
-install(TARGETS exiv2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(EXIV2_ENABLE_TOOLS)
+    add_executable( exiv2 ${EXIV2_SRC} )
+    target_link_libraries( exiv2 PRIVATE exiv2lib )
+    install(TARGETS exiv2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 # TODO This should not be needed here! we need to fix the previous TODO
 target_include_directories(exiv2 PRIVATE ${CMAKE_SOURCE_DIR}/include/)


### PR DESCRIPTION
In a multiarch build, one may want to build binaries only for native arch.