### PR TITLE
LOCALEDIR is used by EXIV2_ENABLE_BUILD_PO so make sure it is defined

### DIFF
--- a/config/FindMSGFMT.cmake
+++ b/config/FindMSGFMT.cmake
@@ -81,7 +81,7 @@ MACRO(ADD_TRANSLATIONS _baseName)
             COMMAND ${MSGFMT_EXECUTABLE} -o ${_out} ${_in}
             DEPENDS ${_in} )
         INSTALL(FILES ${_out}
-            DESTINATION ${LOCALEDIR}/${_file_we}/LC_MESSAGES/
+            DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${_file_we}/LC_MESSAGES/
             RENAME ${_baseName}.mo )
         SET(_outputs ${_outputs} ${_out})
     ENDFOREACH(_file)

--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -32,13 +32,6 @@ if( EXIV2_ENABLE_NLS )
     else()
         set(LIBINTL_LIBRARIES)
     endif()
-    if( NOT LOCALEDIR )
-        set( LOCALEDIR "${CMAKE_INSTALL_LOCALEDIR}" )
-        if( WIN32 )
-            STRING( REPLACE "/" "\\\\" LOCALEDIR ${LOCALEDIR} )
-        endif( WIN32 )
-    endif( NOT LOCALEDIR )
-    add_definitions( -DEXV_LOCALEDIR="${LOCALEDIR}" )
     set( ENABLE_NLS 1 )
     # TODO : This is assuming that Intl is always found. This check should be improved and remove
     # the manual check in config/generateConfigFile.cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,8 @@ SET_TARGET_PROPERTIES( exiv2lib PROPERTIES
     OUTPUT_NAME   exiv2
 )
 
+target_compile_definitions(exiv2lib PRIVATE EXV_LOCALEDIR="${CMAKE_INSTALL_LOCALEDIR}" )
+
 if ( UNIX AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" )
     set (FREEBSD 1)
 endif()
@@ -286,6 +288,7 @@ set( EXIV2_SRC  exiv2.cpp
 )
 
 add_executable( exiv2 ${EXIV2_SRC} )
+target_compile_definitions(exiv2 PRIVATE EXV_LOCALEDIR="${CMAKE_INSTALL_LOCALEDIR}" )
 target_link_libraries( exiv2 PRIVATE exiv2lib )
 install(TARGETS exiv2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
Otherwise it is possible to install translations in `/` if `EXIV2_ENABLE_NLS=OFF`.