### PR TITLE
Cmake doc and cleanup

### DIFF
--- a/README-CMAKE
+++ b/README-CMAKE
@@ -53,6 +53,18 @@ You have to install cmake on your target system. The minimum version required is
 
 Home: http://www.cmake.org/
 
+There are some global CMake options that you can use in Exiv2 :
+
+-DCMAKE_INSTALL_PREFIX : decide where the program will be install on your computer.
+-DCMAKE_BUILD_TYPE     : decide which type of build you want. You can chose between:
+                         "debugfull".     : for hacking. Include all debug information.
+                         "Debug".
+                         "profile".
+                         "relwithdebinfo" : default. use gcc -O2 -g options.
+                         "Release"        : generate stripped and optimized bin files. For packaging.
+
+For knowing more about the specific Exiv2 CMake options, look into the main CMakeLists.txt file.
+
 2 Building and Installing on UNIX-like systems
 ==================================
 
@@ -69,16 +81,6 @@ file) to configure, build and install the library and utilities:
     $ make -j
     $ make install
 
-Usual CMake options :
-
--DCMAKE_INSTALL_PREFIX : decide where the program will be install on your computer.
--DCMAKE_BUILD_TYPE     : decide which type of build you want. You can chose between:
-                         "debugfull".     : for hacking. Include all debug information.
-                         "debug".
-                         "profile".
-                         "relwithdebinfo" : default. use gcc -O2 -g options.
-                         "release"        : generate stripped and optimized bin files. For packaging.
-
 Specific Exiv2 options :
 
 -DBUILD_SHARED_LIBS          : CMake variable controlling whether exiv2lib is build as a shared library (dll). [default=on]
@@ -93,12 +95,6 @@ Specific Exiv2 options :
 -DEXIV2_ENABLE_BUILD_PO      : Build translations files.                         [default=off]
 -DEXIV2_ENABLE_CURL          : USE Libcurl for HttpIo                            [default=off]
 -DEXIV2_ENABLE_SSH           : USE Libssh for SshIo                              [default=off]
-
-Default install locations
-
-Use -DCMAKE_INSTALL_PREFIX like this :
-
-"cmake . -DCMAKE_INSTALL_PREFIX=/usr"  is equivalent to "./configure --prefix=/usr" with automake/configure.
 
 To uninstall Exiv2, run:
 

--- a/README-CMAKE
+++ b/README-CMAKE
@@ -124,38 +124,53 @@ We have two contributed CMake Build Environments:
 
   Exiv2 should be packaged in the dist directory with all the .lib, include and binary files you need.
 
-3 Running CMake commands manually from command line
+ 3 Running CMake commands manually from command line (new)
 
-As in the UNIX case, we can run the following commands from the top directory to configure, 
-build and install the library and utilities:
+  From Exiv2 0.26.0 to 0.26.1 the CMake code of the project was cleaned and now it is possible to configure
+  project from the command line as we do in the Unix sytems. As in the UNIX case, we can run the following
+  commands from the top directory to configure, build and install the library and utilities:
 
-    $ mkdir build
-    $ cd build
+    $ mkdir build && cd build
     $ cmake .. or cmake-gui ..
     $ make -j
     $ make install
 
-The only pre-requisite is to have called before the vcvarsall.bat Visual Studio configuration
-script. For example, with Visual Studio 2017 installed on your system, you will need to run
+  However there are some particularities on Windows that might cause the CMake command does not find
+  the compiler correctly.
 
-    $ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  Previous versions of Visual Studio were creating an environment variable (VSCOMNTOOLS140, for example) that
+  points at the compiler and other resources relevant to that version of the compiler. However in Visual Studio
+  2017, they do not do that anymore.
 
-Before running CMake. If you do not do it, CMake will not be able to determine your compiler.
+  What we recommend is to call the vcvarsall.bat Visual Studio configuration script before running CMake.
+  For example, with Visual Studio 2017 installed on your system, you will need to run
 
-It is also important to note that the default CMake configuration for Windows enable some features
-making use of libraries that probably will not be available in your system. It is possible to
-disable some features, or provide the paths to the INCLUDE folders, or libraries, at the moment of
-calling CMake. In this example, we disable the NLS and PNG support, and we specify the path where we
-have the EXPAT library:
+  $ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+  Afterwards, CMake will identify correctly your Build Tools.
+
+  It is also important to note that the default CMake configuration assume the existence of some libraries
+  in your system. If they are not available, the configuration will fail. It is possible to disable some
+  features, or provide the paths to the INCLUDE folders, or libraries, at the moment of calling CMake the
+  first time.
+
+  In this example, we disable the NLS and PNG support, and we specify the path where we have the EXPAT library:
 
     $ cmake -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=OFF -DCMAKE_PREFIX_PATH="C:\pathToExpat\ ../
 
-    or
+  CMake Generators
+  ----------------
 
-    $ cmake -GNinja -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=OFF -DCMAKE_PREFIX_PATH="C:\pathToExpat\ ../
+  It is also important to note that the default CMake generator is 'Visual Studio' (The version will depend
+  on the vcvarsall.bat script called before running CMake).
 
-Note: For using the Ninja generator you will need to have the ninja build system executable in your
-$PATH. More info at https://ninja-build.org/.
+  If you are not a big fan of Visual Studio you can use other generators like: 'Ninja'. In order to use them
+  you just need to pass the option -GNinja at the moment of calling CMake for the first time:
+
+  $ cmake -GNinja -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=OFF -DCMAKE_PREFIX_PATH="C:\pathToExpat\ ../
+
+  Note: For using the Ninja generator you will need to have the ninja build system executable in your
+  $PATH. More info at https://ninja-build.org/.
 
 4 Building and installing for MinGW Users
 =========================================

--- a/README-CMAKE
+++ b/README-CMAKE
@@ -75,26 +75,10 @@ a) From the command line
 Run the following commands from the top directory (containing this
 file) to configure, build and install the library and utilities:
 
-    $ mkdir build
-    $ cd build
+    $ mkdir build && cd build
     $ cmake .. or cmake-gui ..
     $ make -j
     $ make install
-
-Specific Exiv2 options :
-
--DBUILD_SHARED_LIBS          : CMake variable controlling whether exiv2lib is build as a shared library (dll). [default=on]
--DEXIV2_ENABLE_XMP           : Build with XMP metadata support.                  [default=on ]
--DEXIV2_ENABLE_LIBXMP        : Build a static convenience Library for XMP.       [default=on ]
--DEXIV2_ENABLE_PNG           : Build with png support (requires libz).           [default=on ]
--DEXIV2_ENABLE_NLS           : Build native language support (requires gettext). [default=on ]
--DEXIV2_ENABLE_PRINTUCS2     : Build with Printucs2.                             [default=on ]
--DEXIV2_ENABLE_LENSDATA      : Build including lens data.                        [default=on ]
--DEXIV2_ENABLE_COMMERCIAL    : Build with the EXV_COMMERCIAL_VERSION symbol set. [default=off]
--DEXIV2_ENABLE_BUILD_SAMPLES : Build the unit tests.                             [default=off]
--DEXIV2_ENABLE_BUILD_PO      : Build translations files.                         [default=off]
--DEXIV2_ENABLE_CURL          : USE Libcurl for HttpIo                            [default=off]
--DEXIV2_ENABLE_SSH           : USE Libssh for SshIo                              [default=off]
 
 To uninstall Exiv2, run:
 

--- a/README-CMAKE
+++ b/README-CMAKE
@@ -33,7 +33,7 @@ Robin Mills
 robin@clanmills.com
 Luis Díaz Más
 piponazo@gmail.com
-2017-17-08
+2017-01-09
 
 -------------------------------------------------------------------------------
 
@@ -52,10 +52,6 @@ TABLE OF CONTENTS
 You have to install cmake on your target system. The minimum version required is 3.1.0
 
 Home: http://www.cmake.org/
-Help: http://www.cmake.org/cmake/help/help.html
-Doc:  http://www.cmake.org/cmake/help/documentation.html
-Wiki: http://www.cmake.org/Wiki/CMake
-FAQ:  http://www.cmake.org/Wiki/CMake_FAQ
 
 2 Building and Installing on UNIX-like systems
 ==================================

--- a/README-CMAKE
+++ b/README-CMAKE
@@ -21,8 +21,9 @@ STATUS:
   for MacOS-X, Cygwin, Linux and Visual Studio (2005, 8, 10, 12, 13 and 15)
   The daily build on MinGW/32 is performed using autotools for Qt/Windows Users.
 
-* The existing automake (./configure) will continue to be supported by exiv2
-  There is no plan to adopt CMake as the only build platform.
+* The existing automake (./configure) is currently still be supported by exiv2.
+  There are plans to adopt CMake as the only build platform and drop the automake
+  code and the existing Visual Studio Solutions.
 
 * Team Exiv2 no longer provide support for MinGW (with/without CMake)
   Exiv2 is very difficult to build on MinGW with CMake.
@@ -30,7 +31,9 @@ STATUS:
 
 Robin Mills
 robin@clanmills.com
-2017-06-06
+Luis Díaz Más
+piponazo@gmail.com
+2017-17-08
 
 -------------------------------------------------------------------------------
 
@@ -46,7 +49,7 @@ TABLE OF CONTENTS
 1 CMake resources
 =================
 
-You have to install cmake on your target system.
+You have to install cmake on your target system. The minimum version required is 3.1.0
 
 Home: http://www.cmake.org/
 Help: http://www.cmake.org/cmake/help/help.html
@@ -54,25 +57,21 @@ Doc:  http://www.cmake.org/cmake/help/documentation.html
 Wiki: http://www.cmake.org/Wiki/CMake
 FAQ:  http://www.cmake.org/Wiki/CMake_FAQ
 
-2 Building and Installing on Linux
+2 Building and Installing on UNIX-like systems
 ==================================
 
-This process overs MacOS-X, Linux and Cygwin.
+This process covers MacOS-X, Linux and Cygwin.
 
 a) From the command line
 
 Run the following commands from the top directory (containing this
-file) to configure, build and install the library and utility:
+file) to configure, build and install the library and utilities:
 
     $ mkdir build
     $ cd build
-    $ cmake .. -G "Unix Makefiles"
-    $ make
+    $ cmake .. or cmake-gui ..
+    $ make -j
     $ make install
-
-To modify the configuration
-
-    $ ccmake ..
 
 Usual CMake options :
 
@@ -108,10 +107,6 @@ Use -DCMAKE_INSTALL_PREFIX like this :
 To uninstall Exiv2, run:
 
     $ make uninstall
-
-b) Using the cmake GUI
-
-   ccmake
 
 3 Building and installing for Visual Studio Users
 =================================================
@@ -152,6 +147,39 @@ We have two contributed CMake Build Environments:
    - execute build.cmd (if there are any errors, the script should tell you)
 
   Exiv2 should be packaged in the dist directory with all the .lib, include and binary files you need.
+
+3 Running CMake commands manually from command line
+
+As in the UNIX case, we can run the following commands from the top directory to configure, 
+build and install the library and utilities:
+
+    $ mkdir build
+    $ cd build
+    $ cmake .. or cmake-gui ..
+    $ make -j
+    $ make install
+
+The only pre-requisite is to have called before the vcvarsall.bat Visual Studio configuration
+script. For example, with Visual Studio 2017 installed on your system, you will need to run
+
+    $ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+Before running CMake. If you do not do it, CMake will not be able to determine your compiler.
+
+It is also important to note that the default CMake configuration for Windows enable some features
+making use of libraries that probably will not be available in your system. It is possible to
+disable some features, or provide the paths to the INCLUDE folders, or libraries, at the moment of
+calling CMake. In this example, we disable the NLS and PNG support, and we specify the path where we
+have the EXPAT library:
+
+    $ cmake -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=OFF -DCMAKE_PREFIX_PATH="C:\pathToExpat\ ../
+
+    or
+
+    $ cmake -GNinja -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=OFF -DCMAKE_PREFIX_PATH="C:\pathToExpat\ ../
+
+Note: For using the Ninja generator you will need to have the ninja build system executable in your
+$PATH. More info at https://ninja-build.org/.
 
 4 Building and installing for MinGW Users
 =========================================

--- a/README-CMAKE
+++ b/README-CMAKE
@@ -70,8 +70,6 @@ For knowing more about the specific Exiv2 CMake options, look into the main CMak
 
 This process covers MacOS-X, Linux and Cygwin.
 
-a) From the command line
-
 Run the following commands from the top directory (containing this
 file) to configure, build and install the library and utilities:
 
@@ -79,6 +77,8 @@ file) to configure, build and install the library and utilities:
     $ cmake .. or cmake-gui ..
     $ make -j
     $ make install
+
+Note that the CMake generator used by default on Unix is : 'Makefiles'. However you can chose others like 'Ninja'
 
 To uninstall Exiv2, run:
 

--- a/config/printSummary.cmake
+++ b/config/printSummary.cmake
@@ -1,3 +1,4 @@
+message( STATUS "Install prefix:    ${CMAKE_INSTALL_PREFIX}")
 message( STATUS "None:              ${CMAKE_CXX_FLAGS}" )
 message( STATUS "Debug:             ${CMAKE_CXX_FLAGS_DEBUG}" )
 message( STATUS "Release:           ${CMAKE_CXX_FLAGS_RELEASE}" )


### PR DESCRIPTION
I added some documentation about how to run CMake from the command line on Windows.

I also re-organised a bit the README-CMAKE file. For example, I think it is a bad idea to keep the list of Exiv2 CMake variables in many documentation files. That documentation will get out of sync very easily. Because of that, the best documentation we can have about the Exiv2 CMake options is the CMake code itself!

@clanmills Try to follow the new indications and let me know if you have some problem. We should write this document in such a way that anybody can compile Exiv2 easily.

Actually I am thinking that we should disable more options by default on Windows. For example, right now the option **EXIV2_ENABLE_NLS** is always enabled by default, and the users has to disable it every time that they call cmake on windows. Those libraries are not available on windows by default! 