### PR TITLE
Use CMAKE_DL_LIBS instead of dl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,9 +239,8 @@ if ( MSVC )
     ) 
 
 else()
-    # TODO: Check if this is really needed.
-    if ( UNIX AND NOT FREEBSD )
-        target_link_libraries( exiv2lib PRIVATE dl)
+    if ( UNIX )
+        target_link_libraries( exiv2lib PRIVATE ${CMAKE_DL_LIBS})
     endif()
 
     if (CYGWIN OR MINGW)


### PR DESCRIPTION
cmake provides a wrapper to link against 'dl' which evalutes to nothing on FreeBSD and to dl on Linux for example.
https://cmake.org/cmake/help/v3.6/variable/CMAKE_DL_LIBS.html