### PR TITLE
Fix crash on undefined metadata on some Nikon images

### DIFF
--- a/src/nikonmn.cpp
+++ b/src/nikonmn.cpp
@@ -299,6 +299,8 @@ namespace Exiv2 {
                                                const Value& value,
                                                const ExifData* exifData)
     {
+        if ( ! exifData ) return os << "undefined" ;
+
         if ( value.count() >= 9 ) {
             ByteOrder bo = getKeyString("Exif.MakerNote.ByteOrder",exifData) == "MM" ? bigEndian : littleEndian;
             byte      p[4];


### PR DESCRIPTION
Nikon is also affected by similar issue as just was fixed for Pentax. No separate bug report as backtrace is almost identical to http://dev.exiv2.org/issues/1305
Adapted from: 5405d61623e82896e498c5c8342dd6f42e689115