### PR TITLE
Added missing include for INT_MIN & INT_MAX constants

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <memory>
 #include <cstring>
+#include <climits>
 
 // *****************************************************************************
 // namespace extensions


### PR DESCRIPTION
8a8f60a4e7089fe7bb597770a2daab24a3941d3e broke the build on Fedora 26 with gcc 7.2.1 & clang 4.0.1, as the macro constants INT_MIN & INT_MAX are not automatically included. Including climits fixes this issue.