### PR TITLE
Fixed wrong brackets: size*count + pad can overflow before the cast

### DIFF
--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -227,7 +227,7 @@ namespace Exiv2
                                                   : 1;
 
                 			// #55 memory allocation crash test/data/POC8
-                			long long allocate = (long long) (size*count + pad);
+                			long long allocate = (long long) size*count + pad;
                 			if ( allocate > (long long) io.size() ) {
                     			throw Error(57);
                 			}

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -402,7 +402,7 @@ namespace Exiv2 {
                 // if ( offset > io.size() ) offset = 0; // Denial of service?
 
                 // #55 memory allocation crash test/data/POC8
-                long long allocate = (long long) (size*count + pad+20);
+                long long allocate = (long long) size*count + pad+20;
                 if ( allocate > (long long) io.size() ) {
                     throw Error(57);
                 }


### PR DESCRIPTION
Should fix #76 for the current git head.
However the credit goes to Robin Mills (@clanmills), as he mostly fixed it in 6e3855aed7ba8bb4731fc4087ca7f9078b2f3d97.

The problem with #76 is the contents of the 26th TIFF IFD, with the following contents:
tag: 0x8649
type: 0x1
count: 0xffff ffff
offset: 0x4974

The issue is the size of count (uint32_t), as adding anything to it causes an overflow. Especially the expression:
`(size*count + pad+20)` (from [here](https://github.com/Exiv2/exiv2/blob/master/src/image.cpp#L405))
results in an overflow and gives 20 as a result instead of 0x100000014, thus the condition in the if in the next [line](https://github.com/Exiv2/exiv2/blob/master/src/image.cpp#L406) is false and the program continues to run (until it crashes at [io.read](https://github.com/Exiv2/exiv2/blob/master/src/image.cpp#L416) where the overflow does not occur).

To properly account for the overflow, the brackets have to be removed, as then the result is saved in the correctly sized type and not cast after being calculated in the smaller type.

The brackets have also been removed from bigtiffimage.cpp, where the same issue is present.

I am not 100% sure, if this fully fixes #76, as it was reported against v0.26 and I fixed in in the current git head. I'll try to cherry pick the necessary patches onto v0.26 and see if they fix it there, too.