### PR TITLE
Fix the default configuration CMake+Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,9 @@ option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"     
 if ( EXIV2_ENABLE_WEBREADY )
     set ( EXIV2_ENABLE_CURL ON )
     set ( EXIV2_ENABLE_CURL ON )
-    set ( EXIV2_ENABLE_SSH  ON )
+    if ( UNIX )
+        set ( EXIV2_ENABLE_SSH  ON )
+    endif ()
 endif()
 
 if( EXIV2_ENABLE_COMMERCIAL )


### PR DESCRIPTION
This change should fix the builds with AppVeyor (Windows). 

We are not providing yet libssh with conan, and therefore we have to disable that option by default on Windows. 