### PR TITLE
Generate exv_conf.h file out of the source tree. 

### DIFF
--- a/config/generateConfigFile.cmake
+++ b/config/generateConfigFile.cmake
@@ -67,4 +67,4 @@ return 0;
 
 #####################################################################################
 
-configure_file( config/config.h.cmake ${CMAKE_SOURCE_DIR}/include/exiv2/exv_conf.h @ONLY)
+configure_file( config/config.h.cmake ${CMAKE_BINARY_DIR}/exv_conf.h @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ set( LIBEXIV2_HDR         ../include/exiv2/asfvideo.hpp
                           ../include/exiv2/xmp_exiv2.hpp
                           ../include/exiv2/xmpsidecar.hpp
                           ../include/exiv2/utilsvideo.hpp
-                          ../include/exiv2/exv_conf.h
+                          ${CMAKE_BINARY_DIR}/exv_conf.h
    )
 
 # Private headers only needed to build the library


### PR DESCRIPTION
@Kicer86  noticed that we were putting the auto-generated `exv_conf.h` file inside the source tree. Because of that he was having some issues while developing Exiv2 code.

In this PR I fix the situation described in #92 