### PR TITLE
Amend fix for #9 to apply to other Unix systems

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -2051,7 +2051,11 @@ namespace {
     static pthread_mutex_t cs =  PTHREAD_MUTEX_INITIALIZER;
   #endif
  #else
-  static pthread_mutex_t cs =  PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+  #if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
+    static pthread_mutex_t cs =  PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+   #else
+    static pthread_mutex_t cs =  PTHREAD_MUTEX_INITIALIZER;
+  #endif
  #endif
 #endif
 


### PR DESCRIPTION
At least the musl libc on Linux has the same issue as Mac OS X: the
PTHREAD_RECURSIVE_* static initialiser does not exist.  This is a
documented and purposeful omission:

http://www.openwall.com/lists/musl/2017/02/20/3

This commit uses similar logic to the Apple test on other Unixes.