### PR TITLE
Remove cpp11 features

### DIFF
--- a/config/config.h.cmake
+++ b/config/config.h.cmake
@@ -39,9 +39,6 @@
 #define EXV_ICONV_CONST
 #endif
 
-// Define if you have the <regex> header file.
-#cmakedefine EXV_HAVE_REGEX
-
 // Define if you have the <regex.h> header file.
 #cmakedefine EXV_HAVE_REGEX_H
 

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -47,9 +47,6 @@
 /* Define to 1 if you have the <libintl.h> header file. */
 #undef HAVE_LIBINTL_H
 
-/* Define to 1 if you have the <regex> header file. */
-#undef HAVE_REGEX
-
 /* Define to 1 if you have the <regex.h> header file. */
 #undef HAVE_REGEX_H
 

--- a/config/generateConfigFile.cmake
+++ b/config/generateConfigFile.cmake
@@ -43,7 +43,6 @@ check_include_file( "strings.h" EXV_HAVE_STRINGS_H )
 check_include_file( "sys/mman.h"    EXV_HAVE_SYS_MMAN_H )
 check_include_file( "sys/stat.h"    EXV_HAVE_SYS_STAT_H )
 check_include_file( "sys/types.h"   EXV_HAVE_SYS_TYPES_H )
-check_include_file( "regex"         EXV_HAVE_REGEX )
 check_include_file( "regex.h"       EXV_HAVE_REGEX_H )
 check_include_file( "inttypes.h"    EXV_HAVE_INTTYPES_H )
 

--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -154,10 +154,7 @@ typedef int pid_t;
 # ifndef  __MINGW__
 #  define __MINGW__ 1
 # endif
-// Don't know why MinGW refuses to link libregex
-# ifdef  EXV_HAVE_REGEX
-#  undef EXV_HAVE_REGEX
-# endif
+
 #ifdef EXV_UNICODE_PATH
 #error EXV_UNICODE_PATH is not supported for MinGW builds
 #endif

--- a/include/exiv2/exv_msvc-webready.h
+++ b/include/exiv2/exv_msvc-webready.h
@@ -12,9 +12,6 @@
 #ifndef _EXV_MSVC_H_
 #define _EXV_MSVC_H_
 
-/* Define to 1 if you have the <regex.h> header file. */
-// #define EXV_HAVE_REGEX 1
-
 /* Define to 1 if you have the <process.h> header file. */
 #define EXV_HAVE_PROCESS_H 1
 

--- a/include/exiv2/exv_msvc.h
+++ b/include/exiv2/exv_msvc.h
@@ -62,9 +62,6 @@
 #define EXV_ICONV_CONST
 #endif
 
-/* Define to 1 if you have the <regex.h> header file. */
-/* #undef EXV_HAVE_REGEX */
-
 /* Define to 1 if your system has a GNU libc compatible `malloc' function, and
    to 0 otherwise. */
 /* #undef EXV_HAVE_MALLOC */

--- a/include/exiv2/version.hpp
+++ b/include/exiv2/version.hpp
@@ -37,13 +37,7 @@
 // + standard includes
 #include <vector>
 
-#if   defined(HAVE_REGEX)
-# include <regex>
-  /*!
-   @brief exv_grep_keys_t is a vector of keys to match to strings
-  */
-  typedef std::vector<std::regex> exv_grep_keys_t ;
-#elif defined(EXV_HAVE_REGEX_H)
+#if defined(EXV_HAVE_REGEX_H)
 # include <regex.h>
   /*!
    @brief exv_grep_keys_t is a vector of keys to match to strings

--- a/msvc/ReadMe.txt
+++ b/msvc/ReadMe.txt
@@ -482,7 +482,6 @@ T A B L E  o f  C O N T E N T S
      library=C:\Windows\WinSxS\amd64_microsoft.vc80.crt_1fc8b3b9a1e18e3b_8.0.50727.6195_none_88e41e092fab0294\MSVCP80.dl
      library=C:\Windows\system32\PSAPI.DLL
      library=C:\cygwin64\home\rmills\gnu\exiv2\video-write\msvc\bin\x64\releasedll\libexpat.dll
-     have_regex=0
      have_strerror_r=0
      have_gmtime_r=0
      have_inttypes=0

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -591,10 +591,7 @@ namespace Action {
         for (Params::Greps::const_iterator g = Params::instance().greps_.begin();
                 !result && g != Params::instance().greps_.end(); ++g)
         {
-#if   defined(EXV_HAVE_REGEX)
-            std::smatch m;
-            result = std::regex_search(key,m, *g);
-#elif defined(EXV_HAVE_REGEX_H)
+#if defined(EXV_HAVE_REGEX_H)
             result = regexec( &(*g), key.c_str(), 0, NULL, 0) == 0 ;
 #else
             std::string Pattern(g->pattern_);

--- a/src/exiv2.1
+++ b/src/exiv2.1
@@ -223,11 +223,8 @@ Show unknown tags (default is to suppress tags which don't have a name).
 Only keys which match the given key (grep).
 .br
 Multiple \fB\-g\fP options
-can be used to grep info for several keys.  When the library is build with C++11,
-keys are matched using std::regex::extended.  When build without C++11, keys are
-processed with the system regular expression engine:  see man 3 regex.  Platforms which do not support
-regex use key for a substring match.  You can determine the availability of regex
-using the command: exiv2 -v -V -g have_regex -g cplusplus.
+can be used to grep info for several keys. Example:
+exiv2 -v -V -g webready -g time.
 
 .nf
 exiv2 \-g Date \-pt R.jpg

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -47,9 +47,7 @@ EXIV2_RCSID("@(#) $Id$")
 #include <cassert>
 #include <cctype>
 
-#if   defined(EXV_HAVE_REGEX)
-#include <regex>
-#elif defined(EXV_HAVE_REGEX_H)
+#if defined(EXV_HAVE_REGEX_H)
 #include <regex.h>
 #endif
 
@@ -453,9 +451,7 @@ int Params::evalGrep( const std::string& optarg)
     std::string pattern;
     std::string ignoreCase("/i");
     bool bIgnoreCase = ends_with(optarg,ignoreCase,pattern);
-#if   defined(EXV_HAVE_REGEX)
-    greps_.push_back( std::regex(pattern, bIgnoreCase ? std::regex::icase|std::regex::extended : std::regex::extended) );
-#elif defined(EXV_HAVE_REGEX_H)
+#if defined(EXV_HAVE_REGEX_H)
     // try to compile a reg-exp from the input argument and store it in the vector
     const size_t i = greps_.size();
     greps_.resize(i + 1);

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -42,10 +42,6 @@
 #include <set>
 #include <iostream>
 
-#ifdef EXV_HAVE_REGEX
-#include <regex.h>
-#endif
-
 #ifdef EXV_HAVE_STDINT_H
 #include <unistd.h>
 #endif

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -145,10 +145,7 @@ static bool shouldOutput(const exv_grep_keys_t& greps,const char* key,const std:
       !bPrint && g != greps.end() ; ++g
     ) {
         std::string Key(key);
-#if   defined(EXV_HAVE_REGEX)
-        std::smatch m;
-        bPrint = std::regex_search(Key,m,*g) || std::regex_search(value,m,*g);
-#elif defined(EXV_HAVE_REGEX_H)
+#if defined(EXV_HAVE_REGEX_H)
         bPrint = (  0 == regexec( &(*g), key          , 0, NULL, 0)
                  || 0 == regexec( &(*g), value.c_str(), 0, NULL, 0)
                  );
@@ -256,7 +253,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     "unknown";
 #endif
 
-    int have_regex       =0;
     int have_gmtime_r    =0;
     int have_inttypes    =0;
     int have_libintl     =0;
@@ -316,10 +312,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
 
 #ifdef EXV_HAVE_LIBINTL_H
     have_libintl=1;
-#endif
-
-#ifdef EXV_HAVE_REGEX
-    have_regex=1;
 #endif
 
 #ifdef EXV_HAVE_MEMORY_H
@@ -517,7 +509,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
             output(os,keys,"library",*lib);
     }
 
-    output(os,keys,"have_regex"        ,have_regex       );
     output(os,keys,"have_strerror_r"   ,have_strerror_r  );
     output(os,keys,"have_gmtime_r"     ,have_gmtime_r    );
     output(os,keys,"have_inttypes"     ,have_inttypes    );


### PR DESCRIPTION
We have found some compilations issues with the regex c++11 feature. We do not have any treatment for c++11 in the CMake configuration, and the implementation under the EXV_HAVE_REGEX conditional seemed to be not complete. 

After some discussion we have decided to remove all the c++11 code and stay with c++98. In future release we might decide to move to modern c++, but this would be in a major release. 