### PR TITLE
Work in progress - improvements for bigtiff

### DIFF
--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -81,6 +81,8 @@ typedef int pid_t;
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+#define NOMINMAX
 #include <windows.h>
 
 #endif // _MSC_VER

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -2,6 +2,7 @@
 #include "bigtiffimage.hpp"
 
 #include <cassert>
+#include <limits>
 
 #include "exif.hpp"
 #include "image_int.hpp"

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -324,7 +324,6 @@ namespace Exiv2
                                             byteSwap8(buf, k*size, doSwap_):
                                             byteSwap4(buf, k*size, doSwap_);
 
-                                        std::cerr << "tag = " << Internal::stringFormat("%#x",tag) << std::endl;
                                         printIFD(out, option, ifdOffset, depth);
                                         io.seek(restore, BasicIo::beg);
                                     }


### PR DESCRIPTION
I did some additional improvements against invalid memory allocations from #55 and #56 - I'm checking for integer overflows. Please take a look and reapply it in image.cpp is applicable. 