### PR TITLE
Use nullptr check instead of assertion, by Raphaël Hertzog

### DIFF
--- a/src/tiffvisitor.cpp
+++ b/src/tiffvisitor.cpp
@@ -1294,11 +1294,12 @@ namespace Exiv2 {
             }
             uint16_t tag = getUShort(p, byteOrder());
             TiffComponent::AutoPtr tc = TiffCreator::create(tag, object->group());
-            // The assertion typically fails if a component is not configured in
-            // the TIFF structure table
-            assert(tc.get());
-            tc->setStart(p);
-            object->addChild(tc);
+            if (tc.get()) {
+                tc->setStart(p);
+                object->addChild(tc);
+            } else {
+               EXV_WARNING << "Unable to handle tag " << tag << ".\n";
+            }
             p += 12;
         }
 


### PR DESCRIPTION
Source: [https://github.com/Exiv2/exiv2/issues/57#issuecomment-333086302](https://github.com/Exiv2/exiv2/issues/57#issuecomment-333086302), patch made by Raphaël Hertzog (@rhertzog).

`tc` can be a null pointer when the TIFF tag is unknown (the factory then returns an `auto_ptr(0)`) => as this can happen for corrupted files, an explicit check should be used because an assertion can be turned of in release mode (with `NDEBUG` defined)

This ensures #57 does not show up if somehow the checks in `Image::printIFDStructure` should be bypassed.