### PR TITLE
App veyor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ cache:
     ccache: true
     directories:
     - conan         # Conan installation folder
-    - $HOME/.conan  # Conan configuration and packages
+    - $HOME/conanData     # Conan storage location

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#set -e
-#set -x
+set -e # Enables cheking of return values from each command
+set -x # Prints every command
 
 if [[ "$(uname -s)" == 'Linux' ]]; then
     sudo apt-get install cmake zlib1g-dev libssh-dev libcurl4-openssl-dev gettext libexpat1-dev
@@ -17,6 +17,7 @@ virtualenv conan
 source conan/bin/activate
 pip install conan
 conan --version
+conan config set storage.path=~/conanData
 conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
 mkdir -p ~/.conan/profiles
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,28 @@
-image: Visual Studio 2017
+image: Visual Studio 2015
 
 shallow_clone: true
 
-environment:
-    VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
-
 before_build:
-- cmd: mkdir envs && cd envs
+- cmd: if not exist envs mkdir envs && cd envs
+- cmd: cd envs
 - cmd: python -m virtualenv conan
 - cmd: conan/Scripts/activate
-- cmd: python -m pip install conan==0.26.0
+- cmd: python -m pip install conan==0.27.0
 - cmd: cd ..
 - cmd: conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
+- cmd: conan config set storage.path=c:\Users\appveyor\conanCache
 - cmd: mkdir c:\Users\appveyor\.conan\profiles
-- cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=15\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
+- cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
 - cmd: cat c:\Users\appveyor\.conan\profiles\release
 
 build_script:
   - md build
   - cd build
   - conan install .. --build missing --profile release
-  - cmake -G "Visual Studio 15 2017 Win64" -T "host=x64" -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake -G "Visual Studio 14 2015 Win64" -T "host=x64" -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config Release
   - cmake --build . --target install
+
+cache:
+  - c:\Users\appveyor\conanCache -> conanfile.py
+  - envs -> appveyor.# Conan installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,26 +3,35 @@ image: Visual Studio 2015
 shallow_clone: true
 
 before_build:
-- cmd: if not exist envs mkdir envs && cd envs
-- cmd: cd envs
-- cmd: python -m virtualenv conan
-- cmd: conan/Scripts/activate
-- cmd: python -m pip install conan==0.27.0
-- cmd: cd ..
-- cmd: conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
-- cmd: conan config set storage.path=c:\Users\appveyor\conanCache
-- cmd: mkdir c:\Users\appveyor\.conan\profiles
-- cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
-- cmd: cat c:\Users\appveyor\.conan\profiles\release
+    - cmd: if not exist envs mkdir envs
+    - cmd: cd envs
+    - cmd: python -m virtualenv conan
+    - cmd: conan/Scripts/activate
+    - cmd: python -m pip install conan==0.27.0
+    - cmd: cd ..
+    - cmd: conan --version
+    - cmd: conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
+    - cmd: conan remote list
+    - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
+    - cmd: cat c:\Users\appveyor\.conan\conan.conf
+    - cmd: mkdir c:\Users\appveyor\.conan\profiles
+    - cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
+    - cmd: cat c:\Users\appveyor\.conan\profiles\release
 
 build_script:
-  - md build
-  - cd build
-  - conan install .. --build missing --profile release
-  - cmake -G "Visual Studio 14 2015 Win64" -T "host=x64" -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DCMAKE_INSTALL_PREFIX=install ..
-  - cmake --build . --config Release
-  - cmake --build . --target install
+    - cmd: md build
+    - cmd: cd build
+    - cmd: conan install .. --build missing --profile release
+    - cmd: cmake -G "Visual Studio 14 2015 Win64" -T "host=x64" -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DCMAKE_INSTALL_PREFIX=install ..
+    - cmd: cmake --build . --config Release
+    - cmd: cmake --build . --target install
 
 cache:
-  - c:\Users\appveyor\conanCache -> conanfile.py
-  - envs -> appveyor.# Conan installation
+    - envs                   # Conan installation
+
+# For some reason, if I add into the cache the conanCache folder then I get an error like this when calling conan
+# install:
+#Expat/2.2.1@pix4d/stable: Already installed!
+#zlib/1.2.8@lasote/stable: Already installed!
+#OpenSSL/1.0.2i@lasote/stable: Already installed!
+#ERROR: Error while trying to get recipe sources for libcurl/7.50.3@lasote/stable. No remote defined


### PR DESCRIPTION
Since AppVeyor and conan are having lately some issues to compile binaries for VS2017 I decided to use the Visual Studio 2015 AppVeyor image and compile the Exiv2 project with that version.

Since the conan repositories always have binaries for VS2015, this change notably speed ups the build times in AppVeyor. We do not need anymore to compile the Exiv2 dependencies (libcurl, ssh, zip, etc) for each commit we do in Exiv2. Now, these binaries are fetch from the conan repositories.