### PR TITLE
Cmake dev options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,24 @@ option( EXIV2_ENABLE_DYNAMIC_RUNTIME  "Use dynamic runtime (used for static libs
 option( EXIV2_ENABLE_WIN_UNICODE      "Use Unicode paths (wstring) on Windows"                OFF )
 option( EXIV2_ENABLE_CURL             "USE Libcurl for HttpIo"                                OFF )
 option( EXIV2_ENABLE_SSH              "USE Libssh for SshIo"                                  OFF )
+
 option( EXIV2_BUILD_SAMPLES           "Build sample applications"                             ON  )
 option( EXIV2_BUILD_PO                "Build translations files"                              OFF )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )
 option( EXIV2_BUILD_UNIT_TESTS        "Build unit tests"                                      OFF )
-option( BUILD_WITH_CCACHE             "Use ccache to speed up compile time"                   OFF )
+
+# Only intended to be used by Exiv2 developers/contributors
+option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
+option( EXIV2_TEAM_WARNINGS_AS_ERRORS "Treat warnings as errors"                              OFF )
+set(EXTRA_COMPILE_FLAGS " ")
+
+mark_as_advanced(
+    EXIV2_TEAM_EXTRA_WARNINGS 
+    EXIV2_TEAM_WARNINGS_AS_ERRORS
+    EXTRA_COMPILE_FLAGS
+)
+
+option( BUILD_WITH_CCACHE             "Use ccache to speed up compilations"                   OFF )
 
 if ( EXIV2_ENABLE_WEBREADY )
     set ( EXIV2_ENABLE_CURL ON )

--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -29,6 +29,9 @@ if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
                         " -Wdouble-promotion"
                         " -Wshadow"
                         " -Wuseless-cast"
+                        " -Wpointer-arith" # This warning is also enabled by -Wpedantic
+                        " -Wformat=2"
+                        " -Warray-bounds=2"
                         #" -Wold-style-cast"
                     )
                 endif ()
@@ -60,6 +63,9 @@ if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
                     " -Wconditional-uninitialized"
                     " -Wdirect-ivar-access"
                     " -Weffc++"
+                    " -Wpointer-arith"
+                    " -Wformat=2"
+                    #" -Warray-bounds" # Enabled by default
                     # These two raises lot of warnings. Use them wisely
                     #" -Wconversion"
                     #" -Wold-style-cast"

--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -115,11 +115,6 @@ if(MSVC)
         set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/NODEFAULTLIB:MSVCRT")
     endif()
 
-    # Resolving Redefinition Errors Betwen ws2def.h and winsock.h:
-    #  - http://www.zachburlingame.com/2011/05/resolving-redefinition-errors-betwen-ws2def-h-and-winsock-h/
-    #  - https://stackoverflow.com/questions/11040133/what-does-defining-win32-lean-and-mean-exclude-exactly
-    add_definitions(-DWIN32_LEAN_AND_MEAN)
-
     if ( EXIV2_WARNINGS_AS_ERRORS )
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")

--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -1,12 +1,73 @@
 if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W")
+        set(COMPILER_IS_GCC ON)
+    elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        set(COMPILER_IS_CLANG ON)
     endif()
 
-    if ( CYGWIN OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98") # to support snprintf
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+    if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W")
+
+        if ( CYGWIN OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98") # to support snprintf
+        else()
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+        endif()
+
+        if ( EXIV2_TEAM_WARNINGS_AS_ERRORS )
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+        endif ()
+
+        if ( EXIV2_TEAM_EXTRA_WARNINGS )
+            # Note that this is intended to be used only by Exiv2 developers/contributors.
+
+            if ( COMPILER_IS_GCC )
+                if ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.0 )
+                    string(CONCAT EXTRA_COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+                        " -Wextra"
+                        " -Wlogical-op"
+                        " -Wdouble-promotion"
+                        " -Wshadow"
+                        " -Wuseless-cast"
+                        #" -Wold-style-cast"
+                    )
+                endif ()
+
+                if ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 6.0 )
+                    string(CONCAT EXTRA_COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+                        " -Wduplicated-cond"
+                    )
+                endif ()
+
+                if ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 )
+                    string(CONCAT EXTRA_COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+                        " -Wduplicated-branches"
+                        " -Wrestrict"
+                    )
+                endif ()
+            endif ()
+
+            if ( COMPILER_IS_CLANG )
+                # https://clang.llvm.org/docs/DiagnosticsReference.html
+                # These variables are at least available since clang 3.9.1
+                string(CONCAT EXTRA_COMPILE_FLAGS "-Wextra" 
+                    " -Wdouble-promotion"
+                    " -Wshadow"
+                    " -Wassign-enum"
+                    " -Wmicrosoft"
+                    " -Wcomma"
+                    " -Wcomments"
+                    " -Wconditional-uninitialized"
+                    " -Wdirect-ivar-access"
+                    " -Weffc++"
+                    # These two raises lot of warnings. Use them wisely
+                    #" -Wconversion"
+                    #" -Wold-style-cast"
+                )
+            endif ()
+
+
+        endif ()
     endif()
 
 endif ()
@@ -62,5 +123,16 @@ if(MSVC)
     #  - http://www.zachburlingame.com/2011/05/resolving-redefinition-errors-betwen-ws2def-h-and-winsock-h/
     #  - https://stackoverflow.com/questions/11040133/what-does-defining-win32-lean-and-mean-exclude-exactly
     add_definitions(-DWIN32_LEAN_AND_MEAN)
+
+    if ( EXIV2_WARNINGS_AS_ERRORS )
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
+        set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /WX")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /WX")
+    endif ()
+
+    if ( EXIV2_EXTRA_WARNINGS )
+        string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    endif ()
 
 endif()

--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -75,10 +75,6 @@ endif ()
 # http://stackoverflow.com/questions/10113017/setting-the-msvc-runtime-in-cmake
 if(MSVC)
     set(variables
-      CMAKE_C_FLAGS_DEBUG
-      CMAKE_C_FLAGS_MINSIZEREL
-      CMAKE_C_FLAGS_RELEASE
-      CMAKE_C_FLAGS_RELWITHDEBINFO
       CMAKE_CXX_FLAGS_DEBUG
       CMAKE_CXX_FLAGS_MINSIZEREL
       CMAKE_CXX_FLAGS_RELEASE

--- a/config/printSummary.cmake
+++ b/config/printSummary.cmake
@@ -1,10 +1,3 @@
-message( STATUS "Install prefix:    ${CMAKE_INSTALL_PREFIX}")
-message( STATUS "None:              ${CMAKE_CXX_FLAGS}" )
-message( STATUS "Debug:             ${CMAKE_CXX_FLAGS_DEBUG}" )
-message( STATUS "Release:           ${CMAKE_CXX_FLAGS_RELEASE}" )
-message( STATUS "RelWithDebInfo:    ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" )
-message( STATUS "MinSizeRel:        ${CMAKE_CXX_FLAGS_MINSIZEREL}" )
-
 # output chosen build options
 macro( OptionOutput _outputstring )
     if( ${ARGN} )
@@ -14,6 +7,25 @@ macro( OptionOutput _outputstring )
     endif( ${ARGN} )
     message( STATUS "${_outputstring}${_var}" )
 endmacro( OptionOutput _outputstring )
+
+message( STATUS "Install prefix:    ${CMAKE_INSTALL_PREFIX}")
+message( STATUS "------------------------------------------------------------------" )
+message( STATUS "Compiler info: ${CMAKE_CXX_COMPILER_ID} (${CMAKE_CXX_COMPILER}) ; version: ${CMAKE_CXX_COMPILER_VERSION}")
+message( STATUS "Compiler flags")
+message( STATUS "General:           ${CMAKE_CXX_FLAGS}" )
+if ( NOT EXTRA_COMPILE_FLAGS STREQUAL " " )
+message( STATUS "Extra:             ${EXTRA_COMPILE_FLAGS}" )
+endif()
+message( STATUS "Debug:             ${CMAKE_CXX_FLAGS_DEBUG}" )
+message( STATUS "Release:           ${CMAKE_CXX_FLAGS_RELEASE}" )
+message( STATUS "RelWithDebInfo:    ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}" )
+message( STATUS "MinSizeRel:        ${CMAKE_CXX_FLAGS_MINSIZEREL}" )
+message( STATUS "" )
+message( STATUS "Compiler Options")
+OptionOutput( "Warnings as errors:                 " EXIV2_WARNINGS_AS_ERRORS        )
+OptionOutput( "Use extra compiler warning flags:   " EXIV2_EXTRA_WARNINGS            )
+message( STATUS "" )
+
 
 message( STATUS "Compiler info: ${CMAKE_CXX_COMPILER_ID} (${CMAKE_CXX_COMPILER}) ; version: ${CMAKE_CXX_COMPILER_VERSION}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ set_target_properties( exiv2lib PROPERTIES
     VERSION       ${GENERIC_LIB_VERSION}
     SOVERSION     ${GENERIC_LIB_SOVERSION}
     OUTPUT_NAME   exiv2
+    COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
 )
 
 target_compile_definitions(exiv2lib PRIVATE EXV_LOCALEDIR="${CMAKE_INSTALL_LOCALEDIR}" EXV_BUILDING_LIB )
@@ -286,6 +287,10 @@ set( EXIV2_SRC
 
 if(EXIV2_BUILD_EXIV2_COMMAND)
     add_executable( exiv2 ${EXIV2_SRC} )
+    set_target_properties( exiv2 PROPERTIES
+        COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+    )
+
     target_compile_definitions(exiv2 PRIVATE EXV_LOCALEDIR="${CMAKE_INSTALL_LOCALEDIR}" )
     target_link_libraries( exiv2 PRIVATE exiv2lib )
     if ( BUILD_SHARED_LIBS )


### PR DESCRIPTION
After what it was discussed in #131, I have recreated another PR just with some of the changes proposed there and following some of the suggestions proposed.

In this PR I am adding 2 new CMake variables (disabled by default, and marked as advanced) that are useful for the Exiv2 developers to detect some issues in the code thanks to the compiler flags.

The objective of these flags is to enable some useful flags to detect issues in the code. Note that some of these flags can be a bit aggressive and detect false positives. The developers should use them wisely and comment/un-comment those ones that the find useful.

Things to take into account:

- The relevant changes are isolated in **config/compilerOptions.cmake**.
- The flags are only applied to the targets **exiv2lib** and **exiv2**.
- In following PRs I will address some of the issues detected by these flags. Once I fix all the warnings related to one of the compiler flags, I could add that flag to travis-ci to be sure that we do not have more of these warnings in the code from that moment. 