### PR TITLE
Update zlib version in conanfile.py.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class Exiv2Conan(ConanFile):
 
     def requirements(self):
         self.requires('Expat/2.2.1@pix4d/stable') # From pix4d
-        self.requires('zlib/1.2.8@lasote/stable') # From conan-center
+        self.requires('zlib/1.2.11@lasote/stable') # From conan-center
         self.requires('libcurl/7.50.3@lasote/stable') # From conan-transit (It also brings OpenSSL)
 
         if self.options.unitTests:


### PR DESCRIPTION
The previous version of the zlib recipe failed to compile in new versions of gcc (7.2).

This change only affects to the project when using conan (still in experimental mode)