### PR TITLE
Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+BasedOnStyle: Google
+Language: Cpp
+Standard: Cpp03
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 120
+NamespaceIndentation: All
+
+AccessModifierOffset: -4
+ContinuationIndentWidth: 4
+IndentWidth: 4
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterStruct: true
+    AfterClass: true
+    AfterFunction: true
+    AfterControlStatement: false
+    AfterEnum: true
+    AfterNamespace: true
+
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+...

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -27,25 +27,24 @@
 // included header files
 #include "config.h"
 
-#include "bmpimage.hpp"
-#include "image.hpp"
 #include "basicio.hpp"
+#include "bmpimage.hpp"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
 
 // + standard includes
-#include <string>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions
-namespace Exiv2 {
-
-    BmpImage::BmpImage(BasicIo::AutoPtr io)
-        : Image(ImageType::bmp, mdNone, io)
+namespace Exiv2
+{
+    BmpImage::BmpImage(BasicIo::AutoPtr io) : Image(ImageType::bmp, mdNone, io)
     {
-    } // BmpImage::BmpImage
+    }
 
     std::string BmpImage::mimeType() const
     {
@@ -75,14 +74,12 @@ namespace Exiv2 {
 #ifdef DEBUG
         std::cerr << "Exiv2::BmpImage::readMetadata: Reading Windows bitmap file " << io_->path() << "\n";
 #endif
-        if (io_->open() != 0)
-        {
+        if (io_->open() != 0) {
             throw Error(9, io_->path(), strError());
         }
         IoCloser closer(*io_);
         // Ensure that this is the correct image type
-        if (!isBmpType(*io_, false))
-        {
+        if (!isBmpType(*io_, false)) {
             if (io_->error() || io_->eof()) throw Error(14);
             throw Error(3, "BMP");
         }
@@ -110,26 +107,24 @@ namespace Exiv2 {
           50      4 bytes  important colors       number of "important" colors
         */
         byte buf[54];
-        if (io_->read(buf, sizeof(buf)) == sizeof(buf))
-        {
+        if (io_->read(buf, sizeof(buf)) == sizeof(buf)) {
             pixelWidth_ = getLong(buf + 18, littleEndian);
             pixelHeight_ = getLong(buf + 22, littleEndian);
         }
-    } // BmpImage::readMetadata
+    }
 
     void BmpImage::writeMetadata()
     {
         // Todo: implement me!
         throw(Error(31, "BMP"));
-    } // BmpImage::writeMetadata
+    }
 
     // *************************************************************************
     // free functions
     Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
         Image::AutoPtr image(new BmpImage(io));
-        if (!image->good())
-        {
+        if (!image->good()) {
             image.reset();
         }
         return image;
@@ -138,18 +133,16 @@ namespace Exiv2 {
     bool isBmpType(BasicIo& iIo, bool advance)
     {
         const int32_t len = 2;
-        const unsigned char BmpImageId[2] = { 'B', 'M' };
+        const unsigned char BmpImageId[2] = {'B', 'M'};
         byte buf[len];
         iIo.read(buf, len);
-        if (iIo.error() || iIo.eof())
-        {
+        if (iIo.error() || iIo.eof()) {
             return false;
         }
         bool matched = (memcmp(buf, BmpImageId, len) == 0);
-        if (!advance || !matched)
-        {
+        if (!advance || !matched) {
             iIo.seek(-len, BasicIo::cur);
         }
         return matched;
     }
-}                                       // namespace Exiv2
+}

--- a/src/canonmn.cpp
+++ b/src/canonmn.cpp
@@ -1641,39 +1641,37 @@ namespace Exiv2 {
 
     // Canon Time Info Tag
     const TagInfo CanonMakerNote::tagInfoTi_[] = {
-        TagInfo(0x0001, "TimeZone", N_("Time zone offset"), N_("Time zone offset in minutes"), canonTiId, makerTags, signedLong, 1, printValue),
-        TagInfo(0x0002, "TimeZoneCity", N_("Time zone city"), N_("Time zone city"), canonTiId, makerTags, signedLong, 1, EXV_PRINT_TAG(canonTimeZoneCity)),
-        TagInfo(0x0003, "DaylightSavings", N_("Daylight Savings"), N_("Daylight Saving Time"), canonTiId, makerTags, signedLong, 1, printValue),
-        TagInfo(0xffff, "(UnknownCanonTiTag)", "(UnknownCanonTiTag)", N_("Unknown Canon Time Info tag"), canonTiId, makerTags, signedLong, 1, printValue)
-    };
+        TagInfo(0x0001, "TimeZone", N_("Time zone offset"), N_("Time zone offset in minutes"), canonTiId, makerTags,
+                signedLong, 1, printValue),
+        TagInfo(0x0002, "TimeZoneCity", N_("Time zone city"), N_("Time zone city"), canonTiId, makerTags, signedLong, 1,
+                EXV_PRINT_TAG(canonTimeZoneCity)),
+        TagInfo(0x0003, "DaylightSavings", N_("Daylight Savings"), N_("Daylight Saving Time"), canonTiId, makerTags,
+                signedLong, 1, printValue),
+        TagInfo(0xffff, "(UnknownCanonTiTag)", "(UnknownCanonTiTag)", N_("Unknown Canon Time Info tag"), canonTiId,
+                makerTags, signedLong, 1, printValue)};
 
     const TagInfo* CanonMakerNote::tagListTi()
     {
         return tagInfoTi_;
     }
 
-    std::ostream& CanonMakerNote::printFiFileNumber(std::ostream& os,
-                                                    const Value& value,
-                                                    const ExifData* metadata)
+    std::ostream& CanonMakerNote::printFiFileNumber(std::ostream& os, const Value& value, const ExifData* metadata)
     {
-        std::ios::fmtflags f( os.flags() );
-        if (   !metadata || value.typeId() != unsignedLong
-            || value.count() == 0)
-        {
+        std::ios::fmtflags f(os.flags());
+        if (!metadata || value.typeId() != unsignedLong || value.count() == 0) {
             os << "(" << value << ")";
             os.flags(f);
             return os;
         }
 
         ExifData::const_iterator pos = metadata->findKey(ExifKey("Exif.Image.Model"));
-        if (pos == metadata->end()) return os << "(" << value << ")";
+        if (pos == metadata->end())
+            return os << "(" << value << ")";
 
         // Ported from Exiftool
         std::string model = pos->toString();
-        if (   model.find("20D") != std::string::npos
-            || model.find("350D") != std::string::npos
-            || model.substr(model.size() - 8, 8) == "REBEL XT"
-            || model.find("Kiss Digital N") != std::string::npos) {
+        if (model.find("20D") != std::string::npos || model.find("350D") != std::string::npos ||
+            model.substr(model.size() - 8, 8) == "REBEL XT" || model.find("Kiss Digital N") != std::string::npos) {
             uint32_t val = value.toLong();
             uint32_t dn = (val & 0xffc0) >> 6;
             uint32_t fn = ((val >> 16) & 0xff) + ((val & 0x3f) << 8);
@@ -1681,14 +1679,13 @@ namespace Exiv2 {
             os.flags(f);
             return os;
         }
-        if (   model.find("30D") != std::string::npos
-            || model.find("400D") != std::string::npos
-            || model.find("REBEL XTi") != std::string::npos
-            || model.find("Kiss Digital X") != std::string::npos
-            || model.find("K236") != std::string::npos) {
+        if (model.find("30D") != std::string::npos || model.find("400D") != std::string::npos ||
+            model.find("REBEL XTi") != std::string::npos || model.find("Kiss Digital X") != std::string::npos ||
+            model.find("K236") != std::string::npos) {
             uint32_t val = value.toLong();
             uint32_t dn = (val & 0xffc00) >> 10;
-            while (dn < 100) dn += 0x40;
+            while (dn < 100)
+                dn += 0x40;
             uint32_t fn = ((val & 0x3ff) << 4) + ((val >> 20) & 0x0f);
             os << std::dec << dn << "-" << std::setw(4) << std::setfill('0') << fn;
             os.flags(f);
@@ -1699,23 +1696,17 @@ namespace Exiv2 {
         return os << "(" << value << ")";
     }
 
-    std::ostream& CanonMakerNote::printFocalLength(std::ostream& os,
-                                                   const Value& value,
-                                                   const ExifData* metadata)
+    std::ostream& CanonMakerNote::printFocalLength(std::ostream& os, const Value& value, const ExifData* metadata)
     {
-        std::ios::fmtflags f( os.flags() );
-        if (   !metadata
-            || value.count() < 4
-            || value.typeId() != unsignedShort) {
+        std::ios::fmtflags f(os.flags());
+        if (!metadata || value.count() < 4 || value.typeId() != unsignedShort) {
             os.flags(f);
             return os << value;
         }
 
         ExifKey key("Exif.CanonCs.Lens");
         ExifData::const_iterator pos = metadata->findKey(key);
-        if (   pos != metadata->end()
-            && pos->value().count() >= 3
-            && pos->value().typeId() == unsignedShort) {
+        if (pos != metadata->end() && pos->value().count() >= 3 && pos->value().typeId() == unsignedShort) {
             float fu = pos->value().toFloat(2);
             if (fu != 0.0) {
                 float fl = value.toFloat(1) / fu;


### PR DESCRIPTION
In this PR I propose the addition of a clang-format file for defining the style of the Exiv2 code. 

I tried to be conservative and the options selected are matching (more or less) the style that was used in most parts of the project. Of course, we can discuss about some of these values and change them accordingly to our discussion :).

I also applied these changes to one complete file (that was small) and to few lines of other file. Modern IDEs (like QtCreator) have shortcuts to apply clang-format in a whole file or to the selected text.

You can find more information about clang-format in the following links:

- https://clang.llvm.org/docs/ClangFormat.html
- https://clang.llvm.org/docs/ClangFormatStyleOptions.html