### PR TITLE
New MSVC flag to enable Object Level Parallelism in CMake code

### DIFF
--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -132,4 +132,7 @@ if(MSVC)
         string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     endif ()
 
+    # Object Level Parallelism 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+
 endif()


### PR DESCRIPTION
Simple change to enable Object Level Parallelism when compiling when using CMake + the Visual Studio generator. 

Normally this can be enabled withing the Visual Studio IDE, but this will enable that option by default (what it is something that most people would like to have)