### PR TITLE
Provide a gtestWrapper header to skip useless warnings

### DIFF
--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(unit_tests mainTestRunner.cpp
     test_types.cpp
+    gtestwrapper.h
 )
 
 #TODO Use GTest::GTest once we upgrade the minimum CMake version required

--- a/unitTests/gtestwrapper.h
+++ b/unitTests/gtestwrapper.h
@@ -1,0 +1,14 @@
+#ifndef GTESTWRAPPER_H_
+#define GTESTWRAPPER_H_
+
+#ifdef _MSC_VER
+        #pragma warning(push)
+        #pragma warning(disable : 4251)
+        #pragma warning(disable : 4275)
+#endif
+#include <gtest/gtest.h>
+#ifdef _MSC_VER
+        #pragma warning(pop)
+#endif
+
+#endif // #ifndef GTESTWRAPPER_H_

--- a/unitTests/mainTestRunner.cpp
+++ b/unitTests/mainTestRunner.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include "gtestwrapper.h"
 
 #include <iostream>
 

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include <exiv2/types.hpp>
+
+#include "gtestwrapper.h"
 
 using namespace Exiv2;
 


### PR DESCRIPTION
In this PR I am providing a new gtest wrapper header to be used when writing unit tests.

Instead of using directly the gtest header that throws many warnings into the console when we use Visual Studio, we **must** use this wrapper that will skip some warnings that are useless. 