### PR TITLE
[WIP] Make the testsuite really fail when tests don't pass

### DIFF
--- a/test/functions.source
+++ b/test/functions.source
@@ -109,7 +109,7 @@ reportTest()
         echo "all testcases passed."
     else
         diff $diffargs $lhs $rhs
-	exit $rc
+	exit 3
     fi
 }
 


### PR DESCRIPTION
#167 did not fix the issues with the testsuite completely, as #165 passed travis & appveyor without problems. Apparently the issue is, that the makefile (`test/Makefile` lines 102 - 110) part responsible for `make tests` only aborts with a non-zero exit code if each test script exits with a value > 2. If it is non-zero but less than two it only prints the result.

I have therefore hardcoded the return value of `reportTest()` in the case of a failure, so that `make tests`should fail. I'll also push another commit that will intentionally break the testsuite so that we see that the CI fails. Therefore please don't merge this yet.