### PR TITLE
Add characterization tests for some "futils" function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.o
 *.swp
 *.pyc
+*.txt.user
 .DS_Store
 config.log
 config.status
@@ -13,7 +14,7 @@ libtool
 .deps/
 .libs/
 bin/
-build/
+build*
 config/autom4te.cache/
 config/config.h
 config/config.mk

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -78,7 +78,7 @@ namespace Exiv2 {
       @note Be sure to free() the returned string after use
             Source: http://www.geekhideout.com/urlcode.shtml
      */
-    EXIV2API std::string urlencode(char *str);
+    EXIV2API std::string urlencode(const char *str);
     /*!
       @brief Decode the input url.
       @param str The url needs decoding.

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -78,7 +78,7 @@ namespace Exiv2 {
       @note Be sure to free() the returned string after use
             Source: http://www.geekhideout.com/urlcode.shtml
      */
-    EXIV2API char* urlencode(char* str);
+    EXIV2API std::string urlencode(char *str);
     /*!
       @brief Decode the input url.
       @param str The url needs decoding.

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -56,6 +56,7 @@ namespace Exiv2 {
       @brief  Return the value of environmental variable.
       @param  var The name of environmental variable.
       @return the value of environmental variable. If it's empty, the default value is returned.
+      @throws std::out_of_range when an unexpected EnVar is given as input.
      */
     EXIV2API std::string getEnv(EnVar var);
     /*!
@@ -74,9 +75,7 @@ namespace Exiv2 {
       @brief Encode the input url.
       @param str The url needs encoding.
       @return the url-encoded version of str.
-
-      @note Be sure to free() the returned string after use
-            Source: http://www.geekhideout.com/urlcode.shtml
+      @note Source: http://www.geekhideout.com/urlcode.shtml
      */
     EXIV2API std::string urlencode(const char *str);
     /*!

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1635,10 +1635,10 @@ namespace Exiv2 {
 #ifdef DEBUG
         std::cerr << "RemoteIo::close totalRead_ = " << p_->totalRead_ << std::endl;
 #endif
-		if ( bigBlock_ ) {
-			delete [] bigBlock_;
-			bigBlock_=NULL;
-		}
+        if ( bigBlock_ ) {
+            delete [] bigBlock_;
+            bigBlock_=NULL;
+        }
         return 0;
     }
 
@@ -1855,7 +1855,7 @@ namespace Exiv2 {
 #ifdef DEBUG
             std::cerr << "RemoteIo::mmap nRealData = " << nRealData << std::endl;
 #endif
-		}
+        }
 
         return bigBlock_;
     }

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -2045,7 +2045,7 @@ namespace Exiv2 {
         char* encodeData = new char[encodeLength];
         base64encode(data, size, encodeData, encodeLength);
         // url encode
-        char* urlencodeData = urlencode(encodeData);
+        const std::string urlencodeData = urlencode(encodeData);
         delete[] encodeData;
 
         std::stringstream ss;
@@ -2054,7 +2054,6 @@ namespace Exiv2 {
            << "to="     << to             << "&"
            << "data="   << urlencodeData;
         std::string postData = ss.str();
-        delete[] urlencodeData;
 
         // create the header
         ss.str("");
@@ -2268,7 +2267,7 @@ namespace Exiv2 {
         char* encodeData = new char[encodeLength];
         base64encode(data, size, encodeData, encodeLength);
         // url encode
-        char* urlencodeData = urlencode(encodeData);
+        const std::string urlencodeData = urlencode(encodeData);
         delete[] encodeData;
         std::stringstream ss;
         ss << "path="       << hostInfo.Path << "&"
@@ -2276,7 +2275,6 @@ namespace Exiv2 {
            << "to="         << to            << "&"
            << "data="       << urlencodeData;
         std::string postData = ss.str();
-        delete[] urlencodeData;
 
         curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, postData.c_str());
         // Perform the request, res will get the return code.

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -71,7 +71,7 @@ namespace Exiv2 {
         return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
     } // from_hex
 
-    char* urlencode(char* str) {
+    std::string urlencode(char* str) {
         char* pstr = str;
         char* buf  = (char*)malloc(strlen(str) * 3 + 1);
         char* pbuf = buf;
@@ -85,8 +85,10 @@ namespace Exiv2 {
             pstr++;
         }
         *pbuf = '\0';
-        return buf;
-    } // urlencode
+        std::string ret(buf);
+        free(buf);
+        return ret;
+    }
 
     char* urldecode(const char* str) {
         const char* pstr = str;

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -239,8 +239,8 @@ namespace Exiv2 {
     Protocol fileProtocol(const std::string& path) {
         Protocol result = pFile ;
         struct {
-        	std::string name ;
-        	Protocol    prot ;
+            std::string name ;
+            Protocol    prot ;
         } prots[] =
         { { "http://"   ,pHttp     }
         , { "https://"  ,pHttps    }
@@ -252,8 +252,8 @@ namespace Exiv2 {
         , { "-"         ,pStdin    }
         };
         for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-        	if ( path.find(prots[i].name) == 0 )
-        		result = prots[i].prot;
+            if ( path.find(prots[i].name) == 0 )
+                result = prots[i].prot;
 
         return result;
     } // fileProtocol
@@ -261,8 +261,8 @@ namespace Exiv2 {
     Protocol fileProtocol(const std::wstring& wpath) {
         Protocol result = pFile ;
         struct {
-        	std::wstring wname ;
-        	Protocol      prot ;
+            std::wstring wname ;
+            Protocol      prot ;
         } prots[] =
         { { L"http://"   ,pHttp     }
         , { L"https://"  ,pHttps    }
@@ -274,21 +274,21 @@ namespace Exiv2 {
         , { L"-"         ,pStdin    }
         };
         for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-        	if ( wpath.find(prots[i].wname) == 0 )
-        		result = prots[i].prot;
+            if ( wpath.find(prots[i].wname) == 0 )
+                result = prots[i].prot;
 
         return result;
     } // fileProtocol
 #endif
     bool fileExists(const std::string& path, bool ct)
     {
-		// special case: accept "-" (means stdin)
+        // special case: accept "-" (means stdin)
         if (path.compare("-") == 0 || fileProtocol(path)) {
-			return true;
+            return true;
         }
 
         struct stat buf;
-		int ret = ::stat(path.c_str(), &buf);
+        int ret = ::stat(path.c_str(), &buf);
         if (0 != ret)                    return false;
         if (ct && !S_ISREG(buf.st_mode)) return false;
         return true;
@@ -297,9 +297,9 @@ namespace Exiv2 {
 #ifdef EXV_UNICODE_PATH
     bool fileExists(const std::wstring& wpath, bool ct)
     {
-		// special case: accept "-" (means stdin)
+        // special case: accept "-" (means stdin)
         if (wpath.compare(L"-") == 0 || fileProtocol(wpath)) {
-			return true;
+            return true;
         }
 
         struct _stat buf;

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -71,9 +71,9 @@ namespace Exiv2 {
         return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
     } // from_hex
 
-    std::string urlencode(char* str) {
-        char* pstr = str;
-        char* buf  = (char*)malloc(strlen(str) * 3 + 1);
+    std::string urlencode(const char* str) {
+        const char* pstr = str;
+        char* buf  = new char[strlen(str) * 3 + 1];
         char* pbuf = buf;
         while (*pstr) {
             if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~')
@@ -86,7 +86,7 @@ namespace Exiv2 {
         }
         *pbuf = '\0';
         std::string ret(buf);
-        free(buf);
+        delete [] buf;
         return ret;
     }
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
+#include <stdexcept>
 
 #if defined EXV_HAVE_STRERROR_R && !defined EXV_HAVE_DECL_STRERROR_R
 # ifdef EXV_STRERROR_R_CHAR_P
@@ -58,9 +59,13 @@ namespace Exiv2 {
     const char* ENVARKEY[] = {"EXIV2_HTTP_POST", "EXIV2_TIMEOUT"}; //!< @brief request keys for http exiv2 handler and time-out
 // *****************************************************************************
 // free functions
-    std::string getEnv(EnVar var) {
+    std::string getEnv(EnVar var)
+    {
+        if (var < envHTTPPOST || var > envTIMEOUT) {
+            throw std::out_of_range("Unexpected env variable");
+        }
         return getenv(ENVARKEY[var]) ? getenv(ENVARKEY[var]) : ENVARDEF[var];
-    } // getEnv
+    }
 
     char to_hex(char code) {
         static char hex[] = "0123456789abcdef";
@@ -73,6 +78,8 @@ namespace Exiv2 {
 
     std::string urlencode(const char* str) {
         const char* pstr = str;
+        // \todo try to use std::string for buf and avoid the creation of another string for just
+        // returning the final value
         char* buf  = new char[strlen(str) * 3 + 1];
         char* pbuf = buf;
         while (*pstr) {

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(unit_tests mainTestRunner.cpp
     gtestwrapper.h
     test_types.cpp
     test_tiffheader.cpp
+    test_futils.cpp
 )
 
 #TODO Use GTest::GTest once we upgrade the minimum CMake version required

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -1,0 +1,32 @@
+// File under test
+#include <exiv2/futils.hpp>
+
+// Auxiliary headers
+#include <fstream>
+#include <cstdio>
+#include <cerrno>
+
+#include <gtest/gtest.h>
+
+using namespace Exiv2;
+
+TEST(strError, returnSuccessAfterClosingFile)
+{
+    std::string tmpFile("tmp.dat");
+    std::ofstream auxFile(tmpFile.c_str());
+    auxFile.close();
+    ASSERT_STREQ("Success (errno = 0)", strError().c_str());
+    std::remove(tmpFile.c_str());
+}
+
+TEST(strError, returnNoSuchFileOrDirectoryWhenTryingToOpenNonExistingFile)
+{
+    std::ifstream auxFile("nonExistingFile");
+    ASSERT_STREQ("No such file or directory (errno = 2)", strError().c_str());
+}
+
+TEST(strError, doNotRecognizeUnknownError)
+{
+    errno = 9999;
+    ASSERT_STREQ("Unknown error 9999 (errno = 9999)", strError().c_str());
+}

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -56,7 +56,6 @@ TEST(getEnv, throwsWhenKeyDoesNotExist)
 
 TEST(urlencode, encodesGivenUrl)
 {
-    char *url = urlencode("http://www.geekhideout.com/urlcode.shtml");
-    ASSERT_STREQ("http%3a%2f%2fwww.geekhideout.com%2furlcode.shtml", url);
-    free(url);
+    const std::string url = urlencode("http://www.geekhideout.com/urlcode.shtml");
+    ASSERT_STREQ("http%3a%2f%2fwww.geekhideout.com%2furlcode.shtml", url.c_str());
 }

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -53,3 +53,10 @@ TEST(getEnv, throwsWhenKeyDoesNotExist)
     // works.
     ASSERT_THROW(getEnv(static_cast<EnVar>(3)), std::exception);
 }
+
+TEST(urlencode, encodesGivenUrl)
+{
+    char *url = urlencode("http://www.geekhideout.com/urlcode.shtml");
+    ASSERT_STREQ("http%3a%2f%2fwww.geekhideout.com%2furlcode.shtml", url);
+    free(url);
+}

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -6,7 +6,7 @@
 #include <cstdio>
 #include <cerrno>
 
-#include <gtest/gtest.h>
+#include "gtestwrapper.h"
 
 using namespace Exiv2;
 
@@ -29,4 +29,27 @@ TEST(strError, doNotRecognizeUnknownError)
 {
     errno = 9999;
     ASSERT_STREQ("Unknown error 9999 (errno = 9999)", strError().c_str());
+}
+
+TEST(getEnv, getsDefaultValueWhenExpectedEnvVariableDoesNotExist)
+{
+    ASSERT_STREQ("/exiv2.php", getEnv(envHTTPPOST).c_str());
+    ASSERT_STREQ("40", getEnv(envTIMEOUT).c_str());
+}
+
+TEST(getEnv, getsProperValuesWhenExpectedEnvVariableExists)
+{
+    const char * expectedValue = "test";
+    ASSERT_EQ(0, setenv("EXIV2_HTTP_POST", expectedValue, 1));
+
+    ASSERT_STREQ(expectedValue, getEnv(envHTTPPOST).c_str());
+
+    ASSERT_EQ(0, unsetenv("EXIV2_HTTP_POST"));
+}
+
+TEST(getEnv, throwsWhenKeyDoesNotExist)
+{
+    // This is just a characterisation test that was written to see how the current implementation
+    // works.
+    ASSERT_THROW(getEnv(static_cast<EnVar>(3)), std::exception);
 }


### PR DESCRIPTION
In this PR I am adding characterization tests for some of the functions in **futils.hpp**. Since I want to keep the PRs small I decided to stop in the moment that I decided to change an implementation detail in **exiv2::urlencode**.

Here I am proposing to change the signature of exiv2::urlencode from

```
char* urlencode(char* str)
```
to
```
std::string urlencode(char* str)
```
The reasoning is to free client code from the responsibility of freeing the memory allocated by the method.

The function was only used in two places inside `src/basicio.cpp` and in the new added test. 


