### PR TITLE
Disable travis mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ compiler:
 
 os:
   - linux
-  - osx
 
 matrix:
   exclude:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -15,7 +15,7 @@ fi
 
 virtualenv conan
 source conan/bin/activate
-pip install conan
+pip install conan==0.27.0
 conan --version
 conan config set storage.path=~/conanData
 conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan


### PR DESCRIPTION
The travis-ci default image for Mac OSX seems to have changed recently and this made the Mac builds to fail for our case:

https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce

I propose to disable the Mac builds for the moment and enable them back when we better understand the issues we are having. 