### PR TITLE
Reenable mac builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: cpp
 
-sudo: required
-
-compiler:
-  - gcc
-  - clang
-
-os:
-  - linux
-  - osx
-
 matrix:
-  exclude:
-    - os: osx
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
       compiler: gcc
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+    - os: osx
+      osx_image: xcode9
+      compiler: clang
+      env: PYTHON=3.6.2
 
 env:
     #- CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release" # Default

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ compiler:
 
 os:
   - linux
+  - osx
 
 matrix:
   exclude:

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,12 +3,26 @@
 set -e
 set -x
 
-source conan/bin/activate
+if [[ "$(uname -s)" == 'Linux' ]]; then
+    source conan/bin/activate
+else
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+    pyenv activate conan
+fi
+
 mkdir build && cd build
 conan install .. --build missing --profile release
 cmake ${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=install ..
 make -j2
 make tests
 make install
-cd bin
-./unit_tests
+
+# Only run unit tests on Linux for the moment
+# TODO: Check what is happening on Mac
+if [[ "$(uname -s)" == 'Linux' ]]; then
+    cd bin
+    ./unit_tests
+fi

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ class Exiv2Conan(ConanFile):
             self.options['libcurl'].shared = True
 
     def requirements(self):
-        self.requires('Expat/2.2.1@pix4d/stable') # From pix4d
+        self.requires('Expat/2.2.4@pix4d/stable') # From conan-center
         self.requires('zlib/1.2.11@lasote/stable') # From conan-center
         self.requires('libcurl/7.50.3@lasote/stable') # From conan-transit (It also brings OpenSSL)
 


### PR DESCRIPTION
This PR re-enables the mac osx builds on travis-ci.

There were a problem after travis-ci updated their default OSX images. PyOpenSSL has a SSL certificate problem when it is used with python2. After many trials & errors, I decided to move to python3 that does not have that problem anymore.

The SSL problem was affecting (among other things) to the conan downloads.