### PR TITLE
[AppVeyor, Travis] Re-enable unit tests for Mac and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - os: osx
       osx_image: xcode9
       compiler: clang
-      env: PYTHON=3.6.2
+      env: PYTHON=3.6.2 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON" # All enabled
 
 env:
     #- CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release" # Default

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -40,6 +40,6 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
         printf "[settings]\nos=Linux\narch=x86_64\ncompiler=gcc\ncompiler.version=4.8\ncompiler.libcxx=libstdc++\nbuild_type=Release\n" > ~/.conan/profiles/release
     fi
 else
-    printf "[settings]\nos=Macos\narch=x86_64\ncompiler=apple-clang\ncompiler.version=9.0\ncompiler.libcxx=libstdc++\nbuild_type=Release\n" > ~/.conan/profiles/release
+    printf "[settings]\nos=Macos\narch=x86_64\ncompiler=apple-clang\ncompiler.version=9.0\ncompiler.libcxx=libc++\nbuild_type=Release\n" > ~/.conan/profiles/release
 fi
 

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -19,10 +19,5 @@ cmake ${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=install ..
 make -j2
 make tests
 make install
-
-# Only run unit tests on Linux for the moment
-# TODO: Check what is happening on Mac
-if [[ "$(uname -s)" == 'Linux' ]]; then
-    cd bin
-    ./unit_tests
-fi
+cd bin
+./unit_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,11 @@ build_script:
     - cmd: cd build
     - cmd: conan install .. --build missing --profile release
     - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-    - cmd: cmake -G "Ninja" -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
+    - cmd: cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: ninja
     - cmd: ninja install
-    # TODO : Run tests on windows once we discover why they are crashing
-    #- cmd: cd bin
-    #- cmd: dir
-    #- cmd: unit_tests.exe
+    - cmd: cd bin
+    - cmd: unit_tests.exe
 
 cache:
     - envs                   # Conan installation

--- a/unitTests/mainTestRunner.cpp
+++ b/unitTests/mainTestRunner.cpp
@@ -10,5 +10,5 @@ int main(int argc, char** argv)
 
     std::cout << "Tests finished with return value: " << ret << std::endl;
 
-    return EXIT_SUCCESS;
+    return ret;
 }

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -17,6 +17,8 @@ TEST(strError, returnSuccessAfterClosingFile)
     auxFile.close();
 #ifdef _WIN32
     const char * expectedString = "No error (errno = 0)";
+#elif __APPLE__
+    const char * expectedString = "Undefined error: 0 (errno = 0)";
 #else
     const char * expectedString = "Success (errno = 0)";
 #endif
@@ -36,6 +38,8 @@ TEST(strError, doNotRecognizeUnknownError)
     errno = 9999;
 #ifdef _WIN32
     const char * expectedString = "Unknown error (errno = 9999)";
+#elif __APPLE__
+    const char * expectedString = "Unknown error: 9999 (errno = 9999)";
 #else
     const char * expectedString = "Unknown error 9999 (errno = 9999)";
 #endif


### PR DESCRIPTION
In the case of AppVeyor + Windows, the problem was that we were not indicating the CMAKE_BUILD_TYPE when calling CMake. It is important to set that CMake variable when using
the Ninja generator.

On Mac the issue was coming from the conan profile. We have to use libc++ instead of libstc++ in the mac conan profile.

This PR is address the issue #191 