### PR TITLE
Show the Appveyor badge corresponding to the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=master)](https://travis-ci.org/Exiv2/exiv2)
-[![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp)
+[![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al/branch/master?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp/branch/master)
 
 
 <pre><code>


### PR DESCRIPTION
I recently noticed that we were not shoring the right badge in the main page of the project. This PR should fix the situation. 