### PR TITLE
Reset errno to 0 before unit test probing strerror(errno)

### DIFF
--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -12,6 +12,10 @@ using namespace Exiv2;
 
 TEST(strError, returnSuccessAfterClosingFile)
 {
+    // previous system calls can fail, but errno is not guaranteed to be reset
+    // by a successful system call
+    // -> reset errno so that a real failure is only detected here
+    errno = 0;
     std::string tmpFile("tmp.dat");
     std::ofstream auxFile(tmpFile.c_str());
     auxFile.close();


### PR DESCRIPTION
This should fix #196.