### PR TITLE
Update Fujifilm monochrome color modes

### DIFF
--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -76,11 +76,15 @@ namespace Exiv2 {
 
     //! Color, tag 0x1003
     extern const TagDetails fujiColor[] = {
-        {   0, N_("Normal")               },
-        { 256, N_("High")                 },
-        { 512, N_("Low")                  },
-        { 768, N_("None (black & white)") },
-        { 768, N_("None (black & white)") }     // To silence compiler warning
+        {   0, N_("Normal")                 },
+        { 256, N_("High")                   },
+        { 512, N_("Low")                    },
+        { 768, N_("Monochrome")             },
+        { 769, N_("Monochrome + R Filter")  },
+        { 770, N_("Monochrome + Ye Filter") },
+        { 771, N_("Monochrome + G Filter")  },
+        { 784, N_("Sepia")                  },
+        { 768, N_("Monochrome")             } // To silence compiler warning
     };
 
     //! Tone, tag 0x1004


### PR DESCRIPTION
Update fujiColor tag with descriptions for new Fujifilm monochrome modes. Unlike the various color film simulations the monochrome modes do not use the FilmMode makernote. These new descriptions complement the updated FilmMode descriptions from this patch http://dev.exiv2.org/issues/1179 