### PR TITLE
Fix outdated documentation of PngImage::doWriteMetadata()

### DIFF
--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -110,9 +110,9 @@ namespace Exiv2
         /*!
           @brief Provides the main implementation of writeMetadata() by
                 writing all buffered metadata to the provided BasicIo.
+          @throw Error on input-output errors or when the image data is not valid.
           @param oIo BasicIo instance to write to (a temporary location).
 
-          @return 4 if opening or writing to the associated BasicIo fails
          */
         EXV_DLLLOCAL void doWriteMetadata(BasicIo& oIo);
         //@}


### PR DESCRIPTION
The function does not return anything, it only throws exceptions.