### PR TITLE
Enable integration of Exiv2 as CMake sub-project

### DIFF
--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -1,5 +1,5 @@
 # set include path for FindXXX.cmake files
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/config/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/config/")
 
 # Check if the conan file exist to find the dependencies
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,18 +204,18 @@ endif()
 
 if ( EXIV2_ENABLE_XMP )
     #target_include_directories(exiv2lib PRIVATE ${CMAKE_SOURCE_DIR}/xmpsdk/include)
-    target_link_libraries(exiv2lib PUBLIC xmp)
+    target_link_libraries(exiv2lib PRIVATE xmp)
 endif()
 
 # TODO : We should not include include/exiv2 but only include !!!
 target_include_directories(exiv2lib PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/exiv2>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/exiv2>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<INSTALL_INTERFACE:include>
 )
 
 target_include_directories(exiv2lib_int PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/exiv2>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/exiv2>
 )
 
 if (EXIV2_ENABLE_WEBREADY)

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(xmp
 
 target_include_directories(xmp
     PUBLIC 
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/xmpsdk/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../xmpsdk/include>
     PRIVATE 
         ${EXPAT_INCLUDE_DIR}
 )


### PR DESCRIPTION
When integrating Exiv2 into another CMake project with add_subdirectory() the CMake-run fails on FindIconv, because the CMAKE_MODULE_PATH points to the top-level project, not to the Exiv2-project level.