### PR TITLE
Update to conan 1.1.1 and some of the recipes

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,15 +27,16 @@ fi
 
 python --version
 pip install urllib3[secure] -U #Should solve SSL issues
-pip install conan==0.29.2
+pip install conan==1.1.1
 conan --version
 conan config set storage.path=~/conanData
-conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
+conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
 mkdir -p ~/.conan/profiles
 
 if [[ "$(uname -s)" == 'Linux' ]]; then
     if [ ${CC} == "clang" ]; then
-        printf "[settings]\nos=Linux\narch=x86_64\ncompiler=clang\ncompiler.version=3.9\ncompiler.libcxx=libstdc++\nbuild_type=Release\n" > ~/.conan/profiles/release
+        printf "[settings]\nos=Linux\narch=x86_64\ncompiler=clang\ncompiler.version=5.0\ncompiler.libcxx=libstdc++\nbuild_type=Release\n" > ~/.conan/profiles/release
     else
         printf "[settings]\nos=Linux\narch=x86_64\ncompiler=gcc\ncompiler.version=4.8\ncompiler.libcxx=libstdc++\nbuild_type=Release\n" > ~/.conan/profiles/release
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,21 +19,22 @@ before_build:
     - cmd: cd envs
     - cmd: python -m virtualenv conan
     - cmd: conan/Scripts/activate
-    - cmd: python -m pip install conan==0.27.0
+    - cmd: python -m pip install conan==1.1.1
     - cmd: cd ..
     - cmd: conan --version
-    - cmd: conan remote add conan-pix4d https://api.bintray.com/conan/pix4d/conan
+    - cmd: conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan
     - cmd: conan remote list
     - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
     - cmd: cat c:\Users\appveyor\.conan\conan.conf
     - cmd: mkdir c:\Users\appveyor\.conan\profiles
-    - cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
-    - cmd: cat c:\Users\appveyor\.conan\profiles\release
+      #- cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
+      #- cmd: cat c:\Users\appveyor\.conan\profiles\release
 
 build_script:
     - cmd: md build
     - cmd: cd build
-    - cmd: conan install .. --build missing --profile release
+    - cmd: conan install .. --build missing
+      #- cmd: conan install .. --build missing --profile release
     - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
     - cmd: cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_XMP=ON -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: ninja

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,14 +13,15 @@ class Exiv2Conan(ConanFile):
         # Windows also has some problems (since it uses CMake for configuring the project).
         if os_info.is_windows:
             self.options['libcurl'].shared = True
+        self.options['gtest'].shared = True
 
     def requirements(self):
-        self.requires('Expat/2.2.4@pix4d/stable') # From conan-center
-        self.requires('zlib/1.2.11@lasote/stable') # From conan-center
-        self.requires('libcurl/7.50.3@lasote/stable') # From conan-transit (It also brings OpenSSL)
+        self.requires('Expat/2.2.5@pix4d/stable')
+        self.requires('zlib/1.2.11@conan/stable')
+        self.requires('libcurl/7.56.1@bincrafters/stable') # from conan-bincrafters
 
         if self.options.unitTests:
-            self.requires('gtest/1.8.0@lasote/stable') #From conan-transit
+            self.requires('gtest/1.8.0@bincrafters/stable')
 
     def imports(self):
         self.copy('*.dll', dst='bin', src='bin')


### PR DESCRIPTION
In this PR I am updating the usage of conan so that the CI jobs (travis and appveyor) get more stable. 

* Update dependency on libexpat to version 2.2.5
    This new version of the conan recipe contain packages for new compilers
* Get gtest and libcurl from bincrafters
* Update the zlib dependency
* Use clang-5.0

In the past I also started to use some **cache** features on the travis and appveyor configuration. When we do changes in the conan remotes or conan packages, we have to trash the cache from the CI environments and recreate it. At some point, I will write a document explaining how to deal with those things (for the maintainers of Exiv2).