### PR TITLE
Add enforce() from D

### DIFF
--- a/src/enforce.hpp
+++ b/src/enforce.hpp
@@ -1,0 +1,96 @@
+// ********************************************************* -*- C++ -*-
+/*
+ * Copyright (C) 2004-2018 Exiv2 maintainers
+ *
+ * This program is part of the Exiv2 distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
+ */
+/*!
+  @file    enforce.hpp
+  @brief   Port of D's enforce() to C++ & Exiv2
+  @author  Dan Čermák (D4N)
+           <a href="mailto:dan.cermak@cgc-instruments.com">dan.cermak@cgc-instruments.com</a>
+  @date    11-March-18, D4N: created
+ */
+
+#include <string>
+
+#include "error.hpp"
+
+/*!
+ * @brief Ensure that condition is true, otherwise throw an exception of the
+ * type exception_t
+ *
+ * @tparam exception_t  Exception type that is thrown, must provide a
+ * constructor that accepts a single argument to which arg1 is forwarded.
+ *
+ * @todo once we have C++>=11 use variadic templates and std::forward to remove
+ * all overloads of enforce
+ */
+template <typename exception_t, typename T>
+inline void enforce(bool condition, const T& arg1)
+{
+    if (!condition) {
+        throw exception_t(arg1);
+    }
+}
+
+/*!
+ * @brief Ensure that condition is true, otherwise throw an Exiv2::Error with
+ * the given error_code.
+ */
+inline void enforce(bool condition, Exiv2::ErrorCode err_code)
+{
+    if (!condition) {
+        throw Exiv2::Error(err_code);
+    }
+}
+
+/*!
+ * @brief Ensure that condition is true, otherwise throw an Exiv2::Error with
+ * the given error_code & arg1.
+ */
+template <typename T>
+inline void enforce(bool condition, Exiv2::ErrorCode err_code, const T& arg1)
+{
+    if (!condition) {
+        throw Exiv2::Error(err_code, arg1);
+    }
+}
+
+/*!
+ * @brief Ensure that condition is true, otherwise throw an Exiv2::Error with
+ * the given error_code, arg1 & arg2.
+ */
+template <typename T, typename U>
+inline void enforce(bool condition, Exiv2::ErrorCode err_code, const T& arg1, const U& arg2)
+{
+    if (!condition) {
+        throw Exiv2::Error(err_code, arg1, arg2);
+    }
+}
+
+/*!
+ * @brief Ensure that condition is true, otherwise throw an Exiv2::Error with
+ * the given error_code, arg1, arg2 & arg3.
+ */
+template <typename T, typename U, typename V>
+inline void enforce(bool condition, Exiv2::ErrorCode err_code, const T& arg1, const U& arg2, const V& arg3)
+{
+    if (!condition) {
+        throw Exiv2::Error(err_code, arg1, arg2, arg3);
+    }
+}

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_types.cpp
     test_tiffheader.cpp
     test_futils.cpp
+    test_enforce.cpp
     test_safe_op.cpp
 )
 

--- a/unitTests/test_enforce.cpp
+++ b/unitTests/test_enforce.cpp
@@ -1,0 +1,24 @@
+#include <enforce.hpp>
+
+#include "gtestwrapper.h"
+
+TEST(enforce, errMessage)
+{
+    try {
+        enforce(false, Exiv2::kerErrorMessage, "an error occurred");
+    } catch (const Exiv2::Error& e) {
+        ASSERT_STREQ(e.what(), "an error occurred");
+    }
+}
+
+TEST(enforce, exceptionThrown)
+{
+    ASSERT_NO_THROW(enforce(true, Exiv2::kerErrorMessage));
+
+    ASSERT_THROW(enforce(false, Exiv2::kerErrorMessage), Exiv2::Error);
+    ASSERT_THROW(enforce<std::overflow_error>(false, "error message"), std::overflow_error);
+    ASSERT_THROW(enforce(false, Exiv2::kerMallocFailed), Exiv2::Error);
+    ASSERT_THROW(enforce(false, Exiv2::kerErrorMessage, "error message"), Exiv2::Error);
+    ASSERT_THROW(enforce(false, Exiv2::kerDataSourceOpenFailed, "path", "strerror"), Exiv2::Error);
+    ASSERT_THROW(enforce(false, Exiv2::kerCallFailed, "path", "strerror", "function"), Exiv2::Error);
+}


### PR DESCRIPTION
As #239 is currently blocked by some issues in the webp parser which I have to dig through, I have split of the enforce addition and submitted it via this PR.

In a nutshell, I have just stolen enforce() from the D programming language. It is a boilerplate removal, which behaves similarly to assert:
``` C++
enforce<std::overflow_error>(a < std::numeric_limits<int> - b, "a + b would overflow");
```
enforce will check that the condition is true and if it is not, it will construct a new exception of the provided type, pass the additional parameter to it and throw it. That way, it can be used like assert() but is not fatal and thus much better suited to validate input from external sources.

Once we switch to C++11, we can simplify enforce.hpp a lot by the usage of variadic templates.