### PR TITLE
Add EXTRA_COMPILE_FLAGS to samples & unitTests

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -35,6 +35,8 @@ set( SAMPLES
 foreach(entry ${SAMPLES})
     string( REPLACE ".cpp" "" target ${entry})
     add_executable( ${target} ${target}.cpp )
+    set_target_properties(${target} PROPERTIES
+      COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS})
     list(APPEND APPLICATIONS ${target})
     add_test( ${target}_test ${target} )
     target_link_libraries( ${target} PRIVATE exiv2lib)

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -24,3 +24,7 @@ target_compile_definitions(unit_tests
     PRIVATE
         GTEST_LINKED_AS_SHARED_LIBRARY=1
 )
+
+set_target_properties( unit_tests PROPERTIES
+    COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+)


### PR DESCRIPTION
This PR adds the additional compiler flags added by `-DEXIV2_TEAM_EXTRA_WARNINGS=ON` to the targets in samples/ & unitTests/