### PR TITLE
C++ 11 support: replace auto_ptr with unique_ptr

### DIFF
--- a/config/compilerFlags.cmake
+++ b/config/compilerFlags.cmake
@@ -1,3 +1,7 @@
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
         set(COMPILER_IS_GCC ON)
@@ -9,12 +13,6 @@ if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
 
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W")
-
-        if ( CYGWIN OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98") # to support snprintf
-        else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
-        endif()
 
         if ( EXIV2_TEAM_WARNINGS_AS_ERRORS )
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/config/configure.ac
+++ b/config/configure.ac
@@ -359,7 +359,7 @@ AC_DEFUN([AX_GCC_VERSION], [
 ])
 
 AC_ARG_WITH(std,
-    [  --with-std  use --with-std for c++11. options: --with-std=11|14|c++11|c++14 default/--without-std is c++98],
+    [  --with-std  use --with-std for c++11. options: --with-std=11|14|c++11|c++14 default/--without-std is c++11],
     STD=$withval,
     STD=default)
 
@@ -373,15 +373,15 @@ elif test "$STD" = "default" -o "$STD" = "no" ; then
 	# 1188 v0.26 uses c++98
 	case "$host_os" in
 		*cygwin*)
-			CPPFLAGS="$CPPFLAGS -std=gnu++98"  # cygwin requires gnu++98 to support snprintf
+			CPPFLAGS="$CPPFLAGS -std=gnu++11"  # cygwin requires gnu++98 to support snprintf
 		;;
 		*ming*)
 			CPPFLAGS="$CPPFLAGS"               # mingw doesn't link pthreads if you specify -std !!
 		;;
 		*)
-			CPPFLAGS="$CPPFLAGS -std=c++98"
+			CPPFLAGS="$CPPFLAGS -std=c++11"
 			if [[ ! -z "$GCC_VERSION" ]]; then
-				if [[ "$GCC_VERSION" -ge 6 ]]; then CPPFLAGS="$CPPFLAGS -std=gnu++98" ; fi  # // not GCC 6
+				if [[ "$GCC_VERSION" -ge 6 ]]; then CPPFLAGS="$CPPFLAGS -std=gnu++11" ; fi  # // not GCC 6
 			fi
 		;;
 	esac

--- a/contrib/organize/organize.cpp
+++ b/contrib/organize/organize.cpp
@@ -67,7 +67,7 @@ struct PathPart {
     const Pattern *pat;
     std::string post;
     PathPart(std::string pre_, const Pattern *pat_, std::string post_)
-         : pre(pre_), pat(pat_), post(post_) {}
+	 : pre(pre_), pat(pat_), post(post_) {}
 };
 
 std::vector<PathPart> g_path_parts;
@@ -98,69 +98,69 @@ struct ProcessParams {
     unsigned file_ex_count;
 };
 
-void process_directory(const fs::path &directory, const long depth, 
+void process_directory(const fs::path &directory, const long depth,
     ProcessParams &params);
 
 const Pattern g_patterns[] = {
-    {"@date", "date captured (2009-01-19)", 
-        {exif_date, iptc_date, NULL, file_date} },
+    {"@date", "date captured (2009-01-19)",
+	{exif_date, iptc_date, NULL, file_date} },
     {"@year", "year captured (2009)",
-        {exif_year, iptc_year, NULL, file_year} },
+	{exif_year, iptc_year, NULL, file_year} },
     {"@month", "month captured (01)",
-        {exif_month, iptc_month, NULL, file_month} },
+	{exif_month, iptc_month, NULL, file_month} },
     {"@day", "day captured (19)",
-        {exif_day, iptc_day, NULL, file_day} },
-    {"@time", "time captured (14-35-27)", 
-        {exif_time, iptc_time, NULL, file_time} },
+	{exif_day, iptc_day, NULL, file_day} },
+    {"@time", "time captured (14-35-27)",
+	{exif_time, iptc_time, NULL, file_time} },
     {"@hour", "hour captured (14)",
-        {exif_hour, iptc_hour, NULL, file_hour} },
+	{exif_hour, iptc_hour, NULL, file_hour} },
     {"@min", "minute captured (35)",
-        {exif_minute, iptc_minute, NULL, file_minute} },
+	{exif_minute, iptc_minute, NULL, file_minute} },
     {"@sec", "second captured (27)",
-        {exif_second, iptc_second, NULL, file_second} },
+	{exif_second, iptc_second, NULL, file_second} },
     {"@dim", "pixel dimension (2272-1704)",
-        {exif_dimension, NULL, NULL, file_dimension} },
+	{exif_dimension, NULL, NULL, file_dimension} },
     {"@x", "pixel width (2272)",
-        {exif_width, NULL, NULL, file_width} },
+	{exif_width, NULL, NULL, file_width} },
     {"@y", "pixel height (1704)",
-        {exif_height, NULL, NULL, file_height} },
+	{exif_height, NULL, NULL, file_height} },
     {"@make", "device make (Canon)",
-        {exif_make, NULL, NULL, NULL} },
+	{exif_make, NULL, NULL, NULL} },
     {"@model", "device model (Canon PowerShot S40)",
-        {exif_model, NULL, NULL, NULL} },
+	{exif_model, NULL, NULL, NULL} },
     {"@speed", "shutter speed (1-60)",
-        {exif_speed, NULL, NULL, NULL} },
+	{exif_speed, NULL, NULL, NULL} },
     {"@aper", "aperture (F3.2)",
-        {exif_aperture, NULL, NULL, NULL} },
+	{exif_aperture, NULL, NULL, NULL} },
     {"@iso", "iso speed (400)",
-        {exif_iso, NULL, NULL, NULL} },
+	{exif_iso, NULL, NULL, NULL} },
     {"@focal", "focal length (8.6 mm)",
-        {exif_focal, NULL, NULL, NULL} },
+	{exif_focal, NULL, NULL, NULL} },
     {"@dist", "subject distance (1.03 m)",
-        {exif_distance, NULL, NULL, NULL} },
+	{exif_distance, NULL, NULL, NULL} },
     {"@meter", "meter mode (multi-segment)",
-        {exif_meter, NULL, NULL, NULL} },
+	{exif_meter, NULL, NULL, NULL} },
     {"@macro", "macro mode (Off)",
-        {exif_macro, NULL, NULL, NULL} },
+	{exif_macro, NULL, NULL, NULL} },
     {"@orient", "orientation (top_left)",
-        {exif_orientation, NULL, NULL, NULL} },
+	{exif_orientation, NULL, NULL, NULL} },
     {"@lens", "lens name (Tamron 90mm f-2.8)",
-        {exif_lens, NULL, NULL, NULL} },
+	{exif_lens, NULL, NULL, NULL} },
     {"@key", "first keyword (Family)",
-        {exif_keyword, iptc_keyword, NULL, NULL} },
+	{exif_keyword, iptc_keyword, NULL, NULL} },
 
     {"", "", {NULL, NULL, NULL, NULL} }
 };
 
 
-// Check that 'opt1' and 'opt2' are not specified at the same time. 
-void conflicting(const po::variables_map& vm, 
+// Check that 'opt1' and 'opt2' are not specified at the same time.
+void conflicting(const po::variables_map& vm,
     const char* opt1, const char* opt2)
 {
-    if (vm.count(opt1) && !vm[opt1].defaulted() 
-        && vm.count(opt2) && !vm[opt2].defaulted()) {
-        throw std::logic_error(std::string("conflicting options '") 
-            + opt1 + "' and '" + opt2 + "'");
+    if (vm.count(opt1) && !vm[opt1].defaulted()
+	&& vm.count(opt2) && !vm[opt2].defaulted()) {
+	throw std::logic_error(std::string("conflicting options '")
+	    + opt1 + "' and '" + opt2 + "'");
     }
 }
 
@@ -168,24 +168,24 @@ void conflicting(const po::variables_map& vm,
 void required(const po::variables_map& vm, const char* required)
 {
     if (!vm.count(required) || vm[required].defaulted()) {
-        throw std::logic_error(std::string("required parameter '") + required
-            + "' is missing");
+	throw std::logic_error(std::string("required parameter '") + required
+	    + "' is missing");
     }
 }
 
 void info(const std::string &msg)
 {
     if(g_verbose) {
-        std::cout << msg << "\n";
-        g_neednewline = false;
+	std::cout << msg << "\n";
+	g_neednewline = false;
     }
 }
 
 void error(const std::exception &e, const std::string &msg)
 {
     if(g_neednewline) {
-        std::cout << "\n";
-        g_neednewline = false;
+	std::cout << "\n";
+	g_neednewline = false;
     }
     std::cerr << e.what() << "\n";
     std::cerr << msg << std::endl;
@@ -200,26 +200,26 @@ void usage_full(const po::options_description &options, const char* exname)
 {
     usage_header(exname);
     std::cout << "\n  Creates groups of files in new directories defined by a metadata 'pattern'.\n" <<
-        "  Files are copied, moved, or linked from 'source-dir' to 'dest-dir'.\n" <<
-        "  The destination directory should not be within the source directory.\n\n";
+	"  Files are copied, moved, or linked from 'source-dir' to 'dest-dir'.\n" <<
+	"  The destination directory should not be within the source directory.\n\n";
     std::cout << options;
 
     std::cout << "\nPattern values:\n";
     for( const Pattern *pattern = g_patterns; pattern->pat.length(); ++pattern) {
-        std::cout << "  " << std::setw(8) << std::left << pattern->pat;
-        std::cout << pattern->desc << "\n";
+	std::cout << "  " << std::setw(8) << std::left << pattern->pat;
+	std::cout << pattern->desc << "\n";
     }
 
     std::cout << "\nExamples:\n";
     std::cout << "  `" <<  exname << " -m mess clean @year-@month'\n";
     std::cout << "     Moves files from 'mess' into directories of 'clean' according to\n" <<
-                 "     year-month the file was captured (clean/2006-11/...)\n\n";
+		 "     year-month the file was captured (clean/2006-11/...)\n\n";
     std::cout << "  `" <<  exname << " -o ie source find width-@x/height-@y'\n";
     std::cout << "     Copies files into directories according first to pixel width then pixel\n" <<
-                 "     height. Check iptc then exif metadata (find/width-2272/height-1704/...)\n\n";
+		 "     height. Check iptc then exif metadata (find/width-2272/height-1704/...)\n\n";
     std::cout << "  `" <<  exname << " -lf source find @aper/@hour'\n";
     std::cout << "     Force create symlinks in directories according first to aperture then\n" <<
-                 "     hour captured (find/F3.2/15/...)\n";
+		 "     hour captured (find/F3.2/15/...)\n";
 
     std::cout << std::endl;
 }
@@ -227,65 +227,65 @@ void usage_full(const po::options_description &options, const char* exname)
 void version()
 {
     std::cout << "organized 0.1\n" <<
-        "Copyright (C) 2009 Brad Schick. <schickb@gmail.com>\n\n" <<
-        "This program is free software; you can redistribute it and/or\n"
-        "modify it under the terms of the GNU General Public License\n"
-        "as published by the Free Software Foundation; either version 2\n"
-        "of the License, or (at your option) any later version.\n"
-        "\n"
-        "This program is distributed in the hope that it will be useful,\n"
-        "but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
-        "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
-        "GNU General Public License for more details.\n"
-        "\n"
-        "You should have received a copy of the GNU General Public\n"
-        "License along with this program; if not, write to the Free\n"
-        "Software Foundation, Inc., 51 Franklin Street, Fifth Floor,\n"
-        "Boston, MA 02110-1301 USA" << std::endl;
+	"Copyright (C) 2009 Brad Schick. <schickb@gmail.com>\n\n" <<
+	"This program is free software; you can redistribute it and/or\n"
+	"modify it under the terms of the GNU General Public License\n"
+	"as published by the Free Software Foundation; either version 2\n"
+	"of the License, or (at your option) any later version.\n"
+	"\n"
+	"This program is distributed in the hope that it will be useful,\n"
+	"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+	"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+	"GNU General Public License for more details.\n"
+	"\n"
+	"You should have received a copy of the GNU General Public\n"
+	"License along with this program; if not, write to the Free\n"
+	"Software Foundation, Inc., 51 Franklin Street, Fifth Floor,\n"
+	"Boston, MA 02110-1301 USA" << std::endl;
 }
 
 // Returns empty string if the destination subdirectory could not be determined
 // for the supplied source file.
-std::string build_dest(const fs::path &source_file) 
+std::string build_dest(const fs::path &source_file)
 {
     std::string dest;
 
-    Exiv2::Image::AutoPtr image;
+    Exiv2::Image::UniquePtr image;
     try {
-        image = Exiv2::ImageFactory::open(source_file.string());
-        image->readMetadata();
-    } 
+	image = Exiv2::ImageFactory::open(source_file.string());
+	image->readMetadata();
+    }
     catch(const Exiv2::AnyError&) {
-        // No metadata, let things continue to try file info
+	// No metadata, let things continue to try file info
     }
 
     std::vector<PathPart>::iterator iter = g_path_parts.begin();
     std::vector<PathPart>::iterator end = g_path_parts.end();
     for( ; iter != end; ++iter) {
-        dest += iter->pre;
-        std::string result;
+	dest += iter->pre;
+	std::string result;
 
-        const Pattern *pat = iter->pat;
-        for(unsigned fx = 0; fx < g_run_order.size(); ++fx) {
-            if(g_run_order[fx] != -1 && pat->funcs[g_run_order[fx]]) {
-                if(g_run_order[fx] == FILE_SLOT) {
-                    // Always run file operations
-                    result = pat->funcs[g_run_order[fx]](image.get(), source_file);
-                }
-                else if(image.get()) {
-                    // No point in running metadata operations without an image
-                    result = pat->funcs[g_run_order[fx]](image.get(), source_file);
-                }
-                if(result.length())
-                    break;
-            }
-        }
-        // If we found no data, even for part of pattern, give up and 
-        // return no destination
-        if(!result.length())
-            return result;
-    
-        dest += (result + iter->post);
+	const Pattern *pat = iter->pat;
+	for(unsigned fx = 0; fx < g_run_order.size(); ++fx) {
+	    if(g_run_order[fx] != -1 && pat->funcs[g_run_order[fx]]) {
+		if(g_run_order[fx] == FILE_SLOT) {
+		    // Always run file operations
+		    result = pat->funcs[g_run_order[fx]](image.get(), source_file);
+		}
+		else if(image.get()) {
+		    // No point in running metadata operations without an image
+		    result = pat->funcs[g_run_order[fx]](image.get(), source_file);
+		}
+		if(result.length())
+		    break;
+	    }
+	}
+	// If we found no data, even for part of pattern, give up and
+	// return no destination
+	if(!result.length())
+	    return result;
+
+	dest += (result + iter->post);
     }
     return dest;
 }
@@ -293,25 +293,25 @@ std::string build_dest(const fs::path &source_file)
 bool md5sum(const fs::path &path, md5digest &digest)
 {
     try {
-        Exiv2::FileIo io(path.string());
-        if (io.open() != 0)
-            return false;
-        Exiv2::IoCloser closer(io);
+	Exiv2::FileIo io(path.string());
+	if (io.open() != 0)
+	    return false;
+	Exiv2::IoCloser closer(io);
 
-        Exiv2::byte buff[4096];
-        MD5_CTX context;
-        MD5Init(&context);
+	Exiv2::byte buff[4096];
+	MD5_CTX context;
+	MD5Init(&context);
 
-        long read_count = io.read(buff, 4096);
-        while(read_count) {
-            MD5Update(&context, buff, read_count);
-            read_count = io.read(buff, 4096);
-        }
-        MD5Final(digest, &context);
-        return true;
+	long read_count = io.read(buff, 4096);
+	while(read_count) {
+	    MD5Update(&context, buff, read_count);
+	    read_count = io.read(buff, 4096);
+	}
+	MD5Final(digest, &context);
+	return true;
     }
     catch (std::exception& ) {
-        return false;
+	return false;
     }
 }
 
@@ -321,36 +321,36 @@ int main(int argc, char* argv[])
     po::options_description options("Options");
     // Don't use default values because the help print it ugly and too wide
     options.add_options()
-        ("move,m", "move files rather than copy")
-        ("symlink,s", "symlink files rather than copy (posix only)")
-        ("order,o", po::value<std::string>(), 
-            "order and types of metadata to read\ne=exif, i=iptc, f=file (default: eif)")
-        ("unsorted,u", po::value<std::string>(), 
-            "special directory to store unsorted files (default: unsorted)")
-        ("dups,d", po::value<std::string>(), 
-            "special directory to store files with duplicate names (default: duplicates)")
-        ("force,f", "overwrite duplicate files instead of using special directory")
-        ("rename,r", "rename duplicate files instead of using special directory")
-        ("ignore,i", "ignore both unsorted and duplicate files instead of using special directories")
-        ("ignore-unsorted", "ignore unsorted files instead of using special directory")
-        ("ignore-dups", "ignore duplicate files instead of using special directory")
-        ("verify", "verify copied or moved files and exit if incorrect")
-        ("exclude,x", po::value< std::vector<std::string> >(), 
-            "exclude directories and files that contain arg (case sensitive on all platforms)")
-        ("limit-depth,l", po::value<long>(), 
-            "limit recursion to specified depth (0 disables recursion)")
-        ("verbose,v", "prints operations as they happen")
-        ("dry-run,n", "do not make actual changes (implies verbose)")
-        ("help,h", "show this help message then exit")
-        ("version,V", "show program version then exit")
-        ;
+	("move,m", "move files rather than copy")
+	("symlink,s", "symlink files rather than copy (posix only)")
+	("order,o", po::value<std::string>(),
+	    "order and types of metadata to read\ne=exif, i=iptc, f=file (default: eif)")
+	("unsorted,u", po::value<std::string>(),
+	    "special directory to store unsorted files (default: unsorted)")
+	("dups,d", po::value<std::string>(),
+	    "special directory to store files with duplicate names (default: duplicates)")
+	("force,f", "overwrite duplicate files instead of using special directory")
+	("rename,r", "rename duplicate files instead of using special directory")
+	("ignore,i", "ignore both unsorted and duplicate files instead of using special directories")
+	("ignore-unsorted", "ignore unsorted files instead of using special directory")
+	("ignore-dups", "ignore duplicate files instead of using special directory")
+	("verify", "verify copied or moved files and exit if incorrect")
+	("exclude,x", po::value< std::vector<std::string> >(),
+	    "exclude directories and files that contain arg (case sensitive on all platforms)")
+	("limit-depth,l", po::value<long>(),
+	    "limit recursion to specified depth (0 disables recursion)")
+	("verbose,v", "prints operations as they happen")
+	("dry-run,n", "do not make actual changes (implies verbose)")
+	("help,h", "show this help message then exit")
+	("version,V", "show program version then exit")
+	;
 
     po::options_description hidden("Hidden Options");
     hidden.add_options()
-        ("source-dir", po::value< std::string >(), "directory of files to organize, may end in file wildcard")
-        ("dest-dir", po::value< std::string >(), "designation directory for files, may not be within source-dir")
-        ("pattern", po::value< std::string >(), "subdirectory pattern for grouping files within dest-dir")
-        ;
+	("source-dir", po::value< std::string >(), "directory of files to organize, may end in file wildcard")
+	("dest-dir", po::value< std::string >(), "designation directory for files, may not be within source-dir")
+	("pattern", po::value< std::string >(), "subdirectory pattern for grouping files within dest-dir")
+	;
 
     po::options_description cmdline;
     cmdline.add(options).add(hidden);
@@ -361,205 +361,205 @@ int main(int argc, char* argv[])
     positional.add("pattern", 1);
 
     try {
-        po::variables_map vm;
-        po::store(po::command_line_parser(argc, argv).
-        options(cmdline).positional(positional).run(), vm);
-        po::notify(vm);
+	po::variables_map vm;
+	po::store(po::command_line_parser(argc, argv).
+	options(cmdline).positional(positional).run(), vm);
+	po::notify(vm);
 
-        if (vm.count("help")) {
-            usage_full(options, argv[0]);
-            return 0;
-        }
-    
-        if (vm.count("version")) {
-            version();
-            return 0;
-        }
-    
-        conflicting(vm, "verify", "symlink");
-        conflicting(vm, "move", "symlink");
-        conflicting(vm, "unsorted", "ignore");
-        conflicting(vm, "unsorted", "ignore-unsorted");
-        conflicting(vm, "dups", "ignore");
-        conflicting(vm, "dups", "ignore-dups");
-        conflicting(vm, "force", "ignore");
-        conflicting(vm, "force", "ignore-dups");
-        conflicting(vm, "force", "rename");
-        conflicting(vm, "rename", "ignore");
-        conflicting(vm, "rename", "ignore-dups");
-        required(vm, "source-dir");
-        required(vm, "dest-dir");
-        required(vm, "pattern");
-    
-        const bool dry_run = vm.count("dry-run") != 0;
-        g_verbose = (vm.count("verbose") != 0 || dry_run);
-    
-        std::string order = "eif";
-        if(vm.count("order")) {
-            order = vm["order"].as<std::string>();
-    
-            boost::to_lower(order);
-            if(order.length() > 3) {
-                throw std::logic_error(std::string("order is longer than 4 characters"));
-            }
-        }
-    
-        unsigned i = 0;
-        std::string::iterator end = order.end();
-        for(std::string::iterator iter = order.begin(); iter != end && i < 4; ++iter, ++i) {
-            switch(*iter) {
-                case 'e': 
-                    g_run_order[i] = EXIF_SLOT;
-                    break;
-                case 'i': 
-                    g_run_order[i] = IPTC_SLOT;
-                    break;
-                case 'x': 
-                    throw std::logic_error(std::string("xmp not implemented yet '") + 
-                        *iter + "'");
-                    break;
-                case 'f': 
-                    g_run_order[i] = FILE_SLOT;
-                    break;
-                default:
-                    throw std::logic_error(std::string("unknown order character '") + 
-                        *iter + "'");
-            }
-        }
-    
-        const fs::path source_dir( vm["source-dir"].as<std::string>() );
-        if( !exists(source_dir) || !is_directory(source_dir) ) {
-            throw std::logic_error(std::string("source '") + 
-                source_dir.string() + "' must exist and be a directory");
-        }
-    
-        const fs::path dest_dir( vm["dest-dir"].as<std::string>() );
-        if( exists(dest_dir) && !is_directory(dest_dir) ) {
-            throw std::logic_error(std::string("destination '") + 
-                dest_dir.string() + "' must be a directory");
-        }
-    
-        // Boost doesn't seem to have a way to get a canonical path, so this
-        // simple test is easy to confuse with some ../../'s in the paths. Oh
-        // well, this is good enough for now.
-        fs::path test_dest(dest_dir);
-        for(; !test_dest.empty(); test_dest = test_dest.parent_path()) {
-            if(fs::equivalent(source_dir, test_dest)) {
-                throw std::logic_error(std::string("dest-dir must not be within source-dir"));
-            }
-        }
-    
-        // Disect the pattern
-        std::string pattern = vm["pattern"].as<std::string>();
-        boost::regex regex( "([^@]*)(@[[:alpha:]]+)([^@]*)");
-        boost::sregex_iterator m_iter = make_regex_iterator(pattern, regex);
-        boost::sregex_iterator m_end;
-        for( ; m_iter != m_end; ++m_iter) {
-            const boost::smatch &match = *m_iter;
-            const std::string &pre = match[1];
-            const std::string &pat = match[2];
-            const std::string &post = match[3];
-    
-            // Should put this in a map, but there aren't that many options now
-            bool found = false;
-            for( const Pattern *pattern = g_patterns; pattern->pat.length(); ++pattern) {
-                if(pattern->pat == pat) {
-                    PathPart part(pre, pattern, post);
-                    g_path_parts.push_back(part);
-                    found = true;
-                    break;
-                }
-            }
-        
-            if(!found) {
-                throw std::logic_error(std::string("unknown pattern '") + pat + "'");
-            }
-        }
-    
-        // Assign defaults to params that need them
-        const bool ignore = vm.count("ignore") != 0;
-        std::vector<std::string> excludes;
-        if(vm.count("exclude"))
-            excludes = vm["exclude"].as< std::vector<std::string> >();
-        long limit_depth = LONG_MAX;
-        if(vm.count("limit-depth")) {
-            limit_depth = vm["limit-depth"].as<long>();
-            // Boost program_options doesn't work with unsigned, so do it manually
-            if( limit_depth < 0 )
-                throw std::logic_error(std::string("recursion depth limit must be positive"));
-        }
-        std::string dups = "duplicates";
-        if(vm.count("dups"))
-            dups = vm["dups"].as<std::string>();
-        const fs::path dups_dir = dest_dir / dups;
-    
-        std::string unsorted = "unsorted";
-        if(vm.count("unsorted"))
-            unsorted = vm["unsorted"].as<std::string>();
-        const fs::path unsorted_dir = dest_dir / unsorted;
-    
-        ProcessParams params = {
-            dest_dir, 
-            dry_run,
-            (vm.count("ignore-dups") != 0 || ignore), 
-            (vm.count("ignore-unsorted") != 0 || ignore), 
-            vm.count("force") != 0,
-            vm.count("rename") != 0,
-            vm.count("symlink") != 0, 
-            vm.count("verify") != 0, 
-            vm.count("move") != 0, 
-            limit_depth, 
-            dups_dir, 
-            unsorted_dir, 
-            excludes,
-            0, 0, 0, 0, 0, 0, 0, 0, 0
-        };
-    
-        process_directory(source_dir, 0, params);
-    
-        std::string op = "copied";
-        if(params.symlink)
-            op = "linked";
-        else if(params.move)
-            op = "moved";
-    
-        if(dry_run)
-            op = std::string("would be ") + op;
-    
-        if(g_neednewline)
-            std::cout << "\n";
-    
-        std::cout << "\n" << params.ok_count << " files " << op << "\n";
-        std::cout << "   " << params.dups_count << " duplicates\n";
-        std::cout << "   " << params.unsorted_count << " unsorted\n";
-        if(params.dups_ignored_count)
-            std::cout << params.dups_ignored_count << " duplicates ignored\n";
-        if(params.unsorted_ignored_count)
-            std::cout << params.unsorted_ignored_count << " unsorted ignored\n";
-        if(params.dir_ex_count)
-            std::cout << params.dir_ex_count << " directories excluded\n";
-        if(params.file_ex_count)
-            std::cout << params.file_ex_count << " files excluded\n";
-        if(params.dir_err_count)
-            std::cout << params.dir_err_count << " directory errors\n";
-        if(params.file_err_count)
-            std::cout << params.file_err_count << " file errors\n";
-    
-        return 0;
+	if (vm.count("help")) {
+	    usage_full(options, argv[0]);
+	    return 0;
+	}
+
+	if (vm.count("version")) {
+	    version();
+	    return 0;
+	}
+
+	conflicting(vm, "verify", "symlink");
+	conflicting(vm, "move", "symlink");
+	conflicting(vm, "unsorted", "ignore");
+	conflicting(vm, "unsorted", "ignore-unsorted");
+	conflicting(vm, "dups", "ignore");
+	conflicting(vm, "dups", "ignore-dups");
+	conflicting(vm, "force", "ignore");
+	conflicting(vm, "force", "ignore-dups");
+	conflicting(vm, "force", "rename");
+	conflicting(vm, "rename", "ignore");
+	conflicting(vm, "rename", "ignore-dups");
+	required(vm, "source-dir");
+	required(vm, "dest-dir");
+	required(vm, "pattern");
+
+	const bool dry_run = vm.count("dry-run") != 0;
+	g_verbose = (vm.count("verbose") != 0 || dry_run);
+
+	std::string order = "eif";
+	if(vm.count("order")) {
+	    order = vm["order"].as<std::string>();
+
+	    boost::to_lower(order);
+	    if(order.length() > 3) {
+		throw std::logic_error(std::string("order is longer than 4 characters"));
+	    }
+	}
+
+	unsigned i = 0;
+	std::string::iterator end = order.end();
+	for(std::string::iterator iter = order.begin(); iter != end && i < 4; ++iter, ++i) {
+	    switch(*iter) {
+		case 'e':
+		    g_run_order[i] = EXIF_SLOT;
+		    break;
+		case 'i':
+		    g_run_order[i] = IPTC_SLOT;
+		    break;
+		case 'x':
+		    throw std::logic_error(std::string("xmp not implemented yet '") +
+			*iter + "'");
+		    break;
+		case 'f':
+		    g_run_order[i] = FILE_SLOT;
+		    break;
+		default:
+		    throw std::logic_error(std::string("unknown order character '") +
+			*iter + "'");
+	    }
+	}
+
+	const fs::path source_dir( vm["source-dir"].as<std::string>() );
+	if( !exists(source_dir) || !is_directory(source_dir) ) {
+	    throw std::logic_error(std::string("source '") +
+		source_dir.string() + "' must exist and be a directory");
+	}
+
+	const fs::path dest_dir( vm["dest-dir"].as<std::string>() );
+	if( exists(dest_dir) && !is_directory(dest_dir) ) {
+	    throw std::logic_error(std::string("destination '") +
+		dest_dir.string() + "' must be a directory");
+	}
+
+	// Boost doesn't seem to have a way to get a canonical path, so this
+	// simple test is easy to confuse with some ../../'s in the paths. Oh
+	// well, this is good enough for now.
+	fs::path test_dest(dest_dir);
+	for(; !test_dest.empty(); test_dest = test_dest.parent_path()) {
+	    if(fs::equivalent(source_dir, test_dest)) {
+		throw std::logic_error(std::string("dest-dir must not be within source-dir"));
+	    }
+	}
+
+	// Disect the pattern
+	std::string pattern = vm["pattern"].as<std::string>();
+	boost::regex regex( "([^@]*)(@[[:alpha:]]+)([^@]*)");
+	boost::sregex_iterator m_iter = make_regex_iterator(pattern, regex);
+	boost::sregex_iterator m_end;
+	for( ; m_iter != m_end; ++m_iter) {
+	    const boost::smatch &match = *m_iter;
+	    const std::string &pre = match[1];
+	    const std::string &pat = match[2];
+	    const std::string &post = match[3];
+
+	    // Should put this in a map, but there aren't that many options now
+	    bool found = false;
+	    for( const Pattern *pattern = g_patterns; pattern->pat.length(); ++pattern) {
+		if(pattern->pat == pat) {
+		    PathPart part(pre, pattern, post);
+		    g_path_parts.push_back(part);
+		    found = true;
+		    break;
+		}
+	    }
+
+	    if(!found) {
+		throw std::logic_error(std::string("unknown pattern '") + pat + "'");
+	    }
+	}
+
+	// Assign defaults to params that need them
+	const bool ignore = vm.count("ignore") != 0;
+	std::vector<std::string> excludes;
+	if(vm.count("exclude"))
+	    excludes = vm["exclude"].as< std::vector<std::string> >();
+	long limit_depth = LONG_MAX;
+	if(vm.count("limit-depth")) {
+	    limit_depth = vm["limit-depth"].as<long>();
+	    // Boost program_options doesn't work with unsigned, so do it manually
+	    if( limit_depth < 0 )
+		throw std::logic_error(std::string("recursion depth limit must be positive"));
+	}
+	std::string dups = "duplicates";
+	if(vm.count("dups"))
+	    dups = vm["dups"].as<std::string>();
+	const fs::path dups_dir = dest_dir / dups;
+
+	std::string unsorted = "unsorted";
+	if(vm.count("unsorted"))
+	    unsorted = vm["unsorted"].as<std::string>();
+	const fs::path unsorted_dir = dest_dir / unsorted;
+
+	ProcessParams params = {
+	    dest_dir,
+	    dry_run,
+	    (vm.count("ignore-dups") != 0 || ignore),
+	    (vm.count("ignore-unsorted") != 0 || ignore),
+	    vm.count("force") != 0,
+	    vm.count("rename") != 0,
+	    vm.count("symlink") != 0,
+	    vm.count("verify") != 0,
+	    vm.count("move") != 0,
+	    limit_depth,
+	    dups_dir,
+	    unsorted_dir,
+	    excludes,
+	    0, 0, 0, 0, 0, 0, 0, 0, 0
+	};
+
+	process_directory(source_dir, 0, params);
+
+	std::string op = "copied";
+	if(params.symlink)
+	    op = "linked";
+	else if(params.move)
+	    op = "moved";
+
+	if(dry_run)
+	    op = std::string("would be ") + op;
+
+	if(g_neednewline)
+	    std::cout << "\n";
+
+	std::cout << "\n" << params.ok_count << " files " << op << "\n";
+	std::cout << "   " << params.dups_count << " duplicates\n";
+	std::cout << "   " << params.unsorted_count << " unsorted\n";
+	if(params.dups_ignored_count)
+	    std::cout << params.dups_ignored_count << " duplicates ignored\n";
+	if(params.unsorted_ignored_count)
+	    std::cout << params.unsorted_ignored_count << " unsorted ignored\n";
+	if(params.dir_ex_count)
+	    std::cout << params.dir_ex_count << " directories excluded\n";
+	if(params.file_ex_count)
+	    std::cout << params.file_ex_count << " files excluded\n";
+	if(params.dir_err_count)
+	    std::cout << params.dir_err_count << " directory errors\n";
+	if(params.file_err_count)
+	    std::cout << params.file_err_count << " file errors\n";
+
+	return 0;
     }
     catch (Exiv2::AnyError& e) {
-        error(e, std::string("Aborting"));
-        return -1;
+	error(e, std::string("Aborting"));
+	return -1;
     }
     catch(std::logic_error& e) {
-        error(e, "");
-        usage_header(argv[0]);
-        std::cout << argv[0] << " -h    for more help" << std::endl;
-        return -2;
+	error(e, "");
+	usage_header(argv[0]);
+	std::cout << argv[0] << " -h    for more help" << std::endl;
+	return -2;
     }
     catch(std::exception& e) {
-        error(e, "Aborting");
-        return -3;
+	error(e, "Aborting");
+	return -3;
     }
 }
 
@@ -577,21 +577,21 @@ fs::path uniquify(const fs::path &dest)
 
     boost::smatch match;
     if(boost::regex_search(fname, match, uregex)) {
-        // Matches are indexes into fname, so don't change it while reading values
-        newfname = match[1];
-        number = boost::lexical_cast<short>(match[2]);
-        fname = newfname;
+	// Matches are indexes into fname, so don't change it while reading values
+	newfname = match[1];
+	number = boost::lexical_cast<short>(match[2]);
+	fname = newfname;
     }
 
-    do { 
-        newfname = fname + "(" + boost::lexical_cast<std::string>(++number) + ")" + ext;
-        newdest = parent / newfname;
+    do {
+	newfname = fname + "(" + boost::lexical_cast<std::string>(++number) + ")" + ext;
+	newdest = parent / newfname;
     } while(fs::exists(newdest));
 
     return newdest;
 }
 
-void process_directory(const fs::path &directory, const long depth, 
+void process_directory(const fs::path &directory, const long depth,
     ProcessParams &params)
 {
     // Exclude entire directories
@@ -599,167 +599,166 @@ void process_directory(const fs::path &directory, const long depth,
     std::vector<std::string>::const_iterator x_iter = params.excludes.begin();
     std::vector<std::string>::const_iterator x_end = params.excludes.end();
     for( ; x_iter != x_end; ++x_iter ) {
-        if(boost::contains(directory.string(), *x_iter)) {
-            exclude = true;
-            break;
-        }
+	if(boost::contains(directory.string(), *x_iter)) {
+	    exclude = true;
+	    break;
+	}
     }
     if(exclude) {
-        info(std::string("excluding directory: ") + directory.string() +
-            " matched: " + *x_iter);
-        ++params.dir_ex_count;
-        return;
+	info(std::string("excluding directory: ") + directory.string() +
+	    " matched: " + *x_iter);
+	++params.dir_ex_count;
+	return;
     }
 
     try {
-        fs::directory_iterator p_iter(directory), p_end; 
-        for( ; p_iter != p_end; ++p_iter) {
-            if( is_directory(*p_iter) ) {
-                // recurse if we haven't hit the limit
-                if(depth < params.limit_depth)
-                    process_directory(p_iter->path(), depth + 1, params);
-                else {
-                    info(std::string("depth reached, skipping: ") +
-                        p_iter->path().string());
-                }
-            }
-            else if( is_regular_file(*p_iter) ) {
-        
-                // Check again for excluding file names
-                exclude = false;
-                x_iter = params.excludes.begin();
-                for( ; x_iter != x_end; ++x_iter ) {
-                    if(boost::contains(p_iter->path().string(), *x_iter)) {
-                        exclude = true;
-                        break;
-                    }
-                }
-                if(exclude) {
-                    info(std::string("excluding file: ") + p_iter->path().string() +
-                        " matched: " + *x_iter);
-                    ++params.file_ex_count;
-                    continue;
-                }
-            
-                try {
-                    const fs::path dest_subdir = build_dest(*p_iter);
-                    fs::path dest_file;
-                    if(!dest_subdir.empty())
-                        dest_file = params.dest_dir / dest_subdir;
-                    else if(params.ignore_unsorted) {
-                        info(std::string("ignoring unsorted: ") + p_iter->path().string());
-                        ++params.unsorted_ignored_count;
-                        continue;
-                    }
-                    else {
-                        info(std::string("unsorted file (missing metadata): ") + p_iter->path().string());
-                        dest_file = params.unsorted_dir;
-                        ++params.unsorted_count;
-                    }
-            
-                    dest_file /= p_iter->path().filename();
-                
-                    if(fs::exists(dest_file)) {
-                        if(params.ignore_dups) {
-                            info(std::string("ignoring: ") + p_iter->path().string() +
-                                " duplicates: " +  dest_file.string());
-                            ++params.dups_ignored_count;
-                            continue;
-                        }
-                        else {
-                            if(params.force) {
-                                info(std::string("force removing: ") + dest_file.string() + " for: "
-                                    + p_iter->path().string());
-                                if(!params.dry_run)
-                                    fs::remove(dest_file);
-                            }
-                            else if(params.rename) {
-                                info(std::string("renaming: ") + p_iter->path().string() +
-                                    " duplicates: " +  dest_file.string());
-                                dest_file = uniquify(dest_file);
-                            }
-                            else {
-                                info(std::string("duplicate file: ") + p_iter->path().string() +
-                                    " of: " +  dest_file.string());
-                                dest_file = params.dups_dir / dest_subdir / p_iter->path().filename();
-                                // Ugh, more dup possibilities
-                                if(fs::exists(dest_file)) {
-                                    info(std::string("renaming: ") + p_iter->path().string() +
-                                        " duplicates: " +  dest_file.string());
-                                    dest_file = uniquify(dest_file);
-                                }
-                            }
-                            ++params.dups_count;
-                        }
-                    }
-                
-                    if(!params.dry_run)
-                        fs::create_directories(dest_file.parent_path());
-                
-                    if(params.symlink) {
-                        info(std::string("linking from: ") + p_iter->path().string() + 
-                            " to: " + dest_file.string());
-                        if(!params.dry_run) {
-                            // The target of a symlink must be either absolute (aka complete) or
-                            // relative to the location of the link. Easiest solution is to make
-                            // a complete path.
-                            fs::path target;
-                            if(p_iter->path().is_complete()) 
-                                target = p_iter->path();
-                            else 
-                                target = fs::initial_path() / p_iter->path();
-                            fs::create_symlink(target, dest_file);
-                        }
-                    }
-                    else {
-                        info(std::string("copying from: ") + p_iter->path().string() +
-                            " to: " + dest_file.string());
-                        if(!params.dry_run) {
-                            // Copy the file and restore its write time (needed for posix)
-                            std::time_t time = fs::last_write_time(*p_iter);
-                            fs::copy_file(*p_iter, dest_file);
-                            fs::last_write_time(dest_file, time);
-                            if(params.verify) {
-                                md5digest src_digest, dst_digest;
-                                bool ok = md5sum(p_iter->path(), src_digest);
-                                if(ok)
-                                    ok = md5sum(dest_file, dst_digest);
-                                if(ok)
-                                    ok = (memcmp(src_digest,dst_digest, sizeof(md5digest))==0);
-                                if(!ok) {
-                                    // Should probably find a more appropriate exception for this
-                                    throw std::runtime_error(std::string("File verification failed: '") 
-                                        + p_iter->path().string() + "' differs from '" + 
-                                        dest_file.string() + "'");
-                                } 
-                                else {
-                                    info(std::string("verification passed"));
-                                }
-                            }
-                        }
-                    }
-                    if(params.move) {
-                        info(std::string("removing: ") + p_iter->path().string());
-                        if(!params.dry_run)
-                            fs::remove(*p_iter);
-                    }
-                
-                    if(!g_verbose && (params.ok_count % DOT_EVERY)==0) {
-                        std::cout << "." << std::flush;
-                        g_neednewline = true;
-                    }
-                    ++params.ok_count;
-                }
-                catch(fs::filesystem_error& e) {
-                    error(e, std::string("skipping file: " + p_iter->path().string()));
-                    ++params.file_err_count;
-                }
-            }
-        }
+	fs::directory_iterator p_iter(directory), p_end;
+	for( ; p_iter != p_end; ++p_iter) {
+	    if( is_directory(*p_iter) ) {
+		// recurse if we haven't hit the limit
+		if(depth < params.limit_depth)
+		    process_directory(p_iter->path(), depth + 1, params);
+		else {
+		    info(std::string("depth reached, skipping: ") +
+			p_iter->path().string());
+		}
+	    }
+	    else if( is_regular_file(*p_iter) ) {
+
+		// Check again for excluding file names
+		exclude = false;
+		x_iter = params.excludes.begin();
+		for( ; x_iter != x_end; ++x_iter ) {
+		    if(boost::contains(p_iter->path().string(), *x_iter)) {
+			exclude = true;
+			break;
+		    }
+		}
+		if(exclude) {
+		    info(std::string("excluding file: ") + p_iter->path().string() +
+			" matched: " + *x_iter);
+		    ++params.file_ex_count;
+		    continue;
+		}
+
+		try {
+		    const fs::path dest_subdir = build_dest(*p_iter);
+		    fs::path dest_file;
+		    if(!dest_subdir.empty())
+			dest_file = params.dest_dir / dest_subdir;
+		    else if(params.ignore_unsorted) {
+			info(std::string("ignoring unsorted: ") + p_iter->path().string());
+			++params.unsorted_ignored_count;
+			continue;
+		    }
+		    else {
+			info(std::string("unsorted file (missing metadata): ") + p_iter->path().string());
+			dest_file = params.unsorted_dir;
+			++params.unsorted_count;
+		    }
+
+		    dest_file /= p_iter->path().filename();
+
+		    if(fs::exists(dest_file)) {
+			if(params.ignore_dups) {
+			    info(std::string("ignoring: ") + p_iter->path().string() +
+				" duplicates: " +  dest_file.string());
+			    ++params.dups_ignored_count;
+			    continue;
+			}
+			else {
+			    if(params.force) {
+				info(std::string("force removing: ") + dest_file.string() + " for: "
+				    + p_iter->path().string());
+				if(!params.dry_run)
+				    fs::remove(dest_file);
+			    }
+			    else if(params.rename) {
+				info(std::string("renaming: ") + p_iter->path().string() +
+				    " duplicates: " +  dest_file.string());
+				dest_file = uniquify(dest_file);
+			    }
+			    else {
+				info(std::string("duplicate file: ") + p_iter->path().string() +
+				    " of: " +  dest_file.string());
+				dest_file = params.dups_dir / dest_subdir / p_iter->path().filename();
+				// Ugh, more dup possibilities
+				if(fs::exists(dest_file)) {
+				    info(std::string("renaming: ") + p_iter->path().string() +
+					" duplicates: " +  dest_file.string());
+				    dest_file = uniquify(dest_file);
+				}
+			    }
+			    ++params.dups_count;
+			}
+		    }
+
+		    if(!params.dry_run)
+			fs::create_directories(dest_file.parent_path());
+
+		    if(params.symlink) {
+			info(std::string("linking from: ") + p_iter->path().string() +
+			    " to: " + dest_file.string());
+			if(!params.dry_run) {
+			    // The target of a symlink must be either absolute (aka complete) or
+			    // relative to the location of the link. Easiest solution is to make
+			    // a complete path.
+			    fs::path target;
+			    if(p_iter->path().is_complete())
+				target = p_iter->path();
+			    else
+				target = fs::initial_path() / p_iter->path();
+			    fs::create_symlink(target, dest_file);
+			}
+		    }
+		    else {
+			info(std::string("copying from: ") + p_iter->path().string() +
+			    " to: " + dest_file.string());
+			if(!params.dry_run) {
+			    // Copy the file and restore its write time (needed for posix)
+			    std::time_t time = fs::last_write_time(*p_iter);
+			    fs::copy_file(*p_iter, dest_file);
+			    fs::last_write_time(dest_file, time);
+			    if(params.verify) {
+				md5digest src_digest, dst_digest;
+				bool ok = md5sum(p_iter->path(), src_digest);
+				if(ok)
+				    ok = md5sum(dest_file, dst_digest);
+				if(ok)
+				    ok = (memcmp(src_digest,dst_digest, sizeof(md5digest))==0);
+				if(!ok) {
+				    // Should probably find a more appropriate exception for this
+				    throw std::runtime_error(std::string("File verification failed: '")
+					+ p_iter->path().string() + "' differs from '" +
+					dest_file.string() + "'");
+				}
+				else {
+				    info(std::string("verification passed"));
+				}
+			    }
+			}
+		    }
+		    if(params.move) {
+			info(std::string("removing: ") + p_iter->path().string());
+			if(!params.dry_run)
+			    fs::remove(*p_iter);
+		    }
+
+		    if(!g_verbose && (params.ok_count % DOT_EVERY)==0) {
+			std::cout << "." << std::flush;
+			g_neednewline = true;
+		    }
+		    ++params.ok_count;
+		}
+		catch(fs::filesystem_error& e) {
+		    error(e, std::string("skipping file: " + p_iter->path().string()));
+		    ++params.file_err_count;
+		}
+	    }
+	}
     }
     catch(fs::filesystem_error& e) {
-        error(e, std::string("skipping directory: " + directory.string()));
-        ++params.dir_err_count;
+	error(e, std::string("skipping directory: " + directory.string()));
+	++params.dir_err_count;
     }
 }
-

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -62,7 +62,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        AsfVideo(BasicIo::AutoPtr io);
+        AsfVideo(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -169,7 +169,7 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Windows Asf Video.
     EXIV2API bool isAsfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -31,7 +31,7 @@
 
 // + standard includes
 #include <string>
-#include <memory>       // for std::auto_ptr
+#include <memory>       // for std::unique_ptr
 #include <fstream>      // write the temporary file
 #include <fcntl.h>      // _O_BINARY in FileIo::FileIo
 #include <ctime>        // timestamp for the name of temporary file
@@ -59,8 +59,8 @@ namespace Exiv2 {
      */
     class EXIV2API BasicIo {
     public:
-        //! BasicIo auto_ptr type
-        typedef std::auto_ptr<BasicIo> AutoPtr;
+        //! BasicIo unique_ptr type
+        typedef std::unique_ptr<BasicIo> UniquePtr;
 
         //! Seek starting positions
         enum Position { beg, cur, end };

--- a/include/exiv2/bigtiffimage.hpp
+++ b/include/exiv2/bigtiffimage.hpp
@@ -10,7 +10,7 @@ namespace ImageType
     const int bigtiff = 22;
 }
 
-Image::AutoPtr newBigTiffInstance(BasicIo::AutoPtr, bool);
+Image::UniquePtr newBigTiffInstance(BasicIo::UniquePtr, bool);
 bool isBigTiffType(BasicIo &, bool);
 
 }

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -78,7 +78,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        BmpImage(BasicIo::AutoPtr io);
+        BmpImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -123,7 +123,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Windows Bitmap image.
     EXIV2API bool isBmpType(BasicIo& iIo, bool advance);

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -72,7 +72,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        Cr2Image(BasicIo::AutoPtr io, bool create);
+        Cr2Image(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -156,7 +156,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newCr2Instance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a CR2 image.
     EXIV2API bool isCr2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -80,7 +80,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        CrwImage(BasicIo::AutoPtr io, bool create);
+        CrwImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -166,7 +166,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newCrwInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a CRW image.
     EXIV2API bool isCrwType(BasicIo& iIo, bool advance);

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -279,7 +279,7 @@ namespace Exiv2 {
     class EXIV2API IptcKey : public Key {
     public:
         //! Shortcut for an %IptcKey auto pointer.
-        typedef std::auto_ptr<IptcKey> AutoPtr;
+        typedef std::unique_ptr<IptcKey> UniquePtr;
 
         //! @name Creators
         //@{
@@ -324,7 +324,7 @@ namespace Exiv2 {
         virtual std::string tagName() const;
         virtual std::string tagLabel() const;
         virtual uint16_t tag() const;
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         //! Return the name of the record
         std::string recordName() const;
         //! Return the record id

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -77,7 +77,7 @@ namespace Exiv2
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        EpsImage(BasicIo::AutoPtr io, bool create);
+        EpsImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -117,7 +117,7 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a EPS image.
     EXIV2API bool isEpsType(BasicIo& iIo, bool advance);

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -195,7 +195,7 @@ namespace Exiv2 {
         long toLong(long n =0) const;
         float toFloat(long n =0) const;
         Rational toRational(long n =0) const;
-        Value::AutoPtr getValue() const;
+        Value::UniquePtr getValue() const;
         const Value& value() const;
         //! Return the size of the data area.
         long sizeDataArea() const;
@@ -216,8 +216,8 @@ namespace Exiv2 {
 
     private:
         // DATA
-        ExifKey::AutoPtr key_;                  //!< Key
-        Value::AutoPtr   value_;                //!< Value
+        ExifKey::UniquePtr key_;                  //!< Key
+        Value::UniquePtr   value_;                //!< Value
 
     }; // class Exifdatum
 

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -79,7 +79,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        GifImage(BasicIo::AutoPtr io);
+        GifImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -124,7 +124,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newGifInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a GIF image.
     EXIV2API bool isGifType(BasicIo& iIo, bool advance);

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -80,8 +80,8 @@ namespace Exiv2 {
      */
     class EXIV2API Image {
     public:
-        //! Image auto_ptr type
-        typedef std::auto_ptr<Image> AutoPtr;
+        //! Image unique_ptr type
+        typedef std::unique_ptr<Image> UniquePtr;
 
         //! @name Creators
         //@{
@@ -92,7 +92,7 @@ namespace Exiv2 {
          */
         Image(int              imageType,
               uint16_t         supportedMetadata,
-              BasicIo::AutoPtr io);
+              BasicIo::UniquePtr io);
         //! Virtual Destructor
         virtual ~Image();
         //@}
@@ -484,7 +484,7 @@ namespace Exiv2 {
 
     protected:
         // DATA
-        BasicIo::AutoPtr  io_;                //!< Image data IO pointer
+        BasicIo::UniquePtr  io_;                //!< Image data IO pointer
         ExifData          exifData_;          //!< Exif data container
         IptcData          iptcData_;          //!< IPTC data container
         XmpData           xmpData_;           //!< XMP data container
@@ -522,7 +522,7 @@ namespace Exiv2 {
     }; // class Image
 
     //! Type for function pointer that creates new Image instances
-    typedef Image::AutoPtr (*NewInstanceFct)(BasicIo::AutoPtr io, bool create);
+    typedef Image::UniquePtr (*NewInstanceFct)(BasicIo::UniquePtr io, bool create);
     //! Type for function pointer that checks image types
     typedef bool (*IsThisTypeFct)(BasicIo& iIo, bool advance);
 
@@ -548,13 +548,13 @@ namespace Exiv2 {
           @throw Error If the file is not found or it is unable to connect to the server to
                 read the remote file.
          */
-        static BasicIo::AutoPtr createIo(const std::string& path, bool useCurl = true);
+        static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like createIo() but accepts a unicode path in an std::wstring.
           @note This function is only available on Windows.
          */
-        static BasicIo::AutoPtr createIo(const std::wstring& wpath, bool useCurl = true);
+        static BasicIo::UniquePtr createIo(const std::wstring& wpath, bool useCurl = true);
 #endif
         /*!
           @brief Create an Image subclass of the appropriate type by reading
@@ -569,13 +569,13 @@ namespace Exiv2 {
           @throw Error If opening the file fails or it contains data of an
               unknown image type.
          */
-        static Image::AutoPtr open(const std::string& path, bool useCurl = true);
+        static Image::UniquePtr open(const std::string& path, bool useCurl = true);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like open() but accepts a unicode path in an std::wstring.
           @note This function is only available on Windows.
          */
-        static Image::AutoPtr open(const std::wstring& wpath, bool useCurl = true);
+        static Image::UniquePtr open(const std::wstring& wpath, bool useCurl = true);
 #endif
         /*!
           @brief Create an Image subclass of the appropriate type by reading
@@ -588,7 +588,7 @@ namespace Exiv2 {
               matches that of the data buffer.
           @throw Error If the memory contains data of an unknown image type.
          */
-        static Image::AutoPtr open(const byte* data, long size);
+        static Image::UniquePtr open(const byte* data, long size);
         /*!
           @brief Create an Image subclass of the appropriate type by reading
               the provided BasicIo instance. %Image type is derived from the
@@ -606,7 +606,7 @@ namespace Exiv2 {
               determined, the pointer is 0.
           @throw Error If opening the BasicIo fails
          */
-        static Image::AutoPtr open(BasicIo::AutoPtr io);
+        static Image::UniquePtr open(BasicIo::UniquePtr io);
         /*!
           @brief Create an Image subclass of the requested type by creating a
               new image file. If the file already exists, it will be overwritten.
@@ -616,13 +616,13 @@ namespace Exiv2 {
               type.
           @throw Error If the image type is not supported.
          */
-        static Image::AutoPtr create(int type, const std::string& path);
+        static Image::UniquePtr create(int type, const std::string& path);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like create() but accepts a unicode path in an std::wstring.
           @note This function is only available on Windows.
          */
-        static Image::AutoPtr create(int type, const std::wstring& wpath);
+        static Image::UniquePtr create(int type, const std::wstring& wpath);
 #endif
         /*!
           @brief Create an Image subclass of the requested type by creating a
@@ -632,7 +632,7 @@ namespace Exiv2 {
               type.
           @throw Error If the image type is not supported
          */
-        static Image::AutoPtr create(int type);
+        static Image::UniquePtr create(int type);
         /*!
           @brief Create an Image subclass of the requested type by writing a
               new image to a BasicIo instance. If the BasicIo instance already
@@ -647,7 +647,7 @@ namespace Exiv2 {
           @return An auto-pointer that owns an Image instance of the requested
               type. If the image type is not supported, the pointer is 0.
          */
-        static Image::AutoPtr create(int type, BasicIo::AutoPtr io);
+        static Image::UniquePtr create(int type, BasicIo::UniquePtr io);
         /*!
           @brief Returns the image type of the provided file.
           @param path %Image file. The contents of the file are tested to

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -151,14 +151,14 @@ namespace Exiv2 {
         long toLong(long n =0) const;
         float toFloat(long n =0) const;
         Rational toRational(long n =0) const;
-        Value::AutoPtr getValue() const;
+        Value::UniquePtr getValue() const;
         const Value& value() const;
         //@}
 
     private:
         // DATA
-        IptcKey::AutoPtr key_;                  //!< Key
-        Value::AutoPtr   value_;                //!< Value
+        IptcKey::UniquePtr key_;                  //!< Key
+        Value::UniquePtr   value_;                //!< Value
 
     }; // class Iptcdatum
 

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -71,7 +71,7 @@ namespace Exiv2
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        Jp2Image(BasicIo::AutoPtr io, bool create);
+        Jp2Image(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -135,7 +135,7 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newJp2Instance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a JPEG-2000 image.
     EXIV2API bool isJp2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -183,7 +183,7 @@ namespace Exiv2 {
           @param dataSize Size of initData in bytes.
          */
         JpegBase(int              type,
-                 BasicIo::AutoPtr io,
+                 BasicIo::UniquePtr io,
                  bool             create,
                  const byte       initData[],
                  long             dataSize);
@@ -322,7 +322,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        JpegImage(BasicIo::AutoPtr io, bool create);
+        JpegImage(BasicIo::UniquePtr io, bool create);
         //@}
         //! @name Accessors
         //@{
@@ -383,7 +383,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
                  or if a new file should be created (true).
          */
-        ExvImage(BasicIo::AutoPtr io, bool create);
+        ExvImage(BasicIo::UniquePtr io, bool create);
         //@}
         //! @name Accessors
         //@{
@@ -425,7 +425,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newJpegInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create);
     //! Check if the file iIo is a JPEG image.
     EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
     /*!
@@ -433,7 +433,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newExvInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create);
     //! Check if the file iIo is an EXV file
     EXIV2API bool isExvType(BasicIo& iIo, bool advance);
 

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -75,7 +75,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        MatroskaVideo(BasicIo::AutoPtr io);
+        MatroskaVideo(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -145,7 +145,7 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Matroska Video.
     EXIV2API bool isMkvType(BasicIo& iIo, bool advance);

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -59,7 +59,7 @@ namespace Exiv2 {
     class EXIV2API Key {
     public:
         //! Shortcut for a %Key auto pointer.
-        typedef std::auto_ptr<Key> AutoPtr;
+        typedef std::unique_ptr<Key> UniquePtr;
 
         //! @name Creators
         //@{
@@ -91,7 +91,7 @@ namespace Exiv2 {
                  The caller owns this copy and the auto-pointer ensures that it
                  will be deleted.
          */
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         /*!
           @brief Write the key to an output stream. You do not usually have
                  to use this function; it is used for the implementation of
@@ -266,7 +266,7 @@ namespace Exiv2 {
           @return An auto-pointer containing a pointer to a copy (clone) of the
                   value, 0 if the value is not set.
          */
-        virtual Value::AutoPtr getValue() const =0;
+        virtual Value::UniquePtr getValue() const =0;
         /*!
           @brief Return a constant reference to the value.
 

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -73,7 +73,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        MrwImage(BasicIo::AutoPtr io, bool create);
+        MrwImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -129,7 +129,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newMrwInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a MRW image.
     EXIV2API bool isMrwType(BasicIo& iIo, bool advance);

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -73,7 +73,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        OrfImage(BasicIo::AutoPtr io, bool create);
+        OrfImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -150,7 +150,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newOrfInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is an ORF image.
     EXIV2API bool isOrfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -77,7 +77,7 @@ namespace Exiv2
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        PgfImage(BasicIo::AutoPtr io, bool create);
+        PgfImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -127,7 +127,7 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newPgfInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a PGF image.
     EXIV2API bool isPgfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -78,7 +78,7 @@ namespace Exiv2
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        PngImage(BasicIo::AutoPtr io, bool create);
+        PngImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -129,7 +129,7 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newPngInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a PNG image.
     EXIV2API bool isPngType(BasicIo& iIo, bool advance);

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -249,7 +249,7 @@ namespace Exiv2 {
     {
     public:
         //! Shortcut for an %XmpKey auto pointer.
-        typedef std::auto_ptr<XmpKey> AutoPtr;
+        typedef std::unique_ptr<XmpKey> UniquePtr;
 
         //! @name Creators
         //@{
@@ -298,7 +298,7 @@ namespace Exiv2 {
         //! Properties don't have a tag number. Return 0.
         virtual uint16_t tag() const;
 
-        AutoPtr clone() const;
+        UniquePtr clone() const;
 
         // Todo: Should this be removed? What about tagLabel then?
         //! Return the schema namespace for the prefix of the key

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -80,7 +80,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        PsdImage(BasicIo::AutoPtr io);
+        PsdImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -142,7 +142,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newPsdInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Photoshop image.
     EXIV2API bool isPsdType(BasicIo& iIo, bool advance);

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        QuickTimeVideo(BasicIo::AutoPtr io);
+        QuickTimeVideo(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -241,7 +241,7 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Quick Time Video.
     EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -72,7 +72,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        RafImage(BasicIo::AutoPtr io, bool create);
+        RafImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -129,7 +129,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newRafInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a RAF image.
     EXIV2API bool isRafType(BasicIo& iIo, bool advance);

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        RiffVideo(BasicIo::AutoPtr io);
+        RiffVideo(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -209,7 +209,7 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Riff Video.
     EXIV2API bool isRiffType(BasicIo& iIo, bool advance);

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -70,7 +70,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        Rw2Image(BasicIo::AutoPtr io);
+        Rw2Image(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -149,7 +149,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newRw2Instance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a RW2 image.
     EXIV2API bool isRw2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -149,7 +149,7 @@ namespace Exiv2 {
     class EXIV2API ExifKey : public Key {
     public:
         //! Shortcut for an %ExifKey auto pointer.
-        typedef std::auto_ptr<ExifKey> AutoPtr;
+        typedef std::unique_ptr<ExifKey> UniquePtr;
 
         //! @name Creators
         //@{
@@ -210,7 +210,7 @@ namespace Exiv2 {
         //! Return the default type id for this tag.
         TypeId defaultTypeId() const;       // Todo: should be in the base class
 
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         //! Return the index (unique id of this key within the original Exif data, 0 if not set)
         int idx() const;
         //@}

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -80,7 +80,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        TgaImage(BasicIo::AutoPtr io);
+        TgaImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -125,7 +125,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newTgaInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a Targa v2 image.
     EXIV2API bool isTgaType(BasicIo& iIo, bool advance);

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -75,7 +75,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new file should be created (true).
          */
-        TiffImage(BasicIo::AutoPtr io, bool create);
+        TiffImage(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -211,7 +211,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newTiffInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a TIFF image.
     EXIV2API bool isTiffType(BasicIo& iIo, bool advance);

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -63,7 +63,7 @@ namespace Exiv2 {
     class EXIV2API Value {
     public:
         //! Shortcut for a %Value auto pointer.
-        typedef std::auto_ptr<Value> AutoPtr;
+        typedef std::unique_ptr<Value> UniquePtr;
 
         //! @name Creators
         //@{
@@ -119,7 +119,7 @@ namespace Exiv2 {
                  The caller owns this copy and the auto-pointer ensures that
                  it will be deleted.
          */
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write value to a data buffer.
 
@@ -236,7 +236,7 @@ namespace Exiv2 {
           @return Auto-pointer to the newly created Value. The caller owns this
                   copy and the auto-pointer ensures that it will be deleted.
          */
-        static AutoPtr create(TypeId typeId);
+        static UniquePtr create(TypeId typeId);
 
     protected:
         /*!
@@ -265,7 +265,7 @@ namespace Exiv2 {
     class EXIV2API DataValue : public Value {
     public:
         //! Shortcut for a %DataValue auto pointer.
-        typedef std::auto_ptr<DataValue> AutoPtr;
+        typedef std::unique_ptr<DataValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -302,7 +302,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write value to a character data buffer.
 
@@ -352,7 +352,7 @@ namespace Exiv2 {
     class EXIV2API StringValueBase : public Value {
     public:
         //! Shortcut for a %StringValueBase auto pointer.
-        typedef std::auto_ptr<StringValueBase> AutoPtr;
+        typedef std::unique_ptr<StringValueBase> UniquePtr;
 
         //! @name Creators
         //@{
@@ -389,7 +389,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write value to a character data buffer.
 
@@ -434,7 +434,7 @@ namespace Exiv2 {
     class EXIV2API StringValue : public StringValueBase {
     public:
         //! Shortcut for a %StringValue auto pointer.
-        typedef std::auto_ptr<StringValue> AutoPtr;
+        typedef std::unique_ptr<StringValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -448,7 +448,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         //@}
 
     private:
@@ -466,7 +466,7 @@ namespace Exiv2 {
     class EXIV2API AsciiValue : public StringValueBase {
     public:
         //! Shortcut for a %AsciiValue auto pointer.
-        typedef std::auto_ptr<AsciiValue> AutoPtr;
+        typedef std::unique_ptr<AsciiValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -491,7 +491,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write the ASCII value up to the the first '\\0' character to an
                  output stream.  Any further characters are ignored and not
@@ -553,7 +553,7 @@ namespace Exiv2 {
         }; // class CharsetInfo
 
         //! Shortcut for a %CommentValue auto pointer.
-        typedef std::auto_ptr<CommentValue> AutoPtr;
+        typedef std::unique_ptr<CommentValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -588,7 +588,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         long copy(byte* buf, ByteOrder byteOrder) const;
         /*!
           @brief Write the comment in a format which can be read by
@@ -640,7 +640,7 @@ namespace Exiv2 {
     class EXIV2API XmpValue : public Value {
     public:
         //! Shortcut for a %XmpValue auto pointer.
-        typedef std::auto_ptr<XmpValue> AutoPtr;
+        typedef std::unique_ptr<XmpValue> UniquePtr;
 
         //! XMP array types.
         enum XmpArrayType { xaNone, xaAlt, xaBag, xaSeq };
@@ -731,7 +731,7 @@ namespace Exiv2 {
     class EXIV2API XmpTextValue : public XmpValue {
     public:
         //! Shortcut for a %XmpTextValue auto pointer.
-        typedef std::auto_ptr<XmpTextValue> AutoPtr;
+        typedef std::unique_ptr<XmpTextValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -764,7 +764,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         long size() const;
         virtual long count() const;
         /*!
@@ -813,7 +813,7 @@ namespace Exiv2 {
     class EXIV2API XmpArrayValue : public XmpValue {
     public:
         //! Shortcut for a %XmpArrayValue auto pointer.
-        typedef std::auto_ptr<XmpArrayValue> AutoPtr;
+        typedef std::unique_ptr<XmpArrayValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -839,7 +839,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         virtual long count() const;
         /*!
           @brief Return the <EM>n</EM>-th component of the value as a string.
@@ -910,7 +910,7 @@ namespace Exiv2 {
     class EXIV2API LangAltValue : public XmpValue {
     public:
         //! Shortcut for a %LangAltValue auto pointer.
-        typedef std::auto_ptr<LangAltValue> AutoPtr;
+        typedef std::unique_ptr<LangAltValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -945,7 +945,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         virtual long count() const;
         /*!
           @brief Return the text value associated with the default language
@@ -998,7 +998,7 @@ namespace Exiv2 {
     class EXIV2API DateValue : public Value {
     public:
         //! Shortcut for a %DateValue auto pointer.
-        typedef std::auto_ptr<DateValue> AutoPtr;
+        typedef std::unique_ptr<DateValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -1051,7 +1051,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write value to a character data buffer.
 
@@ -1099,7 +1099,7 @@ namespace Exiv2 {
     class EXIV2API TimeValue : public Value {
     public:
         //! Shortcut for a %TimeValue auto pointer.
-        typedef std::auto_ptr<TimeValue> AutoPtr;
+        typedef std::unique_ptr<TimeValue> UniquePtr;
 
         //! @name Creators
         //@{
@@ -1158,7 +1158,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         /*!
           @brief Write value to a character data buffer.
 
@@ -1255,7 +1255,7 @@ namespace Exiv2 {
     class ValueType : public Value {
     public:
         //! Shortcut for a %ValueType\<T\> auto pointer.
-        typedef std::auto_ptr<ValueType<T> > AutoPtr;
+        typedef std::unique_ptr<ValueType<T> > UniquePtr;
 
         //! @name Creators
         //@{
@@ -1295,7 +1295,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        AutoPtr clone() const { return AutoPtr(clone_()); }
+        UniquePtr clone() const { return UniquePtr(clone_()); }
         virtual long copy(byte* buf, ByteOrder byteOrder) const;
         virtual long count() const;
         virtual long size() const;

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        WebPImage(BasicIo::AutoPtr io);
+        WebPImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators
@@ -133,7 +133,7 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newWebPInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is a WebP Video.
     EXIV2API bool isWebPType(BasicIo& iIo, bool advance);

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -153,7 +153,7 @@ namespace Exiv2 {
         long toLong(long n =0) const;
         float toFloat(long n =0) const;
         Rational toRational(long n =0) const;
-        Value::AutoPtr getValue() const;
+        Value::UniquePtr getValue() const;
         const Value& value() const;
         //@}
 

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
           @param create Specifies if an existing image should be read (false)
               or if a new image should be created (true).
          */
-        XmpSidecar(BasicIo::AutoPtr io, bool create);
+        XmpSidecar(BasicIo::UniquePtr io, bool create);
         //@}
 
         //! @name Manipulators
@@ -111,7 +111,7 @@ namespace Exiv2 {
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newXmpInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2API Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create);
 
     //! Check if the file iIo is an XMP sidecar file.
     EXIV2API bool isXmpType(BasicIo& iIo, bool advance);

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -34,7 +34,7 @@ try {
     std::cout << "Added a few tags the quick way.\n";
 
     // Create a ASCII string value (note the use of create)
-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::asciiString);
+    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
     // Set the value to a string
     v->read("1999:12:31 23:59:59");
     // Add the value together with its key to the Exif data container
@@ -43,7 +43,7 @@ try {
     std::cout << "Added key \"" << key << "\", value \"" << *v << "\"\n";
 
     // Now create a more interesting value (without using the create method)
-    Exiv2::URationalValue::AutoPtr rv(new Exiv2::URationalValue);
+    Exiv2::URationalValue::UniquePtr rv(new Exiv2::URationalValue);
     // Set two rational components from a string
     rv->read("1/2 1/3");
     // Add more elements through the extended interface of rational value
@@ -75,7 +75,7 @@ try {
     // Downcast the Value pointer to its actual type
     Exiv2::URationalValue* prv = dynamic_cast<Exiv2::URationalValue*>(v.release());
     if (prv == 0) throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
-    rv = Exiv2::URationalValue::AutoPtr(prv);
+    rv = Exiv2::URationalValue::UniquePtr(prv);
     // Modify the value directly through the interface of URationalValue
     rv->value_[2] = std::make_pair(88,77);
     // Copy the modified value back to the metadatum
@@ -95,7 +95,7 @@ try {
 
     // *************************************************************************
     // Finally, write the remaining Exif data to the image file
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
 
     image->setExifData(exifData);

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -15,7 +15,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -28,7 +28,7 @@ try {
     image->setXmpData(xmpData);
     image->setExifData(exifData);
     image->writeMetadata();
-    
+
     return 0;
 }
 catch (Exiv2::AnyError& e) {

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -48,7 +48,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert (image.get() != 0);
     image->readMetadata();
     Exiv2::ExifData& ed = image->exifData();

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -25,7 +25,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert (image.get() != 0);
     image->readMetadata();
     Exiv2::ExifData &exifData = image->exifData();

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -30,7 +30,7 @@ try {
     }
     std::string file(argv[1]);
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert (image.get() != 0);
     image->readMetadata();
 
@@ -103,7 +103,7 @@ catch (Exiv2::AnyError& e) {
 
 void write(const std::string& file, Exiv2::ExifData& ed)
 {
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert (image.get() != 0);
     image->setExifData(ed);
     image->writeMetadata();
@@ -111,7 +111,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
 
 void print(const std::string& file)
 {
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert (image.get() != 0);
     image->readMetadata();
 

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -174,7 +174,7 @@ int main(int argc,const char* argv[])
 	}
 
 	if ( !result ) try {
-		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
 		assert(image.get() != 0);
 		image->readMetadata();
 		Exiv2::ExifData &exifData = image->exifData();

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -38,7 +38,7 @@ try {
     	return 0;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -19,7 +19,7 @@ int main(int argc, char* const argv[])
     const char* file = argv[1];
     const char* key  = argv[2];
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
     image->readMetadata();
     Exiv2::ExifData &exifData = image->exifData();

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -278,7 +278,7 @@ try {
     while      (opt[0] == '-') opt++ ; // skip past leading -'s
     char        option = opt[0];
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -568,7 +568,7 @@ bool readImage(const char* path,Options& /* options */)
     bool bResult = false ;
 
     try {
-        Image::AutoPtr image = ImageFactory::open(path);
+        Image::UniquePtr image = ImageFactory::open(path);
         if ( image.get() ) {
             image->readMetadata();
             ExifData &exifData = image->exifData();
@@ -594,7 +594,7 @@ time_t readImageTime(std::string path,std::string* pS=NULL)
 
     do {
         try {
-            Image::AutoPtr image = ImageFactory::open(path);
+            Image::UniquePtr image = ImageFactory::open(path);
             if ( image.get() ) {
                 image->readMetadata();
                 ExifData &exifData = image->exifData();
@@ -867,7 +867,7 @@ int main(int argc,const char* argv[])
             try {
                 time_t t       = readImageTime(path,&stamp) ;
                 Position* pPos = searchTimeDict(gTimeDict,t,Position::deltaMax_);
-                Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+                Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
                 if ( image.get() ) {
                     image->readMetadata();
                     Exiv2::ExifData& exifData = image->exifData();

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -34,7 +34,8 @@ try {
     std::cout << "Time sent: " << iptcData["Iptc.Envelope.TimeSent"] << "\n";
 
     // Open image file
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::
+	UniquePtr image = Exiv2::ImageFactory::open(file);
     assert (image.get() != 0);
 
     // Set IPTC data and write it to the file

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -16,7 +16,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert (image.get() != 0);
     image->readMetadata();
 

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* const argv[])
             return 1;
         }
 
-        Image::AutoPtr image = ImageFactory::open(argv[1]);
+        Image::UniquePtr image = ImageFactory::open(argv[1]);
         assert (image.get() != 0);
         image->readMetadata();
 
@@ -106,7 +106,7 @@ void processAdd(const std::string& line, int num, IptcData &iptcData)
         data = data.substr(1, data.size()-2);
     }
     TypeId type = IptcDataSets::dataSetType(iptcKey.tag(), iptcKey.record());
-    Value::AutoPtr value = Value::create(type);
+    Value::UniquePtr value = Value::create(type);
     value->read(data);
 
     int rc = iptcData.add(iptcKey, value.get());
@@ -157,7 +157,7 @@ void processModify(const std::string& line, int num, IptcData &iptcData)
         data = data.substr(1, data.size()-2);
     }
     TypeId type = IptcDataSets::dataSetType(iptcKey.tag(), iptcKey.record());
-    Value::AutoPtr value = Value::create(type);
+    Value::UniquePtr value = Value::create(type);
     value->read(data);
 
     IptcData::iterator iter = iptcData.findKey(iptcKey);

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -26,7 +26,7 @@ try {
     if (io.error() || !io.eof()) throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
 
     // Read metadata from file
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -53,15 +53,15 @@ try {
     }
 
     // Use MemIo to increase test coverage.
-    Exiv2::BasicIo::AutoPtr fileIo(new Exiv2::FileIo(params.read_));
-    Exiv2::BasicIo::AutoPtr memIo(new Exiv2::MemIo);
+    Exiv2::BasicIo::UniquePtr fileIo(new Exiv2::FileIo(params.read_));
+    Exiv2::BasicIo::UniquePtr memIo(new Exiv2::MemIo);
     memIo->transfer(*fileIo);
 
-    Exiv2::Image::AutoPtr readImg = Exiv2::ImageFactory::open(memIo);
+    Exiv2::Image::UniquePtr readImg = Exiv2::ImageFactory::open(memIo);
     assert(readImg.get() != 0);
     readImg->readMetadata();
 
-    Exiv2::Image::AutoPtr writeImg = Exiv2::ImageFactory::open(params.write_);
+    Exiv2::Image::UniquePtr writeImg = Exiv2::ImageFactory::open(params.write_);
     assert(writeImg.get() != 0);
     if (params.preserve_) writeImg->readMetadata();
     if (params.iptc_) {

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -57,7 +57,7 @@ try {
     Exiv2::BasicIo::UniquePtr memIo(new Exiv2::MemIo);
     memIo->transfer(*fileIo);
 
-    Exiv2::Image::UniquePtr readImg = Exiv2::ImageFactory::open(memIo);
+    Exiv2::Image::UniquePtr readImg = Exiv2::ImageFactory::open(std::move(memIo));
     assert(readImg.get() != 0);
     readImg->readMetadata();
 

--- a/samples/mt-test.cpp
+++ b/samples/mt-test.cpp
@@ -35,7 +35,7 @@ void reportExifMetadataCount(int n,const char* argv[])
 
 	// count the exif metadata in the file
 	try {
-		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[n]);
+		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[n]);
 		assert(image.get() != 0);
 		image->readMetadata();
 

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -16,7 +16,7 @@ try {
     }
     std::string filename(argv[1]);
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(filename);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(filename);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -11,8 +11,8 @@
 int main(int argc, char* const argv[])
 try {
     if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " file\n";
-        return 1;
+	std::cout << "Usage: " << argv[0] << " file\n";
+	return 1;
     }
     std::string filename(argv[1]);
 
@@ -23,21 +23,21 @@ try {
     Exiv2::PreviewManager loader(*image);
     Exiv2::PreviewPropertiesList list = loader.getPreviewProperties();
     for (Exiv2::PreviewPropertiesList::iterator pos = list.begin(); pos != list.end(); pos++) {
-        std::cout << pos->mimeType_
-                  << " preview, type " << pos->id_ << ", "
-                  << pos->size_ << " bytes, "
-                  << pos->width_ << 'x' << pos->height_ << " pixels"
-                  << "\n";
+	std::cout << pos->mimeType_
+		  << " preview, type " << pos->id_ << ", "
+		  << pos->size_ << " bytes, "
+		  << pos->width_ << 'x' << pos->height_ << " pixels"
+		  << "\n";
 
-        Exiv2::PreviewImage preview = loader.getPreviewImage(*pos);
-        preview.writeFile(filename + "_"
-                          + Exiv2::toString(pos->width_) + "x"
-                          + Exiv2::toString(pos->height_));
+	Exiv2::PreviewImage preview = loader.getPreviewImage(*pos);
+	preview.writeFile(filename + "_"
+			  + Exiv2::toString(pos->width_) + "x"
+			  + Exiv2::toString(pos->height_));
     }
 
     // Cleanup
     Exiv2::XmpParser::terminate();
-    
+
     return 0;
 }
 catch (Exiv2::AnyError& e) {

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -35,19 +35,19 @@ try {
     exifData["Exif.Image.Make"]         = "Canon";                 // AsciiValue
     exifData["Exif.Canon.OwnerName"]    = "Tuan";                  // UShortValue
     exifData["Exif.CanonCs.LensType"]   = uint16_t(65535);         // LongValue
-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::asciiString);
+    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
     v->read("2013:06:09 14:30:30");
     Exiv2::ExifKey key("Exif.Image.DateTime");
     exifData.add(key, v.get());
 
-    Exiv2::Image::AutoPtr writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    Exiv2::Image::UniquePtr writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
     assert(writeTest.get() != 0);
     writeTest->setExifData(exifData);
     writeTest->writeMetadata();
 
     // read the result to make sure everything fine
     std::cout << "Print out the new metadata ...\n";
-    Exiv2::Image::AutoPtr readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    Exiv2::Image::UniquePtr readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
     assert(readTest.get() != 0);
     readTest->readMetadata();
     Exiv2::ExifData &exifReadData = readTest->exifData();

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -65,7 +65,7 @@ void mini1(const char* path)
 
 void mini9(const char* path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     tiffImage.readMetadata();
 
     std::cout << "MIME type:  " << tiffImage.mimeType() << "\n";

--- a/samples/toexv.cpp
+++ b/samples/toexv.cpp
@@ -32,7 +32,7 @@
 #include "utils.hpp"
 #include "toexv.hpp"
 
-static size_t exifMetadataCount(Exiv2::Image::AutoPtr& image)
+static size_t exifMetadataCount(Exiv2::Image::UniquePtr& image)
 {
 	size_t result = 0 ;
 	Exiv2::ExifData&                  exif = image->exifData();
@@ -51,7 +51,7 @@ int main(int argc, char* const argv[])
 		if (params.getopt(argc, argv)) return params.usage();
 		if (params.help_             ) return params.help();
 
-		Exiv2::Image::AutoPtr readImage = Exiv2::ImageFactory::open(params.read_);
+		Exiv2::Image::UniquePtr readImage = Exiv2::ImageFactory::open(params.read_);
 		assert(readImage.get() != 0);
 		readImage->readMetadata();
 
@@ -59,8 +59,8 @@ int main(int argc, char* const argv[])
 			std::cout << "exifMetadataCount = " << exifMetadataCount(readImage) << std::endl;
 
 			// create an in-memory file and write the metadata
-			Exiv2::BasicIo::AutoPtr memIo   (new Exiv2::MemIo());
-			Exiv2::Image::AutoPtr   memImage(new Exiv2::ExvImage(memIo,true));
+			Exiv2::BasicIo::UniquePtr memIo   (new Exiv2::MemIo());
+			Exiv2::Image::UniquePtr   memImage(new Exiv2::ExvImage(memIo,true));
 			memImage->setMetadata  (*readImage);
 			memImage->writeMetadata();
 
@@ -73,8 +73,8 @@ int main(int argc, char* const argv[])
 			std::cout << "size = " << size << std::endl;
 
 			// create an in-memory file with buff and read the metadata into buffImage
-			Exiv2::BasicIo::AutoPtr buffIo   (new Exiv2::MemIo(buff,size));
-			Exiv2::Image::AutoPtr   buffImage(new Exiv2::ExvImage(buffIo,false));
+			Exiv2::BasicIo::UniquePtr buffIo   (new Exiv2::MemIo(buff,size));
+			Exiv2::Image::UniquePtr   buffImage(new Exiv2::ExvImage(buffIo,false));
 			assert(buffImage.get() != 0);
 			buffImage->readMetadata();
 
@@ -82,12 +82,12 @@ int main(int argc, char* const argv[])
 
 		} else if ( params.write_ != "-" ) {
 			// create a file and write the metadata
-			Exiv2::Image::AutoPtr writeImage = Exiv2::ImageFactory::create(Exiv2::ImageType::exv,params.write_);
+			Exiv2::Image::UniquePtr writeImage = Exiv2::ImageFactory::create(Exiv2::ImageType::exv,params.write_);
 			params.copyMetadata(readImage,writeImage);
 		} else {
 			// create an in-memory file
-			Exiv2::BasicIo::AutoPtr memIo   (new Exiv2::MemIo());
-			Exiv2::Image::AutoPtr   memImage(new Exiv2::ExvImage(memIo,true));
+			Exiv2::BasicIo::UniquePtr memIo   (new Exiv2::MemIo());
+			Exiv2::Image::UniquePtr   memImage(new Exiv2::ExvImage(memIo,true));
 			params.copyMetadata(readImage,memImage);
 
 			// read a few bytes from the in-memory file
@@ -129,7 +129,7 @@ Params::Params( const char* opts)
 , usage_(false)
 {}
 
-void Params::copyMetadata(Exiv2::Image::AutoPtr& readImage,Exiv2::Image::AutoPtr& writeImage)
+void Params::copyMetadata(Exiv2::Image::UniquePtr& readImage,Exiv2::Image::UniquePtr& writeImage)
 {
 	if (all_    ) writeImage->setMetadata  (*readImage);
 	if (iptc_   ) writeImage->setIptcData  ( readImage->iptcData());

--- a/samples/toexv.hpp
+++ b/samples/toexv.hpp
@@ -70,7 +70,7 @@ public:
     int help(std::ostream& os =std::cout) const;
 
     //! copy metadata from one image to another.
-	void copyMetadata(Exiv2::Image::AutoPtr& readImage,Exiv2::Image::AutoPtr& writeImage);
+    void copyMetadata(Exiv2::Image::UniquePtr& readImage,Exiv2::Image::UniquePtr& writeImage);
 
 }; // class Params
 

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -161,7 +161,7 @@ void testCase(const std::string& file1,
     ExifKey ek(key);
 
     //Open first image
-    Image::AutoPtr image1 = ImageFactory::open(file1);
+    Image::UniquePtr image1 = ImageFactory::open(file1);
     assert(image1.get() != 0);
 
     // Load existing metadata
@@ -177,7 +177,7 @@ void testCase(const std::string& file1,
     pos->setValue(value);
 
     // Open second image
-    Image::AutoPtr image2 = ImageFactory::open(file2);
+    Image::UniquePtr image2 = ImageFactory::open(file2);
     assert(image2.get() != 0);
 
     image2->setExifData(image1->exifData());

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -34,19 +34,19 @@ try {
     Exiv2::ExifData ed1;
     ed1["Exif.Image.Model"] = "Test 1";
 
-    Exiv2::Value::AutoPtr v1 = Exiv2::Value::create(Exiv2::unsignedShort);
+    Exiv2::Value::UniquePtr v1 = Exiv2::Value::create(Exiv2::unsignedShort);
     v1->read("160 161 162 163");
     ed1.add(Exiv2::ExifKey("Exif.Image.SamplesPerPixel"), v1.get());
 
-    Exiv2::Value::AutoPtr v2 = Exiv2::Value::create(Exiv2::signedLong);
+    Exiv2::Value::UniquePtr v2 = Exiv2::Value::create(Exiv2::signedLong);
     v2->read("-2 -1 0 1");
     ed1.add(Exiv2::ExifKey("Exif.Image.XResolution"), v2.get());
 
-    Exiv2::Value::AutoPtr v3 = Exiv2::Value::create(Exiv2::signedRational);
+    Exiv2::Value::UniquePtr v3 = Exiv2::Value::create(Exiv2::signedRational);
     v3->read("-2/3 -1/3 0/3 1/3");
     ed1.add(Exiv2::ExifKey("Exif.Image.YResolution"), v3.get());
 
-    Exiv2::Value::AutoPtr v4 = Exiv2::Value::create(Exiv2::undefined);
+    Exiv2::Value::UniquePtr v4 = Exiv2::Value::create(Exiv2::undefined);
     v4->read("255 254 253 252");
     ed1.add(Exiv2::ExifKey("Exif.Image.WhitePoint"), v4.get());
 
@@ -73,7 +73,7 @@ try {
     print(file);
 
     std::cout <<"\n----- Non-intrusive writing of special Canon MakerNote tags\n";
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
     image->readMetadata();
 
@@ -189,7 +189,7 @@ try {
     std::cout <<"\n----- One IFD0 and one IFD1 tag\n";
     Exiv2::ExifData ed7;
     ed7["Exif.Thumbnail.Artist"] = "Test 7";
-    Exiv2::Value::AutoPtr v5 = Exiv2::Value::create(Exiv2::unsignedShort);
+    Exiv2::Value::UniquePtr v5 = Exiv2::Value::create(Exiv2::unsignedShort);
     v5->read("160 161 162 163");
     ed7.add(Exiv2::ExifKey("Exif.Image.SamplesPerPixel"), v5.get());
     write(file, ed7);
@@ -205,7 +205,7 @@ catch (Exiv2::AnyError& e) {
 
 void write(const std::string& file, Exiv2::ExifData& ed)
 {
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
 
     image->setExifData(ed);
@@ -214,7 +214,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
 
 void print(const std::string& file)
 {
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -24,7 +24,7 @@ try
         return 1;
       }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert (image.get() != 0);
     image->readMetadata();
 

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -1,9 +1,9 @@
 // ***************************************************************** -*- C++ -*-
 // xmpprint.cpp
-// Read an XMP from a video or graphic file, parse it and print 
+// Read an XMP from a video or graphic file, parse it and print
 // all (known) properties.
 // ========================================================================
-// Linux standalone compilation : 
+// Linux standalone compilation :
 //      g++ -o xmprint xmprint.cpp `pkg-config --cflags --libs exiv2`
 // ========================================================================
 
@@ -16,12 +16,12 @@
 
 int main(int argc, char** argv)
 {
-try 
+try
   {
-    if (argc != 2) 
+    if (argc != 2)
       {
-        std::cout << "Usage: " << argv[0] << " file\n";
-        return 1;
+	std::cout << "Usage: " << argv[0] << " file\n";
+	return 1;
       }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
@@ -30,40 +30,39 @@ try
 
     Exiv2::XmpData &xmpData = image->xmpData();
     if (xmpData.empty()) {
-        std::string error(argv[1]);
-        error += ": No XMP data found in the file";
-        throw Exiv2::Error(Exiv2::kerErrorMessage, error);
+	std::string error(argv[1]);
+	error += ": No XMP data found in the file";
+	throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    if (xmpData.empty()) 
+    if (xmpData.empty())
       {
-        std::string error(argv[1]);
-        error += ": No XMP properties found in the XMP packet";
-        throw Exiv2::Error(Exiv2::kerErrorMessage, error);
+	std::string error(argv[1]);
+	error += ": No XMP properties found in the XMP packet";
+	throw Exiv2::Error(Exiv2::kerErrorMessage, error);
       }
 
     for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) 
+	 md != xmpData.end(); ++md)
       {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+	std::cout << std::setfill(' ') << std::left
+		  << std::setw(44)
+		  << md->key() << " "
+		  << std::setw(9) << std::setfill(' ') << std::left
+		  << md->typeName() << " "
+		  << std::dec << std::setw(3)
+		  << std::setfill(' ') << std::right
+		  << md->count() << "  "
+		  << std::dec << md->value()
+		  << std::endl;
       }
 
     Exiv2::XmpParser::terminate();
 
     return 0;
   }
-catch (Exiv2::AnyError& e) 
+catch (Exiv2::AnyError& e)
   {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
     return -1;
   }
 }
-

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -105,7 +105,7 @@ try {
     // properties and language alternatives.
 
     // Add a simple XMP property in a known namespace    
-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpText);
+    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpText);
     v->read("image/jpeg");
     xmpData.add(Exiv2::XmpKey("Xmp.dc.format"), v.get());
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -168,9 +168,9 @@ namespace Action {
     {
     }
 
-    Task::AutoPtr Task::clone() const
+    Task::UniquePtr Task::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     TaskFactory* TaskFactory::instance_ = 0;
@@ -195,7 +195,7 @@ namespace Action {
         }
     } //TaskFactory::cleanup
 
-    void TaskFactory::registerTask(TaskType type, Task::AutoPtr task)
+    void TaskFactory::registerTask(TaskType type, Task::UniquePtr task)
     {
         Registry::iterator i = registry_.find(type);
         if (i != registry_.end()) {
@@ -207,25 +207,25 @@ namespace Action {
     TaskFactory::TaskFactory()
     {
         // Register a prototype of each known task
-        registerTask(adjust,  Task::AutoPtr(new Adjust));
-        registerTask(print,   Task::AutoPtr(new Print));
-        registerTask(rename,  Task::AutoPtr(new Rename));
-        registerTask(erase,   Task::AutoPtr(new Erase));
-        registerTask(extract, Task::AutoPtr(new Extract));
-        registerTask(insert,  Task::AutoPtr(new Insert));
-        registerTask(modify,  Task::AutoPtr(new Modify));
-        registerTask(fixiso,  Task::AutoPtr(new FixIso));
-        registerTask(fixcom,  Task::AutoPtr(new FixCom));
+        registerTask(adjust,  Task::UniquePtr(new Adjust));
+        registerTask(print,   Task::UniquePtr(new Print));
+        registerTask(rename,  Task::UniquePtr(new Rename));
+        registerTask(erase,   Task::UniquePtr(new Erase));
+        registerTask(extract, Task::UniquePtr(new Extract));
+        registerTask(insert,  Task::UniquePtr(new Insert));
+        registerTask(modify,  Task::UniquePtr(new Modify));
+        registerTask(fixiso,  Task::UniquePtr(new FixIso));
+        registerTask(fixcom,  Task::UniquePtr(new FixCom));
     } // TaskFactory c'tor
 
-    Task::AutoPtr TaskFactory::create(TaskType type)
+    Task::UniquePtr TaskFactory::create(TaskType type)
     {
         Registry::const_iterator i = registry_.find(type);
         if (i != registry_.end() && i->second != 0) {
             Task* t = i->second;
             return t->clone();
         }
-        return Task::AutoPtr(0);
+        return Task::UniquePtr(0);
     } // TaskFactory::create
 
     Print::~Print()
@@ -278,7 +278,7 @@ namespace Action {
                       << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->printStructure(out,option);
         return 0;
@@ -291,7 +291,7 @@ namespace Action {
                       << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -532,7 +532,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         // Set defaults for metadata types and data columns
@@ -784,7 +784,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         if (Params::instance().verbose_) {
@@ -801,7 +801,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         bool const manyFiles = Params::instance().files_.size() > 1;
@@ -824,9 +824,9 @@ namespace Action {
         return 0;
     } // Print::printPreviewList
 
-    Print::AutoPtr Print::clone() const
+    Print::UniquePtr Print::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Print* Print::clone_() const
@@ -849,7 +849,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -912,9 +912,9 @@ namespace Action {
         return 1;
     }} // Rename::run
 
-    Rename::AutoPtr Rename::clone() const
+    Rename::UniquePtr Rename::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Rename* Rename::clone_() const
@@ -938,7 +938,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         // Thumbnail must be before Exif
@@ -986,7 +986,7 @@ namespace Action {
                       << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->printStructure(out,option);
         return 0;
@@ -1051,9 +1051,9 @@ namespace Action {
         return 0;
     }
 
-    Erase::AutoPtr Erase::clone() const
+    Erase::UniquePtr Erase::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Erase* Erase::clone_() const
@@ -1114,7 +1114,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -1156,7 +1156,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
         assert(image.get() != 0);
         image->readMetadata();
 
@@ -1194,7 +1194,7 @@ namespace Action {
         bool bStdout = target == "-" ;
 
         if ( rc == 0 ) {
-            Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
+            Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
             assert(image.get() != 0);
             image->readMetadata();
             if ( !image->iccProfileDefined() ) {
@@ -1241,9 +1241,9 @@ namespace Action {
         }
     } // Extract::writePreviewFile
 
-    Extract::AutoPtr Extract::clone() const
+    Extract::UniquePtr Extract::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Extract* Extract::clone_() const
@@ -1342,7 +1342,7 @@ namespace Action {
         for ( long i = 0 ; i < xmpBlob.size_ ; i++ ) {
             xmpPacket += (char) xmpBlob.pData_[i];
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         image->clearXmpData();
@@ -1387,7 +1387,7 @@ namespace Action {
 
         // read in the metadata
         if ( rc == 0 ) {
-            Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+            Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
             assert(image.get() != 0);
             image->readMetadata();
             // clear existing profile, assign the blob and rewrite image
@@ -1414,7 +1414,7 @@ namespace Action {
                       << ": " << _("Failed to open the file\n");
             return -1;
         }
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifThumb exifThumb(image->exifData());
@@ -1424,9 +1424,9 @@ namespace Action {
         return 0;
     } // Insert::insertThumbnail
 
-    Insert::AutoPtr Insert::clone() const
+    Insert::UniquePtr Insert::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Insert* Insert::clone_() const
@@ -1449,7 +1449,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
 
@@ -1523,7 +1523,7 @@ namespace Action {
         Exiv2::ExifData& exifData = pImage->exifData();
         Exiv2::IptcData& iptcData = pImage->iptcData();
         Exiv2::XmpData&  xmpData  = pImage->xmpData();
-        Exiv2::Value::AutoPtr value = Exiv2::Value::create(modifyCmd.typeId_);
+        Exiv2::Value::UniquePtr value = Exiv2::Value::create(modifyCmd.typeId_);
         int rc = value->read(modifyCmd.value_);
         if (0 == rc) {
             if (modifyCmd.metadataId_ == exif) {
@@ -1584,7 +1584,7 @@ namespace Action {
         // If a type was explicitly requested, use it; else
         // use the current type of the metadatum, if any;
         // or the default type
-        Exiv2::Value::AutoPtr value;
+        Exiv2::Value::UniquePtr value;
         if (metadatum) {
             value = metadatum->getValue();
         }
@@ -1661,9 +1661,9 @@ namespace Action {
         Exiv2::XmpProperties::registerNs(modifyCmd.value_, modifyCmd.key_);
     }
 
-    Modify::AutoPtr Modify::clone() const
+    Modify::UniquePtr Modify::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Modify* Modify::clone_() const
@@ -1690,7 +1690,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -1716,9 +1716,9 @@ namespace Action {
         return 1;
     } // Adjust::run
 
-    Adjust::AutoPtr Adjust::clone() const
+    Adjust::UniquePtr Adjust::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Adjust* Adjust::clone_() const
@@ -1825,7 +1825,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -1863,9 +1863,9 @@ namespace Action {
     }
     } // FixIso::run
 
-    FixIso::AutoPtr FixIso::clone() const
+    FixIso::UniquePtr FixIso::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     FixIso* FixIso::clone_() const
@@ -1888,7 +1888,7 @@ namespace Action {
         Timestamp ts;
         if (Params::instance().preserve_) ts.read(path);
 
-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
+        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
         assert(image.get() != 0);
         image->readMetadata();
         Exiv2::ExifData& exifData = image->exifData();
@@ -1904,7 +1904,7 @@ namespace Action {
             }
             return 0;
         }
-        Exiv2::Value::AutoPtr v = pos->getValue();
+        Exiv2::Value::UniquePtr v = pos->getValue();
         const Exiv2::CommentValue* pcv = dynamic_cast<const Exiv2::CommentValue*>(v.get());
         if (!pcv) {
             if (Params::instance().verbose_) {
@@ -1939,9 +1939,9 @@ namespace Action {
     }
     } // FixCom::run
 
-    FixCom::AutoPtr FixCom::clone() const
+    FixCom::UniquePtr FixCom::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     FixCom* FixCom::clone_() const
@@ -2117,9 +2117,9 @@ namespace {
 
         Exiv2::DataBuf stdIn;
         if ( bStdin )  Params::instance().getStdin(stdIn);
-        Exiv2::BasicIo::AutoPtr ioStdin = Exiv2::BasicIo::AutoPtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
+        Exiv2::BasicIo::UniquePtr ioStdin = Exiv2::BasicIo::UniquePtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
 
-        Exiv2::Image::AutoPtr sourceImage = bStdin ? Exiv2::ImageFactory::open(ioStdin) : Exiv2::ImageFactory::open(source);
+        Exiv2::Image::UniquePtr sourceImage = bStdin ? Exiv2::ImageFactory::open(ioStdin) : Exiv2::ImageFactory::open(source);
         assert(sourceImage.get() != 0);
         sourceImage->readMetadata();
 
@@ -2129,7 +2129,7 @@ namespace {
         // Open or create the target file
         std::string target(bStdout ? temporaryPath() : tgt);
 
-        Exiv2::Image::AutoPtr targetImage;
+        Exiv2::Image::UniquePtr targetImage;
         if (Exiv2::fileExists(target)) {
             targetImage = Exiv2::ImageFactory::open(target);
             assert(targetImage.get() != 0);

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -225,7 +225,7 @@ namespace Action {
             Task* t = i->second;
             return t->clone();
         }
-        return Task::UniquePtr(0);
+        return Task::UniquePtr(nullptr);
     } // TaskFactory::create
 
     Print::~Print()

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -2119,7 +2119,7 @@ namespace {
         if ( bStdin )  Params::instance().getStdin(stdIn);
         Exiv2::BasicIo::UniquePtr ioStdin = Exiv2::BasicIo::UniquePtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
 
-        Exiv2::Image::UniquePtr sourceImage = bStdin ? Exiv2::ImageFactory::open(ioStdin) : Exiv2::ImageFactory::open(source);
+        Exiv2::Image::UniquePtr sourceImage = bStdin ? Exiv2::ImageFactory::open(std::move(ioStdin)) : Exiv2::ImageFactory::open(source);
         assert(sourceImage.get() != 0);
         sourceImage->readMetadata();
 

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -74,11 +74,11 @@ namespace Action {
     class Task {
     public:
         //! Shortcut for an auto pointer.
-        typedef std::auto_ptr<Task> AutoPtr;
+        typedef std::unique_ptr<Task> UniquePtr;
         //! Virtual destructor.
         virtual ~Task();
         //! Virtual copy construction.
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         /*!
           @brief Application interface to perform a task.
 
@@ -122,7 +122,7 @@ namespace Action {
                   returned auto pointer and take appropriate action (e.g., throw
                   an exception) if it is 0.
          */
-        Task::AutoPtr create(TaskType type);
+        Task::UniquePtr create(TaskType type);
 
         /*!
           @brief Register a task prototype together with its type.
@@ -136,7 +136,7 @@ namespace Action {
           @param task Pointer to the prototype. Ownership is transferred to the
                  task factory. That's what the auto pointer indicates.
         */
-        void registerTask(TaskType type, Task::AutoPtr task);
+        void registerTask(TaskType type, Task::UniquePtr task);
 
     private:
         //! Prevent construction other than through instance().
@@ -158,8 +158,8 @@ namespace Action {
     public:
         virtual ~Print();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Print> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Print> UniquePtr;
+        UniquePtr clone() const;
 
         //! Print the Jpeg comment
         int printComment();
@@ -215,8 +215,8 @@ namespace Action {
     public:
         virtual ~Rename();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Rename> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Rename> UniquePtr;
+        UniquePtr clone() const;
 
     private:
         virtual Rename* clone_() const;
@@ -227,8 +227,8 @@ namespace Action {
     public:
         virtual ~Adjust();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Adjust> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Adjust> UniquePtr;
+        UniquePtr clone() const;
 
     private:
         virtual Adjust* clone_() const;
@@ -250,8 +250,8 @@ namespace Action {
     public:
         virtual ~Erase();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Erase> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Erase> UniquePtr;
+        UniquePtr clone() const;
 
         /*!
           @brief Delete the thumbnail image, incl IFD1 metadata from the file.
@@ -296,8 +296,8 @@ namespace Action {
     public:
         virtual ~Extract();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Extract> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Extract> UniquePtr;
+        UniquePtr clone() const;
 
         /*!
           @brief Write the thumbnail image to a file. The filename is composed by
@@ -335,8 +335,8 @@ namespace Action {
     public:
         virtual ~Insert();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Insert> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Insert> UniquePtr;
+        UniquePtr clone() const;
 
         /*!
           @brief Insert a Jpeg thumbnail image from a file into file \em path.
@@ -376,15 +376,15 @@ namespace Action {
     public:
         virtual ~Modify();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<Modify> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<Modify> UniquePtr;
+        UniquePtr clone() const;
         Modify() {}
         //! Apply modification commands to the \em pImage, return 0 if successful.
         static int applyCommands(Exiv2::Image* pImage);
 
     private:
         virtual Modify* clone_() const;
-        //! Copy constructor needed because of AutoPtr member
+        //! Copy constructor needed because of UniquePtr member
         Modify(const Modify& /*src*/) : Task() {}
 
         //! Add a metadatum to \em pImage according to \em modifyCmd
@@ -409,8 +409,8 @@ namespace Action {
     public:
         virtual ~FixIso();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<FixIso> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<FixIso> UniquePtr;
+        UniquePtr clone() const;
 
     private:
         virtual FixIso* clone_() const;
@@ -427,8 +427,8 @@ namespace Action {
     public:
         virtual ~FixCom();
         virtual int run(const std::string& path);
-        typedef std::auto_ptr<FixCom> AutoPtr;
-        AutoPtr clone() const;
+        typedef std::unique_ptr<FixCom> UniquePtr;
+        UniquePtr clone() const;
 
     private:
         virtual FixCom* clone_() const;

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -292,7 +292,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     AsfVideo::AsfVideo(BasicIo::UniquePtr io)
-        : Image(ImageType::asf, mdNone, io)
+        : Image(ImageType::asf, mdNone, std::move(io))
     {
     } // AsfVideo::AsfVideo
 
@@ -787,7 +787,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new AsfVideo(io));
+        Image::UniquePtr image(new AsfVideo(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -291,7 +291,7 @@ namespace Exiv2 {
 
     using namespace Exiv2::Internal;
 
-    AsfVideo::AsfVideo(BasicIo::AutoPtr io)
+    AsfVideo::AsfVideo(BasicIo::UniquePtr io)
         : Image(ImageType::asf, mdNone, io)
     {
     } // AsfVideo::AsfVideo
@@ -371,7 +371,7 @@ namespace Exiv2 {
         DataBuf buf(1000);
         unsigned long count = 0, tempLength = 0;
         buf.pData_[4] = '\0' ;
-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
 
         if(compareTag( exvGettext(tv->label_), "Header")) {
             localPosition_ = 0;
@@ -623,7 +623,7 @@ namespace Exiv2 {
         DataBuf buf(5000);
         io_->read(buf.pData_, 2);
         int recordCount = Exiv2::getUShort(buf.pData_, littleEndian), nameLength = 0, dataLength = 0, dataType = 0;
-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
         byte guidBuf[16];   char fileID[37] = "";
 
         while(recordCount--) {
@@ -785,9 +785,9 @@ namespace Exiv2 {
     } // AsfVideo::aspectRatio
 
 
-    Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new AsfVideo(io));
+        Image::UniquePtr image(new AsfVideo(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -145,7 +145,7 @@ namespace Exiv2
         class BigTiffImage: public Image
         {
             public:
-                BigTiffImage(BasicIo::AutoPtr io):
+                BigTiffImage(BasicIo::UniquePtr io):
                     Image(ImageType::bigtiff, mdExif, io),
                     header_(),
                     dataSize_(0),
@@ -427,9 +427,9 @@ namespace Exiv2
     }
 
 
-    Image::AutoPtr newBigTiffInstance(BasicIo::AutoPtr io, bool)
+    Image::UniquePtr newBigTiffInstance(BasicIo::UniquePtr io, bool)
     {
-        return Image::AutoPtr(new BigTiffImage(io));
+        return Image::UniquePtr(new BigTiffImage(io));
     }
 
 

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -146,7 +146,7 @@ namespace Exiv2
         {
             public:
                 BigTiffImage(BasicIo::UniquePtr io):
-                    Image(ImageType::bigtiff, mdExif, io),
+                    Image(ImageType::bigtiff, mdExif, std::move(io)),
                     header_(),
                     dataSize_(0),
                     doSwap_(false)
@@ -429,7 +429,7 @@ namespace Exiv2
 
     Image::UniquePtr newBigTiffInstance(BasicIo::UniquePtr io, bool)
     {
-        return Image::UniquePtr(new BigTiffImage(io));
+        return Image::UniquePtr(new BigTiffImage(std::move(io)));
     }
 
 

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -42,7 +42,7 @@
 // class member definitions
 namespace Exiv2
 {
-    BmpImage::BmpImage(BasicIo::UniquePtr io) : Image(ImageType::bmp, mdNone, io)
+    BmpImage::BmpImage(BasicIo::UniquePtr io) : Image(ImageType::bmp, mdNone, std::move(io))
     {
     }
 
@@ -123,7 +123,7 @@ namespace Exiv2
     // free functions
     Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new BmpImage(io));
+        Image::UniquePtr image(new BmpImage(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -42,7 +42,7 @@
 // class member definitions
 namespace Exiv2
 {
-    BmpImage::BmpImage(BasicIo::AutoPtr io) : Image(ImageType::bmp, mdNone, io)
+    BmpImage::BmpImage(BasicIo::UniquePtr io) : Image(ImageType::bmp, mdNone, io)
     {
     }
 
@@ -121,9 +121,9 @@ namespace Exiv2
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new BmpImage(io));
+        Image::UniquePtr image(new BmpImage(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -47,7 +47,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    Cr2Image::Cr2Image(BasicIo::AutoPtr io, bool /*create*/)
+    Cr2Image::Cr2Image(BasicIo::UniquePtr io, bool /*create*/)
         : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, io)
     {
     } // Cr2Image::Cr2Image
@@ -186,7 +186,7 @@ namespace Exiv2 {
                      ed.end());
         }
 
-        std::auto_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
+        std::unique_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
         OffsetWriter offsetWriter;
         offsetWriter.setOrigin(OffsetWriter::cr2RawIfdOffset, Cr2Header::offset2addr(), byteOrder);
         return TiffParserWorker::encode(io,
@@ -203,9 +203,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newCr2Instance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new Cr2Image(io, create));
+        Image::UniquePtr image(new Cr2Image(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -48,7 +48,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     Cr2Image::Cr2Image(BasicIo::UniquePtr io, bool /*create*/)
-        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, std::move(io))
     {
     } // Cr2Image::Cr2Image
 
@@ -205,7 +205,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new Cr2Image(io, create));
+        Image::UniquePtr image(new Cr2Image(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwedit.cpp
+++ b/src/crwedit.cpp
@@ -43,7 +43,7 @@ try {
     if (io.error() || io.eof()) throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
 
     // Parse the image, starting with a CIFF header component
-    Exiv2::Internal::CiffHeader::AutoPtr parseTree(new Exiv2::Internal::CiffHeader);
+    Exiv2::Internal::CiffHeader::UniquePtr parseTree(new Exiv2::Internal::CiffHeader);
     parseTree->read(buf.pData_, buf.size_);
 
     // Allow user to make changes

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -54,7 +54,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     CrwImage::CrwImage(BasicIo::UniquePtr io, bool /*create*/)
-        : Image(ImageType::crw, mdExif | mdComment, io)
+        : Image(ImageType::crw, mdExif | mdComment, std::move(io))
     {
     } // CrwImage::CrwImage
 
@@ -193,7 +193,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new CrwImage(io, create));
+        Image::UniquePtr image(new CrwImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    CrwImage::CrwImage(BasicIo::AutoPtr io, bool /*create*/)
+    CrwImage::CrwImage(BasicIo::UniquePtr io, bool /*create*/)
         : Image(ImageType::crw, mdExif | mdComment, io)
     {
     } // CrwImage::CrwImage
@@ -140,7 +140,7 @@ namespace Exiv2 {
         CrwParser::encode(blob, buf.pData_, buf.size_, this);
 
         // Write new buffer to file
-        MemIo::AutoPtr tempIo(new MemIo);
+        MemIo::UniquePtr tempIo(new MemIo);
         assert(tempIo.get() != 0);
         tempIo->write((blob.size() > 0 ? &blob[0] : 0), static_cast<long>(blob.size()));
         io_->close();
@@ -154,7 +154,7 @@ namespace Exiv2 {
         assert(pData != 0);
 
         // Parse the image, starting with a CIFF header component
-        CiffHeader::AutoPtr head(new CiffHeader);
+        CiffHeader::UniquePtr head(new CiffHeader);
         head->read(pData, size);
 #ifdef DEBUG
         head->print(std::cerr);
@@ -177,7 +177,7 @@ namespace Exiv2 {
     )
     {
         // Parse image, starting with a CIFF header component
-        CiffHeader::AutoPtr head(new CiffHeader);
+        CiffHeader::UniquePtr head(new CiffHeader);
         if (size != 0) {
             head->read(pData, size);
         }
@@ -191,9 +191,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newCrwInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new CrwImage(io, create));
+        Image::UniquePtr image(new CrwImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -180,7 +180,7 @@ namespace Exiv2 {
 
     void CiffComponent::add(UniquePtr component)
     {
-        doAdd(component);
+        doAdd(std::move(component));
     }
 
     void CiffEntry::doAdd(UniquePtr /*component*/)
@@ -296,7 +296,7 @@ namespace Exiv2 {
             }
             m->setDir(this->tag());
             m->read(pData, size, o, byteOrder);
-            add(m);
+            add(std::move(m));
             o += 10;
         }
     }  // CiffDirectory::readDirectory
@@ -668,7 +668,7 @@ namespace Exiv2 {
                 // Directory doesn't exist yet, add it
                 m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
                 cc_ = m_.get();
-                add(m_);
+                add(std::move(m_));
             }
             // Recursive call to next lower level directory
             cc_ = cc_->add(crwDirs, crwTagId);
@@ -685,7 +685,7 @@ namespace Exiv2 {
                 // Tag doesn't exist yet, add it
                 m_ = UniquePtr(new CiffEntry(crwTagId, tag()));
                 cc_ = m_.get();
-                add(m_);
+                add(std::move(m_));
             }
         }
         return cc_;

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -178,17 +178,17 @@ namespace Exiv2 {
         }
     }
 
-    void CiffComponent::add(AutoPtr component)
+    void CiffComponent::add(UniquePtr component)
     {
         doAdd(component);
     }
 
-    void CiffEntry::doAdd(AutoPtr /*component*/)
+    void CiffEntry::doAdd(UniquePtr /*component*/)
     {
         throw Error(kerFunctionNotSupported, "CiffEntry::add");
     } // CiffEntry::doAdd
 
-    void CiffDirectory::doAdd(AutoPtr component)
+    void CiffDirectory::doAdd(UniquePtr component)
     {
         components_.push_back(component.release());
     } // CiffDirectory::doAdd
@@ -289,10 +289,10 @@ namespace Exiv2 {
         for (uint16_t i = 0; i < count; ++i) {
             if (o + 10 > size) throw Error(kerNotACrwImage);
             uint16_t tag = getUShort(pData + o, byteOrder);
-            CiffComponent::AutoPtr m;
+            CiffComponent::UniquePtr m;
             switch (CiffComponent::typeId(tag)) {
-            case directory: m = CiffComponent::AutoPtr(new CiffDirectory); break;
-            default: m = CiffComponent::AutoPtr(new CiffEntry); break;
+            case directory: m = CiffComponent::UniquePtr(new CiffDirectory); break;
+            default: m = CiffComponent::UniquePtr(new CiffEntry); break;
             }
             m->setDir(this->tag());
             m->read(pData, size, o, byteOrder);
@@ -510,7 +510,7 @@ namespace Exiv2 {
            << ", " << _("size") << " = " << std::dec << size_
            << ", " << _("offset") << " = " << offset_ << "\n";
 
-        Value::AutoPtr value;
+        Value::UniquePtr value;
         if (typeId() != directory) {
             value = Value::create(typeId());
             value->read(pData_, size_, byteOrder);
@@ -666,7 +666,7 @@ namespace Exiv2 {
             }
             if (cc_ == 0) {
                 // Directory doesn't exist yet, add it
-                m_ = AutoPtr(new CiffDirectory(csd.crwDir_, csd.parent_));
+                m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
                 cc_ = m_.get();
                 add(m_);
             }
@@ -683,7 +683,7 @@ namespace Exiv2 {
             }
             if (cc_ == 0) {
                 // Tag doesn't exist yet, add it
-                m_ = AutoPtr(new CiffEntry(crwTagId, tag()));
+                m_ = UniquePtr(new CiffEntry(crwTagId, tag()));
                 cc_ = m_.get();
                 add(m_);
             }
@@ -800,7 +800,7 @@ namespace Exiv2 {
 
         // Make
         ExifKey key1("Exif.Image.Make");
-        Value::AutoPtr value1 = Value::create(ciffComponent.typeId());
+        Value::UniquePtr value1 = Value::create(ciffComponent.typeId());
         uint32_t i = 0;
         for (;    i < ciffComponent.size()
                && ciffComponent.pData()[i] != '\0'; ++i) {
@@ -811,7 +811,7 @@ namespace Exiv2 {
 
         // Model
         ExifKey key2("Exif.Image.Model");
-        Value::AutoPtr value2 = Value::create(ciffComponent.typeId());
+        Value::UniquePtr value2 = Value::create(ciffComponent.typeId());
         uint32_t j = i;
         for (;    i < ciffComponent.size()
                && ciffComponent.pData()[i] != '\0'; ++i) {
@@ -946,7 +946,7 @@ namespace Exiv2 {
         assert(pCrwMapping != 0);
         // create a key and value pair
         ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
-        Value::AutoPtr value;
+        Value::UniquePtr value;
         if (ciffComponent.typeId() != directory) {
             value = Value::create(ciffComponent.typeId());
             uint32_t size = 0;

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -94,8 +94,8 @@ namespace Exiv2 {
      */
     class CiffComponent {
     public:
-        //! CiffComponent auto_ptr type
-        typedef std::auto_ptr<CiffComponent> AutoPtr;
+        //! CiffComponent unique_ptr type
+        typedef std::unique_ptr<CiffComponent> UniquePtr;
         //! Container type to hold all metadata
         typedef std::vector<CiffComponent*> Components;
 
@@ -118,7 +118,7 @@ namespace Exiv2 {
         // Default assignment operator is fine
 
         //! Add a component to the composition
-        void add(AutoPtr component);
+        void add(UniquePtr component);
         /*!
           @brief Add \em crwTagId to the parse tree, if it doesn't exist
                  yet. \em crwDirs contains the path of subdirectories, starting
@@ -261,7 +261,7 @@ namespace Exiv2 {
         //! @name Manipulators
         //@{
         //! Implements add()
-        virtual void doAdd(AutoPtr component) =0;
+        virtual void doAdd(UniquePtr component) =0;
         //! Implements add(). The default implementation does nothing.
         virtual CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId);
         //! Implements remove(). The default implementation does nothing.
@@ -332,7 +332,7 @@ namespace Exiv2 {
         //@{
         using CiffComponent::doAdd;
         // See base class comment
-        virtual void doAdd(AutoPtr component);
+        virtual void doAdd(UniquePtr component);
         /*!
           @brief Implements write(). Writes only the value data of the entry,
                  using writeValueData().
@@ -384,7 +384,7 @@ namespace Exiv2 {
         //! @name Manipulators
         //@{
         // See base class comment
-        virtual void doAdd(AutoPtr component);
+        virtual void doAdd(UniquePtr component);
         // See base class comment
         virtual CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId);
         // See base class comment
@@ -425,7 +425,7 @@ namespace Exiv2 {
     private:
         // DATA
         Components components_; //!< List of components in this dir
-        AutoPtr    m_; // used by recursive doAdd
+        UniquePtr    m_; // used by recursive doAdd
         CiffComponent* cc_;
 
     }; // class CiffDirectory
@@ -438,8 +438,8 @@ namespace Exiv2 {
      */
     class CiffHeader {
     public:
-        //! CiffHeader auto_ptr type
-        typedef std::auto_ptr<CiffHeader> AutoPtr;
+        //! CiffHeader unique_ptr type
+        typedef std::unique_ptr<CiffHeader> UniquePtr;
 
         //! @name Creators
         //@{

--- a/src/crwparse.cpp
+++ b/src/crwparse.cpp
@@ -35,7 +35,7 @@ try {
     if (io.error() || io.eof()) throw Exiv2::Error(kerFailedToReadImageData);
 
     // Parse the image, starting with a CIFF header component
-    Exiv2::Internal::CiffHeader::AutoPtr parseTree(new Exiv2::Internal::CiffHeader);
+    Exiv2::Internal::CiffHeader::UniquePtr parseTree(new Exiv2::Internal::CiffHeader);
     parseTree->read(buf.pData_, buf.size_);
     parseTree->print(std::cout);
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -657,9 +657,9 @@ namespace Exiv2 {
         return record_;
     }
 
-    IptcKey::AutoPtr IptcKey::clone() const
+    IptcKey::UniquePtr IptcKey::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     IptcKey* IptcKey::clone_() const

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1076,7 +1076,7 @@ namespace Exiv2
 {
 
     EpsImage::EpsImage(BasicIo::UniquePtr io, bool create)
-            : Image(ImageType::eps, mdXmp, io)
+            : Image(ImageType::eps, mdXmp, std::move(io))
     {
         //LogMsg::setLevel(LogMsg::debug);
         if (create) {
@@ -1153,7 +1153,7 @@ namespace Exiv2
     // free functions
     Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new EpsImage(io, create));
+        Image::UniquePtr image(new EpsImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -805,7 +805,7 @@ namespace {
             }
 
             // create temporary output file
-            BasicIo::AutoPtr tempIo(new MemIo);
+            BasicIo::UniquePtr tempIo(new MemIo);
             assert (tempIo.get() != 0);
             if (!tempIo->isopen()) {
                 #ifndef SUPPRESS_WARNINGS
@@ -1075,7 +1075,7 @@ namespace {
 namespace Exiv2
 {
 
-    EpsImage::EpsImage(BasicIo::AutoPtr io, bool create)
+    EpsImage::EpsImage(BasicIo::UniquePtr io, bool create)
             : Image(ImageType::eps, mdXmp, io)
     {
         //LogMsg::setLevel(LogMsg::debug);
@@ -1151,9 +1151,9 @@ namespace Exiv2
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new EpsImage(io, create));
+        Image::UniquePtr image(new EpsImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -81,7 +81,7 @@ namespace {
     class Thumbnail {
     public:
         //! Shortcut for a %Thumbnail auto pointer.
-        typedef std::auto_ptr<Thumbnail> AutoPtr;
+        typedef std::unique_ptr<Thumbnail> UniquePtr;
 
         //! @name Creators
         //@{
@@ -90,7 +90,7 @@ namespace {
         //@}
 
         //! Factory function to create a thumbnail for the Exif metadata provided.
-        static AutoPtr create(const Exiv2::ExifData& exifData);
+        static UniquePtr create(const Exiv2::ExifData& exifData);
 
         //! @name Accessors
         //@{
@@ -124,7 +124,7 @@ namespace {
     class TiffThumbnail : public Thumbnail {
     public:
         //! Shortcut for a %TiffThumbnail auto pointer.
-        typedef std::auto_ptr<TiffThumbnail> AutoPtr;
+        typedef std::unique_ptr<TiffThumbnail> UniquePtr;
 
         //! @name Manipulators
         //@{
@@ -148,7 +148,7 @@ namespace {
     class JpegThumbnail : public Thumbnail {
     public:
         //! Shortcut for a %JpegThumbnail auto pointer.
-        typedef std::auto_ptr<JpegThumbnail> AutoPtr;
+        typedef std::unique_ptr<JpegThumbnail> UniquePtr;
 
         //! @name Manipulators
         //@{
@@ -193,8 +193,8 @@ namespace Exiv2 {
     template<typename T>
     Exiv2::Exifdatum& setValue(Exiv2::Exifdatum& exifDatum, const T& value)
     {
-        std::auto_ptr<Exiv2::ValueType<T> > v
-            = std::auto_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
+        std::unique_ptr<Exiv2::ValueType<T> > v
+            = std::unique_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
         v->value_.push_back(value);
         exifDatum.value_ = v;
         return exifDatum;
@@ -408,9 +408,9 @@ namespace Exiv2 {
         return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
     }
 
-    Value::AutoPtr Exifdatum::getValue() const
+    Value::UniquePtr Exifdatum::getValue() const
     {
-        return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
+        return value_.get() == 0 ? Value::UniquePtr(0) : value_->clone();
     }
 
     long Exifdatum::sizeDataArea() const
@@ -430,14 +430,14 @@ namespace Exiv2 {
 
     DataBuf ExifThumbC::copy() const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return DataBuf();
         return thumbnail->copy(exifData_);
     }
 
     long ExifThumbC::writeFile(const std::string& path) const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return 0;
         std::string name = path + thumbnail->extension();
         DataBuf buf(thumbnail->copy(exifData_));
@@ -448,7 +448,7 @@ namespace Exiv2 {
 #ifdef EXV_UNICODE_PATH
     long ExifThumbC::writeFile(const std::wstring& wpath) const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return 0;
         std::wstring name = wpath + thumbnail->wextension();
         DataBuf buf(thumbnail->copy(exifData_));
@@ -459,14 +459,14 @@ namespace Exiv2 {
 #endif
     const char* ExifThumbC::mimeType() const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return "";
         return thumbnail->mimeType();
     }
 
     const char* ExifThumbC::extension() const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return "";
         return thumbnail->extension();
     }
@@ -474,7 +474,7 @@ namespace Exiv2 {
 #ifdef EXV_UNICODE_PATH
     const wchar_t* ExifThumbC::wextension() const
     {
-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
+        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
         if (thumbnail.get() == 0) return EXV_WIDEN("");
         return thumbnail->wextension();
     }
@@ -702,7 +702,7 @@ namespace Exiv2 {
 
         // Encode and check if the result fits into a JPEG Exif APP1 segment
         MemIo mio1;
-        std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
+        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
         WriteMethod wm = TiffParserWorker::encode(mio1,
                                                   pData,
                                                   size,
@@ -836,26 +836,26 @@ namespace Exiv2 {
 namespace {
 
     //! @cond IGNORE
-    Thumbnail::AutoPtr Thumbnail::create(const Exiv2::ExifData& exifData)
+    Thumbnail::UniquePtr Thumbnail::create(const Exiv2::ExifData& exifData)
     {
-        Thumbnail::AutoPtr thumbnail;
+        Thumbnail::UniquePtr thumbnail;
         const Exiv2::ExifKey k1("Exif.Thumbnail.Compression");
         Exiv2::ExifData::const_iterator pos = exifData.findKey(k1);
         if (pos != exifData.end()) {
             if (pos->count() == 0) return thumbnail;
             long compression = pos->toLong();
             if (compression == 6) {
-                thumbnail = Thumbnail::AutoPtr(new JpegThumbnail);
+                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
             }
             else {
-                thumbnail = Thumbnail::AutoPtr(new TiffThumbnail);
+                thumbnail = Thumbnail::UniquePtr(new TiffThumbnail);
             }
         }
         else {
             const Exiv2::ExifKey k2("Exif.Thumbnail.JPEGInterchangeFormat");
             pos = exifData.findKey(k2);
             if (pos != exifData.end()) {
-                thumbnail = Thumbnail::AutoPtr(new JpegThumbnail);
+                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
             }
         }
         return thumbnail;

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -410,12 +410,12 @@ namespace Exiv2 {
 
     Value::UniquePtr Exifdatum::getValue() const
     {
-        return value_.get() == 0 ? Value::UniquePtr(0) : value_->clone();
+        return value_.get() == nullptr ? Value::UniquePtr(nullptr) : value_->clone();
     }
 
     long Exifdatum::sizeDataArea() const
     {
-        return value_.get() == 0 ? 0 : value_->sizeDataArea();
+        return value_.get() == nullptr ? 0 : value_->sizeDataArea();
     }
 
     DataBuf Exifdatum::dataArea() const

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -196,7 +196,7 @@ namespace Exiv2 {
         std::unique_ptr<Exiv2::ValueType<T> > v
             = std::unique_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
         v->value_.push_back(value);
-        exifDatum.value_ = v;
+        exifDatum.value_ = std::move(v);
         return exifDatum;
     }
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -148,7 +148,7 @@ int main(int argc, char* const argv[])
 
     // Create the required action class
     Action::TaskFactory& taskFactory = Action::TaskFactory::instance();
-    Action::Task::AutoPtr task
+    Action::Task::UniquePtr task
         = taskFactory.create(Action::TaskType(params.action_));
     assert(task.get());
 

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -43,7 +43,7 @@
 namespace Exiv2 {
 
     GifImage::GifImage(BasicIo::UniquePtr io)
-        : Image(ImageType::gif, mdNone, io)
+        : Image(ImageType::gif, mdNone, std::move(io))
     {
     } // GifImage::GifImage
 
@@ -106,7 +106,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new GifImage(io));
+        Image::UniquePtr image(new GifImage(std::move(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -42,7 +42,7 @@
 // class member definitions
 namespace Exiv2 {
 
-    GifImage::GifImage(BasicIo::AutoPtr io)
+    GifImage::GifImage(BasicIo::UniquePtr io)
         : Image(ImageType::gif, mdNone, io)
     {
     } // GifImage::GifImage
@@ -104,9 +104,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newGifInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new GifImage(io));
+        Image::UniquePtr image(new GifImage(io));
         if (!image->good())
         {
             image.reset();

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -150,7 +150,7 @@ namespace Exiv2 {
 
     Image::Image(int              imageType,
                  uint16_t         supportedMetadata,
-                 BasicIo::AutoPtr io)
+                 BasicIo::UniquePtr io)
         : io_(io),
           pixelWidth_(0),
           pixelHeight_(0),
@@ -829,82 +829,82 @@ namespace Exiv2 {
         return ImageType::none;
     } // ImageFactory::getType
 
-    BasicIo::AutoPtr ImageFactory::createIo(const std::string& path, bool useCurl)
+    BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, bool useCurl)
     {
         Protocol fProt = fileProtocol(path);
 
 #ifdef EXV_USE_SSH
         if (fProt == pSsh || fProt == pSftp) {
-            return BasicIo::AutoPtr(new SshIo(path)); // may throw
+            return BasicIo::UniquePtr(new SshIo(path)); // may throw
         }
 #endif
 
 #ifdef EXV_USE_CURL
         if (useCurl && (fProt == pHttp || fProt == pHttps || fProt == pFtp)) {
-            return BasicIo::AutoPtr(new CurlIo(path)); // may throw
+            return BasicIo::UniquePtr(new CurlIo(path)); // may throw
         }
 #endif
 
         if (fProt == pHttp)
-            return BasicIo::AutoPtr(new HttpIo(path)); // may throw
+            return BasicIo::UniquePtr(new HttpIo(path)); // may throw
         if (fProt == pFileUri)
-            return BasicIo::AutoPtr(new FileIo(pathOfFileUrl(path)));
+            return BasicIo::UniquePtr(new FileIo(pathOfFileUrl(path)));
         if (fProt == pStdin || fProt == pDataUri)
-            return BasicIo::AutoPtr(new XPathIo(path)); // may throw
+            return BasicIo::UniquePtr(new XPathIo(path)); // may throw
 
-        return BasicIo::AutoPtr(new FileIo(path));
+        return BasicIo::UniquePtr(new FileIo(path));
 
         (void)(useCurl);
     } // ImageFactory::createIo
 
 #ifdef EXV_UNICODE_PATH
-    BasicIo::AutoPtr ImageFactory::createIo(const std::wstring& wpath, bool useCurl)
+    BasicIo::UniquePtr ImageFactory::createIo(const std::wstring& wpath, bool useCurl)
     {
         Protocol fProt = fileProtocol(wpath);
 #if EXV_USE_SSH == 1
         if (fProt == pSsh || fProt == pSftp) {
-            return BasicIo::AutoPtr(new SshIo(wpath));
+            return BasicIo::UniquePtr(new SshIo(wpath));
         }
 #endif
 #if EXV_USE_CURL == 1
         if (useCurl && (fProt == pHttp || fProt == pHttps || fProt == pFtp)) {
-            return BasicIo::AutoPtr(new CurlIo(wpath));
+            return BasicIo::UniquePtr(new CurlIo(wpath));
         }
 #endif
         if (fProt == pHttp)
-            return BasicIo::AutoPtr(new HttpIo(wpath));
+            return BasicIo::UniquePtr(new HttpIo(wpath));
         if (fProt == pFileUri)
-            return BasicIo::AutoPtr(new FileIo(pathOfFileUrl(wpath)));
+            return BasicIo::UniquePtr(new FileIo(pathOfFileUrl(wpath)));
         if (fProt == pStdin || fProt == pDataUri)
-            return BasicIo::AutoPtr(new XPathIo(wpath)); // may throw
-        return BasicIo::AutoPtr(new FileIo(wpath));
+            return BasicIo::UniquePtr(new XPathIo(wpath)); // may throw
+        return BasicIo::UniquePtr(new FileIo(wpath));
     } // ImageFactory::createIo
 #endif
-    Image::AutoPtr ImageFactory::open(const std::string& path, bool useCurl)
+    Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
     {
-        Image::AutoPtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
+        Image::UniquePtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
         if (image.get() == 0) throw Error(kerFileContainsUnknownImageType, path);
         return image;
     }
 
 #ifdef EXV_UNICODE_PATH
-    Image::AutoPtr ImageFactory::open(const std::wstring& wpath, bool useCurl)
+    Image::UniquePtr ImageFactory::open(const std::wstring& wpath, bool useCurl)
     {
-        Image::AutoPtr image = open(ImageFactory::createIo(wpath, useCurl)); // may throw
+        Image::UniquePtr image = open(ImageFactory::createIo(wpath, useCurl)); // may throw
         if (image.get() == 0) throw WError(kerFileContainsUnknownImageType, wpath);
         return image;
     }
 
 #endif
-    Image::AutoPtr ImageFactory::open(const byte* data, long size)
+    Image::UniquePtr ImageFactory::open(const byte* data, long size)
     {
-        BasicIo::AutoPtr io(new MemIo(data, size));
-        Image::AutoPtr image = open(io); // may throw
+        BasicIo::UniquePtr io(new MemIo(data, size));
+        Image::UniquePtr image = open(io); // may throw
         if (image.get() == 0) throw Error(kerMemoryContainsUnknownImageType);
         return image;
     }
 
-    Image::AutoPtr ImageFactory::open(BasicIo::AutoPtr io)
+    Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io)
     {
         if (io->open() != 0) {
             throw Error(kerDataSourceOpenFailed, io->path(), strError());
@@ -914,58 +914,58 @@ namespace Exiv2 {
                 return registry[i].newInstance_(io, false);
             }
         }
-        return Image::AutoPtr();
+        return Image::UniquePtr();
     } // ImageFactory::open
 
-    Image::AutoPtr ImageFactory::create(int type,
+    Image::UniquePtr ImageFactory::create(int type,
                                         const std::string& path)
     {
-        std::auto_ptr<FileIo> fileIo(new FileIo(path));
+        std::unique_ptr<FileIo> fileIo(new FileIo(path));
         // Create or overwrite the file, then close it
         if (fileIo->open("w+b") != 0) {
             throw Error(kerFileOpenFailed, path, "w+b", strError());
         }
         fileIo->close();
-        BasicIo::AutoPtr io(fileIo);
-        Image::AutoPtr image = create(type, io);
+        BasicIo::UniquePtr io(fileIo);
+        Image::UniquePtr image = create(type, io);
         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
         return image;
     }
 
 #ifdef EXV_UNICODE_PATH
-    Image::AutoPtr ImageFactory::create(int type,
+    Image::UniquePtr ImageFactory::create(int type,
                                         const std::wstring& wpath)
     {
-        std::auto_ptr<FileIo> fileIo(new FileIo(wpath));
+        std::unique_ptr<FileIo> fileIo(new FileIo(wpath));
         // Create or overwrite the file, then close it
         if (fileIo->open("w+b") != 0) {
             throw WError(kerFileOpenFailed, wpath, "w+b", strError().c_str());
         }
         fileIo->close();
-        BasicIo::AutoPtr io(fileIo);
-        Image::AutoPtr image = create(type, io);
+        BasicIo::UniquePtr io(fileIo);
+        Image::UniquePtr image = create(type, io);
         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
         return image;
     }
 
 #endif
-    Image::AutoPtr ImageFactory::create(int type)
+    Image::UniquePtr ImageFactory::create(int type)
     {
-        BasicIo::AutoPtr io(new MemIo);
-        Image::AutoPtr image = create(type, io);
+        BasicIo::UniquePtr io(new MemIo);
+        Image::UniquePtr image = create(type, io);
         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
         return image;
     }
 
-    Image::AutoPtr ImageFactory::create(int type,
-                                        BasicIo::AutoPtr io)
+    Image::UniquePtr ImageFactory::create(int type,
+                                        BasicIo::UniquePtr io)
     {
         // BasicIo instance does not need to be open
         const Registry* r = find(registry, type);
         if (0 != r) {
             return r->newInstance_(io, true);
         }
-        return Image::AutoPtr();
+        return Image::UniquePtr();
     } // ImageFactory::create
 
 // *****************************************************************************

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -95,8 +95,8 @@ namespace Exiv2 {
     Iptcdatum::Iptcdatum(const Iptcdatum& rhs)
         : Metadatum(rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
     }
 
     Iptcdatum::~Iptcdatum()
@@ -105,7 +105,7 @@ namespace Exiv2 {
 
     long Iptcdatum::copy(byte* buf, ByteOrder byteOrder) const
     {
-        return value_.get() == 0 ? 0 : value_->copy(buf, byteOrder);
+        return value_.get() == nullptr ? 0 : value_->copy(buf, byteOrder);
     }
 
     std::ostream& Iptcdatum::write(std::ostream& os, const ExifData*) const
@@ -115,47 +115,47 @@ namespace Exiv2 {
 
     std::string Iptcdatum::key() const
     {
-        return key_.get() == 0 ? "" : key_->key();
+        return key_.get() == nullptr ? "" : key_->key();
     }
 
     std::string Iptcdatum::recordName() const
     {
-        return key_.get() == 0 ? "" : key_->recordName();
+        return key_.get() == nullptr ? "" : key_->recordName();
     }
 
     uint16_t Iptcdatum::record() const
     {
-        return key_.get() == 0 ? 0 : key_->record();
+        return key_.get() == nullptr ? 0 : key_->record();
     }
 
     const char* Iptcdatum::familyName() const
     {
-        return key_.get() == 0 ? "" : key_->familyName();
+        return key_.get() == nullptr ? "" : key_->familyName();
     }
 
     std::string Iptcdatum::groupName() const
     {
-        return key_.get() == 0 ? "" : key_->groupName();
+        return key_.get() == nullptr ? "" : key_->groupName();
     }
 
     std::string Iptcdatum::tagName() const
     {
-        return key_.get() == 0 ? "" : key_->tagName();
+        return key_.get() == nullptr ? "" : key_->tagName();
     }
 
     std::string Iptcdatum::tagLabel() const
     {
-        return key_.get() == 0 ? "" : key_->tagLabel();
+        return key_.get() == nullptr ? "" : key_->tagLabel();
     }
 
     uint16_t Iptcdatum::tag() const
     {
-        return key_.get() == 0 ? 0 : key_->tag();
+        return key_.get() == nullptr ? 0 : key_->tag();
     }
 
     TypeId Iptcdatum::typeId() const
     {
-        return value_.get() == 0 ? invalidTypeId : value_->typeId();
+        return value_.get() == nullptr ? invalidTypeId : value_->typeId();
     }
 
     const char* Iptcdatum::typeName() const
@@ -170,47 +170,47 @@ namespace Exiv2 {
 
     long Iptcdatum::count() const
     {
-        return value_.get() == 0 ? 0 : value_->count();
+        return value_.get() == nullptr ? 0 : value_->count();
     }
 
     long Iptcdatum::size() const
     {
-        return value_.get() == 0 ? 0 : value_->size();
+        return value_.get() == nullptr ? 0 : value_->size();
     }
 
     std::string Iptcdatum::toString() const
     {
-        return value_.get() == 0 ? "" : value_->toString();
+        return value_.get() == nullptr ? "" : value_->toString();
     }
 
     std::string Iptcdatum::toString(long n) const
     {
-        return value_.get() == 0 ? "" : value_->toString(n);
+        return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
     long Iptcdatum::toLong(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toLong(n);
+        return value_.get() == nullptr ? -1 : value_->toLong(n);
     }
 
     float Iptcdatum::toFloat(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toFloat(n);
+        return value_.get() == nullptr ? -1 : value_->toFloat(n);
     }
 
     Rational Iptcdatum::toRational(long n) const
     {
-        return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+        return value_.get() == nullptr ? Rational(-1, 1) : value_->toRational(n);
     }
 
     Value::UniquePtr Iptcdatum::getValue() const
     {
-        return value_.get() == 0 ? Value::UniquePtr(0) : value_->clone();
+        return value_.get() == nullptr ? Value::UniquePtr(nullptr) : value_->clone();
     }
 
     const Value& Iptcdatum::value() const
     {
-        if (value_.get() == 0) throw Error(kerValueNotSet);
+        if (value_.get() == nullptr) throw Error(kerValueNotSet);
         return *value_;
     }
 
@@ -220,10 +220,10 @@ namespace Exiv2 {
         Metadatum::operator=(rhs);
 
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
 
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
 
         return *this;
     } // Iptcdatum::operator=
@@ -256,7 +256,7 @@ namespace Exiv2 {
 
     int Iptcdatum::setValue(const std::string& value)
     {
-        if (value_.get() == 0) {
+        if (value_.get() == nullptr) {
             TypeId type = IptcDataSets::dataSetType(tag(), record());
             value_ = Value::create(type);
         }

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -232,7 +232,7 @@ namespace Exiv2 {
     {
         UShortValue::UniquePtr v(new UShortValue);
         v->value_.push_back(value);
-        value_ = v;
+        value_ = std::move(v);
         return *this;
     }
 

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -203,9 +203,9 @@ namespace Exiv2 {
         return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
     }
 
-    Value::AutoPtr Iptcdatum::getValue() const
+    Value::UniquePtr Iptcdatum::getValue() const
     {
-        return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
+        return value_.get() == 0 ? Value::UniquePtr(0) : value_->clone();
     }
 
     const Value& Iptcdatum::value() const
@@ -230,7 +230,7 @@ namespace Exiv2 {
 
     Iptcdatum& Iptcdatum::operator=(const uint16_t& value)
     {
-        UShortValue::AutoPtr v(new UShortValue);
+        UShortValue::UniquePtr v(new UShortValue);
         v->value_.push_back(value);
         value_ = v;
         return *this;
@@ -548,7 +548,7 @@ namespace {
               uint32_t         sizeData
     )
     {
-        Exiv2::Value::AutoPtr value;
+        Exiv2::Value::UniquePtr value;
         Exiv2::TypeId type = Exiv2::IptcDataSets::dataSetType(dataSet, record);
         value = Exiv2::Value::create(type);
         int rc = value->read(data, sizeData, Exiv2::bigEndian);

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -138,7 +138,7 @@ struct Jp2UuidBox
 namespace Exiv2
 {
 
-    Jp2Image::Jp2Image(BasicIo::AutoPtr io, bool create)
+    Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create)
             : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, io)
     {
         if (create)
@@ -566,7 +566,7 @@ namespace Exiv2
                                 if ( (rawData.pData_[0]      == rawData.pData_[1])
                                     &&   (rawData.pData_[0]=='I' || rawData.pData_[0]=='M' )
                                     ) {
-                                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(rawData.pData_,rawData.size_));
+                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(rawData.pData_,rawData.size_));
                                     printTiffStructure(*p,out,option,depth);
                                 }
                             }
@@ -601,7 +601,7 @@ namespace Exiv2
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -921,9 +921,9 @@ namespace Exiv2
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newJp2Instance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new Jp2Image(io, create));
+        Image::UniquePtr image(new Jp2Image(io, create));
         if (!image->good())
         {
             image.reset();

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -139,7 +139,7 @@ namespace Exiv2
 {
 
     Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create)
-            : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, io)
+            : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, std::move(io))
     {
         if (create)
         {
@@ -923,7 +923,7 @@ namespace Exiv2
     // free functions
     Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new Jp2Image(io, create));
+        Image::UniquePtr image(new Jp2Image(std::move(io), create));
         if (!image->good())
         {
             image.reset();

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -301,7 +301,7 @@ namespace Exiv2 {
 
     JpegBase::JpegBase(int type, BasicIo::UniquePtr io, bool create,
                        const byte initData[], long dataSize)
-        : Image(type, mdExif | mdIptc | mdXmp | mdComment, io)
+        : Image(type, mdExif | mdIptc | mdXmp | mdComment, std::move(io))
     {
         if (create) {
             initImage(initData, dataSize);
@@ -1253,7 +1253,7 @@ namespace Exiv2 {
         0x11,0x03,0x11,0x00,0x3F,0x00,0xA0,0x00,0x0F,0xFF,0xD9 };
 
     JpegImage::JpegImage(BasicIo::UniquePtr io, bool create)
-        : JpegBase(ImageType::jpeg, io, create, blank_, sizeof(blank_))
+        : JpegBase(ImageType::jpeg, std::move(io), create, blank_, sizeof(blank_))
     {
     }
 
@@ -1280,7 +1280,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new JpegImage(io, create));
+        Image::UniquePtr image(new JpegImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }
@@ -1305,7 +1305,7 @@ namespace Exiv2 {
     const byte ExvImage::blank_[] = { 0xff,0x01,'E','x','i','v','2',0xff,0xd9 };
 
     ExvImage::ExvImage(BasicIo::UniquePtr io, bool create)
-        : JpegBase(ImageType::exv, io, create, blank_, sizeof(blank_))
+        : JpegBase(ImageType::exv, std::move(io), create, blank_, sizeof(blank_))
     {
     }
 
@@ -1334,7 +1334,7 @@ namespace Exiv2 {
     Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create)
     {
         Image::UniquePtr image;
-        image = Image::UniquePtr(new ExvImage(io, create));
+        image = Image::UniquePtr(new ExvImage(std::move(io), create));
         if (!image->good()) image.reset();
         return image;
     }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -299,7 +299,7 @@ namespace Exiv2 {
 
     } // Photoshop::setIptcIrb
 
-    JpegBase::JpegBase(int type, BasicIo::AutoPtr io, bool create,
+    JpegBase::JpegBase(int type, BasicIo::UniquePtr io, bool create,
                        const byte initData[], long dataSize)
         : Image(type, mdExif | mdIptc | mdXmp | mdComment, io)
     {
@@ -767,7 +767,7 @@ namespace Exiv2 {
                                 IptcData::printStructure(out, exif, size, depth);
                             } else {
                                 // create a copy on write memio object with the data, then print the structure
-                                BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(exif + start, size - start));
+                                BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(exif + start, size - start));
                                 if (start < max)
                                     printTiffStructure(*p, out, option, depth);
                             }
@@ -841,7 +841,7 @@ namespace Exiv2 {
             // exiv2 -pS E.jpg
 
             // binary copy io_ to a temporary file
-            BasicIo::AutoPtr tempIo(new MemIo);
+            BasicIo::UniquePtr tempIo(new MemIo);
 
             assert(tempIo.get() != 0);
             for (uint64_t i = 0; i < (count / 2) + 1; i++) {
@@ -874,7 +874,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -1252,7 +1252,7 @@ namespace Exiv2 {
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xFF,0xDA,0x00,0x0C,0x03,0x01,0x00,0x02,
         0x11,0x03,0x11,0x00,0x3F,0x00,0xA0,0x00,0x0F,0xFF,0xD9 };
 
-    JpegImage::JpegImage(BasicIo::AutoPtr io, bool create)
+    JpegImage::JpegImage(BasicIo::UniquePtr io, bool create)
         : JpegBase(ImageType::jpeg, io, create, blank_, sizeof(blank_))
     {
     }
@@ -1278,9 +1278,9 @@ namespace Exiv2 {
         return isJpegType(iIo, advance);
     }
 
-    Image::AutoPtr newJpegInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new JpegImage(io, create));
+        Image::UniquePtr image(new JpegImage(io, create));
         if (!image->good()) {
             image.reset();
         }
@@ -1304,7 +1304,7 @@ namespace Exiv2 {
     const char ExvImage::exiv2Id_[] = "Exiv2";
     const byte ExvImage::blank_[] = { 0xff,0x01,'E','x','i','v','2',0xff,0xd9 };
 
-    ExvImage::ExvImage(BasicIo::AutoPtr io, bool create)
+    ExvImage::ExvImage(BasicIo::UniquePtr io, bool create)
         : JpegBase(ImageType::exv, io, create, blank_, sizeof(blank_))
     {
     }
@@ -1331,10 +1331,10 @@ namespace Exiv2 {
         return isExvType(iIo, advance);
     }
 
-    Image::AutoPtr newExvInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image;
-        image = Image::AutoPtr(new ExvImage(io, create));
+        Image::UniquePtr image;
+        image = Image::UniquePtr(new ExvImage(io, create));
         if (!image->good()) image.reset();
         return image;
     }

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -477,7 +477,7 @@ namespace Exiv2 {
 
     using namespace Exiv2::Internal;
 
-    MatroskaVideo::MatroskaVideo(BasicIo::AutoPtr io)
+    MatroskaVideo::MatroskaVideo(BasicIo::UniquePtr io)
         : Image(ImageType::mkv, mdNone, io)
     {
     } // MatroskaVideo::MatroskaVideo
@@ -736,9 +736,9 @@ namespace Exiv2 {
         else              return 0;
     } // MatroskaVideo::findBlockSize
 
-    Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new MatroskaVideo(io));
+        Image::UniquePtr image(new MatroskaVideo(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -478,7 +478,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     MatroskaVideo::MatroskaVideo(BasicIo::UniquePtr io)
-        : Image(ImageType::mkv, mdNone, io)
+        : Image(ImageType::mkv, mdNone, std::move(io))
     {
     } // MatroskaVideo::MatroskaVideo
 
@@ -738,7 +738,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new MatroskaVideo(io));
+        Image::UniquePtr image(new MatroskaVideo(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/metadatum.cpp
+++ b/src/metadatum.cpp
@@ -42,9 +42,9 @@ namespace Exiv2 {
     {
     }
 
-    Key::AutoPtr Key::clone() const
+    Key::UniquePtr Key::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     Key& Key::operator=(const Key& /*rhs*/)

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -45,7 +45,7 @@
 // class member definitions
 namespace Exiv2 {
 
-    MrwImage::MrwImage(BasicIo::AutoPtr io, bool /*create*/)
+    MrwImage::MrwImage(BasicIo::UniquePtr io, bool /*create*/)
         : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, io)
     {
     } // MrwImage::MrwImage
@@ -152,9 +152,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newMrwInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new MrwImage(io, create));
+        Image::UniquePtr image(new MrwImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -46,7 +46,7 @@
 namespace Exiv2 {
 
     MrwImage::MrwImage(BasicIo::UniquePtr io, bool /*create*/)
-        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, std::move(io))
     {
     } // MrwImage::MrwImage
 
@@ -154,7 +154,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new MrwImage(io, create));
+        Image::UniquePtr image(new MrwImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/mrwthumb.cpp
+++ b/src/mrwthumb.cpp
@@ -14,7 +14,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -51,7 +51,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     OrfImage::OrfImage(BasicIo::UniquePtr io, bool create)
-        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ io,create)
+        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ std::move(io), create)
     {
         setTypeSupported(ImageType::orf, mdExif | mdIptc | mdXmp);
     } // OrfImage::OrfImage
@@ -215,7 +215,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new OrfImage(io, create));
+        Image::UniquePtr image(new OrfImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -50,7 +50,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    OrfImage::OrfImage(BasicIo::AutoPtr io, bool create)
+    OrfImage::OrfImage(BasicIo::UniquePtr io, bool create)
         : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ io,create)
     {
         setTypeSupported(ImageType::orf, mdExif | mdIptc | mdXmp);
@@ -198,7 +198,7 @@ namespace Exiv2 {
                      ed.end());
         }
 
-        std::auto_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
+        std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
         return TiffParserWorker::encode(io,
                                         pData,
                                         size,
@@ -213,9 +213,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newOrfInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new OrfImage(io, create));
+        Image::UniquePtr image(new OrfImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -83,7 +83,7 @@ namespace Exiv2 {
     }
 
     PgfImage::PgfImage(BasicIo::UniquePtr io, bool create)
-            : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, io)
+	: Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, std::move(io))
             , bSwap_(isBigEndianPlatform())
     {
         if (create)
@@ -317,7 +317,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new PgfImage(io, create));
+        Image::UniquePtr image(new PgfImage(std::move(io), create));
         if (!image->good())
         {
             image.reset();

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -82,7 +82,7 @@ namespace Exiv2 {
         return result;
     }
 
-    PgfImage::PgfImage(BasicIo::AutoPtr io, bool create)
+    PgfImage::PgfImage(BasicIo::UniquePtr io, bool create)
             : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, io)
             , bSwap_(isBigEndianPlatform())
     {
@@ -144,7 +144,7 @@ namespace Exiv2 {
         if (io_->error()) throw Error(kerFailedToReadImageData);
         if (bufRead != imgData.size_) throw Error(kerInputDataReadFailed);
 
-        Image::AutoPtr image = Exiv2::ImageFactory::open(imgData.pData_, imgData.size_);
+        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.pData_, imgData.size_);
         image->readMetadata();
         exifData() = image->exifData();
         iptcData() = image->iptcData();
@@ -159,7 +159,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -193,7 +193,7 @@ namespace Exiv2 {
         int w, h;
         DataBuf header      = readPgfHeaderStructure(*io_, w, h);
 
-        Image::AutoPtr img  = ImageFactory::create(ImageType::png);
+        Image::UniquePtr img  = ImageFactory::create(ImageType::png);
 
         img->setExifData(exifData_);
         img->setIptcData(iptcData_);
@@ -315,9 +315,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newPgfInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new PgfImage(io, create));
+        Image::UniquePtr image(new PgfImage(io, create));
         if (!image->good())
         {
             image.reset();

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     PngImage::PngImage(BasicIo::UniquePtr io, bool create)
-            : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, io)
+	: Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, std::move(io))
     {
         if (create)
         {
@@ -703,7 +703,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new PngImage(io, create));
+        Image::UniquePtr image(new PngImage(std::move(io), create));
         if (!image->good())
         {
             image.reset();

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -63,7 +63,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    PngImage::PngImage(BasicIo::AutoPtr io, bool create)
+    PngImage::PngImage(BasicIo::UniquePtr io, bool create)
             : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, io)
     {
         if (create)
@@ -327,7 +327,7 @@ namespace Exiv2 {
                             if ( parsedBuf.size_ ) {
                                 if ( bExif ) {
                                     // create memio object with the data, then print the structure
-                                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(parsedBuf.pData_+6,parsedBuf.size_-6));
+                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(parsedBuf.pData_+6,parsedBuf.size_-6));
                                     printTiffStructure(*p,out,option,depth);
                                 }
                                 if ( bIptc ) {
@@ -490,7 +490,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -701,9 +701,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newPngInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new PngImage(io, create));
+        Image::UniquePtr image(new PngImage(io, create));
         if (!image->good())
         {
             image.reset();

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -91,10 +91,10 @@ namespace {
         virtual ~Loader() {}
 
         //! Loader auto pointer
-        typedef std::auto_ptr<Loader> AutoPtr;
+        typedef std::unique_ptr<Loader> UniquePtr;
 
         //! Create a Loader subclass for requested id
-        static AutoPtr create(PreviewId id, const Image &image);
+        static UniquePtr create(PreviewId id, const Image &image);
 
         //! Check if a preview image with given params exists in the image
         virtual bool valid() const { return valid_; }
@@ -116,7 +116,7 @@ namespace {
         Loader(PreviewId id, const Image &image);
 
         //! Functions that creates a loader from given parameters
-        typedef AutoPtr (*CreateFunc)(PreviewId id, const Image &image, int parIdx);
+        typedef UniquePtr (*CreateFunc)(PreviewId id, const Image &image, int parIdx);
 
         //! Structure to list possible loaders
         struct LoaderList {
@@ -168,7 +168,7 @@ namespace {
     };
 
     //! Function to create new LoaderNative
-    Loader::AutoPtr createLoaderNative(PreviewId id, const Image &image, int parIdx);
+    Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx);
 
     //! Loader for Jpeg previews that are not read into ExifData directly
     class LoaderExifJpeg : public Loader {
@@ -202,7 +202,7 @@ namespace {
     };
 
     //! Function to create new LoaderExifJpeg
-    Loader::AutoPtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
+    Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
 
     //! Loader for Jpeg previews that are read into ExifData
     class LoaderExifDataJpeg : public Loader {
@@ -235,7 +235,7 @@ namespace {
     };
 
     //! Function to create new LoaderExifDataJpeg
-    Loader::AutoPtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
+    Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
 
     //! Loader for Tiff previews - it can get image data from ExifData or image_.io() as needed
     class LoaderTiff : public Loader {
@@ -272,7 +272,7 @@ namespace {
     };
 
     //! Function to create new LoaderTiff
-    Loader::AutoPtr createLoaderTiff(PreviewId id, const Image &image, int parIdx);
+    Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx);
 
     //! Loader for JPEG previews stored in the XMP metadata
     class LoaderXmpJpeg : public Loader {
@@ -295,7 +295,7 @@ namespace {
     };
 
     //! Function to create new LoaderXmpJpeg
-    Loader::AutoPtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
+    Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
 
 // *****************************************************************************
 // class member definitions
@@ -375,16 +375,16 @@ namespace {
         { "Image2",    0,                               0   }   // 7
     };
 
-    Loader::AutoPtr Loader::create(PreviewId id, const Image &image)
+    Loader::UniquePtr Loader::create(PreviewId id, const Image &image)
     {
         if (id < 0 || id >= Loader::getNumLoaders())
-            return AutoPtr();
+            return UniquePtr();
 
         if (loaderList_[id].imageMimeType_ &&
             std::string(loaderList_[id].imageMimeType_) != std::string(image.mimeType()))
-            return AutoPtr();
+            return UniquePtr();
 
-        AutoPtr loader = loaderList_[id].create_(id, image, loaderList_[id].parIdx_);
+        UniquePtr loader = loaderList_[id].create_(id, image, loaderList_[id].parIdx_);
 
         if (loader.get() && !loader->valid()) loader.reset();
         return loader;
@@ -428,9 +428,9 @@ namespace {
         }
     }
 
-    Loader::AutoPtr createLoaderNative(PreviewId id, const Image &image, int parIdx)
+    Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx)
     {
-        return Loader::AutoPtr(new LoaderNative(id, image, parIdx));
+        return Loader::UniquePtr(new LoaderNative(id, image, parIdx));
     }
 
     PreviewProperties LoaderNative::getProperties() const
@@ -504,7 +504,7 @@ namespace {
         const DataBuf data = getData();
         if (data.size_ == 0) return false;
         try {
-            Image::AutoPtr image = ImageFactory::open(data.pData_, data.size_);
+            Image::UniquePtr image = ImageFactory::open(data.pData_, data.size_);
             if (image.get() == 0) return false;
             image->readMetadata();
 
@@ -548,9 +548,9 @@ namespace {
         valid_ = true;
     }
 
-    Loader::AutoPtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx)
+    Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx)
     {
-        return Loader::AutoPtr(new LoaderExifJpeg(id, image, parIdx));
+        return Loader::UniquePtr(new LoaderExifJpeg(id, image, parIdx));
     }
 
     PreviewProperties LoaderExifJpeg::getProperties() const
@@ -593,7 +593,7 @@ namespace {
         const Exiv2::byte* base = io.mmap();
 
         try {
-            Image::AutoPtr image = ImageFactory::open(base + offset_, size_);
+            Image::UniquePtr image = ImageFactory::open(base + offset_, size_);
             if (image.get() == 0) return false;
             image->readMetadata();
 
@@ -626,9 +626,9 @@ namespace {
         valid_ = true;
     }
 
-    Loader::AutoPtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx)
+    Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx)
     {
-        return Loader::AutoPtr(new LoaderExifDataJpeg(id, image, parIdx));
+        return Loader::UniquePtr(new LoaderExifDataJpeg(id, image, parIdx));
     }
 
     PreviewProperties LoaderExifDataJpeg::getProperties() const
@@ -670,7 +670,7 @@ namespace {
         if (buf.size_ == 0) return false;
 
         try {
-            Image::AutoPtr image = ImageFactory::open(buf.pData_, buf.size_);
+            Image::UniquePtr image = ImageFactory::open(buf.pData_, buf.size_);
             if (image.get() == 0) return false;
             image->readMetadata();
 
@@ -738,9 +738,9 @@ namespace {
         valid_ = true;
     }
 
-    Loader::AutoPtr createLoaderTiff(PreviewId id, const Image &image, int parIdx)
+    Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx)
     {
-        return Loader::AutoPtr(new LoaderTiff(id, image, parIdx));
+        return Loader::UniquePtr(new LoaderTiff(id, image, parIdx));
     }
 
     PreviewProperties LoaderTiff::getProperties() const
@@ -859,9 +859,9 @@ namespace {
         valid_ = true;
     }
 
-    Loader::AutoPtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx)
+    Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx)
     {
-        return Loader::AutoPtr(new LoaderXmpJpeg(id, image, parIdx));
+        return Loader::UniquePtr(new LoaderXmpJpeg(id, image, parIdx));
     }
 
     PreviewProperties LoaderXmpJpeg::getProperties() const
@@ -1137,7 +1137,7 @@ namespace Exiv2 {
         PreviewPropertiesList list;
         // go through the loader table and store all successfully created loaders in the list
         for (PreviewId id = 0; id < Loader::getNumLoaders(); ++id) {
-            Loader::AutoPtr loader = Loader::create(id, image_);
+            Loader::UniquePtr loader = Loader::create(id, image_);
             if (loader.get() && loader->readDimensions()) {
                 PreviewProperties props = loader->getProperties();
                 DataBuf buf             = loader->getData(); // #16 getPreviewImage()
@@ -1151,7 +1151,7 @@ namespace Exiv2 {
 
     PreviewImage PreviewManager::getPreviewImage(const PreviewProperties &properties) const
     {
-        Loader::AutoPtr loader = Loader::create(properties.id_, image_);
+        Loader::UniquePtr loader = Loader::create(properties.id_, image_);
         DataBuf buf;
         if (loader.get()) {
             buf = loader->getData();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2756,9 +2756,9 @@ namespace Exiv2 {
         return *this;
     }
 
-    XmpKey::AutoPtr XmpKey::clone() const
+    XmpKey::UniquePtr XmpKey::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     XmpKey* XmpKey::clone_() const

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -122,7 +122,7 @@ enum {
 namespace Exiv2 {
 
     PsdImage::PsdImage(BasicIo::UniquePtr io)
-        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, std::move(io))
     {
     } // PsdImage::PsdImage
 
@@ -679,7 +679,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new PsdImage(io));
+        Image::UniquePtr image(new PsdImage(std::move(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -121,7 +121,7 @@ enum {
 // class member definitions
 namespace Exiv2 {
 
-    PsdImage::PsdImage(BasicIo::AutoPtr io)
+    PsdImage::PsdImage(BasicIo::UniquePtr io)
         : Image(ImageType::psd, mdExif | mdIptc | mdXmp, io)
     {
     } // PsdImage::PsdImage
@@ -344,7 +344,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -677,9 +677,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newPsdInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new PsdImage(io));
+        Image::UniquePtr image(new PsdImage(io));
         if (!image->good())
         {
             image.reset();

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -607,7 +607,7 @@ namespace Exiv2 {
 
     using namespace Exiv2::Internal;
 
-    QuickTimeVideo::QuickTimeVideo(BasicIo::AutoPtr io)
+    QuickTimeVideo::QuickTimeVideo(BasicIo::UniquePtr io)
             : Image(ImageType::qtime, mdNone, io)
             , timeScale_(1)
     {
@@ -1393,7 +1393,7 @@ namespace Exiv2 {
         DataBuf buf(5);
         std::memset(buf.pData_, 0x0, buf.size_);
         buf.pData_[4] = '\0';
-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
         const TagVocabulary* td;
 
         for (int i = 0; size/4 != 0; size -=4, i++) {
@@ -1627,8 +1627,8 @@ namespace Exiv2 {
     } // QuickTimeVideo::aspectRatio
 
 
-    Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool /*create*/) {
-        Image::AutoPtr image(new QuickTimeVideo(io));
+    Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool /*create*/) {
+        Image::UniquePtr image(new QuickTimeVideo(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -608,7 +608,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     QuickTimeVideo::QuickTimeVideo(BasicIo::UniquePtr io)
-            : Image(ImageType::qtime, mdNone, io)
+            : Image(ImageType::qtime, mdNone, std::move(io))
             , timeScale_(1)
     {
     } // QuickTimeVideo::QuickTimeVideo
@@ -1628,7 +1628,7 @@ namespace Exiv2 {
 
 
     Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool /*create*/) {
-        Image::UniquePtr image(new QuickTimeVideo(io));
+        Image::UniquePtr image(new QuickTimeVideo(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -47,7 +47,7 @@
 namespace Exiv2 {
 
     RafImage::RafImage(BasicIo::UniquePtr io, bool /*create*/)
-        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, std::move(io))
     {
     } // RafImage::RafImage
 
@@ -327,7 +327,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new RafImage(io, create));
+        Image::UniquePtr image(new RafImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -46,7 +46,7 @@
 // class member definitions
 namespace Exiv2 {
 
-    RafImage::RafImage(BasicIo::AutoPtr io, bool /*create*/)
+    RafImage::RafImage(BasicIo::UniquePtr io, bool /*create*/)
         : Image(ImageType::raf, mdExif | mdIptc | mdXmp, io)
     {
     } // RafImage::RafImage
@@ -325,9 +325,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newRafInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new RafImage(io, create));
+        Image::UniquePtr image(new RafImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -502,7 +502,7 @@ namespace Exiv2 {
 namespace Exiv2 {
     using namespace Exiv2::Internal;
 
-    RiffVideo::RiffVideo(BasicIo::AutoPtr io)
+    RiffVideo::RiffVideo(BasicIo::UniquePtr io)
             : Image(ImageType::riff, mdNone, io)
     {
     } // RiffVideo::RiffVideo
@@ -578,7 +578,7 @@ namespace Exiv2 {
 
                 if ( equalsRiffTag(chunkId, RIFF_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
                     // create memio object with the payload, then print the structure
-                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(payload.pData_,payload.size_));
+                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.pData_,payload.size_));
                     printTiffStructure(*p,out,option,depth);
                 }
 
@@ -1304,9 +1304,9 @@ namespace Exiv2 {
         xmpData_["Xmp.video.Duration"] = duration; //Duration in number of seconds
     } // RiffVideo::fillDuration
 
-    Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new RiffVideo(io));
+        Image::UniquePtr image(new RiffVideo(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -503,7 +503,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     RiffVideo::RiffVideo(BasicIo::UniquePtr io)
-            : Image(ImageType::riff, mdNone, io)
+             : Image(ImageType::riff, mdNone, std::move(io))
     {
     } // RiffVideo::RiffVideo
 
@@ -1306,7 +1306,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new RiffVideo(io));
+        Image::UniquePtr image(new RiffVideo(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     Rw2Image::Rw2Image(BasicIo::UniquePtr io)
-        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, std::move(io))
     {
     } // Rw2Image::Rw2Image
 
@@ -249,7 +249,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new Rw2Image(io));
+        Image::UniquePtr image(new Rw2Image(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -48,7 +48,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    Rw2Image::Rw2Image(BasicIo::AutoPtr io)
+    Rw2Image::Rw2Image(BasicIo::UniquePtr io)
         : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, io)
     {
     } // Rw2Image::Rw2Image
@@ -148,7 +148,7 @@ namespace Exiv2 {
         if (list.size() != 1) return;
         ExifData exifData;
         PreviewImage preview = loader.getPreviewImage(*list.begin());
-        Image::AutoPtr image = ImageFactory::open(preview.pData(), preview.size());
+        Image::UniquePtr image = ImageFactory::open(preview.pData(), preview.size());
         if (image.get() == 0) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to open RW2 preview image.\n";
@@ -247,9 +247,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newRw2Instance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new Rw2Image(io));
+        Image::UniquePtr image(new Rw2Image(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -3229,9 +3229,9 @@ namespace Exiv2 {
         return p_->tag_;
     }
 
-    ExifKey::AutoPtr ExifKey::clone() const
+    ExifKey::UniquePtr ExifKey::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     ExifKey* ExifKey::clone_() const

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -43,7 +43,7 @@
 namespace Exiv2 {
 
     TgaImage::TgaImage(BasicIo::UniquePtr io)
-        : Image(ImageType::tga, mdNone, io)
+        : Image(ImageType::tga, mdNone, std::move(io))
     {
     } // TgaImage::TgaImage
 
@@ -128,7 +128,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new TgaImage(io));
+        Image::UniquePtr image(new TgaImage(std::move(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -42,7 +42,7 @@
 // class member definitions
 namespace Exiv2 {
 
-    TgaImage::TgaImage(BasicIo::AutoPtr io)
+    TgaImage::TgaImage(BasicIo::UniquePtr io)
         : Image(ImageType::tga, mdNone, io)
     {
     } // TgaImage::TgaImage
@@ -126,9 +126,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newTgaInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new TgaImage(io));
+        Image::UniquePtr image(new TgaImage(io));
         if (!image->good())
         {
             image.reset();

--- a/src/tiff-test.cpp
+++ b/src/tiff-test.cpp
@@ -30,7 +30,7 @@ void print(const ExifData& exifData);
 
 int main()
 try {
-    BasicIo::AutoPtr io(new FileIo("image.tif"));
+    BasicIo::UniquePtr io(new FileIo("image.tif"));
     TiffImage tiffImage(io, false);
     ExifData& exifData = tiffImage.exifData();
     exifData["Exif.Image.ImageWidth"] = uint32_t(42);

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -289,9 +289,9 @@ namespace Exiv2 {
     {
     }
 
-    TiffComponent::AutoPtr TiffComponent::clone() const
+    TiffComponent::UniquePtr TiffComponent::clone() const
     {
-        return AutoPtr(doClone());
+        return UniquePtr(doClone());
     }
 
     TiffEntry* TiffEntry::doClone() const
@@ -373,7 +373,7 @@ namespace Exiv2 {
         if (pData_ == 0) size_ = 0;
     }
 
-    void TiffEntryBase::updateValue(Value::AutoPtr value, ByteOrder byteOrder)
+    void TiffEntryBase::updateValue(Value::UniquePtr value, ByteOrder byteOrder)
     {
         if (value.get() == 0) return;
         uint32_t newSize = value->size();
@@ -386,7 +386,7 @@ namespace Exiv2 {
         setValue(value);
     } // TiffEntryBase::updateValue
 
-    void TiffEntryBase::setValue(Value::AutoPtr value)
+    void TiffEntryBase::setValue(Value::UniquePtr value)
     {
         if (value.get() == 0) return;
         tiffType_ = toTiffType(value->typeId());
@@ -613,7 +613,7 @@ namespace Exiv2 {
     {
         uint16_t tag = static_cast<uint16_t>(idx / cfg()->tagStep());
         int32_t sz = EXV_MIN(def.size(tag, cfg()->group_), TiffEntryBase::doSize() - idx);
-        TiffComponent::AutoPtr tc = TiffCreator::create(tag, cfg()->group_);
+        TiffComponent::UniquePtr tc = TiffCreator::create(tag, cfg()->group_);
         TiffBinaryElement* tp = dynamic_cast<TiffBinaryElement*>(tc.get());
         // The assertion typically fails if a component is not configured in
         // the TIFF structure table (TiffCreator::tiffTreeStruct_)
@@ -629,7 +629,7 @@ namespace Exiv2 {
     TiffComponent* TiffComponent::addPath(uint16_t tag,
                                           TiffPath& tiffPath,
                                           TiffComponent* const pRoot,
-                                          TiffComponent::AutoPtr object)
+                                          TiffComponent::UniquePtr object)
     {
         return doAddPath(tag, tiffPath, pRoot, object);
     } // TiffComponent::addPath
@@ -637,7 +637,7 @@ namespace Exiv2 {
     TiffComponent* TiffComponent::doAddPath(uint16_t  /*tag*/,
                                             TiffPath& /*tiffPath*/,
                                             TiffComponent* const /*pRoot*/,
-                                            TiffComponent::AutoPtr /*object*/)
+                                            TiffComponent::UniquePtr /*object*/)
     {
         return this;
     } // TiffComponent::doAddPath
@@ -645,7 +645,7 @@ namespace Exiv2 {
     TiffComponent* TiffDirectory::doAddPath(uint16_t tag,
                                             TiffPath& tiffPath,
                                             TiffComponent* const pRoot,
-                                            TiffComponent::AutoPtr object)
+                                            TiffComponent::UniquePtr object)
     {
         assert(tiffPath.size() > 1);
         tiffPath.pop();
@@ -671,7 +671,7 @@ namespace Exiv2 {
             }
         }
         if (tc == 0) {
-            TiffComponent::AutoPtr atc;
+            TiffComponent::UniquePtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
                 atc = object;
             }
@@ -697,7 +697,7 @@ namespace Exiv2 {
     TiffComponent* TiffSubIfd::doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object)
+                                         TiffComponent::UniquePtr object)
     {
         assert(!tiffPath.empty());
         const TiffPathItem tpi1 = tiffPath.top();
@@ -721,7 +721,7 @@ namespace Exiv2 {
                 tc = addChild(object);
             }
             else {
-                TiffComponent::AutoPtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
+                TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
                 tc = addChild(atc);
             }
             setCount(static_cast<uint32_t>(ifds_.size()));
@@ -732,7 +732,7 @@ namespace Exiv2 {
     TiffComponent* TiffMnEntry::doAddPath(uint16_t tag,
                                           TiffPath& tiffPath,
                                           TiffComponent* const pRoot,
-                                          TiffComponent::AutoPtr object)
+                                          TiffComponent::UniquePtr object)
     {
         assert(!tiffPath.empty());
         const TiffPathItem tpi1 = tiffPath.top();
@@ -754,7 +754,7 @@ namespace Exiv2 {
     TiffComponent* TiffIfdMakernote::doAddPath(uint16_t tag,
                                                TiffPath& tiffPath,
                                                TiffComponent* const pRoot,
-                                               TiffComponent::AutoPtr object)
+                                               TiffComponent::UniquePtr object)
     {
         return ifd_.addPath(tag, tiffPath, pRoot, object);
     }
@@ -762,7 +762,7 @@ namespace Exiv2 {
     TiffComponent* TiffBinaryArray::doAddPath(uint16_t tag,
                                               TiffPath& tiffPath,
                                               TiffComponent* const pRoot,
-                                              TiffComponent::AutoPtr object)
+                                              TiffComponent::UniquePtr object)
     {
         pRoot_ = pRoot;
         if (tiffPath.size() == 1) {
@@ -786,7 +786,7 @@ namespace Exiv2 {
             }
         }
         if (tc == 0) {
-            TiffComponent::AutoPtr atc;
+            TiffComponent::UniquePtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
                 atc = object;
             }
@@ -801,24 +801,24 @@ namespace Exiv2 {
         return tc->addPath(tag, tiffPath, pRoot, object);
     } // TiffBinaryArray::doAddPath
 
-    TiffComponent* TiffComponent::addChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffComponent::addChild(TiffComponent::UniquePtr tiffComponent)
     {
         return doAddChild(tiffComponent);
     } // TiffComponent::addChild
 
-    TiffComponent* TiffComponent::doAddChild(AutoPtr /*tiffComponent*/)
+    TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/)
     {
         return 0;
     } // TiffComponent::doAddChild
 
-    TiffComponent* TiffDirectory::doAddChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
         TiffComponent* tc = tiffComponent.release();
         components_.push_back(tc);
         return tc;
     } // TiffDirectory::doAddChild
 
-    TiffComponent* TiffSubIfd::doAddChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffSubIfd::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
         TiffDirectory* d = dynamic_cast<TiffDirectory*>(tiffComponent.release());
         assert(d);
@@ -826,7 +826,7 @@ namespace Exiv2 {
         return d;
     } // TiffSubIfd::doAddChild
 
-    TiffComponent* TiffMnEntry::doAddChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffMnEntry::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
         TiffComponent* tc = 0;
         if (mn_) {
@@ -835,12 +835,12 @@ namespace Exiv2 {
         return tc;
     } // TiffMnEntry::doAddChild
 
-    TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
         return ifd_.addChild(tiffComponent);
     }
 
-    TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
         TiffComponent* tc = tiffComponent.release();
         elements_.push_back(tc);
@@ -848,17 +848,17 @@ namespace Exiv2 {
         return tc;
     } // TiffBinaryArray::doAddChild
 
-    TiffComponent* TiffComponent::addNext(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffComponent::addNext(TiffComponent::UniquePtr tiffComponent)
     {
         return doAddNext(tiffComponent);
     } // TiffComponent::addNext
 
-    TiffComponent* TiffComponent::doAddNext(AutoPtr /*tiffComponent*/)
+    TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
     {
         return 0;
     } // TiffComponent::doAddNext
 
-    TiffComponent* TiffDirectory::doAddNext(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
         TiffComponent* tc = 0;
         if (hasNext_) {
@@ -868,7 +868,7 @@ namespace Exiv2 {
         return tc;
     } // TiffDirectory::doAddNext
 
-    TiffComponent* TiffMnEntry::doAddNext(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffMnEntry::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
         TiffComponent* tc = 0;
         if (mn_) {
@@ -877,7 +877,7 @@ namespace Exiv2 {
         return tc;
     } // TiffMnEntry::doAddNext
 
-    TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::AutoPtr tiffComponent)
+    TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
         return ifd_.addNext(tiffComponent);
     }
@@ -1881,19 +1881,19 @@ namespace Exiv2 {
         return lhs->group() < rhs->group();
     }
 
-    TiffComponent::AutoPtr newTiffEntry(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(new TiffEntry(tag, group));
+        return TiffComponent::UniquePtr(new TiffEntry(tag, group));
     }
 
-    TiffComponent::AutoPtr newTiffMnEntry(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffMnEntry(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(new TiffMnEntry(tag, group, mnId));
+        return TiffComponent::UniquePtr(new TiffMnEntry(tag, group, mnId));
     }
 
-    TiffComponent::AutoPtr newTiffBinaryElement(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffBinaryElement(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(new TiffBinaryElement(tag, group));
+        return TiffComponent::UniquePtr(new TiffBinaryElement(tag, group));
     }
 
 }}                                      // namespace Internal, Exiv2

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -383,7 +383,7 @@ namespace Exiv2 {
         memset(pData_, 0x0, size_);
         size_ = value->copy(pData_, byteOrder);
         assert(size_ == newSize);
-        setValue(value);
+        setValue(std::move(value));
     } // TiffEntryBase::updateValue
 
     void TiffEntryBase::setValue(Value::UniquePtr value)
@@ -622,7 +622,7 @@ namespace Exiv2 {
         tp->setData(const_cast<byte*>(pData() + idx), sz);
         tp->setElDef(def);
         tp->setElByteOrder(cfg()->byteOrder_);
-        addChild(tc);
+        addChild(std::move(tc));
         return sz;
     } // TiffBinaryArray::addElement
 
@@ -631,7 +631,7 @@ namespace Exiv2 {
                                           TiffComponent* const pRoot,
                                           TiffComponent::UniquePtr object)
     {
-        return doAddPath(tag, tiffPath, pRoot, object);
+        return doAddPath(tag, tiffPath, pRoot, std::move(object));
     } // TiffComponent::addPath
 
     TiffComponent* TiffComponent::doAddPath(uint16_t  /*tag*/,
@@ -673,7 +673,7 @@ namespace Exiv2 {
         if (tc == 0) {
             TiffComponent::UniquePtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
-                atc = object;
+                atc = std::move(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
@@ -685,13 +685,13 @@ namespace Exiv2 {
             if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != 0) return 0;
 
             if (tpi.extendedTag() == Tag::next) {
-                tc = this->addNext(atc);
+                tc = this->addNext(std::move(atc));
             }
             else {
-                tc = this->addChild(atc);
+                tc = this->addChild(std::move(atc));
             }
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
     } // TiffDirectory::doAddPath
 
     TiffComponent* TiffSubIfd::doAddPath(uint16_t tag,
@@ -718,15 +718,14 @@ namespace Exiv2 {
         }
         if (tc == 0) {
             if (tiffPath.size() == 1 && object.get() != 0) {
-                tc = addChild(object);
+                tc = addChild(std::move(object));
             }
             else {
-                TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
-                tc = addChild(atc);
+		tc = addChild(TiffComponent::UniquePtr(new TiffDirectory(tpi1.tag(), tpi2.group())));
             }
             setCount(static_cast<uint32_t>(ifds_.size()));
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
     } // TiffSubIfd::doAddPath
 
     TiffComponent* TiffMnEntry::doAddPath(uint16_t tag,
@@ -748,7 +747,7 @@ namespace Exiv2 {
             mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
             assert(mn_);
         }
-        return mn_->addPath(tag, tiffPath, pRoot, object);
+        return mn_->addPath(tag, tiffPath, pRoot, std::move(object));
     } // TiffMnEntry::doAddPath
 
     TiffComponent* TiffIfdMakernote::doAddPath(uint16_t tag,
@@ -756,7 +755,7 @@ namespace Exiv2 {
                                                TiffComponent* const pRoot,
                                                TiffComponent::UniquePtr object)
     {
-        return ifd_.addPath(tag, tiffPath, pRoot, object);
+        return ifd_.addPath(tag, tiffPath, pRoot, std::move(object));
     }
 
     TiffComponent* TiffBinaryArray::doAddPath(uint16_t tag,
@@ -788,22 +787,22 @@ namespace Exiv2 {
         if (tc == 0) {
             TiffComponent::UniquePtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
-                atc = object;
+                atc = std::move(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
             assert(atc.get() != 0);
             assert(tpi.extendedTag() != Tag::next);
-            tc = addChild(atc);
+            tc = addChild(std::move(atc));
             setCount(static_cast<uint32_t>(elements_.size()));
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
     } // TiffBinaryArray::doAddPath
 
     TiffComponent* TiffComponent::addChild(TiffComponent::UniquePtr tiffComponent)
     {
-        return doAddChild(tiffComponent);
+        return doAddChild(std::move(tiffComponent));
     } // TiffComponent::addChild
 
     TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/)
@@ -830,14 +829,14 @@ namespace Exiv2 {
     {
         TiffComponent* tc = 0;
         if (mn_) {
-            tc =  mn_->addChild(tiffComponent);
+            tc =  mn_->addChild(std::move(tiffComponent));
         }
         return tc;
     } // TiffMnEntry::doAddChild
 
     TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
-        return ifd_.addChild(tiffComponent);
+        return ifd_.addChild(std::move(tiffComponent));
     }
 
     TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::UniquePtr tiffComponent)
@@ -850,7 +849,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::addNext(TiffComponent::UniquePtr tiffComponent)
     {
-        return doAddNext(tiffComponent);
+        return doAddNext(std::move(tiffComponent));
     } // TiffComponent::addNext
 
     TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
@@ -872,14 +871,14 @@ namespace Exiv2 {
     {
         TiffComponent* tc = 0;
         if (mn_) {
-            tc = mn_->addNext(tiffComponent);
+            tc = mn_->addNext(std::move(tiffComponent));
         }
         return tc;
     } // TiffMnEntry::doAddNext
 
     TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        return ifd_.addNext(tiffComponent);
+        return ifd_.addNext(std::move(tiffComponent));
     }
 
     void TiffComponent::accept(TiffVisitor& visitor)

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -827,7 +827,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc =  mn_->addChild(std::move(tiffComponent));
         }
@@ -854,12 +854,12 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
     {
-        return 0;
+        return nullptr;
     } // TiffComponent::doAddNext
 
     TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (hasNext_) {
             tc = tiffComponent.release();
             pNext_ = tc;
@@ -869,7 +869,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc = mn_->addNext(std::move(tiffComponent));
         }

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -174,8 +174,8 @@ namespace Exiv2 {
      */
     class TiffComponent {
     public:
-        //! TiffComponent auto_ptr type
-        typedef std::auto_ptr<TiffComponent> AutoPtr;
+        //! TiffComponent unique_ptr type
+        typedef std::unique_ptr<TiffComponent> UniquePtr;
         //! Container type to hold all metadata
         typedef std::vector<TiffComponent*> Components;
 
@@ -204,20 +204,20 @@ namespace Exiv2 {
         TiffComponent* addPath(uint16_t tag,
                                TiffPath& tiffPath,
                                TiffComponent* const pRoot,
-                               AutoPtr object =AutoPtr(0));
+                               UniquePtr object =UniquePtr(0));
         /*!
           @brief Add a child to the component. Default is to do nothing.
           @param tiffComponent Auto pointer to the component to add.
           @return Return a pointer to the newly added child element or 0.
          */
-        TiffComponent* addChild(AutoPtr tiffComponent);
+        TiffComponent* addChild(UniquePtr tiffComponent);
         /*!
             @brief Add a "next" component to the component. Default is to do
                    nothing.
             @param tiffComponent Auto pointer to the component to add.
             @return Return a pointer to the newly added "next" element or 0.
          */
-        TiffComponent* addNext(AutoPtr tiffComponent);
+        TiffComponent* addNext(UniquePtr tiffComponent);
         /*!
           @brief Interface to accept visitors (Visitor pattern). Visitors
                  can perform operations on all components of the composite.
@@ -266,7 +266,7 @@ namespace Exiv2 {
                  without any children). The caller owns this copy and the
                  auto-pointer ensures that it will be deleted.
          */
-        AutoPtr clone() const;
+        UniquePtr clone() const;
         /*!
           @brief Write the IFD data of this component to a binary image.
                  Return the number of bytes written. Components derived from
@@ -322,11 +322,11 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t  tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
+                                         TiffComponent::UniquePtr object);
         //! Implements addChild(). The default implementation does nothing.
-        virtual TiffComponent* doAddChild(AutoPtr tiffComponent);
+        virtual TiffComponent* doAddChild(UniquePtr tiffComponent);
         //! Implements addNext(). The default implementation does nothing.
-        virtual TiffComponent* doAddNext(AutoPtr tiffComponent);
+        virtual TiffComponent* doAddNext(UniquePtr tiffComponent);
         //! Implements accept().
         virtual void doAccept(TiffVisitor& visitor) =0;
         //! Implements write().
@@ -446,13 +446,13 @@ namespace Exiv2 {
 
           Update binary value data and call setValue().
         */
-        void updateValue(Value::AutoPtr value, ByteOrder byteOrder);
+        void updateValue(Value::UniquePtr value, ByteOrder byteOrder);
         /*!
           @brief Set tag value. Takes ownership of the pointer passed in.
 
           Update type, count and the pointer to the value.
         */
-        void setValue(Value::AutoPtr value);
+        void setValue(Value::UniquePtr value);
         //@}
 
         //! @name Accessors
@@ -889,9 +889,9 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
+                                         TiffComponent::UniquePtr object);
+        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
+        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
         virtual void doAccept(TiffVisitor& visitor);
         /*!
           @brief Implements write(). Write the TIFF directory, values and
@@ -1005,8 +1005,8 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
+                                         TiffComponent::UniquePtr object);
+        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
         virtual void doAccept(TiffVisitor& visitor);
         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
         /*!
@@ -1090,9 +1090,9 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
+                                         TiffComponent::UniquePtr object);
+        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
+        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
         virtual void doAccept(TiffVisitor& visitor);
         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
         /*!
@@ -1222,9 +1222,9 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
+                                         TiffComponent::UniquePtr object);
+        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
+        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
         virtual void doAccept(TiffVisitor& visitor);
         /*!
           @brief Implements write(). Write the Makernote header, TIFF directory,
@@ -1436,11 +1436,11 @@ namespace Exiv2 {
         virtual TiffComponent* doAddPath(uint16_t tag,
                                          TiffPath& tiffPath,
                                          TiffComponent* const pRoot,
-                                         TiffComponent::AutoPtr object);
+                                         TiffComponent::UniquePtr object);
         /*!
           @brief Implements addChild(). Todo: Document it!
          */
-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
+        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
         virtual void doAccept(TiffVisitor& visitor);
         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
         /*!
@@ -1584,83 +1584,83 @@ namespace Exiv2 {
     bool cmpGroupLt(TiffComponent const* lhs, TiffComponent const* rhs);
 
     //! Function to create and initialize a new TIFF entry
-    TiffComponent::AutoPtr newTiffEntry(uint16_t tag, IfdId group);
+    TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group);
 
     //! Function to create and initialize a new TIFF makernote entry
-    TiffComponent::AutoPtr newTiffMnEntry(uint16_t tag, IfdId group);
+    TiffComponent::UniquePtr newTiffMnEntry(uint16_t tag, IfdId group);
 
     //! Function to create and initialize a new binary array element
-    TiffComponent::AutoPtr newTiffBinaryElement(uint16_t tag, IfdId group);
+    TiffComponent::UniquePtr newTiffBinaryElement(uint16_t tag, IfdId group);
 
     //! Function to create and initialize a new TIFF directory
     template<IfdId newGroup>
-    TiffComponent::AutoPtr newTiffDirectory(uint16_t tag, IfdId /*group*/)
+    TiffComponent::UniquePtr newTiffDirectory(uint16_t tag, IfdId /*group*/)
     {
-        return TiffComponent::AutoPtr(new TiffDirectory(tag, newGroup));
+        return TiffComponent::UniquePtr(new TiffDirectory(tag, newGroup));
     }
 
     //! Function to create and initialize a new TIFF sub-directory
     template<IfdId newGroup>
-    TiffComponent::AutoPtr newTiffSubIfd(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffSubIfd(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(new TiffSubIfd(tag, group, newGroup));
+        return TiffComponent::UniquePtr(new TiffSubIfd(tag, group, newGroup));
     }
 
     //! Function to create and initialize a new binary array entry
     template<const ArrayCfg* arrayCfg, int N, const ArrayDef (&arrayDef)[N]>
-    TiffComponent::AutoPtr newTiffBinaryArray0(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffBinaryArray0(uint16_t tag, IfdId group)
     {
         // *& acrobatics is a workaround for a MSVC 7.1 bug
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffBinaryArray(tag, group, arrayCfg, *(&arrayDef), N));
     }
 
     //! Function to create and initialize a new simple binary array entry
     template<const ArrayCfg* arrayCfg>
-    TiffComponent::AutoPtr newTiffBinaryArray1(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffBinaryArray1(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffBinaryArray(tag, group, arrayCfg, 0, 0));
     }
 
     //! Function to create and initialize a new complex binary array entry
     template<const ArraySet* arraySet, int N, CfgSelFct cfgSelFct>
-    TiffComponent::AutoPtr newTiffBinaryArray2(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffBinaryArray2(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffBinaryArray(tag, group, arraySet, N, cfgSelFct));
     }
 
     //! Function to create and initialize a new TIFF entry for a thumbnail (data)
     template<uint16_t szTag, IfdId szGroup>
-    TiffComponent::AutoPtr newTiffThumbData(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffThumbData(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffDataEntry(tag, group, szTag, szGroup));
     }
 
     //! Function to create and initialize a new TIFF entry for a thumbnail (size)
     template<uint16_t dtTag, IfdId dtGroup>
-    TiffComponent::AutoPtr newTiffThumbSize(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffThumbSize(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffSizeEntry(tag, group, dtTag, dtGroup));
     }
 
     //! Function to create and initialize a new TIFF entry for image data
     template<uint16_t szTag, IfdId szGroup>
-    TiffComponent::AutoPtr newTiffImageData(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffImageData(uint16_t tag, IfdId group)
     {
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffImageEntry(tag, group, szTag, szGroup));
     }
 
     //! Function to create and initialize a new TIFF entry for image data (size)
     template<uint16_t dtTag, IfdId dtGroup>
-    TiffComponent::AutoPtr newTiffImageSize(uint16_t tag, IfdId group)
+    TiffComponent::UniquePtr newTiffImageSize(uint16_t tag, IfdId group)
     {
         // Todo: Same as newTiffThumbSize - consolidate (rename)?
-        return TiffComponent::AutoPtr(
+        return TiffComponent::UniquePtr(
             new TiffSizeEntry(tag, group, dtTag, dtGroup));
     }
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -204,7 +204,7 @@ namespace Exiv2 {
         TiffComponent* addPath(uint16_t tag,
                                TiffPath& tiffPath,
                                TiffComponent* const pRoot,
-                               UniquePtr object =UniquePtr(0));
+                               UniquePtr object =UniquePtr(nullptr));
         /*!
           @brief Add a child to the component. Default is to do nothing.
           @param tiffComponent Auto pointer to the component to add.

--- a/src/tifffwd_int.hpp
+++ b/src/tifffwd_int.hpp
@@ -103,10 +103,10 @@ namespace Exiv2 {
     );
     /*!
       @brief Type for a function pointer for a function to create a TIFF component.
-             Use TiffComponent::AutoPtr, it is not used in this declaration only
+             Use TiffComponent::UniquePtr, it is not used in this declaration only
              to reduce dependencies.
      */
-    typedef std::auto_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
+    typedef std::unique_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
 
     //! Stack to hold a path from the TIFF root element to a TIFF entry
     typedef std::stack<TiffPathItem> TiffPath;

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -71,7 +71,7 @@ namespace Exiv2 {
 
     using namespace Internal;
 
-    TiffImage::TiffImage(BasicIo::AutoPtr io, bool /*create*/)
+    TiffImage::TiffImage(BasicIo::UniquePtr io, bool /*create*/)
         : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, io),
           pixelWidth_(0), pixelHeight_(0)
     {
@@ -289,7 +289,7 @@ namespace Exiv2 {
                      ed.end());
         }
 
-        std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
+        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
         return TiffParserWorker::encode(io,
                                         pData,
                                         size,
@@ -304,9 +304,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newTiffInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new TiffImage(io, create));
+        Image::UniquePtr image(new TiffImage(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -72,7 +72,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     TiffImage::TiffImage(BasicIo::UniquePtr io, bool /*create*/)
-        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, io),
+        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, std::move(io)),
           pixelWidth_(0), pixelHeight_(0)
     {
     } // TiffImage::TiffImage
@@ -306,7 +306,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new TiffImage(io, create));
+        Image::UniquePtr image(new TiffImage(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1495,7 +1495,7 @@ namespace Exiv2 {
     TiffComponent::UniquePtr TiffCreator::create(uint32_t extendedTag,
                                                IfdId    group)
     {
-        TiffComponent::UniquePtr tc(0);
+        TiffComponent::UniquePtr tc(nullptr);
         uint16_t tag = static_cast<uint16_t>(extendedTag & 0xffff);
         const TiffGroupStruct* ts = find(tiffGroupStruct_,
                                          TiffGroupStruct::Key(extendedTag, group));
@@ -1653,7 +1653,7 @@ namespace Exiv2 {
               TiffHeaderBase*    pHeader
     )
     {
-        if (pData == 0 || size == 0) return TiffComponent::UniquePtr(0);
+        if (pData == 0 || size == 0) return TiffComponent::UniquePtr(nullptr);
         if (!pHeader->read(pData, size) || pHeader->offset() >= size) {
             throw Error(kerNotAnImage, "TIFF");
         }

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1492,10 +1492,10 @@ namespace Exiv2 {
         return key.r_ == root_ && key.g_ == group_;
     }
 
-    TiffComponent::AutoPtr TiffCreator::create(uint32_t extendedTag,
+    TiffComponent::UniquePtr TiffCreator::create(uint32_t extendedTag,
                                                IfdId    group)
     {
-        TiffComponent::AutoPtr tc(0);
+        TiffComponent::UniquePtr tc(0);
         uint16_t tag = static_cast<uint16_t>(extendedTag & 0xffff);
         const TiffGroupStruct* ts = find(tiffGroupStruct_,
                                          TiffGroupStruct::Key(extendedTag, group));
@@ -1546,12 +1546,12 @@ namespace Exiv2 {
     )
     {
         // Create standard TIFF header if necessary
-        std::auto_ptr<TiffHeaderBase> ph;
+        std::unique_ptr<TiffHeaderBase> ph;
         if (!pHeader) {
-            ph = std::auto_ptr<TiffHeaderBase>(new TiffHeader);
+            ph = std::unique_ptr<TiffHeaderBase>(new TiffHeader);
             pHeader = ph.get();
         }
-        TiffComponent::AutoPtr rootDir = parse(pData, size, root, pHeader);
+        TiffComponent::UniquePtr rootDir = parse(pData, size, root, pHeader);
         if (0 != rootDir.get()) {
             TiffDecoder decoder(exifData,
                                 iptcData,
@@ -1587,7 +1587,7 @@ namespace Exiv2 {
         assert(pHeader);
         assert(pHeader->byteOrder() != invalidByteOrder);
         WriteMethod writeMethod = wmIntrusive;
-        TiffComponent::AutoPtr parsedTree = parse(pData, size, root, pHeader);
+        TiffComponent::UniquePtr parsedTree = parse(pData, size, root, pHeader);
         PrimaryGroups primaryGroups;
         findPrimaryGroups(primaryGroups, parsedTree.get());
         if (0 != parsedTree.get()) {
@@ -1604,7 +1604,7 @@ namespace Exiv2 {
             if (!encoder.dirty()) writeMethod = wmNonIntrusive;
         }
         if (writeMethod == wmIntrusive) {
-            TiffComponent::AutoPtr createdTree = TiffCreator::create(root, ifdIdNotSet);
+            TiffComponent::UniquePtr createdTree = TiffCreator::create(root, ifdIdNotSet);
             if (0 != parsedTree.get()) {
                 // Copy image tags from the original image to the composite
                 TiffCopier copier(createdTree.get(), root, pHeader, &primaryGroups);
@@ -1622,7 +1622,7 @@ namespace Exiv2 {
             encoder.add(createdTree.get(), parsedTree.get(), root);
             // Write binary representation from the composite tree
             DataBuf header = pHeader->write();
-            BasicIo::AutoPtr tempIo(new MemIo);
+            BasicIo::UniquePtr tempIo(new MemIo);
             assert(tempIo.get() != 0);
             IoWrapper ioWrapper(*tempIo, header.pData_, header.size_, pOffsetWriter);
             uint32_t imageIdx(uint32_t(-1));
@@ -1646,18 +1646,18 @@ namespace Exiv2 {
         return writeMethod;
     } // TiffParserWorker::encode
 
-    TiffComponent::AutoPtr TiffParserWorker::parse(
+    TiffComponent::UniquePtr TiffParserWorker::parse(
         const byte*              pData,
               uint32_t           size,
               uint32_t           root,
               TiffHeaderBase*    pHeader
     )
     {
-        if (pData == 0 || size == 0) return TiffComponent::AutoPtr(0);
+        if (pData == 0 || size == 0) return TiffComponent::UniquePtr(0);
         if (!pHeader->read(pData, size) || pHeader->offset() >= size) {
             throw Error(kerNotAnImage, "TIFF");
         }
-        TiffComponent::AutoPtr rootDir = TiffCreator::create(root, ifdIdNotSet);
+        TiffComponent::UniquePtr rootDir = TiffCreator::create(root, ifdIdNotSet);
         if (0 != rootDir.get()) {
             rootDir->setStart(pData + pHeader->offset());
             TiffRwState state(pHeader->byteOrder(), 0);

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -257,7 +257,7 @@ namespace Exiv2 {
                  component creation function. If the pointer that is returned
                  is 0, then the TIFF entry should be ignored.
         */
-        static std::auto_ptr<TiffComponent> create(uint32_t extendedTag,
+        static std::unique_ptr<TiffComponent> create(uint32_t extendedTag,
                                                    IfdId    group);
         /*!
           @brief Get the path, i.e., a list of extended tag and group pairs, from
@@ -350,7 +350,7 @@ namespace Exiv2 {
                            composite structure. If \em pData is 0 or \em size
                            is 0, the return value is a 0 pointer.
          */
-        static std::auto_ptr<TiffComponent> parse(
+        static std::unique_ptr<TiffComponent> parse(
             const byte*              pData,
                   uint32_t           size,
                   uint32_t           root,

--- a/src/tiffmn-test.cpp
+++ b/src/tiffmn-test.cpp
@@ -48,7 +48,7 @@ catch (const Error& e) {
 
 void canonmn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "Canon";
@@ -61,7 +61,7 @@ void canonmn(const std::string& path)
 
 void fujimn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "FUJIFILM";
@@ -74,7 +74,7 @@ void fujimn(const std::string& path)
 
 void minoltamn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "Minolta";
@@ -87,7 +87,7 @@ void minoltamn(const std::string& path)
 
 void nikon1mn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "NIKON";
@@ -100,7 +100,7 @@ void nikon1mn(const std::string& path)
 
 void nikon2mn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "NIKON";
@@ -113,7 +113,7 @@ void nikon2mn(const std::string& path)
 
 void nikon3mn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "NIKON";
@@ -126,7 +126,7 @@ void nikon3mn(const std::string& path)
 
 void olympusmn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "OLYMPUS";
@@ -139,7 +139,7 @@ void olympusmn(const std::string& path)
 
 void panasonicmn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "Panasonic";
@@ -152,7 +152,7 @@ void panasonicmn(const std::string& path)
 
 void sigmamn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "SIGMA";
@@ -165,7 +165,7 @@ void sigmamn(const std::string& path)
 
 void sony1mn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "SONY";
@@ -178,7 +178,7 @@ void sony1mn(const std::string& path)
 
 void sony2mn(const std::string& path)
 {
-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
+    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
     ExifData& exifData = tiffImage.exifData();
 
     exifData["Exif.Image.Make"] = "SONY";

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1308,7 +1308,7 @@ namespace Exiv2 {
 #endif
                 return;
             }
-            TiffComponent::UniquePtr tc(0);
+            TiffComponent::UniquePtr tc(nullptr);
             uint32_t next = getLong(p, byteOrder());
             if (next) {
                 tc = TiffCreator::create(Tag::next, object->group());

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -212,7 +212,7 @@ namespace Exiv2 {
         assert(object != 0);
 
         if (pHeader_->isImageTag(object->tag(), object->group(), pPrimaryGroups_)) {
-            TiffComponent::AutoPtr clone = object->clone();
+            TiffComponent::UniquePtr clone = object->clone();
             // Assumption is that the corresponding TIFF entry doesn't exist
             TiffPath tiffPath;
             TiffCreator::getPath(tiffPath, object->tag(), object->group(), root_);
@@ -572,7 +572,7 @@ namespace Exiv2 {
             irbKey.setIdx(pos->idx());
         }
         if (rawIptc.size_ != 0 && (del || pos == exifData_.end())) {
-            Value::AutoPtr value = Value::create(unsignedLong);
+            Value::UniquePtr value = Value::create(unsignedLong);
             DataBuf buf;
             if (rawIptc.size_ % 4 != 0) {
                 // Pad the last unsignedLong value with 0s
@@ -596,7 +596,7 @@ namespace Exiv2 {
             irbBuf = Photoshop::setIptcIrb(irbBuf.pData_, irbBuf.size_, iptcData_);
             exifData_.erase(pos);
             if (irbBuf.size_ != 0) {
-                Value::AutoPtr value = Value::create(unsignedByte);
+                Value::UniquePtr value = Value::create(unsignedByte);
                 value->read(irbBuf.pData_, irbBuf.size_, invalidByteOrder);
                 Exifdatum iptcDatum(irbKey, value.get());
                 exifData_.add(iptcDatum);
@@ -626,7 +626,7 @@ namespace Exiv2 {
         }
         if (!xmpPacket.empty()) {
             // Set the XMP Exif tag to the new value
-            Value::AutoPtr value = Value::create(unsignedByte);
+            Value::UniquePtr value = Value::create(unsignedByte);
             value->read(reinterpret_cast<const byte*>(&xmpPacket[0]),
                         static_cast<long>(xmpPacket.size()),
                         invalidByteOrder);
@@ -1290,7 +1290,7 @@ namespace Exiv2 {
                 return;
             }
             uint16_t tag = getUShort(p, byteOrder());
-            TiffComponent::AutoPtr tc = TiffCreator::create(tag, object->group());
+            TiffComponent::UniquePtr tc = TiffCreator::create(tag, object->group());
             if (tc.get()) {
                 tc->setStart(p);
                 object->addChild(tc);
@@ -1308,7 +1308,7 @@ namespace Exiv2 {
 #endif
                 return;
             }
-            TiffComponent::AutoPtr tc(0);
+            TiffComponent::UniquePtr tc(0);
             uint32_t next = getLong(p, byteOrder());
             if (next) {
                 tc = TiffCreator::create(Tag::next, object->group());
@@ -1367,7 +1367,7 @@ namespace Exiv2 {
                     break;
                 }
                 // If there are multiple dirs, group is incremented for each
-                TiffComponent::AutoPtr td(new TiffDirectory(object->tag(),
+                TiffComponent::UniquePtr td(new TiffDirectory(object->tag(),
                                                             static_cast<IfdId>(object->newGroup_ + i)));
                 td->setStart(pData_ + baseOffset() + offset);
                 object->addChild(td);
@@ -1549,7 +1549,7 @@ namespace Exiv2 {
                 size = 0;
             }
         }
-        Value::AutoPtr v = Value::create(typeId);
+        Value::UniquePtr v = Value::create(typeId);
         if (!v.get()) {
             throw Error(kerCorruptedMetadata);
         }
@@ -1660,7 +1660,7 @@ namespace Exiv2 {
         ByteOrder bo = object->elByteOrder();
         if (bo == invalidByteOrder) bo = byteOrder();
         TypeId typeId = toTypeId(object->elDef()->tiffType_, object->tag(), object->group());
-        Value::AutoPtr v = Value::create(typeId);
+        Value::UniquePtr v = Value::create(typeId);
         assert(v.get());
         v->read(pData, size, bo);
 

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -216,7 +216,7 @@ namespace Exiv2 {
             // Assumption is that the corresponding TIFF entry doesn't exist
             TiffPath tiffPath;
             TiffCreator::getPath(tiffPath, object->tag(), object->group(), root_);
-            pRoot_->addPath(object->tag(), tiffPath, pRoot_, clone);
+            pRoot_->addPath(object->tag(), tiffPath, pRoot_, std::move(clone));
 #ifdef DEBUG
             ExifKey key(object->tag(), groupName(object->group()));
             std::cerr << "Copied " << key << "\n";
@@ -1293,7 +1293,7 @@ namespace Exiv2 {
             TiffComponent::UniquePtr tc = TiffCreator::create(tag, object->group());
             if (tc.get()) {
                 tc->setStart(p);
-                object->addChild(tc);
+                object->addChild(std::move(tc));
             } else {
                EXV_WARNING << "Unable to handle tag " << tag << ".\n";
             }
@@ -1328,7 +1328,7 @@ namespace Exiv2 {
                     return;
                 }
                 tc->setStart(pData_ + baseOffset() + next);
-                object->addNext(tc);
+                object->addNext(std::move(tc));
             }
         } // object->hasNext()
 
@@ -1370,7 +1370,7 @@ namespace Exiv2 {
                 TiffComponent::UniquePtr td(new TiffDirectory(object->tag(),
                                                             static_cast<IfdId>(object->newGroup_ + i)));
                 td->setStart(pData_ + baseOffset() + offset);
-                object->addChild(td);
+                object->addChild(std::move(td));
             }
         }
 #ifndef SUPPRESS_WARNINGS
@@ -1565,7 +1565,7 @@ namespace Exiv2 {
         	::free(buffer);
         }
 
-        object->setValue(v);
+        object->setValue(std::move(v));
         object->setData(pData, size);
         object->setOffset(offset);
         object->setIdx(nextIdx(object->group()));
@@ -1664,7 +1664,7 @@ namespace Exiv2 {
         assert(v.get());
         v->read(pData, size, bo);
 
-        object->setValue(v);
+        object->setValue(std::move(v));
         object->setOffset(0);
         object->setIdx(nextIdx(object->group()));
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -64,71 +64,71 @@ namespace Exiv2 {
         return *this;
     }
 
-    Value::AutoPtr Value::create(TypeId typeId)
+    Value::UniquePtr Value::create(TypeId typeId)
     {
-        AutoPtr value;
+        UniquePtr value;
         switch (typeId) {
         case invalidTypeId:
         case signedByte:
         case unsignedByte:
-            value = AutoPtr(new DataValue(typeId));
+            value = UniquePtr(new DataValue(typeId));
             break;
         case asciiString:
-            value = AutoPtr(new AsciiValue);
+            value = UniquePtr(new AsciiValue);
             break;
         case unsignedShort:
-            value = AutoPtr(new ValueType<uint16_t>);
+            value = UniquePtr(new ValueType<uint16_t>);
             break;
         case unsignedLong:
         case tiffIfd:
-            value = AutoPtr(new ValueType<uint32_t>(typeId));
+            value = UniquePtr(new ValueType<uint32_t>(typeId));
             break;
         case unsignedRational:
-            value = AutoPtr(new ValueType<URational>);
+            value = UniquePtr(new ValueType<URational>);
             break;
         case undefined:
-            value = AutoPtr(new DataValue);
+            value = UniquePtr(new DataValue);
             break;
         case signedShort:
-            value = AutoPtr(new ValueType<int16_t>);
+            value = UniquePtr(new ValueType<int16_t>);
             break;
         case signedLong:
-            value = AutoPtr(new ValueType<int32_t>);
+            value = UniquePtr(new ValueType<int32_t>);
             break;
         case signedRational:
-            value = AutoPtr(new ValueType<Rational>);
+            value = UniquePtr(new ValueType<Rational>);
             break;
         case tiffFloat:
-            value = AutoPtr(new ValueType<float>);
+            value = UniquePtr(new ValueType<float>);
             break;
         case tiffDouble:
-            value = AutoPtr(new ValueType<double>);
+            value = UniquePtr(new ValueType<double>);
             break;
         case string:
-            value = AutoPtr(new StringValue);
+            value = UniquePtr(new StringValue);
             break;
         case date:
-            value = AutoPtr(new DateValue);
+            value = UniquePtr(new DateValue);
             break;
         case time:
-            value = AutoPtr(new TimeValue);
+            value = UniquePtr(new TimeValue);
             break;
         case comment:
-            value = AutoPtr(new CommentValue);
+            value = UniquePtr(new CommentValue);
             break;
         case xmpText:
-            value = AutoPtr(new XmpTextValue);
+            value = UniquePtr(new XmpTextValue);
             break;
         case xmpBag:
         case xmpSeq:
         case xmpAlt:
-            value = AutoPtr(new XmpArrayValue(typeId));
+            value = UniquePtr(new XmpArrayValue(typeId));
             break;
         case langAlt:
-            value = AutoPtr(new LangAltValue);
+            value = UniquePtr(new LangAltValue);
             break;
         default:
-            value = AutoPtr(new DataValue(typeId));
+            value = UniquePtr(new DataValue(typeId));
             break;
         }
         return value;
@@ -688,9 +688,9 @@ namespace Exiv2 {
         return 0;
     }
 
-    XmpTextValue::AutoPtr XmpTextValue::clone() const
+    XmpTextValue::UniquePtr XmpTextValue::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     long XmpTextValue::size() const
@@ -758,9 +758,9 @@ namespace Exiv2 {
         return 0;
     }
 
-    XmpArrayValue::AutoPtr XmpArrayValue::clone() const
+    XmpArrayValue::UniquePtr XmpArrayValue::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     long XmpArrayValue::count() const
@@ -832,9 +832,9 @@ namespace Exiv2 {
         return 0;
     }
 
-    LangAltValue::AutoPtr LangAltValue::clone() const
+    LangAltValue::UniquePtr LangAltValue::clone() const
     {
-        return AutoPtr(clone_());
+        return UniquePtr(clone_());
     }
 
     long LangAltValue::count() const

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -63,7 +63,7 @@ namespace Exiv2 {
 namespace Exiv2 {
     using namespace Exiv2::Internal;
 
-    WebPImage::WebPImage(BasicIo::AutoPtr io)
+    WebPImage::WebPImage(BasicIo::UniquePtr io)
     : Image(ImageType::webp, mdNone, io)
     {
     } // WebPImage::WebPImage
@@ -118,7 +118,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::AutoPtr tempIo(new MemIo);
+        BasicIo::UniquePtr tempIo(new MemIo);
         assert (tempIo.get() != 0);
 
         doWriteMetadata(*tempIo); // may throw
@@ -456,7 +456,7 @@ namespace Exiv2 {
 
                 if ( equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
                     // create memio object with the payload, then print the structure
-                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(payload.pData_,payload.size_));
+                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.pData_,payload.size_));
                     printTiffStructure(*p,out,option,depth);
                 }
 
@@ -686,9 +686,9 @@ namespace Exiv2 {
 
     /* =========================================== */
 
-    Image::AutoPtr newWebPInstance(BasicIo::AutoPtr io, bool /*create*/)
+    Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new WebPImage(io));
+        Image::UniquePtr image(new WebPImage(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     WebPImage::WebPImage(BasicIo::UniquePtr io)
-    : Image(ImageType::webp, mdNone, io)
+	: Image(ImageType::webp, mdNone, std::move(io))
     {
     } // WebPImage::WebPImage
 
@@ -688,7 +688,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new WebPImage(io));
+        Image::UniquePtr image(new WebPImage(std::move(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -141,17 +141,17 @@ namespace Exiv2 {
 
     Xmpdatum::Impl::Impl(const Impl& rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
     }
 
     Xmpdatum::Impl& Xmpdatum::Impl::operator=(const Impl& rhs)
     {
         if (this == &rhs) return *this;
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
         return *this;
     }
 
@@ -180,37 +180,37 @@ namespace Exiv2 {
 
     std::string Xmpdatum::key() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->key();
+        return p_->key_.get() == nullptr ? "" : p_->key_->key();
     }
 
     const char* Xmpdatum::familyName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->familyName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->familyName();
     }
 
     std::string Xmpdatum::groupName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->groupName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->groupName();
     }
 
     std::string Xmpdatum::tagName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagName();
     }
 
     std::string Xmpdatum::tagLabel() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagLabel();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagLabel();
     }
 
     uint16_t Xmpdatum::tag() const
     {
-        return p_->key_.get() == 0 ? 0 : p_->key_->tag();
+        return p_->key_.get() == nullptr ? 0 : p_->key_->tag();
     }
 
     TypeId Xmpdatum::typeId() const
     {
-        return p_->value_.get() == 0 ? invalidTypeId : p_->value_->typeId();
+        return p_->value_.get() == nullptr ? invalidTypeId : p_->value_->typeId();
     }
 
     const char* Xmpdatum::typeName() const
@@ -225,47 +225,47 @@ namespace Exiv2 {
 
     long Xmpdatum::count() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->count();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->count();
     }
 
     long Xmpdatum::size() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->size();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->size();
     }
 
     std::string Xmpdatum::toString() const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString();
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString();
     }
 
     std::string Xmpdatum::toString(long n) const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString(n);
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString(n);
     }
 
     long Xmpdatum::toLong(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toLong(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toLong(n);
     }
 
     float Xmpdatum::toFloat(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toFloat(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toFloat(n);
     }
 
     Rational Xmpdatum::toRational(long n) const
     {
-        return p_->value_.get() == 0 ? Rational(-1, 1) : p_->value_->toRational(n);
+        return p_->value_.get() == nullptr ? Rational(-1, 1) : p_->value_->toRational(n);
     }
 
     Value::UniquePtr Xmpdatum::getValue() const
     {
-        return p_->value_.get() == 0 ? Value::UniquePtr(0) : p_->value_->clone();
+        return p_->value_.get() == nullptr ? Value::UniquePtr(nullptr) : p_->value_->clone();
     }
 
     const Value& Xmpdatum::value() const
     {
-        if (p_->value_.get() == 0) throw Error(kerValueNotSet);
+        if (p_->value_.get() == nullptr) throw Error(kerValueNotSet);
         return *p_->value_;
     }
 
@@ -300,7 +300,7 @@ namespace Exiv2 {
 
     int Xmpdatum::setValue(const std::string& value)
     {
-        if (p_->value_.get() == 0) {
+        if (p_->value_.get() == nullptr) {
             TypeId type = xmpText;
             if (0 != p_->key_.get()) {
                 type = XmpProperties::propertyType(*p_->key_.get());

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -95,7 +95,7 @@ namespace {
                    const XMP_OptionBits& opt);
 
     //! Make an XMP key from a schema namespace and property path
-    Exiv2::XmpKey::AutoPtr makeXmpKey(const std::string& schemaNs,
+    Exiv2::XmpKey::UniquePtr makeXmpKey(const std::string& schemaNs,
                                       const std::string& propPath);
 #endif // EXV_HAVE_XMP_TOOLKIT
 
@@ -129,8 +129,8 @@ namespace Exiv2 {
         Impl& operator=(const Impl& rhs);              //!< Assignment
 
         // DATA
-        XmpKey::AutoPtr key_;                          //!< Key
-        Value::AutoPtr  value_;                        //!< Value
+        XmpKey::UniquePtr key_;                          //!< Key
+        Value::UniquePtr  value_;                        //!< Value
     };
 
     Xmpdatum::Impl::Impl(const XmpKey& key, const Value* pValue)
@@ -258,9 +258,9 @@ namespace Exiv2 {
         return p_->value_.get() == 0 ? Rational(-1, 1) : p_->value_->toRational(n);
     }
 
-    Value::AutoPtr Xmpdatum::getValue() const
+    Value::UniquePtr Xmpdatum::getValue() const
     {
-        return p_->value_.get() == 0 ? Value::AutoPtr(0) : p_->value_->clone();
+        return p_->value_.get() == 0 ? Value::UniquePtr(0) : p_->value_->clone();
     }
 
     const Value& Xmpdatum::value() const
@@ -600,10 +600,10 @@ namespace Exiv2 {
                 }
                 continue;
             }
-            XmpKey::AutoPtr key = makeXmpKey(schemaNs, propPath);
+            XmpKey::UniquePtr key = makeXmpKey(schemaNs, propPath);
             if (XMP_ArrayIsAltText(opt)) {
                 // Read Lang Alt property
-                LangAltValue::AutoPtr val(new LangAltValue);
+                LangAltValue::UniquePtr val(new LangAltValue);
                 XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
                 while (count-- > 0) {
                     // Get the text
@@ -650,7 +650,7 @@ namespace Exiv2 {
                 }
                 if (simpleArray) {
                     // Read the array into an XmpArrayValue
-                    XmpArrayValue::AutoPtr val(new XmpArrayValue(arrayValueTypeId(opt)));
+                    XmpArrayValue::UniquePtr val(new XmpArrayValue(arrayValueTypeId(opt)));
                     XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
                     while (count-- > 0) {
                         iter.Next(&schemaNs, &propPath, &propValue, &opt);
@@ -661,7 +661,7 @@ namespace Exiv2 {
                     continue;
                 }
             }
-            XmpTextValue::AutoPtr val(new XmpTextValue);
+            XmpTextValue::UniquePtr val(new XmpTextValue);
             if (   XMP_PropIsStruct(opt)
                 || XMP_PropIsArray(opt)) {
                 // Create a metadatum with only XMP options
@@ -951,7 +951,7 @@ namespace {
     {}
 #endif // DEBUG
 
-    Exiv2::XmpKey::AutoPtr makeXmpKey(const std::string& schemaNs,
+    Exiv2::XmpKey::UniquePtr makeXmpKey(const std::string& schemaNs,
                                       const std::string& propPath)
     {
         std::string property;
@@ -965,7 +965,7 @@ namespace {
         if (prefix.empty()) {
             throw Exiv2::Error(Exiv2::kerNoPrefixForNamespace, propPath, schemaNs);
         }
-        return Exiv2::XmpKey::AutoPtr(new Exiv2::XmpKey(prefix, property));
+        return Exiv2::XmpKey::UniquePtr(new Exiv2::XmpKey(prefix, property));
     } // makeXmpKey
 #endif // EXV_HAVE_XMP_TOOLKIT
 

--- a/src/xmpdump.cpp
+++ b/src/xmpdump.cpp
@@ -15,7 +15,7 @@ try {
         return 1;
     }
 
-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
     assert(image.get() != 0);
     image->readMetadata();
 

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -52,7 +52,7 @@ namespace {
 namespace Exiv2 {
 
 
-    XmpSidecar::XmpSidecar(BasicIo::AutoPtr io, bool create)
+    XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, bool create)
         : Image(ImageType::xmp, mdXmp, io)
     {
         if (create) {
@@ -155,7 +155,7 @@ namespace Exiv2 {
             if (xmpPacket_.substr(0, 5)  != "<?xml") {
                 xmpPacket_ = xmlHeader + xmpPacket_ + xmlFooter;
             }
-            BasicIo::AutoPtr tempIo(new MemIo);
+            BasicIo::UniquePtr tempIo(new MemIo);
             assert(tempIo.get() != 0);
             // Write XMP packet
             if (   tempIo->write(reinterpret_cast<const byte*>(xmpPacket_.data()),
@@ -169,9 +169,9 @@ namespace Exiv2 {
 
     // *************************************************************************
     // free functions
-    Image::AutoPtr newXmpInstance(BasicIo::AutoPtr io, bool create)
+    Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::AutoPtr image(new XmpSidecar(io, create));
+        Image::UniquePtr image(new XmpSidecar(io, create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
 
 
     XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, bool create)
-        : Image(ImageType::xmp, mdXmp, io)
+        : Image(ImageType::xmp, mdXmp, std::move(io))
     {
         if (create) {
             if (io_->open() == 0) {
@@ -171,7 +171,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new XmpSidecar(io, create));
+        Image::UniquePtr image(new XmpSidecar(std::move(io), create));
         if (!image->good()) {
             image.reset();
         }


### PR DESCRIPTION
This is an enormous PR, consisting of mostly enormous commits which are mass replaces of `auto_ptr` with `unique_ptr`.