### PR TITLE
Fix some gcc warnings and add unit tests

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1151,14 +1151,14 @@ namespace Exiv2 {
         char plusMinus = '+';
         if (time_.tzHour < 0 || time_.tzMinute < 0) plusMinus = '-';
 
-        int wrote = sprintf(temp,
+        const int wrote = sprintf(temp,
                    "%02d%02d%02d%1c%02d%02d",
                    time_.hour, time_.minute, time_.second,
                    plusMinus, abs(time_.tzHour), abs(time_.tzMinute));
 
         assert(wrote == 11);
-        std::memcpy(buf, temp, 11);
-        return 11;
+        std::memcpy(buf, temp, wrote);
+        return wrote;
     }
 
     const TimeValue::Time& TimeValue::getTime() const

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -977,11 +977,10 @@ namespace Exiv2 {
         // sprintf wants to add the null terminator, so use oversized buffer
         char temp[9];
 
-        int wrote = sprintf(temp, "%04d%02d%02d",
-                            date_.year, date_.month, date_.day);
+        int wrote = sprintf(temp, "%04d%02d%02d", date_.year, date_.month, date_.day);
         assert(wrote == 8);
-        std::memcpy(buf, temp, 8);
-        return 8;
+        std::memcpy(buf, temp, wrote);
+        return wrote;
     }
 
     const DateValue::Date& DateValue::getDate() const

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_enforce.cpp
     test_safe_op.cpp
     test_XmpKey.cpp
+    test_DateValue.cpp
 )
 
 #TODO Use GTest::GTest once we upgrade the minimum CMake version required

--- a/unitTests/test_DateValue.cpp
+++ b/unitTests/test_DateValue.cpp
@@ -75,7 +75,10 @@ TEST(ADateValue, doNotReadFromStringWithExpectedSizeButNotCorrectContent)
 TEST(ADateValue, copyToByteBuffer)
 {
     const DateValue dateValue (2018, 4, 2);
-    byte buffer[9];
+    const byte expectedDate[8] = {0x32, 0x30, 0x31, 0x38, 0x30, 0x34, 0x30, 0x32 }; // 20180402
+    byte buffer[8];
     ASSERT_EQ(8, dateValue.copy(buffer));
-    ASSERT_STREQ("20180402", reinterpret_cast<const char *>(buffer));
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_EQ(expectedDate[i], buffer[i]);
+    }
 }

--- a/unitTests/test_DateValue.cpp
+++ b/unitTests/test_DateValue.cpp
@@ -1,0 +1,81 @@
+#include "value.hpp"
+
+#include "gtestwrapper.h"
+
+using namespace Exiv2;
+
+TEST(ADateValue, isDefaultConstructed)
+{
+    const DateValue dateValue;
+    ASSERT_EQ(0, dateValue.getDate().year);
+    ASSERT_EQ(0, dateValue.getDate().month);
+    ASSERT_EQ(0, dateValue.getDate().day);
+}
+
+TEST(ADateValue, isConstructedWithArgs)
+{
+    const DateValue dateValue (2018, 4, 2);
+    ASSERT_EQ(2018, dateValue.getDate().year);
+    ASSERT_EQ(4, dateValue.getDate().month);
+    ASSERT_EQ(2, dateValue.getDate().day);
+}
+
+
+TEST(ADateValue, readFromByteBufferWithExpectedSize)
+{
+    DateValue dateValue;
+    const byte date[8] = {0x32, 0x30, 0x31, 0x38, 0x30, 0x34, 0x30, 0x32 }; // 20180402
+    ASSERT_EQ(0, dateValue.read(date, 8));
+    ASSERT_EQ(2018, dateValue.getDate().year);
+    ASSERT_EQ(4, dateValue.getDate().month);
+    ASSERT_EQ(2, dateValue.getDate().day);
+}
+
+TEST(ADateValue, doNotReadFromByteBufferWithoutExpectedSize)
+{
+    DateValue dateValue;
+    const byte date[8] = {0x32, 0x30, 0x31, 0x38, 0x30, 0x34, 0x30, 0x32 }; // 20180402
+    ASSERT_EQ(1, dateValue.read(date, 9));
+}
+
+TEST(ADateValue, doNotReadFromByteBufferWithExpectedSizeButNotCorrectContent)
+{
+    DateValue dateValue;
+    const byte date[8] = {0x32, 0x30, 0x31, 0x38, 0x30, 0x34, 0x23, 0x23 }; // 201804##
+    ASSERT_EQ(1, dateValue.read(date, 8));
+}
+
+
+TEST(ADateValue, readFromStringWithExpectedSize)
+{
+    DateValue dateValue;
+    const std::string date ("2018-04-02");
+    ASSERT_EQ(0, dateValue.read(date));
+    ASSERT_EQ(2018, dateValue.getDate().year);
+    ASSERT_EQ(4, dateValue.getDate().month);
+    ASSERT_EQ(2, dateValue.getDate().day);
+}
+
+TEST(ADateValue, doNotReadFromStringWithoutExpectedSize)
+{
+    DateValue dateValue;
+    const std::string date ("20180402");
+    ASSERT_EQ(1, dateValue.read(date));
+}
+
+TEST(ADateValue, doNotReadFromStringWithExpectedSizeButNotCorrectContent)
+{
+    DateValue dateValue;
+    const std::string date ("2018-aa-bb");
+    ASSERT_EQ(1, dateValue.read(date));
+}
+
+
+
+TEST(ADateValue, copyToByteBuffer)
+{
+    const DateValue dateValue (2018, 4, 2);
+    byte buffer[9];
+    ASSERT_EQ(8, dateValue.copy(buffer));
+    ASSERT_STREQ("20180402", reinterpret_cast<const char *>(buffer));
+}


### PR DESCRIPTION
I noticed that when we compile the code in Release mode we still have some gcc compiler warnings and I decided to fix few of them.

Before doing that I decided to add few unit tests for the class **DateValue**. I feel more confortable doing changes to code which I do not know by having some unit tests around that code. Something interesting that I noticed is that the function `read` expect different format depending on the variant used (byte array or std::string). Is that behavior correct @clanmills ? or did I just a bug ?