### PR TITLE
Remove 'using namespace' from public header

### DIFF
--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -33,10 +33,6 @@
 #include "exif.hpp"
 #include "image.hpp"
 
-// *****************************************************************************
-// namespace extensions
-using namespace Exiv2::Internal;
-
 namespace Exiv2 {
 
 // *****************************************************************************
@@ -94,7 +90,7 @@ namespace Exiv2 {
           @param tv Pointer to current tag,
           @param size Size of the data block used to store Tag Information.
          */
-        void tagDecoder(const TagVocabulary* tv, uint64_t size);
+        void tagDecoder(const Internal::TagVocabulary* tv, uint64_t size);
         /*!
           @brief Interpret File_Properties tag information, and save it in
               the respective XMP container.


### PR DESCRIPTION
Just a minor improvement. I noticed there was an usage of `usign namespace` in one of the public headers, what it is known as a bad practice. 