### PR TITLE
Fix Appveyor builds by disabling the search of Iconv on Windows

### DIFF
--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -43,11 +43,13 @@ if( EXIV2_ENABLE_NLS )
     # the manual check in config/generateConfigFile.cmake
 endif( )
 
-include( FindIconv )
-if( ICONV_FOUND )
-    message ( "-- ICONV_INCLUDE_DIR : " ${ICONV_INCLUDE_DIR} )
-    message ( "-- ICONV_LIBRARIES : " ${ICONV_LIBRARIES} )
-    message ( "-- ICONV_ACCEPTS_CONST_INPUT : ${ICONV_ACCEPTS_CONST_INPUT}" )
+if(UNIX) # TODO: Try to support this on Windows
+    include( FindIconv )
+    if( ICONV_FOUND )
+        message ( "-- ICONV_INCLUDE_DIR : " ${ICONV_INCLUDE_DIR} )
+        message ( "-- ICONV_LIBRARIES : " ${ICONV_LIBRARIES} )
+        message ( "-- ICONV_ACCEPTS_CONST_INPUT : ${ICONV_ACCEPTS_CONST_INPUT}" )
+    endif()
 endif()
 
 if( EXIV2_BUILD_PO )


### PR DESCRIPTION
This PR fix the AppVeyor CI check that started to fail recently. The reason of these failures seems to be a combination of two facts:

1. Appveyor updated their windows images and they are using CMake 3.11 now (released few days ago).
2. We have a customized CMake finder for Iconv (`config/FindIconv.cmake`) that seems to have some issues with the recent CMake version.

It is important to note that Iconv has not been used on AppVeyor until now. We would need to bring the Iconv dependency by conan or other means. I do not know if it is a interesting feature to have on Windows or not, but anyways I have left a TODO comment in the CMake code to enable the usage of Iconv on Windows in the future. 

Note that it is important to merge this PR as soon as possible to fix the Appveyor CI checks for the rest of  PRs.