### PR TITLE
Add characterisation tests for the XmpKey class

### DIFF
--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -245,7 +245,8 @@ namespace Exiv2 {
     /*!
       @brief Concrete keys for XMP metadata.
      */
-    class EXIV2API XmpKey : public Key {
+    class EXIV2API XmpKey : public Key
+    {
     public:
         //! Shortcut for an %XmpKey auto pointer.
         typedef std::auto_ptr<XmpKey> AutoPtr;
@@ -313,10 +314,10 @@ namespace Exiv2 {
         struct Impl;
         Impl* p_;
 
-    }; // class XmpKey
+    };  // class XmpKey
 
-// *****************************************************************************
-// free functions
+    // *****************************************************************************
+    // free functions
 
     //! Output operator for property info
     EXIV2API std::ostream& operator<<(std::ostream& os, const XmpPropertyInfo& propertyInfo);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2693,9 +2693,12 @@ namespace Exiv2 {
     }
 
     //! @brief Internal Pimpl structure with private members and data of class XmpKey.
-    struct XmpKey::Impl {
-        Impl() {}                       //!< Default constructor
-        Impl(const std::string& prefix, const std::string& property); //!< Constructor
+    struct XmpKey::Impl
+    {
+        Impl()
+        {
+        }                                                              //!< Default constructor
+        Impl(const std::string& prefix, const std::string& property);  //!< Constructor
 
         /*!
           @brief Parse and convert the \em key string into property and prefix.
@@ -2704,20 +2707,21 @@ namespace Exiv2 {
 
           @throw Error if the key cannot be decomposed.
         */
-        void decomposeKey(const std::string& key); //!< Misterious magic
+        void decomposeKey(const std::string& key);  //!< Misterious magic
 
         // DATA
-        static const char* familyName_; //!< "Xmp"
+        static const char* familyName_;  //!< "Xmp"
 
-        std::string prefix_;            //!< Prefix
-        std::string property_;          //!< Property name
+        std::string prefix_;    //!< Prefix
+        std::string property_;  //!< Property name
     };
 
     //! @brief Constructor for Internal Pimpl structure XmpKey::Impl::Impl
     XmpKey::Impl::Impl(const std::string& prefix, const std::string& property)
     {
         // Validate prefix
-        if (XmpProperties::ns(prefix).empty()) throw Error(kerNoNamespaceForPrefix, prefix);
+        if (XmpProperties::ns(prefix).empty())
+            throw Error(kerNoNamespaceForPrefix, prefix);
 
         property_ = property;
         prefix_ = prefix;
@@ -2725,14 +2729,12 @@ namespace Exiv2 {
 
     const char* XmpKey::Impl::familyName_ = "Xmp";
 
-    XmpKey::XmpKey(const std::string& key)
-        : p_(new Impl)
+    XmpKey::XmpKey(const std::string& key) : p_(new Impl)
     {
         p_->decomposeKey(key);
     }
 
-    XmpKey::XmpKey(const std::string& prefix, const std::string& property)
-        : p_(new Impl(prefix, property))
+    XmpKey::XmpKey(const std::string& prefix, const std::string& property) : p_(new Impl(prefix, property))
     {
     }
 
@@ -2741,14 +2743,14 @@ namespace Exiv2 {
         delete p_;
     }
 
-    XmpKey::XmpKey(const XmpKey& rhs)
-        : Key(rhs), p_(new Impl(*rhs.p_))
+    XmpKey::XmpKey(const XmpKey& rhs) : Key(rhs), p_(new Impl(*rhs.p_))
     {
     }
 
     XmpKey& XmpKey::operator=(const XmpKey& rhs)
     {
-        if (this == &rhs) return *this;
+        if (this == &rhs)
+            return *this;
         Key::operator=(rhs);
         *p_ = *rhs.p_;
         return *this;
@@ -2787,7 +2789,8 @@ namespace Exiv2 {
     std::string XmpKey::tagLabel() const
     {
         const char* pt = XmpProperties::propertyTitle(*this);
-        if (!pt) return tagName();
+        if (!pt)
+            return tagName();
         return pt;
     }
 
@@ -2806,25 +2809,34 @@ namespace Exiv2 {
     {
         // Get the family name, prefix and property name parts of the key
         std::string::size_type pos1 = key.find('.');
-        if (pos1 == std::string::npos) throw Error(kerInvalidKey, key);
+        if (pos1 == std::string::npos) {
+            throw Error(kerInvalidKey, key);
+        }
         std::string familyName = key.substr(0, pos1);
         if (0 != strcmp(familyName.c_str(), familyName_)) {
             throw Error(kerInvalidKey, key);
         }
         std::string::size_type pos0 = pos1 + 1;
         pos1 = key.find('.', pos0);
-        if (pos1 == std::string::npos) throw Error(kerInvalidKey, key);
+        if (pos1 == std::string::npos) {
+            throw Error(kerInvalidKey, key);
+        }
         std::string prefix = key.substr(pos0, pos1 - pos0);
-        if (prefix == "") throw Error(kerInvalidKey, key);
+        if (prefix == "") {
+            throw Error(kerInvalidKey, key);
+        }
         std::string property = key.substr(pos1 + 1);
-        if (property == "") throw Error(kerInvalidKey, key);
+        if (property == "") {
+            throw Error(kerInvalidKey, key);
+        }
 
         // Validate prefix
-        if (XmpProperties::ns(prefix).empty()) throw Error(kerNoNamespaceForPrefix, prefix);
+        if (XmpProperties::ns(prefix).empty())
+            throw Error(kerNoNamespaceForPrefix, prefix);
 
         property_ = property;
         prefix_ = prefix;
-    } // XmpKey::Impl::decomposeKey
+    }  // XmpKey::Impl::decomposeKey
 
     // *************************************************************************
     // free functions

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_futils.cpp
     test_enforce.cpp
     test_safe_op.cpp
+    test_XmpKey.cpp
 )
 
 #TODO Use GTest::GTest once we upgrade the minimum CMake version required

--- a/unitTests/test_XmpKey.cpp
+++ b/unitTests/test_XmpKey.cpp
@@ -1,0 +1,86 @@
+#include <exiv2/error.hpp>
+#include <exiv2/properties.hpp>
+
+#include "gtestwrapper.h"
+
+using namespace Exiv2;
+
+namespace
+{
+    const std::string expectedFamily("Xmp");
+    const std::string expectedPrefix("prefix");
+    const std::string expectedProperty("prop");
+    const std::string expectedKey(expectedFamily + "." + expectedPrefix + "." + expectedProperty);
+    const std::string notRegisteredValidKey("Xmp.noregistered.prop");
+}
+
+// Test Fixture which register a namespace with a prefix. This is needed to test the correct
+// behavior of the XmpKey class
+class AXmpKey : public testing::Test
+{
+public:
+    static void SetUpTestCase()
+    {
+        XmpProperties::registerNs(expectedFamily, expectedPrefix);
+    }
+
+    void checkValidity(const XmpKey& key)
+    {
+        ASSERT_EQ(expectedKey, key.key());
+        ASSERT_EQ(expectedFamily, key.familyName());
+        ASSERT_EQ(expectedPrefix, key.groupName());
+        ASSERT_EQ(expectedProperty, key.tagName());
+        ASSERT_EQ(expectedProperty, key.tagLabel());
+        ASSERT_EQ(0, key.tag());
+        ASSERT_STREQ("Xmp/", key.ns().c_str());
+    }
+};
+
+TEST_F(AXmpKey, correctlyInstantiateWithValidKey)
+{
+    XmpKey key(expectedKey);
+    checkValidity(key);
+}
+
+TEST_F(AXmpKey, correctlyInstantiatedWithValidPrefixAndProperty)
+{
+    XmpKey key(expectedPrefix, expectedProperty);
+    checkValidity(key);
+}
+
+TEST_F(AXmpKey, canBeCopiedConstructed)
+{
+    XmpKey key(expectedPrefix, expectedProperty);
+    XmpKey copiedKey(key);
+    checkValidity(copiedKey);
+}
+
+TEST_F(AXmpKey, canBeCopied)
+{
+    XmpKey key(expectedPrefix, expectedProperty);
+    XmpKey copiedKey("Xmp.prefix.prop2");
+    copiedKey = key;
+    checkValidity(copiedKey);
+}
+
+TEST_F(AXmpKey, canBeCloned)
+{
+    XmpKey key(expectedPrefix, expectedProperty);
+    XmpKey::AutoPtr clonedKey = key.clone();
+    checkValidity(*clonedKey);
+}
+
+TEST_F(AXmpKey, throwsWithNotRegisteredWellFormedKey)
+{
+    ASSERT_THROW(XmpKey key(notRegisteredValidKey), Error);
+}
+
+TEST_F(AXmpKey, throwsWithNotRegisteredPrefix)
+{
+    ASSERT_THROW(XmpKey key("badPrefix", expectedProperty), Error);
+}
+
+TEST_F(AXmpKey, throwsWithBadFormedKey)
+{
+    ASSERT_THROW(XmpKey key(expectedProperty), Error);  // It should have the format ns.prefix.key
+}


### PR DESCRIPTION
While studying the code **XmpKey** I decided to:

- Add characterisation unit tests for the current behavior.
- clang-format the code for which I have added tests.

I will probably dedicate more time to add characterisation tests to the existing code, since it provides a proper safety net to address refactorings. 