### PR TITLE
samples/geotag.cpp: fixed debugging code to be in the correct ifdef

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -420,13 +420,13 @@ int timeZoneAdjust()
 #else
     struct tm local = *localtime(&now) ;
     offset          = local.tm_gmtoff ;
-#endif
 
 #if DEBUG
     struct tm utc = *gmtime(&now);
     printf("utc  :  offset = %6d dst = %d time = %s", 0     ,utc  .tm_isdst, asctime(&utc  ));
     printf("local:  offset = %6d dst = %d time = %s", offset,local.tm_isdst, asctime(&local));
     printf("timeZoneAdjust = %6d\n",offset);
+#endif
 #endif
     return offset ;
 }


### PR DESCRIPTION
This fixes for me the debug build on MSVC platforms. I define 'DEBUG' manually for debug builds so the commit may not be officially required. But it should also not hurt. Without this PR, I get an error:
```
D:\Debug\Shared\exiv2-0.26.1-trunk\samples\geotag.cpp(428): error: identifier "local" is undefined
      printf("local:  offset = %6d dst = %d time = %s", offset,local.tm_isdst, asctime(&local));
                                                               ^
```