### PR TITLE
Fix MSVC warning C4267: conversion from 'size_t' to 'long'

### DIFF
--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -268,12 +268,12 @@ namespace Exiv2
 #endif
 
                             const long pad = 3 ; // 3 padding bytes 2 0 0
-			    const size_t data_length = Safe::add(subBox.length, static_cast<uint32_t>(8));
-			    // data_length makes no sense if it is larger than the rest of the file
-			    if (data_length > io_->size() - io_->tell()) {
-				throw Error(kerCorruptedMetadata);
-			    }
-                            DataBuf data(data_length);
+                            const size_t data_length = Safe::add(subBox.length, static_cast<uint32_t>(8));
+                            // data_length makes no sense if it is larger than the rest of the file
+                            if (data_length > io_->size() - io_->tell()) {
+                                throw Error(kerCorruptedMetadata);
+                            }
+                            DataBuf data(static_cast<long>(data_length));
                             io_->read(data.pData_,data.size_);
                             const long    iccLength = getULong(data.pData_+pad, bigEndian);
                             // subtracting pad from data.size_ is safe:


### PR DESCRIPTION
Apart of fixing the warning, I also fixed the indentation (we were using tabs instead of spaces there)