### PR TITLE
Install conan-dependencies DLLs into install/bin.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,5 +24,5 @@ class Exiv2Conan(ConanFile):
             self.requires('gtest/1.8.0@bincrafters/stable')
 
     def imports(self):
-        self.copy('*.dll', dst='bin', src='bin')
+        self.copy('*.dll', dst='conanDlls', src='bin')
         self.copy('*.dylib', dst='bin', src='lib')

--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -72,3 +72,10 @@ endif()
 if (EXIV2_BUILD_UNIT_TESTS)
     find_package(GTest REQUIRED)
 endif()
+
+# On Windows we are interested in placing the DLLs together to the binaries in the install/bin
+# folder, at the installation step. On other platforms we do not care about that, since the 
+# RPATHs will point the locations where the libraries where found.
+if (USING_CONAN AND WIN32)
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/conanDlls/ DESTINATION bin)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,13 @@ if(EXIV2_BUILD_EXIV2_COMMAND)
     endif()
 
     target_sources(exiv2    PRIVATE getopt_win32.c)
+
+    # Copy DLLs from conan packages to the bin folder
+    if (USING_CONAN AND WIN32)
+        add_custom_command(TARGET exiv2 POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/conanDlls ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    endif()
+
     install(TARGETS exiv2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
We also changed the way in which we copy the DLLs to the bin folder inside the build directory.
Before we were directly placing the conan-deps DLLs into the bin folder directly. Now we place
them into a directory called conanDlls, and from there we copy them to bin or install/bin
at build and install steps respectively.

@clanmills this should solve the problem you described in #276 about the missing dlls in **build/install/bin**. Please, let me know if this solves the case. 