### PR TITLE
Testsuite update

### DIFF
--- a/tests/bugfixes/github/test_CVE_2017_1000126.py
+++ b/tests/bugfixes/github/test_CVE_2017_1000126.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/175"
 
-    filename = "{data_path}/cve_2017_1000126_stack-oob-read.webp"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/cve_2017_1000126_stack-oob-read.webp"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_1000127.py
+++ b/tests/bugfixes/github/test_CVE_2017_1000127.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestPoC(system_tests.Case):
+class TestPoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/176"
 
-    filename = "{data_path}/heap-oob-write.tiff"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/heap-oob-write.tiff"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11336.py
+++ b/tests/bugfixes/github/test_CVE_2017_11336.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/49"
 
-    filename = "{data_path}/POC2"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC2"
+    commands = ["$exiv2 " + filename]
     retval = [1]
     stdout = [""]
     stderr = [
-        """{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+        """$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]

--- a/tests/bugfixes/github/test_CVE_2017_11337.py
+++ b/tests/bugfixes/github/test_CVE_2017_11337.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/50"
 
-    filename = "{data_path}/POC3"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC3"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11338.py
+++ b/tests/bugfixes/github/test_CVE_2017_11338.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/51"
 
-    filename = "{data_path}/POC4"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC4"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11339.py
+++ b/tests/bugfixes/github/test_CVE_2017_11339.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/52"
 
-    filename = "{data_path}/POC5"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC5"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11340.py
+++ b/tests/bugfixes/github/test_CVE_2017_11340.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/53"
 
-    filename = "{data_path}/POC6"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC6"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11553.py
+++ b/tests/bugfixes/github/test_CVE_2017_11553.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/54"
 
-    filename = "{data_path}/POC7"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC7"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11591.py
+++ b/tests/bugfixes/github/test_CVE_2017_11591.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/55"
 
-    filename = "{data_path}/POC8"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC8"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11592.py
+++ b/tests/bugfixes/github/test_CVE_2017_11592.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/56"
 
-    filename = "{data_path}/POC9"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC9"
+    commands = ["$exiv2 " + filename]
     stdout = [""""""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_11683.py
+++ b/tests/bugfixes/github/test_CVE_2017_11683.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/57"
 
-    filename = "{data_path}/POC"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{kerInvalidTypeValue}:  0
-{exiv2_exception_message} """ + filename + """:
-{kerInvalidTypeValue}
+    stderr = ["""$kerInvalidTypeValue:  0
+$exiv2_exception_message """ + filename + """:
+$kerInvalidTypeValue
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_12955.py
+++ b/tests/bugfixes/github/test_CVE_2017_12955.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/58"
 
-    filename = "{data_path}/POC11"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC11"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_12956.py
+++ b/tests/bugfixes/github/test_CVE_2017_12956.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/59"
 
-    filename = "{data_path}/POC12"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC12"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_12957.py
+++ b/tests/bugfixes/github/test_CVE_2017_12957.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/60"
 
-    filename = "{data_path}/POC13"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC13"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14857.py
+++ b/tests/bugfixes/github/test_CVE_2017_14857.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/76"
 
-    filename = "{data_path}/010_bad_free"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/010_bad_free"
+    commands = ["$exiv2 " + filename]
     retval = [1]
     stdout = [""]
     stderr = [
-        """{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+        """$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]

--- a/tests/bugfixes/github/test_CVE_2017_14858.py
+++ b/tests/bugfixes/github/test_CVE_2017_14858.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/138"
 
-    filename = "{data_path}/007-heap-buffer-over"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/007-heap-buffer-over"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14859.py
+++ b/tests/bugfixes/github/test_CVE_2017_14859.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/74"
 
-    filename = "{data_path}/005-invalid-mem"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/005-invalid-mem"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]
 

--- a/tests/bugfixes/github/test_CVE_2017_14860.py
+++ b/tests/bugfixes/github/test_CVE_2017_14860.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/73"
 
-    filename = "{data_path}/003-heap-buffer-over"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/003-heap-buffer-over"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14861.py
+++ b/tests/bugfixes/github/test_CVE_2017_14861.py
@@ -3,17 +3,17 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = [
         "https://github.com/Exiv2/exiv2/issues/139",
         "https://bugzilla.redhat.com/show_bug.cgi?id=1494787"
     ]
 
-    filename = "{data_path}/009-stack-over"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/009-stack-over"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14862.py
+++ b/tests/bugfixes/github/test_CVE_2017_14862.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/75"
 
-    filename = "{data_path}/008-invalid-mem"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/008-invalid-mem"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]
 

--- a/tests/bugfixes/github/test_CVE_2017_14863.py
+++ b/tests/bugfixes/github/test_CVE_2017_14863.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/132"
 
-    filename = "{data_path}/01-Null-exiv2-poc"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/01-Null-exiv2-poc"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14864.py
+++ b/tests/bugfixes/github/test_CVE_2017_14864.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/73"
 
-    filename = "{data_path}/02-Invalid-mem-def"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/02-Invalid-mem-def"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14865.py
+++ b/tests/bugfixes/github/test_CVE_2017_14865.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/134"
 
-    filename = "{data_path}/004-heap-buffer-over"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/004-heap-buffer-over"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{kerInvalidTypeValue}:  250
-{exiv2_exception_message} """ + filename + """:
-{kerInvalidTypeValue}
+    stderr = ["""$kerInvalidTypeValue:  250
+$exiv2_exception_message """ + filename + """:
+$kerInvalidTypeValue
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_14866.py
+++ b/tests/bugfixes/github/test_CVE_2017_14866.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/140"
 
-    filename = "{data_path}/006-heap-buffer-over"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/006-heap-buffer-over"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_17669.py
+++ b/tests/bugfixes/github/test_CVE_2017_17669.py
@@ -3,16 +3,16 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/187"
 
-    filename = "{data_path}/issue_187"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/issue_187"
+    commands = ["$exiv2 " + filename]
     retval = [1]
     stdout = [""]
     stderr = [
-	"""{exiv2_exception_message} """ + filename + """:
-{kerFailedToReadImageData}
+	"""$exiv2_exception_message """ + filename + """:
+$kerFailedToReadImageData
 """
     ]

--- a/tests/bugfixes/github/test_CVE_2017_17722.py
+++ b/tests/bugfixes/github/test_CVE_2017_17722.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/208"
 
-    filename = "{data_path}/2018-01-09-exiv2-crash-001.tiff"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/2018-01-09-exiv2-crash-001.tiff"
+    commands = ["$exiv2 " + filename]
     retval = [1]
     stdout = [""]
     stderr = [
-        """{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+        """$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]

--- a/tests/bugfixes/github/test_CVE_2017_17725.py
+++ b/tests/bugfixes/github/test_CVE_2017_17725.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/188"
     found_by = ["Wei You", "@youwei1988"]
 
-    filename = "{data_path}/poc_2017-12-12_issue188"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/poc_2017-12-12_issue188"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_overflow_exception_message} """ + filename + """:
-{addition_overflow_message}
+    stderr = ["""$exiv2_overflow_exception_message """ + filename + """:
+$addition_overflow_message
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2017_18005.py
+++ b/tests/bugfixes/github/test_CVE_2017_18005.py
@@ -3,7 +3,7 @@
 import system_tests
 
 
-class TestPoC(system_tests.Case):
+class TestPoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/168"
 
@@ -12,20 +12,20 @@ Error: Offset of directory Image, entry 0x0117 is out of bounds: Offset = 0x3030
 """ + 12 * """Error: Offset of directory Image, entry 0x3030 is out of bounds: Offset = 0x30303030; truncating the entry
 """
 
-    filename = "{data_path}/cve_2017_18005_reproducer.tiff"
+    filename = "$data_path/cve_2017_18005_reproducer.tiff"
 
     commands = [
-        "{exiv2} -v pr -P EIXxgklnycsvth " + filename,
-        "{exiv2json} " + filename
+        "$exiv2 -v pr -P EIXxgklnycsvth " + filename,
+        "$exiv2json " + filename
     ]
 
     stdout = ["""File 1/1: """ + filename + """
 0x0117 Image        Exif.Image.StripByteCounts                   StripByteCounts             Strip Byte Count               SByte       0   0  
 
 """,
-    """{{
-	"Exif": {{
-		"Image": {{
+    """{
+	"Exif": {
+		"Image": {
 			"StripByteCounts": 0,
 			"0x3030": 0,
 			"0x3030": "",
@@ -40,9 +40,9 @@ Error: Offset of directory Image, entry 0x0117 is out of bounds: Offset = 0x3030
 			"0x3030": 0,
 			"0x3030": 0,
 			"0x3030": 0
-		}}
-	}}
-}}
+		}
+	}
+}
 """
     ]
     stderr = [

--- a/tests/bugfixes/github/test_CVE_2017_9953.py
+++ b/tests/bugfixes/github/test_CVE_2017_9953.py
@@ -3,14 +3,14 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/144"
 
-    filename = "{data_path}/POC1"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/POC1"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerInvalidMalloc}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerInvalidMalloc
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_CVE_2018_4868.py
+++ b/tests/bugfixes/github/test_CVE_2018_4868.py
@@ -3,16 +3,16 @@
 import system_tests
 
 
-class TestCvePoC(system_tests.Case):
+class TestCvePoC(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/202"
     cve_url = "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-4868"
     found_by = ["afl", "topsecLab", "xcainiao"]
 
-    filename = "{data_path}/exiv2-memorymmap-error"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/exiv2-memorymmap-error"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_issue_159.py
+++ b/tests/bugfixes/github/test_issue_159.py
@@ -3,18 +3,18 @@
 import system_tests
 
 
-class TestFirstPoC(system_tests.Case):
+class TestFirstPoC(metaclass=system_tests.CaseMeta):
     """
     Regression test for the first bug described in:
     https://github.com/Exiv2/exiv2/issues/159
     """
     url = "https://github.com/Exiv2/exiv2/issues/159"
 
-    filename = "{data_path}/printStructure"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/printStructure"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerCorruptedMetadata}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerCorruptedMetadata
 """]
     retval = [1]
 

--- a/tests/bugfixes/github/test_issue_170.py
+++ b/tests/bugfixes/github/test_issue_170.py
@@ -3,15 +3,15 @@
 import system_tests
 
 
-class DecodeIHDRChunkOutOfBoundsRead(system_tests.Case):
+class DecodeIHDRChunkOutOfBoundsRead(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/170"
 
-    filename = "{data_path}/issue_170_poc"
+    filename = "$data_path/issue_170_poc"
 
-    commands = ["{exiv2} " + filename]
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerFailedToReadImageData}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerFailedToReadImageData
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_issue_20.py
+++ b/tests/bugfixes/github/test_issue_20.py
@@ -3,7 +3,7 @@
 import system_tests
 
 
-class TamronSupport(system_tests.Case):
+class TamronSupport(metaclass=system_tests.CaseMeta):
 
     description = "Added support for 'Tamron SP 15-30mm f/2.8 Di VC USD A012' and 'Tamron SP 90mm f/2.8 Di VC USD MACRO1:1'"
 
@@ -14,9 +14,9 @@ class TamronSupport(system_tests.Case):
         "TamronSP90mmF2.8DiVCUSDMacroF004.exv",
         "TamronSP90mmF2.8DiVCUSDMacroF017.exv"
     ]
-    commands = ["{exiv2} -pa --grep lens/i ../../../test/data/" + files[0]] \
+    commands = ["$exiv2 -pa --grep lens/i ../../../test/data/" + files[0]] \
         + list(map(
-            lambda fname: "{exiv2} -pa --grep lenstype/i ../../../test/data/" + fname,
+            lambda fname: "$exiv2 -pa --grep lenstype/i ../../../test/data/" + fname,
             files[1:]
         ))
     retval = [0] * len(files)

--- a/tests/bugfixes/github/test_issue_227.py
+++ b/tests/bugfixes/github/test_issue_227.py
@@ -3,7 +3,7 @@
 import system_tests
 
 
-class SigmaLenses(system_tests.Case):
+class SigmaLenses(metaclass=system_tests.CaseMeta):
 
     files = [
         "Sigma_120-300_DG_OS_HSM_Sport_lens.exv",
@@ -12,7 +12,7 @@ class SigmaLenses(system_tests.Case):
     ]
 
     commands = list(
-        map(lambda fname: "{exiv2} -pa --grep lens/i {data_path}/" + fname, files)
+        map(lambda fname: "$exiv2 -pa --grep lens/i $data_path/" + fname, files)
     )
 
     retval = 3 * [0]

--- a/tests/bugfixes/github/test_issue_246.py
+++ b/tests/bugfixes/github/test_issue_246.py
@@ -2,15 +2,16 @@
 
 import system_tests
 
-class TestFirstPoC(system_tests.Case):
+
+class TestFirstPoC(metaclass=system_tests.CaseMeta):
     """
     Regression test for the first bug described in:
     https://github.com/Exiv2/exiv2/issues/246
     """
     url = "https://github.com/Exiv2/exiv2/issues/246"
 
-    filename = "{data_path}/1-string-format.jpg"
-    commands = ["{exiv2} -pS " + filename]
+    filename = "$data_path/1-string-format.jpg"
+    commands = ["$exiv2 -pS " + filename]
     stdout = [
         """STRUCTURE OF JPEG FILE: """ + filename + """
  address | marker       |  length | data
@@ -19,7 +20,7 @@ class TestFirstPoC(system_tests.Case):
 """]
 
 
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerNoImageInInputData}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerNoImageInInputData
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_issue_247.py
+++ b/tests/bugfixes/github/test_issue_247.py
@@ -2,15 +2,15 @@
 
 import system_tests
 
-class TestFirstPoC(system_tests.Case):
+class TestFirstPoC(metaclass=system_tests.CaseMeta):
     """
     Regression test for the first bug described in:
     https://github.com/Exiv2/exiv2/issues/247
     """
     url = "https://github.com/Exiv2/exiv2/issues/247"
 
-    filename = "{data_path}/2-invalid-memory-access"
-    commands = ["{exiv2} -pt " + filename]
+    filename = "$data_path/2-invalid-memory-access"
+    commands = ["$exiv2 -pt " + filename]
     stdout = [
         """Exif.Image.Make                              Ascii       6  Canon
 Exif.Image.Orientation                       Short       1  top, left

--- a/tests/bugfixes/github/test_issue_253.py
+++ b/tests/bugfixes/github/test_issue_253.py
@@ -2,17 +2,18 @@
 
 import system_tests
 
-class TestFirstPoC(system_tests.Case):
+
+class TestFirstPoC(metaclass=system_tests.CaseMeta):
     """
     Regression test for the first bug described in:
     https://github.com/Exiv2/exiv2/issues/253
     """
     url = "https://github.com/Exiv2/exiv2/issues/253"
 
-    filename = "{data_path}/3-stringformat-outofbound-read"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/3-stringformat-outofbound-read"
+    commands = ["$exiv2 " + filename]
     stdout = [""]
-    stderr = ["""{exiv2_exception_message} """ + filename + """:
-{kerNotAJpeg}
+    stderr = ["""$exiv2_exception_message """ + filename + """:
+$kerNotAJpeg
 """]
     retval = [1]

--- a/tests/bugfixes/github/test_issue_45.py
+++ b/tests/bugfixes/github/test_issue_45.py
@@ -3,12 +3,12 @@
 import system_tests
 
 
-class Sigma24_105mmRecognization(system_tests.Case):
+class Sigma24_105mmRecognization(metaclass=system_tests.CaseMeta):
 
     url = "https://github.com/Exiv2/exiv2/issues/45"
 
-    filename = "{data_path}/exiv2-g45.exv"
-    commands = ["{exiv2} -pa --grep lens/i " + filename]
+    filename = "$data_path/exiv2-g45.exv"
+    commands = ["$exiv2 -pa --grep lens/i " + filename]
     stdout = ["""Exif.CanonCs.LensType                        Short       1  Sigma 24-105mm F4 DG OS HSM [Art 013]
 Exif.CanonCs.Lens                            Short       3  24.0 - 105.0 mm
 Exif.CanonCf.LensAFStopButton                Short       1  0

--- a/tests/bugfixes/github/test_regression_issue_201.py
+++ b/tests/bugfixes/github/test_regression_issue_201.py
@@ -3,9 +3,9 @@
 import system_tests
 
 
-class ShadowingError(system_tests.Case):
+class ShadowingError(metaclass=system_tests.CaseMeta):
 
-    commands = ["{exiv2} -PE {data_path}/IMGP0020.exv"]
+    commands = ["$exiv2 -PE $data_path/IMGP0020.exv"]
     stdout = [""]
     stderr = [""]
     retval = [0]

--- a/tests/bugfixes/redmine/test_1305.py
+++ b/tests/bugfixes/redmine/test_1305.py
@@ -3,7 +3,7 @@
 import system_tests
 
 
-class Issue1305Test(system_tests.Case):
+class Issue1305Test(metaclass=system_tests.CaseMeta):
     err_msg_dir_img = """Warning: Directory Image, entry 0x3030 has unknown Exif (TIFF) type 12336; setting type size 1.
 Error: Directory Image, entry 0x3030 has invalid size 808464432*1; skipping entry.
 """
@@ -19,8 +19,8 @@ Error: Directory Pentax, entry 0x3030 has invalid size 808464432*1; skipping ent
     name = "regression test for issue 1305"
     url = "http://dev.exiv2.org/issues/1305"
 
-    filename = "{data_path}/IMGP0006-min.jpg"
-    commands = ["{exiv2} " + filename]
+    filename = "$data_path/IMGP0006-min.jpg"
+    commands = ["$exiv2 " + filename]
     stdout = ["""File name       : """ + filename + """
 File size       : 12341 Bytes
 MIME type       : image/jpeg

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -430,7 +430,15 @@ Then navigate to the `tests/` subdirectory and run:
 python3 runner.py
 ```
 
+One can supply the script with a directory where the suite should look for the
+tests (it will search the directory recursively). If omitted, the runner will
+look in the directory where the configuration file is located.
+
 The runner script also supports the optional arguments `--config_file` which
 allows to provide a different test suite configuration file than the default
 `suite.conf`. It also forwards the verbosity setting via the `-v`/`--verbose`
 flags to Python's unittest module.
+
+Optionally one can provide the `--debug` flag which will instruct test suite to
+print all command invocations and all expected and obtained outputs to the
+standard output.

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -274,6 +274,45 @@ This section describes more advanced features that are probably not necessary
 the "standard" usage of the test suite.
 
 
+### Using a different output encoding
+
+The test suite will try to interpret the program's output as utf-8 encoded
+strings and if that fails it will try the `iso-8859-1` encoding (also know as
+`latin-1`).
+
+If the tested program outputs characters in another encoding then it can be
+supplied as the `encodings` parameter in each test case:
+``` python
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+
+class AnInformativeName(metaclass=system_tests.CaseMeta):
+
+    encodings = ['ascii']
+
+    filename = "invalid_input_file"
+    commands = [
+	    "$binary -c $import_file -i $filename"
+	]
+    retval = ["$abort_exit_value"]
+    stdout = ["Reading $filename"]
+    stderr = [
+        """$abort_error
+error in $filename
+"""
+    ]
+```
+
+The test suite will try to decode the program's output with the provided
+encodings in the order that they appear in the list. It will select the first
+encoding that can decode the output successfully. If no encoding is able to
+decode the program's output, then an error is raised. The list of all supported
+encodings can be found
+[here](https://docs.python.org/3/library/codecs.html#standard-encodings).
+
+
 ### Creating file copies
 
 For tests that modify their input file it is useful to run these with a

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -15,16 +15,34 @@ if __name__ == '__main__':
         "--config_file",
         type=str,
         nargs=1,
+        help="Path to the suite's configuration file",
         default=['suite.conf']
     )
     parser.add_argument(
         "--verbose", "-v",
         action='count',
+        help="verbosity level",
         default=1
     )
+    parser.add_argument(
+        "--debug",
+        help="enable debugging output",
+        action='store_true'
+    )
+
+    parser.add_argument(
+        "dir",
+        help="directory where the test are searched for (defaults to the config"
+        "file's location)",
+        default=None,
+        type=str,
+        nargs='?'
+    )
+
     args = parser.parse_args()
     conf_file = args.config_file[0]
-    discovery_root = os.path.dirname(conf_file)
+    discovery_root = os.path.dirname(conf_file if args.dir is None else args.dir)
+    system_tests.set_debug_mode(args.debug)
 
     system_tests.configure_suite(conf_file)
 

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -12,7 +12,8 @@ exiv2_path: ../build/bin
 exiv2: ${ENV:exiv2_path}/exiv2${ENV:binary_extension}
 exiv2json: ${ENV:exiv2_path}/exiv2json${ENV:binary_extension}
 data_path: ../test/data
-tiff-test: ${ENV:exiv2_path}/tiff-test${ENV:binary_extension}
+tiff_test: ${ENV:exiv2_path}/tiff-test${ENV:binary_extension}
+
 
 [variables]
 kerFailedToReadImageData: Failed to read image data

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -506,10 +506,12 @@ def test_run(self):
                 sep='\n'
             )
 
-        self.assertFalse(timeout["flag"] and "Timeout reached")
+        self.assertFalse(timeout["flag"], msg="Timeout reached")
         self.compare_stdout(i, command, processed_stdout, stdout)
         self.compare_stderr(i, command, processed_stderr, stderr)
-        self.assertEqual(retval, proc.returncode)
+        self.assertEqual(
+            retval, proc.returncode, msg="Return value does not match"
+        )
 
 
 class Case(unittest.TestCase):
@@ -552,11 +554,15 @@ class Case(unittest.TestCase):
         unittest.TestCase. This function can be overridden in a child class to
         implement a custom check.
         """
-        self.assertMultiLineEqual(expected_stdout, got_stdout)
+        self.assertMultiLineEqual(
+            expected_stdout, got_stdout, msg="Standard output does not match"
+        )
 
     def compare_stderr(self, i, command, got_stderr, expected_stderr):
         """ Same as compare_stdout only for standard-error. """
-        self.assertMultiLineEqual(expected_stderr, got_stderr)
+        self.assertMultiLineEqual(
+            expected_stderr, got_stderr, msg="Standard error does not match"
+        )
 
     def expand_variables(self, unexpanded_string):
         """

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -435,6 +435,11 @@ def test_run(self):
     CaseMeta metaclass. This ensures that it is run by each system test
     **after** setUp() and setUpClass() were run.
     """
+    if not (len(self.commands) == len(self.retval)
+            == len(self.stdout) == len(self.stderr)):
+        raise ValueError(
+            "commands, retval, stdout and stderr don't have the same length"
+        )
     for i, command, retval, stdout, stderr in zip(range(len(self.commands)),
                                                   self.commands,
                                                   self.retval,

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -8,6 +8,7 @@ import threading
 import shlex
 import sys
 import shutil
+import string
 import unittest
 
 
@@ -75,6 +76,7 @@ class CasePreservingConfigParser(configparser.ConfigParser):
         return option
 
 
+#: global parameters extracted from the test suite's configuration file
 _parameters = {}
 
 
@@ -406,42 +408,75 @@ class CopyFiles(FileDecoratorBase):
         return shutil.copyfile(expanded_file_name, new_name)
 
 
+def test_run(self):
+    """
+    This function reads in the members commands, retval, stdout, stderr and runs
+    the `expand_variables` function on each. The resulting commands are then run
+    using the subprocess module and compared against the expected values that
+    were provided in the static members via `compare_stdout` and
+    `compare_stderr`. Furthermore a threading.Timer is used to abort the
+    execution if a configured timeout is reached.
+
+    It is automatically added as a member function to each system test by the
+    CaseMeta metaclass. This ensures that it is run by each system test
+    **after** setUp() and setUpClass() were run.
+    """
+    for i, command, retval, stdout, stderr in zip(range(len(self.commands)),
+                                                  self.commands,
+                                                  self.retval,
+                                                  self.stdout,
+                                                  self.stderr):
+        command, retval, stdout, stderr = map(
+            self.expand_variables, [command, retval, stdout, stderr]
+        )
+        retval = int(retval)
+        timeout = {"flag": False}
+
+        proc = subprocess.Popen(
+            _cmd_splitter(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.work_dir
+        )
+
+        def timeout_reached(timeout):
+            timeout["flag"] = True
+            proc.kill()
+
+        t = threading.Timer(
+            _parameters["timeout"], timeout_reached, args=[timeout]
+        )
+        t.start()
+        got_stdout, got_stderr = proc.communicate()
+        t.cancel()
+
+        processed_stdout = _process_output_post(got_stdout.decode('utf-8'))
+        processed_stderr = _process_output_post(got_stderr.decode('utf-8'))
+
+        self.assertFalse(timeout["flag"] and "Timeout reached")
+        self.compare_stdout(i, command, processed_stdout, stdout)
+        self.compare_stderr(i, command, processed_stderr, stderr)
+        self.assertEqual(retval, proc.returncode)
+
+
 class Case(unittest.TestCase):
     """
     System test case base class, provides the functionality to interpret static
-    class members as system tests and runs them.
+    class members as system tests.
 
-    This class reads in the members commands, retval, stdout, stderr and runs
-    the format function on each, where format is called with the kwargs being a
-    merged dictionary of all variables that were extracted from the suite's
-    configuration file and all static members of the current class.
-
-    The resulting commands are then run using the subprocess module and compared
-    against the expected values that were provided in the static
-    members. Furthermore a threading.Timer is used to abort the execution if a
-    configured timeout is reached.
-
-    The class itself must be inherited from, otherwise it is not useful at all,
-    as it does not provide any static members that could be used to run system
-    tests. However, a class that inherits from this class needn't provide any
-    member functions at all, the inherited test_run() function performs all
-    required functionality in child classes.
+    The class itself only provides utility functions and system tests need not
+    inherit from it, as it is automatically added via the CaseMeta metaclass.
     """
 
-    """ maxDiff set so that arbitrarily large diffs will be shown """
+    #: maxDiff set so that arbitrarily large diffs will be shown
     maxDiff = None
 
     @classmethod
     def setUpClass(cls):
         """
-        This function adds the variables variable_dict & work_dir to the class.
-
-        work_dir - set to the file where the current class is defined
-        variable_dict - a merged dictionary of all static members of the current
-                        class and all variables extracted from the suite's
-                        configuration file
+        This function adds the variable work_dir to the class, which is the path
+        to the directory where the python source file is located.
         """
-        cls.variable_dict = _disjoint_dict_merge(cls.__dict__, _parameters)
         cls.work_dir = os.path.dirname(inspect.getfile(cls))
 
     def compare_stdout(self, i, command, got_stdout, expected_stdout):
@@ -463,68 +498,82 @@ class Case(unittest.TestCase):
         self.assertMultiLineEqual(expected_stdout, got_stdout)
 
     def compare_stderr(self, i, command, got_stderr, expected_stderr):
-        """
-        Same as compare_stdout only for standard-error.
-        """
+        """ Same as compare_stdout only for standard-error. """
         self.assertMultiLineEqual(expected_stderr, got_stderr)
 
-    def expand_variables(self, string):
+    def expand_variables(self, unexpanded_string):
         """
-        Expands all variables in curly braces in the given string using the
-        dictionary variable_dict.
+        Expands all variables of the form ``$var`` in the given string using the
+        dictionary `variable_dict`.
 
-        The expansion itself is performed by the builtin string method format().
-        A KeyError indicates that the supplied string contains a variable
-        in curly braces that is missing from self.variable_dict
+        The expansion itself is performed by the string's template module using
+        via `safe_substitute`.
         """
-        return str(string).format(**self.variable_dict)
+        return string.Template(str(unexpanded_string))\
+            .safe_substitute(**self.variable_dict)
 
-    def test_run(self):
-        """
-        Actual system test function which runs the provided commands,
-        pre-processes all variables and post processes the output before passing
-        it on to compare_stderr() & compare_stdout().
-        """
 
-        for i, command, retval, stdout, stderr in zip(range(len(self.commands)),
-                                                      self.commands,
-                                                      self.retval,
-                                                      self.stdout,
-                                                      self.stderr):
-            command, retval, stdout, stderr = map(
-                self.expand_variables, [command, retval, stdout, stderr]
-            )
-            retval = int(retval)
-            timeout = {"flag": False}
+class CaseMeta(type):
+    """ System tests generation metaclass.
 
-            proc = subprocess.Popen(
-                _cmd_splitter(command),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                cwd=self.work_dir
-            )
+    This metaclass is performs the following tasks:
 
-            def timeout_reached(timeout):
-                timeout["flag"] = True
-                proc.kill()
+    1. Add the `test_run` function as a member of the test class
+    2. Add the `Case` class as the parent class
+    3. Expand all variables already defined in the class, so that any additional
+       code does not have to perform this task
 
-            t = threading.Timer(
-                _parameters["timeout"], timeout_reached, args=[timeout]
-            )
-            t.start()
-            got_stdout, got_stderr = proc.communicate()
-            t.cancel()
+    Using a metaclass instead of inheriting from case has the advantage, that we
+    can expand all variables in the strings before any test case or even the
+    class constructor is run! Thus users will immediately see the expanded
+    result. Also adding the `test_run` function as a direct member and not via
+    inheritance enforces that it is being run **after** the test cases setUp &
+    setUpClass (which oddly enough seems not to be the case in the unittest
+    module where test functions of the parent class run before setUpClass of the
+    child class).
+    """
 
-            self.assertFalse(timeout["flag"] and "Timeout reached")
-            self.compare_stdout(
-                i, command,
-                _process_output_post(got_stdout.decode('utf-8')), stdout
-            )
-            self.compare_stderr(
-                i, command,
-                _process_output_post(got_stderr.decode('utf-8')), stderr
-            )
-            self.assertEqual(retval, proc.returncode)
+    def __new__(mcs, clsname, bases, dct):
+
+        changed = False
+
+        # expand all non-private variables by brute force
+        # => try all expanding all elements defined in the current class until
+        # there is no change in them any more
+        keys = [key for key in list(dct.keys()) if not key.startswith('_')]
+        while not changed:
+            for key in keys:
+
+                old_value = dct[key]
+
+                # only try expanding strings and lists
+                if isinstance(old_value, str):
+                    new_value = string.Template(old_value).safe_substitute(
+                        **_disjoint_dict_merge(dct, _parameters)
+                    )
+                elif isinstance(old_value, list):
+                    # do not try to expand anything but strings in the list
+                    new_value = [
+                        string.Template(elem).safe_substitute(
+                            **_disjoint_dict_merge(dct, _parameters)
+                        )
+                        if isinstance(elem, str) else elem
+                        for elem in old_value
+                    ]
+                else:
+                    continue
+
+                if old_value != new_value:
+                    changed = True
+                    dct[key] = new_value
+
+        dct['variable_dict'] = _disjoint_dict_merge(dct, _parameters)
+        dct['test_run'] = test_run
+
+        if Case not in bases:
+            bases += (Case,)
+
+        return super(CaseMeta, mcs).__new__(mcs, clsname, bases, dct)
 
 
 def check_no_ASAN_UBSAN_errors(self, i, command, got_stderr, expected_stderr):

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -80,6 +80,20 @@ class CasePreservingConfigParser(configparser.ConfigParser):
 _parameters = {}
 
 
+#: setting whether debug mode is enabled or not
+_debug_mode = False
+
+
+def set_debug_mode(debug):
+    """ Enable or disable debug mode
+
+    In debug mode the test suite will print out all commands that it runs, the
+    expected output and the actually obtained output
+    """
+    global _debug_mode
+    _debug_mode = debug
+
+
 def configure_suite(config_file):
     """
     Populates a global datastructure with the parameters from the suite's
@@ -432,6 +446,14 @@ def test_run(self):
         retval = int(retval)
         timeout = {"flag": False}
 
+        if _debug_mode:
+            print(
+                '', "="*80, "will run: " + command, "expected stdout:", stdout,
+                "expected stderr:", stderr,
+                "expected return value: {:d}".format(retval),
+                sep='\n'
+            )
+
         proc = subprocess.Popen(
             _cmd_splitter(command),
             stdout=subprocess.PIPE,
@@ -452,6 +474,14 @@ def test_run(self):
 
         processed_stdout = _process_output_post(got_stdout.decode('utf-8'))
         processed_stderr = _process_output_post(got_stderr.decode('utf-8'))
+
+        if _debug_mode:
+            print(
+                "got stdout:", processed_stdout, "got stderr:",
+                processed_stderr, "got return value: {:d}"
+                .format(proc.returncode),
+                sep='\n'
+            )
 
         self.assertFalse(timeout["flag"] and "Timeout reached")
         self.compare_stdout(i, command, processed_stdout, stdout)

--- a/tests/tiff_test/test_tag_compare.py
+++ b/tests/tiff_test/test_tag_compare.py
@@ -3,7 +3,7 @@
 import system_tests
 
 
-class OutputTagExtract(system_tests.Case):
+class OutputTagExtract(metaclass=system_tests.CaseMeta):
     """
     Test whether exiv2 -pa $file and exiv2 -pS $file produces the same output.
     """
@@ -107,7 +107,7 @@ class OutputTagExtract(system_tests.Case):
             self.compare_pS_pa()
 
     commands = [
-        "{exiv2} %s {data_path}/mini9.tif" % (opt) for opt in ["-pa", "-pS"]
+        "$exiv2 %s $data_path/mini9.tif" % (opt) for opt in ["-pa", "-pS"]
     ]
 
     stderr = [""] * 2
@@ -131,7 +131,7 @@ Exif.Image.YResolution                       Rational    1  72
 Exif.Image.PlanarConfiguration               Short       1  1
 Exif.Image.ResolutionUnit                    Short       1  inch
 """,
-        """STRUCTURE OF TIFF FILE (II): {data_path}/mini9.tif
+        """STRUCTURE OF TIFF FILE (II): $data_path/mini9.tif
  address |    tag                              |      type |    count |    offset | value
      254 | 0x00fe NewSubfileType               |      LONG |        1 |           | 0
      266 | 0x0100 ImageWidth                   |     SHORT |        1 |           | 9
@@ -150,5 +150,5 @@ Exif.Image.ResolutionUnit                    Short       1  inch
      422 | 0x011b YResolution                  |  RATIONAL |        1 |       518 | 1207959552/16777216
      434 | 0x011c PlanarConfiguration          |     SHORT |        1 |           | 1
      446 | 0x0128 ResolutionUnit               |     SHORT |        1 |           | 2
-END {data_path}/mini9.tif
+END $data_path/mini9.tif
 """]

--- a/tests/tiff_test/test_tiff_test_program.py
+++ b/tests/tiff_test/test_tiff_test_program.py
@@ -3,10 +3,10 @@
 import system_tests
 
 
-@system_tests.CopyFiles("{data_path}/mini9.tif")
-class TestTiffTestProg(system_tests.Case):
+@system_tests.CopyFiles("$data_path/mini9.tif")
+class TestTiffTestProg(metaclass=system_tests.CaseMeta):
 
-    commands = ["{tiff-test} {data_path}/mini9_copy.tif"]
+    commands = ["$tiff_test $data_path/mini9_copy.tif"]
 
     stdout = [
         """Test 1: Writing empty Exif data without original binary data: ok.

--- a/tests/writing_tests.md
+++ b/tests/writing_tests.md
@@ -11,13 +11,13 @@ The simplest test has the following structure:
 import system_tests
 
 
-class GoodTestName(system_tests.Case):
+class GoodTestName(metaclass=system_tests.CaseMeta):
 
-    filename = "{data_path}/test_file"
-    commands = ["{exiv2} " + filename, "{exiv2} " + filename + '_2']
+    filename = "$data_path/test_file"
+    commands = ["$exiv2 $filename", "$exiv2 $filename" + '_2']
     stdout = [""] * 2
-    stderr = ["""{exiv2_exception_msg} """ + filename + """:
-{error_58_message}
+    stderr = ["""$exiv2_exception_msg $filename:
+$kerFailedToReadImageData
 """] * 2
     retval = [1] * 2
 ```
@@ -25,8 +25,8 @@ class GoodTestName(system_tests.Case):
 The test suite will run the provided commands in `commands` and compare them to
 the output in `stdout` and `stderr` and it will compare the return values.
 
-The strings in curly braces are variables either defined in this test's class or
-are taken from the suite's configuration file (see `doc.md` for a complete
+The strings after a `$` are variables either defined in this test's class or are
+taken from the suite's configuration file (see `doc.md` for a complete
 explanation).
 
 When creating new tests, follow roughly these steps:


### PR DESCRIPTION
This is yet another update for the testsuite that I felt was sort of necessary and sort of handy when porting the redmine issues.

The main changes are:
- variable substitution in the system tests is now done via Python's templates => instead of `{var}` simply write `$var` (that's about it)
- the test setup is now done via a metaclass instead of inheriting from a subclass of `unittest.TestCase`

The reason for the latter change is that I wanted to be able to include local variables (defined in the test class, like `filename`) in the `stdout` without having to manually concatenate strings. That was unfortunately impossible, as it requires multiple invocations of the `expand_variables` function which throws errors once you try to escape curly braces. Using the template module was a suitable workaround, since it can keep unexpanded `$` in the strings and not fail.

The metaclass turned out to be required as I originally wanted to do the string expansion that is now in `CaseMeta.__new__` in `Case.setUpClass`. However, `setUpClass` seemed to run **after** `test_run` for whatever reason and the expansion was not yet visible (I guess it has something to do with `test_run` belonging to the parent class and `setUpClass` to the child class). Thus the only way I could think of was to use a metaclass which expands all variables once each system test class is created (not an instance of it, the class itself!), which seems to solve the problem.