### PR TITLE
Control usage of <stdint.h> via EXV_HAVE_STDINT_H.

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -526,7 +526,7 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class FileIo
 
@@ -726,7 +726,7 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class MemIo
 

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -312,7 +312,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     };  // class XmpKey
 

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -222,7 +222,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class ExifKey
 

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -179,6 +179,9 @@ namespace Exiv2 {
     */
     class EXIV2API XmpData {
     public:
+        //! Default constructor
+        XmpData() : xmpMetadata_(), xmpPacket_(), usePacket_(0) {}
+
         //! XmpMetadata iterator type
         typedef XmpMetadata::iterator iterator;
         //! XmpMetadata const iterator type

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -160,7 +160,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class Xmpdatum
 

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1091,9 +1091,9 @@ namespace Exiv2 {
 
     void MemIo::Impl::reserve(long wcount)
     {
-        long need = wcount + idx_;
+        const long need = wcount + idx_;
         long    blockSize =     32*1024;   // 32768           `
-        long maxBlockSize = 4*1024*1024;
+        const long maxBlockSize = 4*1024*1024;
 
         if (!isMalloced_) {
             // Minimum size for 1st block
@@ -1102,7 +1102,9 @@ namespace Exiv2 {
             if (  data == NULL ) {
                 throw Error(kerMallocFailed);
             }
-            std::memcpy(data, data_, size_);
+            if (data_ != NULL) {
+                std::memcpy(data, data_, size_);
+            }
             data_ = data;
             sizeAlloced_ = size;
             isMalloced_ = true;
@@ -1146,7 +1148,9 @@ namespace Exiv2 {
     {
         p_->reserve(wcount);
         assert(p_->isMalloced_);
-        std::memcpy(&p_->data_[p_->idx_], data, wcount);
+        if (data != NULL) {
+            std::memcpy(&p_->data_[p_->idx_], data, wcount);
+        }
         p_->idx_ += wcount;
         return wcount;
     }

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -371,7 +371,6 @@ namespace Exiv2 {
     FileIo::~FileIo()
     {
         close();
-        delete p_;
     }
 
     int FileIo::munmap()
@@ -1141,7 +1140,6 @@ namespace Exiv2 {
         if (p_->isMalloced_) {
             std::free(p_->data_);
         }
-        delete p_;
     }
 
     long MemIo::write(const byte* data, long wcount)

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2740,7 +2740,6 @@ namespace Exiv2 {
 
     XmpKey::~XmpKey()
     {
-        delete p_;
     }
 
     XmpKey::XmpKey(const XmpKey& rhs) : Key(rhs), p_(new Impl(*rhs.p_))

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -3168,10 +3168,7 @@ namespace Exiv2 {
     {
     }
 
-    ExifKey::~ExifKey()
-    {
-        delete p_;
-    }
+    ExifKey::~ExifKey() {}
 
     ExifKey& ExifKey::operator=(const ExifKey& rhs)
     {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -380,7 +380,9 @@ namespace Exiv2 {
         if (newSize > size_) {
             setData(DataBuf(newSize));
         }
-        memset(pData_, 0x0, size_);
+        if (pData_ != NULL) {
+            memset(pData_, 0x0, size_);
+        }
         size_ = value->copy(pData_, byteOrder);
         assert(size_ == newSize);
         setValue(value);

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -175,7 +175,6 @@ namespace Exiv2 {
 
     Xmpdatum::~Xmpdatum()
     {
-        delete p_;
     }
 
     std::string Xmpdatum::key() const

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -598,13 +598,15 @@ class CaseMeta(type):
 
     def __new__(mcs, clsname, bases, dct):
 
-        changed = False
+        changed = True
 
         # expand all non-private variables by brute force
         # => try all expanding all elements defined in the current class until
         # there is no change in them any more
         keys = [key for key in list(dct.keys()) if not key.startswith('_')]
-        while not changed:
+        while changed:
+            changed = False
+
             for key in keys:
 
                 old_value = dct[key]

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -300,7 +300,7 @@ class FileDecoratorBase(object):
         Returns a new setUp() function that can be used as a class
         member function (i.e. invoked via self.setUp()).
 
-        It's functionality is described in this classes' docstring.
+        Its functionality is described in this classes' docstring.
         """
 
         def setUp(other):
@@ -399,7 +399,7 @@ class CopyFiles(FileDecoratorBase):
     copy of the files specified as the parameters passed to the decorator.
 
     Example:
-    >>> @CopyFiles("{some_var}/file.txt", "{another_var}/other_file.png")
+    >>> @CopyFiles("$some_var/file.txt", "$another_var/other_file.png")
     ... class Foo(Case):
     ...     pass
 

--- a/xmpsdk/include/XMP_Const.h
+++ b/xmpsdk/include/XMP_Const.h
@@ -12,8 +12,8 @@
 #include "XMP_Environment.h"
 
    #include <stddef.h>
-
-#if XMP_MacBuild	// ! No stdint.h on Windows and some UNIXes.
+   
+#if EXV_HAVE_STDINT_H	// ! No stdint.h on Windows and some UNIXes.
     #include <stdint.h>
 #endif
 
@@ -34,7 +34,7 @@ extern "C" {
 // case only the declarations of the XMP_... types needs to change, not all of the uses. These
 // types are used where fixed sizes are required in order to have a known ABI for a DLL build.
 
-#if XMP_MacBuild
+#if EXV_HAVE_STDINT_H
 
     typedef int8_t   XMP_Int8;
     typedef int16_t  XMP_Int16;

--- a/xmpsdk/include/XMP_Const.h
+++ b/xmpsdk/include/XMP_Const.h
@@ -13,7 +13,7 @@
 
    #include <stddef.h>
    
-#if EXV_HAVE_STDINT_H	// ! No stdint.h on Windows and some UNIXes.
+#if defined(EXV_HAVE_STDINT_H)	// ! No stdint.h on Windows and some UNIXes.
     #include <stdint.h>
 #endif
 
@@ -34,7 +34,7 @@ extern "C" {
 // case only the declarations of the XMP_... types needs to change, not all of the uses. These
 // types are used where fixed sizes are required in order to have a known ABI for a DLL build.
 
-#if EXV_HAVE_STDINT_H
+#if defined(EXV_HAVE_STDINT_H)
 
     typedef int8_t   XMP_Int8;
     typedef int16_t  XMP_Int16;

--- a/xmpsdk/include/XMP_Const.h
+++ b/xmpsdk/include/XMP_Const.h
@@ -1,6 +1,8 @@
 #ifndef __XMP_Const_h__
 #define __XMP_Const_h__ 1
 
+#include <exiv2/config.h>
+
 // =================================================================================================
 // Copyright 2002-2008 Adobe Systems Incorporated
 // All Rights Reserved.

--- a/xmpsdk/include/XMP_Const.h
+++ b/xmpsdk/include/XMP_Const.h
@@ -12,8 +12,8 @@
 #include "XMP_Environment.h"
 
    #include <stddef.h>
-
-#if XMP_MacBuild	// ! No stdint.h on Windows and some UNIXes.
+   
+#if defined(EXV_HAVE_STDINT_H)	// ! No stdint.h on Windows and some UNIXes.
     #include <stdint.h>
 #endif
 
@@ -34,7 +34,7 @@ extern "C" {
 // case only the declarations of the XMP_... types needs to change, not all of the uses. These
 // types are used where fixed sizes are required in order to have a known ABI for a DLL build.
 
-#if XMP_MacBuild
+#if defined(EXV_HAVE_STDINT_H)
 
     typedef int8_t   XMP_Int8;
     typedef int16_t  XMP_Int16;


### PR DESCRIPTION
Harmonize usage of <stdint.h> in XMP_Const.h: all other usages are controlled by EXV_HAVE_STDINT_H.   This fixes test failures on linux 64-bit.