### PR TITLE
Fix some undefined behavior and memory leaks

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -526,7 +526,7 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class FileIo
 
@@ -726,7 +726,7 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class MemIo
 

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -312,7 +312,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     };  // class XmpKey
 

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -222,7 +222,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class ExifKey
 

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -179,6 +179,9 @@ namespace Exiv2 {
     */
     class EXIV2API XmpData {
     public:
+        //! Default constructor
+        XmpData() : xmpMetadata_(), xmpPacket_(), usePacket_(0) {}
+
         //! XmpMetadata iterator type
         typedef XmpMetadata::iterator iterator;
         //! XmpMetadata const iterator type

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -160,7 +160,7 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
-        Impl* p_;
+        std::auto_ptr<Impl> p_;
 
     }; // class Xmpdatum
 

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1091,9 +1091,9 @@ namespace Exiv2 {
 
     void MemIo::Impl::reserve(long wcount)
     {
-        long need = wcount + idx_;
+        const long need = wcount + idx_;
         long    blockSize =     32*1024;   // 32768           `
-        long maxBlockSize = 4*1024*1024;
+        const long maxBlockSize = 4*1024*1024;
 
         if (!isMalloced_) {
             // Minimum size for 1st block
@@ -1102,7 +1102,9 @@ namespace Exiv2 {
             if (  data == NULL ) {
                 throw Error(kerMallocFailed);
             }
-            std::memcpy(data, data_, size_);
+            if (data_ != NULL) {
+                std::memcpy(data, data_, size_);
+            }
             data_ = data;
             sizeAlloced_ = size;
             isMalloced_ = true;
@@ -1146,7 +1148,9 @@ namespace Exiv2 {
     {
         p_->reserve(wcount);
         assert(p_->isMalloced_);
-        std::memcpy(&p_->data_[p_->idx_], data, wcount);
+        if (data != NULL) {
+            std::memcpy(&p_->data_[p_->idx_], data, wcount);
+        }
         p_->idx_ += wcount;
         return wcount;
     }

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -371,7 +371,6 @@ namespace Exiv2 {
     FileIo::~FileIo()
     {
         close();
-        delete p_;
     }
 
     int FileIo::munmap()
@@ -1141,7 +1140,6 @@ namespace Exiv2 {
         if (p_->isMalloced_) {
             std::free(p_->data_);
         }
-        delete p_;
     }
 
     long MemIo::write(const byte* data, long wcount)

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2740,7 +2740,6 @@ namespace Exiv2 {
 
     XmpKey::~XmpKey()
     {
-        delete p_;
     }
 
     XmpKey::XmpKey(const XmpKey& rhs) : Key(rhs), p_(new Impl(*rhs.p_))

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -3168,10 +3168,7 @@ namespace Exiv2 {
     {
     }
 
-    ExifKey::~ExifKey()
-    {
-        delete p_;
-    }
+    ExifKey::~ExifKey() {}
 
     ExifKey& ExifKey::operator=(const ExifKey& rhs)
     {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -380,7 +380,9 @@ namespace Exiv2 {
         if (newSize > size_) {
             setData(DataBuf(newSize));
         }
-        memset(pData_, 0x0, size_);
+        if (pData_ != NULL) {
+            memset(pData_, 0x0, size_);
+        }
         size_ = value->copy(pData_, byteOrder);
         assert(size_ == newSize);
         setValue(value);

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -175,7 +175,6 @@ namespace Exiv2 {
 
     Xmpdatum::~Xmpdatum()
     {
-        delete p_;
     }
 
     std::string Xmpdatum::key() const


### PR DESCRIPTION
This PR fixes the following undefined behavior:
- several calls to `memcpy` & `memset` take a null pointer, this is now no longer the case
- `XmpData` had no default constructor, so the value of its member variables is unspecified when a new `XmpData` is constructed.

There were also some subtle memory leaks in all classes using the Pimpl idiom: the constructor would allocate a new `Impl` class and store it in a raw pointer. This leaks memory if the constructor throws an exception, as then the destructor (which would free the `Impl`) is never called. I have therefore replaced the raw pointers with smart pointers which are freed automatically.