### PR TITLE
Simplify code around strerror_r

### DIFF
--- a/config/config.h.cmake
+++ b/config/config.h.cmake
@@ -25,8 +25,8 @@
 // Define if you want video support.
 #cmakedefine EXV_ENABLE_VIDEO
 
-// Define if you have correct declaration of strerror_r().
-#cmakedefine EXV_HAVE_DECL_STRERROR_R
+// Define if you have the strerror_r function.
+#cmakedefine EXV_HAVE_STRERROR_R
 
 // Define to enable the Windows unicode path support.
 #cmakedefine EXV_UNICODE_PATH
@@ -56,15 +56,6 @@
 #define      EXV_HAVE_STDINT_H
 #endif
 #endif
-
-// Define if you have the strerror function.
-#cmakedefine EXV_HAVE_STRERROR
-
-// Define if you have the strerror_r function.
-#cmakedefine EXV_HAVE_STRERROR_R
-
-// Define if strerror_r returns char *.
-#cmakedefine STRERROR_R_CHAR_P
 
 // Define if you have the <strings.h> header file.
 #cmakedefine EXV_HAVE_STRINGS_H

--- a/config/generateConfigFile.cmake
+++ b/config/generateConfigFile.cmake
@@ -22,11 +22,8 @@ set(EXV_UNICODE_PATH     ${EXIV2_ENABLE_WIN_UNICODE})
 check_function_exists( gmtime_r EXV_HAVE_GMTIME_R )
 check_function_exists( mmap     EXV_HAVE_MMAP )
 check_function_exists( munmap   EXV_HAVE_MUNMAP )
-check_function_exists( strerror     EXV_HAVE_STRERROR )
 check_function_exists( strerror_r   EXV_HAVE_STRERROR_R )
 check_function_exists( timegm       EXV_HAVE_TIMEGM )
-
-# TODO : Do something about EXV_STRERROR_R_CHAR_P
 
 # TODO: This check should be removed and rely on the check done in findDependencies.cmake
 check_include_file( "libintl.h" EXV_HAVE_LIBINTL_H )
@@ -45,21 +42,5 @@ check_include_file( "inttypes.h"    EXV_HAVE_INTTYPES_H )
 if (NOT EXV_HAVE_LIBINTL_H)
     set(EXV_ENABLE_NLS 0)
 endif()
-
-
-include(CheckCSourceCompiles)
-#####################################################################################
-# strerror_r returns char*
-
-# NOTE : reverting commit #2041, which break compilation under linux and windows
-
-CHECK_C_SOURCE_COMPILES( "#include <string.h>
-int main() {
-char * c;
-c = strerror_r(0,c,0);
-return 0;
-}" EXV_HAVE_DECL_STRERROR_R )
-
-#####################################################################################
 
 configure_file( config/config.h.cmake ${CMAKE_BINARY_DIR}/exv_conf.h @ONLY)

--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -144,11 +144,6 @@ typedef int pid_t;
 ///// End symbol visibility /////////
 
 ///// Start of platform marcos /////////
-// Linux GCC 4.8 appears to be confused about strerror_r
-#if !defined(EXV_STRERROR_R_CHAR_P) &&  defined( __gnu_linux__) && defined(__GLIBC__)
-#define EXV_STRERROR_R_CHAR_P
-#endif
-
 #if defined(__MINGW32__) || defined(__MINGW64__)
 # ifndef  __MING__
 #  define __MING__  1

--- a/include/exiv2/exv_msvc.h
+++ b/include/exiv2/exv_msvc.h
@@ -14,10 +14,6 @@
 /* Define to 1 if you have the `alarm' function. */
 /* #undef EXV_HAVE_ALARM */
 
-/* Define to 1 if you have the declaration of `strerror_r', and to 0 if you
-   don't. */
-/* #undef EXV_HAVE_DECL_STRERROR_R */
-
 /* Define to 1 if you have the `gmtime_r' function. */
 /* #undef EXV_HAVE_GMTIME_R */
 
@@ -82,8 +78,8 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 /* #undef EXV_HAVE_STDINT_H */
 
-/* Define to 1 if you have the `strerror' function. */
-#define EXV_HAVE_STRERROR 1
+/* Define to 1 if you have the <stdlib.h> header file. */
+/* #undef EXV_HAVE_STDLIB_H */
 
 /* Define to 1 if you have the `strerror_r' function. */
 /* #undef EXV_HAVE_STRERROR_R */

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -259,7 +259,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     int have_stdint      =0;
     int have_stdlib      =0;
     int have_strlib      =0;
-    int have_strerror    =0;
     int have_strerror_r  =0;
     int have_strings_h   =0;
     int have_mmap        =0;
@@ -324,10 +323,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
 
 #ifdef EXV_HAVE_STDLIB_H
     have_stdlib=1;
-#endif
-
-#ifdef EXV_HAVE_STRERROR
-    have_strerror=1;
 #endif
 
 #ifdef EXV_HAVE_STRERROR_R
@@ -500,7 +495,6 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     output(os,keys,"have_stdint"       ,have_stdint      );
     output(os,keys,"have_stdlib"       ,have_stdlib      );
     output(os,keys,"have_strlib"       ,have_strlib      );
-    output(os,keys,"have_strerror"     ,have_strerror    );
     output(os,keys,"have_strerror_r"   ,have_strerror_r  );
     output(os,keys,"have_strings_h"    ,have_strings_h   );
     output(os,keys,"have_mmap"         ,have_mmap        );


### PR DESCRIPTION
I am spending some time trying to clean all the warnings I get on gcc on Release mode. In this PR I just wanted to fix the warning I was getting by the usage of **strerror_r**:

```
/media/linuxDev/programming/exiv2/src/futils.cpp:349: warning: ignoring return value of ‘char* strerror_r(int, char*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
         strerror_r(error, buf, n);
         ~~~~~~~~~~^~~~~~~~~~~~~~~
```
The first strange thing I noticed is that the code was exercising the line 349 when I was expecting the code flow to reach the first block of code here:

```
# if defined EXV_STRERROR_R_CHAR_P && defined _GNU_SOURCE
        char *buf = 0;
        char buf2[n];
        std::memset(buf2, 0x0, n);
        buf = strerror_r(error, buf2, n);
# else
        char buf[n];
        std::memset(buf, 0x0, n);
        strerror_r(error, buf, n);
# endif
```
The reason is that we were not handling the definition of `EXV_STRERROR_R_CHAR_P` in none of our configuration systems (autotools, msvc solutions, cmake) and the logic in the C++ was very convoluted and difficult to understand. 

I started to investigate more about all the STRERROR stuff and I noticed that we had several definitions for controlling the usage of the strerror functions family. In this PR I am trying to simplify it a bit. These are the things I have done:

- Assume the usage of the **char *** version of `strerror_e` for linux. 
- Assume the usage of the **int** version of `strerror_e` for `__APPLE__` (XSI-Compliant). 
- Always assume the existence of `strerror` (It should be always available on C++98 compilers). We do not need to check whether it exists.

After few iterations I achieved to have everything working on CI (note that we already have some unit tests exercising that function on CI). 