### PR TITLE
Free potentially allocated regexes from Params::evalGrep

### DIFF
--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -193,6 +193,14 @@ Params& Params::instance()
     return *instance_;
 }
 
+Params::~Params() {
+#if defined(EXV_HAVE_REGEX_H)
+    for (size_t i=0; i<instance().greps_.size(); ++i) {
+        regfree(&instance().greps_.at(i));
+    }
+#endif
+}
+
 void Params::cleanup()
 {
     delete instance_;

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -296,6 +296,9 @@ private:
     //! Prevent copy-construction: not implemented.
     Params(const Params& rhs);
 
+    //! Destructor, frees any allocated regexes in greps_
+    ~Params();
+
     //! @name Helpers
     //@{
     int setLogLevel(const std::string& optarg);


### PR DESCRIPTION
In `Params::evalGrep` regcomp allocates some internal space for the regex objects, which must be freed manually via `regfree()`. This was however only done when the call to `regcomp()` failed and not on success. As the regexes are needed later, they have to be deallocated by the destructor.