### PR TITLE
conan: Use GTest as a static library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,6 @@ class Exiv2Conan(ConanFile):
     def configure(self):
         if not os_info.is_macos:
             self.options['libcurl'].shared = True
-        self.options['gtest'].shared = True
 
     def requirements(self):
         self.requires('Expat/2.2.5@pix4d/stable')

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -14,17 +14,13 @@ target_link_libraries(unit_tests
     PRIVATE
         exiv2lib
         ${GTEST_BOTH_LIBRARIES}
+        Threads::Threads
 )
 
 target_include_directories(unit_tests
     PRIVATE
         ${GTEST_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/src
-)
-
-target_compile_definitions(unit_tests
-    PRIVATE
-        GTEST_LINKED_AS_SHARED_LIBRARY=1
 )
 
 set_target_properties( unit_tests PROPERTIES


### PR DESCRIPTION
In #281 we had a brief discussion about using GTest as a shared or static library. Since for us it is not a big deal, and it could actually simplify things in the CI side, I am just switching from shared to static here. 