### PR TITLE
App veyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,14 +27,11 @@ before_build:
     - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
     - cmd: cat c:\Users\appveyor\.conan\conan.conf
     - cmd: mkdir c:\Users\appveyor\.conan\profiles
-      #- cmd: printf "os=Windows\narch=x86\ncompiler=Visual Studio\ncompiler.version=14\ncompiler.runtime=MD\nbuild_type=Release\n" > c:\Users\appveyor\.conan\profiles\release
-      #- cmd: cat c:\Users\appveyor\.conan\profiles\release
 
 build_script:
     - cmd: md build
     - cmd: cd build
     - cmd: conan install .. --build missing
-      #- cmd: conan install .. --build missing --profile release
     - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
     - cmd: cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: ninja
@@ -46,11 +43,5 @@ build_script:
     - cmd: c:\Python36\python.exe runner.py -v
 
 cache:
-    - envs                   # Conan installation
-
-# For some reason, if I add into the cache the conanCache folder then I get an error like this when calling conan
-# install:
-#Expat/2.2.1@pix4d/stable: Already installed!
-#zlib/1.2.8@lasote/stable: Already installed!
-#OpenSSL/1.0.2i@lasote/stable: Already installed!
-#ERROR: Error while trying to get recipe sources for libcurl/7.50.3@lasote/stable. No remote defined
+    - envs                          # Conan installation
+    - c:\Users\appveyor\conanCache  # Conan cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ before_build:
     - cmd: cd envs
     - cmd: python -m virtualenv conan
     - cmd: conan/Scripts/activate
-    - cmd: python -m pip install conan==1.1.1
+    - cmd: python -m pip install conan==1.3.3
     - cmd: cd ..
     - cmd: conan --version
     - cmd: conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan


### PR DESCRIPTION
Enable the caching of the conanCache directory so that we do not need to fetch the packages from the remotes in every job execution.

Furthermore I have updated conan to the latest stable version. 

Note that this PR fixes #331 