### PR TITLE
Doc with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,11 @@ if( EXIV2_BUILD_UNIT_TESTS )
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # Requires CMake 3.3.3
 endif()
 
-include(config/findDependencies.cmake)
-include(config/compilerFlags.cmake)
-include(config/generateConfigFile.cmake )
+include(config/findDependencies.cmake   REQUIRED)
+include(config/compilerFlags.cmake      REQUIRED)
+include(config/generateConfigFile.cmake REQUIRED)
+include(config/generateDoc.cmake        REQUIRED)
+
 include_directories(${CMAKE_BINARY_DIR})  # Make the exv_conf.h file visible for the full project
 
 include( config/CMakeChecks.txt )
@@ -117,19 +119,6 @@ endif()
 ##
 # tests
 add_custom_target(tests       COMMAND env EXIV2_BINDIR="${CMAKE_BINARY_DIR}"/bin make tests       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" )
-
-##
-# http://dev.exiv2.org/boards/3/topics/1364
-# effectively does a make doc on the root directory
-# has to run 'make config' and './configure'
-# and copy bin/taglist to <exiv2dir>/bin/taglist for use by 'make doc'
-if( MINGW OR UNIX OR APPLE)
-  add_custom_target(doc
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/doc"
-    COMMAND chmod +x ./cmake_doc.sh
-    COMMAND ./cmake_doc.sh "${CMAKE_BINARY_DIR}"
-  )
-endif()
 
 include( config/printSummary.cmake )
 

--- a/config/Doxyfile.in
+++ b/config/Doxyfile.in
@@ -14,18 +14,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 
-# This tag specifies the encoding used for all characters in the config file
-# that follow. The default is UTF-8 which is also the encoding used for all
-# text before the first occurrence of this tag. Doxygen uses libiconv (or the
-# iconv built into libc) for the transcoding. See
-# http://www.gnu.org/software/libiconv for the list of possible encodings.
-
 DOXYFILE_ENCODING      = UTF-8
-
-# The PROJECT_NAME tag is a single word (or sequence of words) that should
-# identify the project. Note that if you do not use Doxywizard you need
-# to put quotes around the project name if it contains spaces.
-
 PROJECT_NAME           = Exiv2
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
@@ -668,7 +657,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = ../src/ ../include/exiv2/
+INPUT                  = @INCDIR@ \
+                         @SRCDIR@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -700,19 +690,19 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../samples/Jzon.h \
-                         ../samples/Jzon.cpp \
-                         ../src/actions.hpp \
-                         ../src/actions.cpp \
-                         ../src/getopt_win32.c \
-                         ../src/localtime.c \
-                         ../src/getopt_win32.h \
-                         ../src/private.h \
-                         ../src/timegm.h \
-                         ../src/tzfile.h \
-                         ../src/fff.h \
-                         ../include/exiv2/exv_msvc.h \
-                         ../include/exiv2/exv_msvc-webready.h
+EXCLUDE                = @ROOTDIR@/samples/Jzon.h \
+                         @ROOTDIR@/samples/Jzon.cpp \
+                         @SRCDIR@/actions.hpp \
+                         @SRCDIR@/actions.cpp \
+                         @SRCDIR@/getopt_win32.c \
+                         @SRCDIR@/localtime.c \
+                         @SRCDIR@/getopt_win32.h \
+                         @SRCDIR@/private.h \
+                         @SRCDIR@/timegm.h \
+                         @SRCDIR@/tzfile.h \
+                         @SRCDIR@/fff.h \
+                         @INCDIR@/exv_msvc.h \
+                         @INCDIR@/exv_msvc-webready.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -740,7 +730,7 @@ EXCLUDE_SYMBOLS        =
 # directories that contain example code fragments that are included (see
 # the \include command).
 
-EXAMPLE_PATH           = ../samples/
+EXAMPLE_PATH           = @ROOTDIR@/samples/
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp
@@ -1043,42 +1033,11 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # of the generated HTML documentation.
 
 GENERATE_HTMLHELP      = NO
-
-# If the GENERATE_HTMLHELP tag is set to YES, the CHM_FILE tag can
-# be used to specify the file name of the resulting .chm file. You
-# can add a path in front of the file if the result should not be
-# written to the html output directory.
-
 CHM_FILE               =
-
-# If the GENERATE_HTMLHELP tag is set to YES, the HHC_LOCATION tag can
-# be used to specify the location (absolute path including file name) of
-# the HTML help compiler (hhc.exe). If non-empty doxygen will try to run
-# the HTML help compiler on the generated index.hhp.
-
 HHC_LOCATION           =
-
-# If the GENERATE_HTMLHELP tag is set to YES, the GENERATE_CHI flag
-# controls if a separate .chi index file is generated (YES) or that
-# it should be included in the master .chm file (NO).
-
 GENERATE_CHI           = NO
-
-# If the GENERATE_HTMLHELP tag is set to YES, the CHM_INDEX_ENCODING
-# is used to encode HtmlHelp index (hhk), content (hhc) and project file
-# content.
-
 CHM_INDEX_ENCODING     =
-
-# If the GENERATE_HTMLHELP tag is set to YES, the BINARY_TOC flag
-# controls whether a binary table of contents is generated (YES) or a
-# normal table of contents (NO) in the .chm file.
-
 BINARY_TOC             = NO
-
-# The TOC_EXPAND flag can be set to YES to add extra items for group members
-# to the contents of the HTML help documentation and to the tree view.
-
 TOC_EXPAND             = NO
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and

--- a/config/generateDoc.cmake
+++ b/config/generateDoc.cmake
@@ -1,0 +1,33 @@
+# -helper macro to add a "doc" target with CMake build system.
+# and configure doxy.config.in to doxy.config
+#
+# target "doc" allows building the documentation with doxygen/dot on WIN32, Linux and Mac
+#
+
+macro(generate_documentation DOX_CONFIG_FILE)
+    if(NOT EXISTS "${DOX_CONFIG_FILE}")
+        message(FATAL_ERROR "Configuration file for doxygen not found")
+    endif()
+
+    #Define variables
+    set(INCDIR  "${PROJECT_SOURCE_DIR}/include/exiv2")
+    set(SRCDIR  "${PROJECT_SOURCE_DIR}/src")
+    set(ROOTDIR "${PROJECT_SOURCE_DIR}")
+    #set(TESTSDIR "${PROJECT_SOURCE_DIR}/tests")
+
+    configure_file(${DOX_CONFIG_FILE} ${CMAKE_CURRENT_BINARY_DIR}/doxy.config @ONLY) #OUT-OF-PLACE LOCATION
+    set(DOXY_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/doxy.config")
+    add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${DOXY_CONFIG})
+
+    install(DIRECTORY "${PROJECT_BINARY_DIR}/doc/html/" DESTINATION "share/doc/lib${PROJECT_NAME}")
+
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES doc)
+endmacro()
+
+find_package(Doxygen)
+
+if(DOXYGEN_FOUND)
+    message(STATUS "Doxygen found. Adding 'doc' target for generating the documentation")
+    generate_documentation("${PROJECT_SOURCE_DIR}/config/Doxyfile.in")
+endif()
+

--- a/config/printSummary.cmake
+++ b/config/printSummary.cmake
@@ -62,6 +62,7 @@ OptionOutput( "Building exiv2 command:             " EXIV2_BUILD_EXIV2_COMMAND  
 OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES             )
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
+OptionOutput( "Doxygen doc:                        " DOXYGEN_FOUND                   )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
 
 


### PR DESCRIPTION
In this PR I am changing the CMake code that generate the project documentation with Doxygen.

Before we were calling from CMake the scrip `cmake_doc.sh` that had to configure the project with the autotools to call `make doc`later. Since in #338 we are removing the autotools scripts, this functionality was going to be affected. 

Now we purely use CMake to create a new CMake target `doc`. Note that we have included a cmake template (`config/Doxyfile.in`) which will be populated by some values inferred by CMake (i.e, the paths to the source files). CMake will generate the final version of the Doxyfile in the build folder, and it will run **Doxygen** to generate the **html** folder inside the build folder too.

Note that the old files (which are not used anymore) will be removed later.

Fixes #339 