### PR TITLE
Iconv for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for exiv2 library
 
-cmake_minimum_required( VERSION 3.1.0 )
+cmake_minimum_required( VERSION 3.3.2 )
 project( exiv2 )
 
 include(GNUInstallDirs)

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,9 @@ class Exiv2Conan(ConanFile):
         self.requires('zlib/1.2.11@conan/stable')
         self.requires('libcurl/7.60.0@bincrafters/stable')
 
+        if os_info.is_windows:
+            self.requires('libiconv/1.15@bincrafters/stable')
+
         if self.options.unitTests:
             self.requires('gtest/1.8.0@bincrafters/stable')
 

--- a/config/FindIconv.cmake
+++ b/config/FindIconv.cmake
@@ -60,7 +60,7 @@ endif()
 # If any cache variable is already set, we'll skip this test.
 if(NOT DEFINED Iconv_IS_BUILT_IN)
   if(UNIX AND NOT DEFINED Iconv_INCLUDE_DIR AND NOT DEFINED Iconv_LIBRARY)
-    cmake_push_check_state(RESET)
+    include(CheckCSourceCompiles)
     # We always suppress the message here: Otherwise on supported systems
     # not having iconv in their C library (e.g. those using libiconv)
     # would always display a confusing "Looking for iconv - not found" message
@@ -87,7 +87,6 @@ if(NOT DEFINED Iconv_IS_BUILT_IN)
     else()
       check_cxx_source_compiles("${Iconv_IMPLICIT_TEST_CODE}" Iconv_IS_BUILT_IN)
     endif()
-    cmake_pop_check_state()
   else()
     set(Iconv_IS_BUILT_IN FALSE)
   endif()

--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -50,13 +50,10 @@ if( EXIV2_ENABLE_NLS )
     # the manual check in config/generateConfigFile.cmake
 endif( )
 
-if(UNIX) # TODO: Try to support this on Windows
-    include( FindIconv )
-    if( ICONV_FOUND )
-        message ( "-- ICONV_INCLUDE_DIR : " ${ICONV_INCLUDE_DIR} )
-        message ( "-- ICONV_LIBRARIES : " ${ICONV_LIBRARIES} )
-        message ( "-- ICONV_ACCEPTS_CONST_INPUT : ${ICONV_ACCEPTS_CONST_INPUT}" )
-    endif()
+include( FindIconv )
+if( ICONV_FOUND )
+    message ( "-- ICONV_INCLUDE_DIR : " ${Iconv_INCLUDE_DIR} )
+    message ( "-- ICONV_LIBRARIES : " ${Iconv_LIBRARY} )
 endif()
 
 if( EXIV2_BUILD_PO )

--- a/config/findDependencies.cmake
+++ b/config/findDependencies.cmake
@@ -50,7 +50,7 @@ if( EXIV2_ENABLE_NLS )
     # the manual check in config/generateConfigFile.cmake
 endif( )
 
-include( FindIconv )
+find_package(Iconv)
 if( ICONV_FOUND )
     message ( "-- ICONV_INCLUDE_DIR : " ${Iconv_INCLUDE_DIR} )
     message ( "-- ICONV_LIBRARIES : " ${Iconv_LIBRARY} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -275,8 +275,7 @@ if( EXIV2_ENABLE_NLS )
 endif()
 
 if( ICONV_FOUND )
-    target_include_directories( exiv2lib SYSTEM PRIVATE ${ICONV_INCLUDE_DIR})
-    target_link_libraries( exiv2lib PRIVATE  ${ICONV_LIBRARIES} )
+    target_link_libraries( exiv2lib PRIVATE Iconv::Iconv )
 endif()
 
 


### PR DESCRIPTION
This PR fixes #267.

There is a libiconv conan recipe available in [conan-center](https://bintray.com/bincrafters/public-conan/libiconv%3Abincrafters/1.15%3Astable) and we started to use it here. 

However the customised CMake finder that we had in the repository was not able to find the headers and libraries managed by conan. After updating this CMake file by the one available in the [CMake repository](https://github.com/Kitware/CMake/blob/master/Modules/FindIconv.cmake), CMake was able to find libiconv correctly. 

Note that we cannot use directly the module provided by CMake, since this is just available in very recent versions of CMake (starting from version 3.10) and our minimum required version is 3.1.

In future releases of Exiv2 we could update the minimum required version of CMake and remove the custom file we have in our project. 