### PR TITLE
TimeValue tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,6 +180,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library( exiv2lib_int OBJECT ${LIBEXIV2_PRIVATE_SRC} ${LIBEXIV2_PRIVATE_HDR})
 add_library( exiv2lib ${LIBEXIV2_SRC} ${LIBEXIV2_HDR} $<TARGET_OBJECTS:exiv2lib_int>)
 
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+    # Do not check format overflows on this file, to skip a false positive warning
+    set_source_files_properties(value.cpp PROPERTIES COMPILE_FLAGS -Wno-format-overflow)
+endif()
+
 set_target_properties( exiv2lib PROPERTIES
     VERSION       ${GENERIC_LIB_VERSION}
     SOVERSION     ${GENERIC_LIB_SOVERSION}

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_safe_op.cpp
     test_XmpKey.cpp
     test_DateValue.cpp
+    test_TimeValue.cpp
     test_cr2header_int.cpp
     test_helper_functions.cpp
 )

--- a/unitTests/test_TimeValue.cpp
+++ b/unitTests/test_TimeValue.cpp
@@ -1,0 +1,103 @@
+#include "value.hpp"
+
+#include "gtestwrapper.h"
+
+using namespace Exiv2;
+
+TEST(ATimeValue, isDefaultConstructed)
+{
+    const TimeValue value;
+    ASSERT_EQ(0, value.getTime().hour);
+    ASSERT_EQ(0, value.getTime().minute);
+    ASSERT_EQ(0, value.getTime().second);
+    ASSERT_EQ(0, value.getTime().tzHour);
+    ASSERT_EQ(0, value.getTime().tzMinute);
+}
+
+TEST(ATimeValue, isConstructedWithArgs)
+{
+    const TimeValue value (23, 55, 2);
+    ASSERT_EQ(23, value.getTime().hour);
+    ASSERT_EQ(55, value.getTime().minute);
+    ASSERT_EQ(2,  value.getTime().second);
+    ASSERT_EQ(0, value.getTime().tzHour);
+    ASSERT_EQ(0, value.getTime().tzMinute);
+}
+
+/// \todo add tests to check what happen with values out of valid ranges
+
+TEST(ATimeValue, canBeReadFromStringHMS)
+{
+    TimeValue value;
+    const std::string hms("23:55:02");
+    ASSERT_EQ(0, value.read(hms));
+    ASSERT_EQ(23, value.getTime().hour);
+    ASSERT_EQ(55, value.getTime().minute);
+    ASSERT_EQ(2,  value.getTime().second);
+    ASSERT_EQ(0, value.getTime().tzHour);
+    ASSERT_EQ(0, value.getTime().tzMinute);
+}
+
+TEST(ATimeValue, canBeReadFromWideString)
+{
+    TimeValue value;
+    const std::string hms("23:55:02+04:04");
+    ASSERT_EQ(0, value.read(hms));
+    ASSERT_EQ(23, value.getTime().hour);
+    ASSERT_EQ(55, value.getTime().minute);
+    ASSERT_EQ(2,  value.getTime().second);
+    ASSERT_EQ(4, value.getTime().tzHour);
+    ASSERT_EQ(4, value.getTime().tzMinute);
+}
+
+TEST(ATimeValue, canBeReadFromWideStringNegative)
+{
+    TimeValue value;
+    const std::string hms("23:55:02-04:04");
+    ASSERT_EQ(0, value.read(hms));
+    ASSERT_EQ(23, value.getTime().hour);
+    ASSERT_EQ(55, value.getTime().minute);
+    ASSERT_EQ(2,  value.getTime().second);
+    ASSERT_EQ(-4, value.getTime().tzHour);
+    ASSERT_EQ(-4, value.getTime().tzMinute);
+}
+
+/// \todo check what we should do here.
+TEST(ATimeValue, canBeReadFromWideStringOther)
+{
+    TimeValue value;
+    const std::string hms("23:55:02?04:04");
+    ASSERT_EQ(0, value.read(hms));
+    ASSERT_EQ(23, value.getTime().hour);
+    ASSERT_EQ(55, value.getTime().minute);
+    ASSERT_EQ(2,  value.getTime().second);
+    ASSERT_EQ(4, value.getTime().tzHour);
+    ASSERT_EQ(4, value.getTime().tzMinute);
+}
+
+TEST(ATimeValue, cannotReadFromStringWithBadFormat)
+{
+    TimeValue value;
+    ASSERT_EQ(1, value.read("aa:55:02")); // String with non-digit chars
+    ASSERT_EQ(1, value.read("25:55:02")); // Hours >= 24
+    ASSERT_EQ(1, value.read("23:65:02")); // Minutes >= 60
+    ASSERT_EQ(1, value.read("23:55:62")); // Seconds >= 60
+    ASSERT_EQ(1, value.read("23:55:02+25:04")); // tzHour >= 24
+    ASSERT_EQ(1, value.read("23:55:02+04:66")); // tzMinutes >= 60
+
+    /// \todo This one does not fail
+    //ASSERT_EQ(1, value.read("23:55:02+04:06:06")); // More components than expected
+}
+
+TEST(ATimeValue, isCopiedToBuffer)
+{
+    const TimeValue value (23, 55, 2);
+    byte buffer[11];
+    ASSERT_EQ(11, value.copy(buffer));
+
+    const byte expectedDate[11] = {'2', '3', '5', '5', '0', '2',
+                                   '+', '0', '0', '0', '0'};
+    for (int i = 0; i < 11; ++i) {
+        ASSERT_EQ(expectedDate[i], buffer[i]) << "i: " << i;
+    }
+}


### PR DESCRIPTION
I started to work in this branch with the aim of analysing the warning we were getting with GCC 7 in the file `value.cpp`:

```
[1/38] Building CXX object src/CMakeFiles/exiv2lib.dir/value.cpp.o
../src/value.cpp: In member function ‘virtual long int Exiv2::TimeValue::copy(Exiv2::byte*, Exiv2::ByteOrder) const’:
../src/value.cpp:1150:10: warning: ‘%02d’ directive writing between 2 and 10 bytes into a region of size between 0 and 5 [-Wformat-overflow=]
     long TimeValue::copy(byte* buf, ByteOrder /*byteOrder*/) const
          ^~~~~~~~~
../src/value.cpp:1150:10: note: directive argument in the range [0, 2147483647]
../src/value.cpp:1150:10: note: directive argument in the range [0, 2147483647]
In file included from /usr/include/stdio.h:862:0,
                 from ../include/exiv2/config.h:207,
                 from ../include/exiv2/types.hpp:34,
                 from ../include/exiv2/value.hpp:35,
                 from ../src/value.cpp:30:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:34:43: note: ‘__builtin___sprintf_chk’ output between 12 and 55 bytes into a destination of size 12
       __bos (__s), __fmt, __va_arg_pack ());
```
However after investigating a bit I think this is a false positive, and I have added this line to skip those checks in the file:

```
set_source_files_properties(value.cpp PROPERTIES COMPILE_FLAGS -Wno-format-overflow)
```
However, while I was investigating this issue I have been adding unit tests to the class TimeValue, and I've found some interesting things:

- The parametrized constructor does not perform range checks. 
- The function TimeValue::copy was copying the time to a buffer without ':' . So for the time 23:55:02+04:04 it was placing into the buffer --> 235502+0404. @clanmills do you think this is a bug ?
- I was expecting this to fail `value.read("23:55:02+04:06:06")` but it did not fail. So the read function is not checking for strings longer than expected.

I did a change to fix what I think is a bug in `TimeValue::copy` but it made some tests to fail:

```
OK
make[2]: Leaving directory '/home/luis/programming/exiv2/test'
*** FAILED
*** geotag-test.sh result = 3
*** icc-test.sh result = 3
*** webp-test.sh result = 3
```
I'm creating this PR to discuss what to do. If you guys think this is a real bug we can adapt the tests.