### PR TITLE
Require dot command for 'doc' and change output folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option( EXIV2_BUILD_SAMPLES           "Build sample applications"               
 option( EXIV2_BUILD_PO                "Build translations files"                              OFF )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )
 option( EXIV2_BUILD_UNIT_TESTS        "Build unit tests"                                      OFF )
+option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentation"            OFF )
 
 # Only intended to be used by Exiv2 developers/contributors
 option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
@@ -88,7 +89,12 @@ endif()
 include(config/findDependencies.cmake   REQUIRED)
 include(config/compilerFlags.cmake      REQUIRED)
 include(config/generateConfigFile.cmake REQUIRED)
-include(config/generateDoc.cmake        REQUIRED)
+
+if (EXIV2_BUILD_DOC)
+    include(config/generateDoc.cmake        REQUIRED)
+    generate_documentation("${PROJECT_SOURCE_DIR}/config/Doxyfile.in")
+endif()
+
 
 include_directories(${CMAKE_BINARY_DIR})  # Make the exv_conf.h file visible for the full project
 

--- a/config/Doxyfile.in
+++ b/config/Doxyfile.in
@@ -41,7 +41,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = doc
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output

--- a/config/generateDoc.cmake
+++ b/config/generateDoc.cmake
@@ -26,8 +26,10 @@ endmacro()
 
 find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
-    message(STATUS "Doxygen found. Adding 'doc' target for generating the documentation")
+if(DOXYGEN_FOUND AND DOXYGEN_DOT_EXECUTABLE)
+    message(STATUS "Doxygen and dot found. Adding 'doc' target for generating the documentation")
     generate_documentation("${PROJECT_SOURCE_DIR}/config/Doxyfile.in")
+else()
+    message(STATUS "doxygen or dot not found. Both commands are needed for the adding the 'doc' target")
 endif()
 

--- a/config/generateDoc.cmake
+++ b/config/generateDoc.cmake
@@ -4,6 +4,8 @@
 # target "doc" allows building the documentation with doxygen/dot on WIN32, Linux and Mac
 #
 
+find_package(Doxygen REQUIRED dot)
+
 macro(generate_documentation DOX_CONFIG_FILE)
     if(NOT EXISTS "${DOX_CONFIG_FILE}")
         message(FATAL_ERROR "Configuration file for doxygen not found")
@@ -23,13 +25,3 @@ macro(generate_documentation DOX_CONFIG_FILE)
 
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES doc)
 endmacro()
-
-find_package(Doxygen)
-
-if(DOXYGEN_FOUND AND DOXYGEN_DOT_EXECUTABLE)
-    message(STATUS "Doxygen and dot found. Adding 'doc' target for generating the documentation")
-    generate_documentation("${PROJECT_SOURCE_DIR}/config/Doxyfile.in")
-else()
-    message(STATUS "doxygen or dot not found. Both commands are needed for the adding the 'doc' target")
-endif()
-

--- a/config/printSummary.cmake
+++ b/config/printSummary.cmake
@@ -62,7 +62,7 @@ OptionOutput( "Building exiv2 command:             " EXIV2_BUILD_EXIV2_COMMAND  
 OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES             )
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
-OptionOutput( "Doxygen doc:                        " DOXYGEN_FOUND                   )
+OptionOutput( "Doxygen doc:                        " DOXYGEN_FOUND AND DOXYGEN_DOT_EXECUTABLE )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
 
 

--- a/config/printSummary.cmake
+++ b/config/printSummary.cmake
@@ -62,7 +62,7 @@ OptionOutput( "Building exiv2 command:             " EXIV2_BUILD_EXIV2_COMMAND  
 OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES             )
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
-OptionOutput( "Doxygen doc:                        " DOXYGEN_FOUND AND DOXYGEN_DOT_EXECUTABLE )
+OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC                 )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
 
 


### PR DESCRIPTION
dot is needed to generate the exiv2 documentation. Furthermore we were
generating the documentation in ${PROJECT_BINARY_DIR}/html while the
CMake 'install' command was expecting to find the documentation directory
at ${PROJECT_BINARY_DIR}/doc/html. This has been also fixed in this
commit.

This PR fixes the problem described in #354 