### PR TITLE
Add Gitlab deploy stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,19 +1,32 @@
-# default build for all distros
-# only create artifacts of the build directory when something fails (for cmake logs)
-# cache the ccache/ directory for each job separately
-.build_template: &distro_build
+# all builds use the same ccache folder in the project root that is cached
+variables:
+  CCACHE_BASEDIR: '$CI_PROJECT_DIR'
+  CCACHE_DIR: '$CI_PROJECT_DIR/ccache'
+
+# default config for all distros:
+# - install dependencies via script
+# - create ccache dir & setup caching of it (for each job separately)
+.build_config: &default_config
   before_script:
     - ci/install_dependencies.sh
+    - mkdir -p ccache
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - ccache/
+
+# default build job:
+# - run build script
+# - only create artifacts of the build directory when something fails
+#   (for cmake logs)
+.build_template: &distro_build
   script:
     - python3 ci/test_build.py
   artifacts:
     when: on_failure
     paths:
       - build/
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - ccache/
+
 
 stages:
   - test
@@ -21,33 +34,38 @@ stages:
 
 Fedora:
   image: fedora:28
+  <<: *default_config
   <<: *distro_build
 
 Debian:
   image: debian:9
+  <<: *default_config
   <<: *distro_build
 
 Archlinux:
   image: base/archlinux
+  <<: *default_config
   <<: *distro_build
 
 Ubuntu:
   image: ubuntu:18.04
+  <<: *default_config
   <<: *distro_build
 
 CentOS:
   image: centos:7
+  <<: *default_config
   <<: *distro_build
 
 OpenSUSE:
   image: opensuse:tumbleweed
+  <<: *default_config
   <<: *distro_build
 
 Install:
   image: fedora:28
   stage: deploy
-  before_script:
-    - ci/install_dependencies.sh
+  <<: *default_config
   script:
     - mkdir build && cd build
     - cmake -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=/usr/ -DBUILD_WITH_CCACHE=ON ..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,10 @@
     paths:
       - ccache/
 
+stages:
+  - test
+  - deploy
+
 Fedora:
   image: fedora:28
   <<: *distro_build
@@ -38,3 +42,16 @@ CentOS:
 OpenSUSE:
   image: opensuse:tumbleweed
   <<: *distro_build
+
+Install:
+  image: fedora:28
+  stage: deploy
+  before_script:
+    - ci/install_dependencies.sh
+  script:
+    - mkdir build && cd build
+    - cmake -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=/usr/ -DBUILD_WITH_CCACHE=ON ..
+    - make -j $(nproc)
+    - make install
+    - make clean
+    - EXIV2_BINDIR=/usr/bin/ make tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,6 @@ variables:
     paths:
       - build/
 
-
 stages:
   - test
   - deploy
@@ -73,3 +72,20 @@ Install:
     - make install
     - make clean
     - EXIV2_BINDIR=/usr/bin/ make tests
+
+pages:
+  image: fedora:28
+  stage: deploy
+  <<: *default_config
+  script:
+    - dnf -y install doxygen graphviz
+    - mkdir build && cd build
+    - cmake -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_DOC=ON ..
+    - make doc
+    - cd ..
+    - mv build/doc/html/ public/
+  artifacts:
+    paths:
+      - public
+  only:
+    - master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 
 ##
 # tests
-add_custom_target(tests       COMMAND env EXIV2_BINDIR="${CMAKE_BINARY_DIR}"/bin make tests       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" )
+add_custom_target(tests       COMMAND env EXIV2_BUILDDIR="${CMAKE_BINARY_DIR}" make tests       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" )
 
 include( config/printSummary.cmake )
 

--- a/ci/test_build.py
+++ b/ci/test_build.py
@@ -37,10 +37,8 @@ def call_wrapper(*args, **kwargs):
         sys.exit(return_code)
 
 
-# create build & ccache directory (ccache could already exist in the CI's cache)
+# create build directory
 os.mkdir("build")
-if not os.path.exists('ccache'):
-    os.mkdir("ccache")
 
 root_dir = os.path.abspath(os.getcwd())
 
@@ -64,8 +62,6 @@ for params in itertools.product(SHARED_LIBS, CCS, BUILD_TYPES):
     env_copy = os.environ.copy()
     env_copy["CC"] = cc
     env_copy["CXX"] = cxx
-    env_copy["CCACHE_BASEDIR"] = root_dir
-    env_copy["CCACHE_DIR"] = os.path.join(root_dir, "ccache")
 
     # location of the binaries for the new test suite:
     env_copy["EXIV2_BINDIR"] = os.path.join(cwd, "bin")

--- a/ci/test_build.py
+++ b/ci/test_build.py
@@ -68,7 +68,7 @@ for params in itertools.product(SHARED_LIBS, CCS, BUILD_TYPES):
     env_copy["CCACHE_DIR"] = os.path.join(root_dir, "ccache")
 
     # location of the binaries for the new test suite:
-    env_copy["EXIV2_PATH"] = os.path.join(cwd, "bin")
+    env_copy["EXIV2_BINDIR"] = os.path.join(cwd, "bin")
 
     kwargs = {"env": env_copy, "cwd": cwd}
 

--- a/config/Doxyfile.in
+++ b/config/Doxyfile.in
@@ -1596,7 +1596,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       = html/exiv2.xml
+GENERATE_TAGFILE       = doc/html/exiv2.xml
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed
 # in the class index. If set to NO only the inherited external classes

--- a/test/functions.source
+++ b/test/functions.source
@@ -442,7 +442,11 @@ prepareTest()
 	datadir="../data"
 
 	if [ -z "$EXIV2_BINDIR" ] ; then
-		bin="$here/../bin/"
+                if [ -z "$EXIV2_BUILDDIR" ]; then
+                        bin="$EXIV2_BUILDDIR/bin/"
+                else
+                        bin="$here/../build/bin/"
+                fi
 	else
 		bin="$EXIV2_BINDIR/"
 	fi

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -2,7 +2,7 @@
 timeout: 1
 
 [ENV]
-exiv2_path: EXIV2_PATH
+exiv2_path: EXIV2_BINDIR
 binary_extension: EXIV2_EXT
 
 [ENV fallback]


### PR DESCRIPTION
In this PR I am adding a new stage to the GitLab CI. This feature is basically another step: after all distros have been tested, GitLab will run the jobs belonging to the next stage. Those are currently:
1. try to install exiv2 and run the test suite with the installed binaries
2. build the documentation and upload it to https://d4n.gitlab.io/exiv2/ (for builds on `master` only)

This required some changes:
- `make tests` now no longer gets `EXIV2_BINDIR` but `EXIV2_BUILDDIR` via cmake as the environment variable. This was necessary to be able to run the tests from the installed directory but also not breaking test runs from the build directory. The normal workflow shouldn't change at all.
- ccache settings are now handled in `.gitlab-ci.yml`
- a small fix in the `Doxyfile` as the tagfile was not adjusted to the new path and the documentation generation would fail