### PR TITLE
Fix accidentally removed tests target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,13 @@ endif()
 
 ##
 # tests
-add_custom_target(tests       COMMAND env EXIV2_BUILDDIR="${CMAKE_BINARY_DIR}" make tests       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" )
+add_custom_target(tests
+    COMMAND env EXIV2_BUILDDIR="${CMAKE_BINARY_DIR}" make test
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
+)
+
+get_directory_property(SAMPLES DIRECTORY samples DEFINITION APPLICATIONS)
+add_dependencies(tests exiv2lib exiv2 ${SAMPLES})
 
 include(cmake/printSummary.cmake)
 


### PR DESCRIPTION
#338 removed the non-cmake configuration tools. Unfortunately also the Makefile in the project's root directory got deleted, which was called from cmake via `make tests` (the Makefile itself then called the `test` target in the Makefile in `test/`). Thus the testsuite got effectively disabled.

This PR fixes this. 

~~~TODO: `tests` does not depend on anything. It fails miserably if called before `make`.~~~ (should be fixed now)