### PR TITLE
cmake: new option to enable compilations with coverage flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
+      env: COVERAGE=1 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DBUILD_WITH_COVERAGE=ON" # All enabled + Coverage
     - os: linux
       dist: trusty
       sudo: required

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ mark_as_advanced(
 )
 
 option( BUILD_WITH_CCACHE             "Use ccache to speed up compilations"                   OFF )
+option( BUILD_WITH_COVERAGE           "Add compiler flags to generate coverage stats"         OFF )
 
 if ( EXIV2_ENABLE_WEBREADY )
     set ( EXIV2_ENABLE_CURL ON )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| Travis        | AppVeyor      | GitLab|
-|:-------------:|:-------------:|:-----:|
-| [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=master)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al/branch/master?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp/branch/master) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/master/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/master) |
+| Travis        | AppVeyor      | GitLab| Codecov|
+|:-------------:|:-------------:|:-----:|:------:|
+| [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=master)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al/branch/master?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp/branch/master) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/master/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/master) | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/master/graph/badge.svg)](https://codecov.io/gh/Exiv2/exiv2) |
 
 
 <pre><code>

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -28,7 +28,8 @@ fi
 
 python --version
 pip install urllib3[secure] -U #Should solve SSL issues
-pip install conan==1.1.1
+pip install conan==1.6.1
+pip install codecov
 conan --version
 conan config set storage.path=~/conanData
 conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -31,3 +31,8 @@ make tests
 make install
 cd bin
 ./unit_tests
+
+if [ -n "$COVERAGE" ]; then
+    cd ..
+    bash <(curl -s https://codecov.io/bash)
+fi

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -19,6 +19,15 @@ if ( MINGW OR UNIX ) # MINGW, Linux, APPLE, CYGWIN
     endif()
 
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
+
+        if(BUILD_WITH_COVERAGE)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage")
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+        endif()
+
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W")
 
         if ( CYGWIN OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0))

--- a/cmake/printSummary.cmake
+++ b/cmake/printSummary.cmake
@@ -63,6 +63,7 @@ OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES        
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
 OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC                 )
+OptionOutput( "Building with coverage flags:       " BUILD_WITH_COVERAGE             )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
 
 


### PR DESCRIPTION
This PR introduces a new CMake option to easily add the gcc/clang compiler flags to enable the coverage reports. Find more details about this topic in #390 