### PR TITLE
CMake: Add RPATH configuration for Linux/Solaris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,7 @@
-# CMakeLists.txt for exiv2 library
-
 cmake_minimum_required( VERSION 3.3.2 )
 project( exiv2 )
 
-include(GNUInstallDirs)
-include(CheckFunctionExists)
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
-
-set(CMAKE_MACOSX_RPATH ON)
-
-if (APPLE)
-    set(CMAKE_INSTALL_RPATH "@loader_path")
-endif()
+include(cmake/mainSetup.cmake  REQUIRED)
 
 set( PACKAGE_COPYRIGHT      "Andreas Huggel" )
 set( PACKAGE_BUGREPORT      "http://github.com/exiv2/exiv2" )

--- a/cmake/mainSetup.cmake
+++ b/cmake/mainSetup.cmake
@@ -1,0 +1,22 @@
+# In this file we configure some CMake settings we do not want to make visible directly in the main
+# CMakeLists.txt file.
+
+include(GNUInstallDirs)
+include(CheckFunctionExists)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
+
+
+if (UNIX)
+    if (APPLE)
+        set(CMAKE_MACOSX_RPATH ON)
+        set(CMAKE_INSTALL_RPATH "@loader_path")
+    else()
+        set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    endif()
+endif()


### PR DESCRIPTION
This PR fixes the situation described in #358. 

Note that this RPATH setup is following a recommendation from the CMake documentation:
https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling#recommendations

I have used this approach successfully in other projects, and it plays very well with CPack for the packaging process.