### PR TITLE
Fix warnings reported by gcc in Release mode

### DIFF
--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -11,8 +11,6 @@
 #include <cassert>
 #include <cmath>
 
-#define UNUSED(expr) do { (void)(expr); } while (0)
-
 bool isEqual(float a, float b)
 {
     double d = std::fabs(a - b);

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -1133,49 +1133,73 @@ namespace {
         return true;
     } // parseTime
 
-    int parseCommonTargets(const std::string& optarg,
-                           const std::string& action)
+    void printUnrecognizedArgument(const char argc, const std::string& action)
     {
-        int rc     = 0;
+        std::cerr << Params::instance().progname() << ": " << _("Unrecognized ")
+                  << action << " " << _("target") << " `"  << argc << "'\n";
+    }
+
+    int parseCommonTargets(const std::string& optarg, const std::string& action)
+    {
+        int rc = 0;
         int target = 0;
-        int all    = Params::ctExif | Params::ctIptc | Params::ctComment | Params::ctXmp;
-        int extra  = Params::ctXmpSidecar|Params::ctExif|Params::ctIptc|Params::ctXmp;
+        int all = Params::ctExif | Params::ctIptc | Params::ctComment | Params::ctXmp;
+        int extra = Params::ctXmpSidecar | Params::ctExif | Params::ctIptc | Params::ctXmp;
         for (size_t i = 0; rc == 0 && i < optarg.size(); ++i) {
             switch (optarg[i]) {
-            case 'e': target |= Params::ctExif; break;
-            case 'i': target |= Params::ctIptc; break;
-            case 'x': target |= Params::ctXmp; break;
-            case 'c': target |= Params::ctComment; break;
-            case 't': target |= Params::ctThumb; break;
-            case 'C': target |= Params::ctIccProfile; break;
-            case 'I': target |= Params::ctIptcRaw;break;
-            case '-': target |= Params::ctStdInOut;break;
-            case 'a': target |= all ; break;
-            case 'X': target |= extra ; // -eX
-                 if ( i > 0 ) { // -eXX or -iXX
-                    target |=  Params::ctXmpRaw ;
-                    target &= ~extra; // turn off those bits
-                 }
-            break;
+                case 'e':
+                    target |= Params::ctExif;
+                    break;
+                case 'i':
+                    target |= Params::ctIptc;
+                    break;
+                case 'x':
+                    target |= Params::ctXmp;
+                    break;
+                case 'c':
+                    target |= Params::ctComment;
+                    break;
+                case 't':
+                    target |= Params::ctThumb;
+                    break;
+                case 'C':
+                    target |= Params::ctIccProfile;
+                    break;
+                case 'I':
+                    target |= Params::ctIptcRaw;
+                    break;
+                case '-':
+                    target |= Params::ctStdInOut;
+                    break;
+                case 'a':
+                    target |= all;
+                    break;
+                case 'X':
+                    target |= extra;  // -eX
+                    if (i > 0) {      // -eXX or -iXX
+                        target |= Params::ctXmpRaw;
+                        target &= ~extra;  // turn off those bits
+                    }
+                    break;
 
-            case 'p':
-            {
-                if (strcmp(action.c_str(), "extract") == 0) {
-                    i += (size_t) parsePreviewNumbers(Params::instance().previewNumbers_, optarg, (int) i + 1);
-                    target |= Params::ctPreview;
+                case 'p': {
+                    if (strcmp(action.c_str(), "extract") == 0) {
+                        i += (size_t)parsePreviewNumbers(Params::instance().previewNumbers_, optarg, (int)i + 1);
+                        target |= Params::ctPreview;
+                        break;
+                    }
+                    printUnrecognizedArgument(optarg[i], action);
+                    rc = -1;
                     break;
                 }
-                // fallthrough
-            }
-            default:
-                std::cerr << Params::instance().progname() << ": " << _("Unrecognized ")
-                          << action << " " << _("target") << " `"  << optarg[i] << "'\n";
-                rc = -1;
-                break;
+                default:
+                    printUnrecognizedArgument(optarg[i], action);
+                    rc = -1;
+                    break;
             }
         }
         return rc ? rc : target;
-    } // parseCommonTargets
+    }
 
     int parsePreviewNumbers(Params::PreviewNumbers& previewNumbers,
                             const std::string& optarg,

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -40,6 +40,7 @@
 #include "jpgimage.hpp"
 #include "tiffimage.hpp"
 #include "tiffimage_int.hpp"
+#include "unused.h"
 
 // *****************************************************************************
 namespace {
@@ -525,7 +526,7 @@ namespace {
         : Loader(id, image)
     {
         offset_ = 0;
-		const ExifData &exifData = image_.exifData();
+        const ExifData &exifData = image_.exifData();
         ExifData::const_iterator pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
         if (pos != exifData.end() && pos->count() > 0) {
             offset_ = pos->toLong();
@@ -1038,7 +1039,8 @@ namespace Exiv2 {
     {
         pData_ = data.pData_;
         size_ = data.size_;
-        data.release();
+        std::pair<byte*, long> ret = data.release();
+        UNUSED(ret);
     }
 
     PreviewImage::~PreviewImage()

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -28,6 +28,7 @@
 // included header files
 #include "types.hpp"
 #include "i18n.h"                               // for _exvGettext
+#include "unused.h"
 
 // + standard includes
 #ifdef EXV_UNICODE_PATH
@@ -124,7 +125,8 @@ namespace Exiv2 {
     DataBuf::DataBuf(DataBuf& rhs)
         : pData_(rhs.pData_), size_(rhs.size_)
     {
-        rhs.release();
+        std::pair<byte*, long> ret = rhs.release();
+        UNUSED(ret);
     }
 
     DataBuf::DataBuf(const byte* pData, long size)

--- a/unitTests/test_helper_functions.cpp
+++ b/unitTests/test_helper_functions.cpp
@@ -7,7 +7,7 @@ TEST(string_from_unterminated, terminatedArray)
     const char data[5] = {'a', 'b', 'c', 0, 'd'};
     const std::string res = string_from_unterminated(data, 5);
 
-    ASSERT_EQ(res.size(), 3);
+    ASSERT_EQ(res.size(), 3u);
     ASSERT_STREQ(res.c_str(), "abc");
 }
 
@@ -16,6 +16,6 @@ TEST(string_from_unterminated, unterminatedArray)
     const char data[4] = {'a', 'b', 'c', 'd'};
     const std::string res = string_from_unterminated(data, 4);
 
-    ASSERT_EQ(res.size(), 4);
+    ASSERT_EQ(res.size(), 4u);
     ASSERT_STREQ(res.c_str(), "abcd");
 }


### PR DESCRIPTION
There were some remaining warnings reported by GCC that I have cleaned up in this branch.

There are still some others warnings in `crwimage_int.cpp` that I want to clean up in the future, but it would need more work and I would like to understand the CRW support first. 