### PR TITLE
Testsuite improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COVERAGE=1 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DBUILD_WITH_COVERAGE=ON -DEXIV2_TEAM_USE_SANITIZERS=ON" # All enabled + Coverage
+      env: COVERAGE=1 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DBUILD_WITH_COVERAGE=ON" # All enabled + Coverage
+
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      env:
+        - WITH_VALGRIND=1
+        - CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON"
 
     - os: linux
       dist: trusty
@@ -19,7 +27,7 @@ matrix:
           - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - g++-8
-      env: CC=gcc-8 CXX=g++-8 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_TEAM_USE_SANITIZERS=ON"
+      env: CC=gcc-8 CXX=g++-8 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON"
 
     - os: linux
       dist: trusty
@@ -29,7 +37,7 @@ matrix:
     - os: osx
       osx_image: xcode9
       compiler: clang
-      env: PYTHON=3.6.2 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_TEAM_USE_SANITIZERS=ON" # All enabled
+      env: PYTHON=3.6.2 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON" # All enabled
 
 env:
     #- CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release" # Default

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,6 +6,9 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
     sudo apt-get update
     sudo apt-get install cmake zlib1g-dev libssh-dev gettext
     sudo apt-get install python-pip libxml2-utils
+    if [ -n "$WITH_VALGRIND" ]; then
+        sudo apt-get install valgrind
+    fi
     sudo pip install virtualenv
     virtualenv conan
     source conan/bin/activate

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,7 +5,17 @@ set -x
 
 if [[ "$(uname -s)" == 'Linux' ]]; then
     source conan/bin/activate
+
+    if [ "$CC" == "clang" ]; then
+        # clang + Ubuntu don't like to run with UBSAN, but ASAN works
+        export CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_CXX_FLAGS=\"-fsanitize=address\" -DCMAKE_C_FLAGS=\"-fsanitize=address\" -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=address\" -DCMAKE_MODULE_LINKER_FLAGS=\"-fsanitize=address\""
+    elif [ -n "$WITH_VALGRIND" ]; then
+        export EXIV2_VALGRIND="valgrind --quiet"
+    else
+        export CMAKE_OPTIONS="$CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=ON"
+    fi
 else
+    export CMAKE_OPTIONS="$CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=ON"
     export PYENV_VERSION=$PYTHON
     export PATH="/Users/travis/.pyenv/shims:${PATH}"
     eval "$(pyenv init -)"
@@ -16,15 +26,17 @@ fi
 
 mkdir build && cd build
 conan install .. --build missing --profile release
+
 cmake ${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=install ..
 make -j2 VERBOSE=1
 
 make tests
 make install
+pushd .
 cd bin
-./unit_tests
+$EXIV2_VALGRIND ./unit_tests
+popd
 
 if [ -n "$COVERAGE" ]; then
-    cd ..
     bash <(curl -s https://codecov.io/bash)
 fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -19,9 +19,6 @@ conan install .. --build missing --profile release
 cmake ${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=install ..
 make -j2 VERBOSE=1
 
-#On most systems, you can set the TZ environment variable to set the timezone for a process. It's a POSIX feature.
-export TZ=UTC
-
 make tests
 make install
 cd bin

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -404,6 +404,7 @@ namespace Exiv2 {
                     throw Error(kerInvalidMalloc);
                 }
                 DataBuf  buf((long)allocate);  // allocate a buffer
+                std::memset(buf.pData_, 0, buf.size_);
                 std::memcpy(buf.pData_,dir.pData_+8,4);  // copy dir[8:11] into buffer (short strings)
                 const bool bOffsetIsPointer = count*size > 4;
 

--- a/tests/bugfixes/redmine/test_issue_1043.py
+++ b/tests/bugfixes/redmine/test_issue_1043.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import string
+
+import system_tests
+
+
+class FailureOnCifsShares(metaclass=system_tests.CaseMeta):
+
+    url = "http://dev.exiv2.org/issues/1043"
+    num = 1043
+
+    original_file = system_tests.path("$data_path/exiv2-bug884c.jpg")
+
+    files = [
+        system_tests.path("$data_path/bug$num-" + char + ".jpg")
+        for char in string.ascii_uppercase
+    ]
+
+    def setUp(self):
+        for fname in self.files:
+            shutil.copyfile(self.original_file, fname)
+
+    def tearDown(self):
+        for fname in self.files:
+            os.remove(fname)
+
+    commands = [
+        """$exiv2 -u -v -M"set Exif.Photo.UserComment Test Bug $num my filename is {fname_short}" {fname}"""\
+        .format(fname=fname, fname_short=os.path.split(fname)[1])
+        for fname in files
+    ] + [
+        # workaround for * wildcard in bash:
+        """$exiv2 -PE -g UserComment {!s}""".format(" ".join(files))
+    ]
+
+    retval = [0] * (len(files) + 1)
+    stdout = [
+        """File 1/1: {fname}
+Set Exif.Photo.UserComment "Test Bug $num my filename is {fname_short}" (Comment)
+"""
+        .format(fname=fname, fname_short=os.path.split(fname)[1])
+        for fname in files
+    ] + [
+        """""".join(
+            """{fname}  Exif.Photo.UserComment                       Undefined  50  Test Bug $num my filename is {fname_short}
+"""
+            .format(fname=fname, fname_short=os.path.split(fname)[1])
+            for fname in files
+        )
+    ]
+
+    stderr= [""] * (len(files) + 1)

--- a/tests/bugfixes/redmine/test_issue_1054.py
+++ b/tests/bugfixes/redmine/test_issue_1054.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
-import unittest
-import os
 
 import system_tests
 
-@unittest.skipUnless(os.getenv('TZ') == 'UTC', "Testcase only works with the timezone set to UTC")
+
 class Exiv2jsonRecursiveJsonTreeWithXMP(metaclass=system_tests.CaseMeta):
 
     url = "http://dev.exiv2.org/issues/1054"
+
+    env = {
+        'TZ': 'UTC'
+    }
 
     filename1 = system_tests.path("$data_path/BlueSquare.xmp")
     filename2 = system_tests.path("$data_path/exiv2-bug784.jpg")

--- a/tests/bugfixes/redmine/test_issue_1074.py
+++ b/tests/bugfixes/redmine/test_issue_1074.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import hashlib
+
+import system_tests
+
+
+class IccProfileInApp2Segment(metaclass=system_tests.CaseMeta):
+
+    url = "http://dev.exiv2.org/issues/1074"
+    num = 1074
+
+    encodings = [bytes]
+
+    filenames = [
+        system_tests.path("$data_path/" + fname)
+        for fname in (
+            "exiv2-bug$num.png", "imagemagick.png", "Reagan.tiff", "Reagan.jpg"
+        )
+    ]
+
+    commands = [
+        "$exiv2 -pC " + fname for fname in filenames
+    ]
+
+    def compare_stdout(self, i, command, got_stdout, expected_stdout):
+        self.assertEqual(
+            hashlib.md5(got_stdout).hexdigest(), expected_stdout
+        )
+
+    stderr = [bytes()] * len(filenames)
+    stdout = [
+        "5c02432934195866147d8cbfa49f3fcf",
+        "cf0aeee7fdc11b20ad8a19d65628488e",
+        "1d3fda2edb4a89ab60a23c5f7c7d81dd",
+        "50b9125494306a6fc1b7c4f2a1a8d49d"
+    ]
+    retval = [0] * len(filenames)

--- a/tests/bugfixes/redmine/test_issue_1137.py
+++ b/tests/bugfixes/redmine/test_issue_1137.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+
+@system_tests.CopyFiles("$data_path/exiv2-empty.jpg")
+class MetadataPiping(metaclass=system_tests.CaseMeta):
+
+    url = "http://dev.exiv2.org/issues/1137"
+
+    filename = system_tests.path("$data_path/exiv2-empty_copy.jpg")
+    Stonehenge = system_tests.path("$data_path/Stonehenge.exv")
+
+    commands = [
+        """$exiv2 -pa                   $filename""",
+        """$exiv2 -PkV --grep GPSL      $Stonehenge""",
+        """$exiv2 -m- $filename""",
+        """$exiv2 -pa  --grep GPSL      $filename"""
+    ]
+
+    output_grep_GPSL = """set Exif.GPSInfo.GPSLatitudeRef                   N
+set Exif.GPSInfo.GPSLatitude                      51/1 106969/10000 0/1
+set Exif.GPSInfo.GPSLongitudeRef                  W
+set Exif.GPSInfo.GPSLongitude                     1/1 495984/10000 0/1
+"""
+
+    stdin = [
+        None,
+        None,
+        output_grep_GPSL,
+        None
+    ]
+
+    stdout = [
+        "",
+        output_grep_GPSL,
+        "",
+        """Exif.GPSInfo.GPSLatitudeRef                  Ascii       2  North
+Exif.GPSInfo.GPSLatitude                     Rational    3  51deg 10.69690' 
+Exif.GPSInfo.GPSLongitudeRef                 Ascii       2  West
+Exif.GPSInfo.GPSLongitude                    Rational    3  1deg 49.59840' 
+"""
+    ]

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -381,6 +381,40 @@ Using the bytes encoding has the following limitations:
   valid `bytes`
 
 
+### Setting and modifying environment variables
+
+The test suite supports setting or modifying environment variables for
+individual test cases. This can be accomplished by adding a member dictionary
+named `env` with the appropriate variable names and keys:
+``` python
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+
+class AnInformativeName(metaclass=CaseMeta):
+
+    env = {
+        "MYVAR": 26,
+        "USER": "foobar"
+    }
+
+    # if you want a pristine environment, consisting only of MYVAR & USER,
+    # uncomment the following line:
+    # inherit_env = False
+
+    # the rest of the test case follows
+```
+
+All commands belonging to this test case will be run with a modified environment
+where the variables `MYVAR` and `USER` will be set to the specified
+values. By default the environment is inherited from the user's environment and
+the specified variables in `env` take precedence over the variables in the
+user's environment (in the above example the variable `$USER` would be
+overridden). If no variables should be inherited set `inherit_env` to `False`
+and your test case will get only the specified environment variables.
+
+
 ### Creating file copies
 
 For tests that modify their input file it is useful to run these with a

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -312,6 +312,48 @@ This section describes more advanced features that are probably not necessary
 the "standard" usage of the test suite.
 
 
+### Providing standard input to commands
+
+The test suite supports providing a standard input to commands in a similar
+fashion as the standard output and error are specified: it expects a list (with
+the length equal to the number of commands) of standard inputs (either strings
+or `bytes`). For commands that expect no standard input, simply set the
+respective entry to `None`:
+``` python
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+
+class AnInformativeName(metaclass=system_tests.CaseMeta):
+
+    commands = [
+	    "$binary -c $import_file --",
+        "$binary -c $import_file --"
+	]
+    retval = [1, 1]
+    stdin = [
+        "read file a",
+        None
+    ]
+    stdout = [
+        "Reading...",
+        ""
+    ]
+    stderr = [
+        "Error",
+        "No input provided"
+    ]
+```
+
+In this example, the command `$binary -c $import_file --` would be run twice,
+first with the standard input `read file a` and second without any input
+(resulting in the error `No input provided`).
+
+If all commands don't expect any standard input, omit the attribute `stdin`, the
+test suite will implicitly assume `None` for every command.
+
+
 ### Using a different output encoding
 
 The test suite will try to interpret the program's output as utf-8 encoded

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -562,7 +562,9 @@ python3 runner.py
 
 One can supply the script with a directory where the suite should look for the
 tests (it will search the directory recursively). If omitted, the runner will
-look in the directory where the configuration file is located.
+look in the directory where the configuration file is located. It is also
+possible to instead pass a file as the parameter, the test suite will then only
+run the tests from this file.
 
 The runner script also supports the optional arguments `--config_file` which
 allows to provide a different test suite configuration file than the default

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -550,6 +550,43 @@ class AnInformativeName(metaclass=system_tests.CaseMeta):
 ```
 
 
+### Running all commands under valgrind
+
+The test suite can run all commands under a memory checker like
+[valgrind](http://valgrind.org/) or [dr. memory](http://drmemory.org/). This
+option can be enabled by adding the entry `memcheck` in the `General` section of
+the configuration file, which specifies the command to invoke the memory
+checking tool. The test suite will then prefix **all** commands with the
+specified command.
+
+For example this configuration file:
+``` ini
+[General]
+timeout: 0.1
+memcheck: valgrind --quiet
+```
+will result in every command specified in the test cases being run as `valgrind
+--quiet $command`.
+
+When running your test cases under a memory checker, please take the following
+into account:
+
+- valgrind and dr. memory slow the program execution down by a factor of
+  10-20. Therefore the test suite will increase the timeout value by a factor of
+  20 or by the value specified in the option `memcheck_timeout_penalty` in the
+  `General` section.
+
+- valgrind reports by default on success to stderr, be sure to run it with
+  `--quiet`. Otherwise successful tests will fail under valgrind, as unexpected
+  output is present on stderr
+
+- valgrind and ASAN cannot be used together
+
+- Although the option is called `memcheck`, it can be used to execute all
+  commands via a wrapper that has a completely different purpose (e.g. to
+  collect test coverage).
+
+
 ### Manually expanding variables in strings
 
 In case completely custom checks have to be run but one still wants to access

--- a/tests/doc.md
+++ b/tests/doc.md
@@ -351,6 +351,36 @@ encodings can be found
 [here](https://docs.python.org/3/library/codecs.html#standard-encodings).
 
 
+### Working with binary output
+
+Some programs output binary data directly to stdout or stderr. Such programs can
+be also tested by specifying the type `bytes` as the only member in the
+`encodings` list and supplying `stdout` and/or `stderr` as `bytes` and not as a
+string.
+
+An example test case would look like this:
+``` python
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+
+class AnInformativeName(metaclass=system_tests.CaseMeta):
+
+    encodings = [bytes]
+
+    commands = ["$prog --dump-binary"]
+    retval = [1]
+    stdout = [bytes([1, 2, 3, 4, 16, 42])]
+    stderr = [bytes()]
+```
+
+Using the bytes encoding has the following limitations:
+- variables of the form `$some_var` cannot be expanded in `stdout` and `stderr`
+- if the `bytes` encoding is specified, then both `stderr` and `stdout` must be
+  valid `bytes`
+
+
 ### Creating file copies
 
 For tests that modify their input file it is useful to run these with a

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -1,9 +1,11 @@
 [General]
 timeout: 1
+memcheck: ${ENV:valgrind}
 
 [ENV]
 exiv2_path: EXIV2_BINDIR
 binary_extension: EXIV2_EXT
+valgrind: EXIV2_VALGRIND
 
 [ENV fallback]
 exiv2_path: ../build/bin

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -701,6 +701,9 @@ class CaseMeta(type):
 
     def __new__(mcs, clsname, bases, dct):
 
+        assert len(_parameters) != 0, \
+            "Internal error: substitution dictionary not populated"
+
         changed = True
 
         # expand all non-private variables by brute force

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -535,6 +535,7 @@ def test_run(self):
             _cmd_splitter(command),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=self._get_env(),
             cwd=self.work_dir,
             shell=_SUBPROCESS_SHELL
         )
@@ -611,6 +612,8 @@ class Case(unittest.TestCase):
     #: the first encoding that does not raise a UnicodeError is used
     encodings = ['utf-8', 'iso-8859-1']
 
+    inherit_env = True
+
     @classmethod
     def setUpClass(cls):
         """
@@ -618,6 +621,27 @@ class Case(unittest.TestCase):
         path to the directory where the python source file is located.
         """
         cls.work_dir = os.path.dirname(inspect.getfile(cls))
+
+    def _get_env(self):
+        """ Return an appropriate env value for subprocess.Popen.
+
+        This function returns either an appropriately populated dictionary or
+        None (the latter if this class has no attribute env). If a dictionary
+        is returned, then it will be either exactly self.env (when inherit_env
+        is False) or a copy of the current environment merged with self.env
+        (the values from self.env take precedence).
+        """
+        if not hasattr(self, "env"):
+            return None
+
+        if not self.inherit_env:
+            return self.env
+
+        env_copy = os.environ.copy()
+        for key in self.env:
+            env_copy[key] = self.env[key]
+
+        return env_copy
 
     def _compare_output(self, i, command, got, expected, msg=None):
         """ Compares the expected and actual output of a test case. """

--- a/tests/system_tests.py
+++ b/tests/system_tests.py
@@ -35,14 +35,15 @@ else:
 
 def _disjoint_dict_merge(d1, d2):
     """
-    Merges two dictionaries with no common keys together and returns the result.
+    Merges two dictionaries whose keys are disjoint sets and returns the
+    resulting dictionary:
 
     >>> d1 = {"a": 1}
     >>> d2 = {"b": 2, "c": 3}
     >>> _disjoint_dict_merge(d1, d2) == {"a": 1, "b": 2, "c": 3}
     True
 
-    Calling this function with dictionaries that share keys raises a ValueError:
+    Passing dictionaries that share keys raises a ValueError:
     >>> _disjoint_dict_merge({"a": 1, "b": 6}, {"b": 2, "a": 3})
     Traceback (most recent call last):
      ..
@@ -112,12 +113,12 @@ def configure_suite(config_file):
     3. extract the environment variables given in the ``ENV`` section
     4. save all entries from the ``variables`` section in the global
        datastructure
-    5. interpret all entries in the ``paths`` section as relative paths from the
-       configuration file, expand them to absolute paths and save them in the
-       global datastructure
+    5. interpret all entries in the ``paths`` section as relative paths from
+       the configuration file, expand them to absolute paths and save them in
+       the global datastructure
 
-    For further information concerning the rationale behind this, please consult
-    the documentation in ``doc.md``.
+    For further information concerning the rationale behind this, please
+    consult the documentation in ``doc.md``.
     """
 
     if not os.path.exists(config_file):
@@ -134,11 +135,12 @@ def configure_suite(config_file):
     config.read(config_file)
 
     _parameters["suite_root"] = os.path.split(os.path.abspath(config_file))[0]
-    _parameters["timeout"] = config.getfloat("General", "timeout", fallback=1.0)
+    _parameters["timeout"] = config.getfloat(
+        "General", "timeout", fallback=1.0)
 
     if 'variables' in config and 'paths' in config:
-        intersecting_keys = set(config["paths"].keys())\
-                            .intersection(set(config["variables"].keys()))
+        intersecting_keys = set(config["paths"].keys()) \
+            .intersection(set(config["variables"].keys()))
         if len(intersecting_keys) > 0:
             raise ValueError(
                 "The sections 'paths' and 'variables' must not share keys, "
@@ -494,10 +496,10 @@ def path(path_string):
 
 def test_run(self):
     """
-    This function reads in the members commands, retval, stdout, stderr and runs
-    the `expand_variables` function on each. The resulting commands are then run
-    using the subprocess module and compared against the expected values that
-    were provided in the static members via `compare_stdout` and
+    This function reads in the members commands, retval, stdout, stderr and
+    runs the `expand_variables` function on each. The resulting commands are
+    then run using the subprocess module and compared against the expected
+    values that were provided in the static members via `compare_stdout` and
     `compare_stderr`. Furthermore a threading.Timer is used to abort the
     execution if a configured timeout is reached.
 
@@ -608,8 +610,8 @@ class Case(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        This function adds the variable work_dir to the class, which is the path
-        to the directory where the python source file is located.
+        This function adds the variable work_dir to the class, which is the
+        path to the directory where the python source file is located.
         """
         cls.work_dir = os.path.dirname(inspect.getfile(cls))
 
@@ -641,8 +643,8 @@ class Case(unittest.TestCase):
 
     def expand_variables(self, unexpanded_string):
         """
-        Expands all variables of the form ``$var`` in the given string using the
-        dictionary `variable_dict`.
+        Expands all variables of the form ``$var`` in the given string using
+        the dictionary `variable_dict`.
 
         The expansion itself is performed by the string's template module using
         via `safe_substitute`.
@@ -686,17 +688,17 @@ class CaseMeta(type):
 
     1. Add the `test_run` function as a member of the test class
     2. Add the `Case` class as the parent class
-    3. Expand all variables already defined in the class, so that any additional
-       code does not have to perform this task
+    3. Expand all variables already defined in the class, so that any
+       additional code does not have to perform this task
 
-    Using a metaclass instead of inheriting from case has the advantage, that we
-    can expand all variables in the strings before any test case or even the
+    Using a metaclass instead of inheriting from Case has the advantage, that
+    we can expand all variables in the strings before any test case or even the
     class constructor is run! Thus users will immediately see the expanded
     result. Also adding the `test_run` function as a direct member and not via
     inheritance enforces that it is being run **after** the test cases setUp &
     setUpClass (which oddly enough seems not to be the case in the unittest
-    module where test functions of the parent class run before setUpClass of the
-    child class).
+    module where test functions of the parent class run before setUpClass of
+    the child class).
     """
 
     def __new__(mcs, clsname, bases, dct):


### PR DESCRIPTION
This PR adds some missing features, which allow us to port the remaining redmine issues:
- allow stdout & stderr to be binary (unencoded) data
- set environment variables explicitly for test cases
- supply stdin to commands
- run the test cases under valgrind

Todo:
- run the whole test suite under valgrind (there are currently minor bugs preventing that)
- run the test suite under dr. memory on Windows