### PR TITLE
Travis CI: Remove gcc-8 matrix entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      compiler: gcc-8
-      addons:
-        apt:
-          update: true
-          sources:
-          - sourceline: 'ppa:ubuntu-toolchain-r/test'
-          packages:
-            - g++-8
-      env: CC=gcc-8 CXX=g++-8 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_VIDEO=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON"
-
-    - os: linux
-      dist: trusty
-      sudo: required
       compiler: clang
 
     - os: osx


### PR DESCRIPTION
Travis was overriding CC & CXX with the default gcc/g++ for some reason => gcc 4.8 was being used instead of gcc 8.

I'll try to fix the situation with this PR.