### PR TITLE
Apvveyor - Enable Visual Studio versions 2008, 2010, 2012 and VS2013 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ environment:
       CMAKE_GENERATOR: Visual Studio 9 2008 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 9
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 10
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 11 2012 Win64
       INTEGRATION_TESTS: 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,28 +19,28 @@ environment:
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 11
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86_amd64
+      ARCHITECTURE: x86_64
       UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 12 2013 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 12
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86_amd64
+      ARCHITECTURE: x86_64
       UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 14
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86_amd64
+      ARCHITECTURE: x86_64
       UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 15
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
-      ARCHITECTURE: x86_amd64
+      ARCHITECTURE: x86_64
       UNIT_TESTS: ON
 
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,31 +5,37 @@ environment:
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 9
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 10
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 11 2012 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 11
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86_amd64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 12 2013 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 12
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86_amd64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 14
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86_amd64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 15
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+      ARCHITECTURE: x86_amd64
 
 shallow_clone: true
 
@@ -56,6 +62,8 @@ before_build:
     - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
     - cmd: conan profile new --detect default
     - cmd: conan profile update settings.compiler.version=%VS_COMPILER_VERSION% default
+    - cmd: conan profile update settings.arch=%ARCHITECTURE% default
+    - cmd: conan profile update settings.arch_build=%ARCHITECTURE% default
     - cmd: cat c:\Users\appveyor\.conan\conan.conf
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,16 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      CMAKE_GENERATOR: Visual Studio 9 2008 Win64
+      INTEGRATION_TESTS: 0
+      VS_COMPILER_VERSION: 9
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      CMAKE_GENERATOR: Visual Studio 10 2010 Win64
+      INTEGRATION_TESTS: 0
+      VS_COMPILER_VERSION: 10
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 11 2012 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,25 @@
 environment:
   matrix:
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      #CMAKE_GENERATOR: Visual Studio 12 2013 Win64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      CMAKE_GENERATOR: Visual Studio 11 2012 Win64
+      INTEGRATION_TESTS: 0
+      VS_COMPILER_VERSION: 11
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      CMAKE_GENERATOR: Visual Studio 12 2013 Win64
+      INTEGRATION_TESTS: 0
+      VS_COMPILER_VERSION: 12
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
+      INTEGRATION_TESTS: 1
+      VS_COMPILER_VERSION: 14
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
+      INTEGRATION_TESTS: 1
+      VS_COMPILER_VERSION: 15
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 
 shallow_clone: true
 
@@ -31,21 +45,25 @@ before_build:
     - cmd: conan remote list
     - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
     - cmd: conan profile new --detect default
+    - cmd: conan profile update settings.compiler.version=%VS_COMPILER_VERSION% default
     - cmd: cat c:\Users\appveyor\.conan\conan.conf
 
 build_script:
     - cmd: md build
     - cmd: cd build
+    - cmd: call "%VCVARS%" x86_amd64
     - cmd: conan install .. --build missing
     - cmd: echo %CMAKE_GENERATOR%
     - cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: cmake --build . --config Release
     - cmd: cmake --build . --config Release --target install
+
+after_build:
     - cmd: cd bin
     - cmd: unit_tests.exe
     - cmd: cd ../../tests/
     - cmd: set EXIV2_EXT=.exe
-    - cmd: c:\Python36\python.exe runner.py -v
+    - cmd: if %INTEGRATION_TESTS% == "1" c:\Python36\python.exe runner.py -v
 
 cache:
     - envs                          # Conan installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,36 +6,42 @@ environment:
       VS_COMPILER_VERSION: 9
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
       ARCHITECTURE: x86
+      UNIT_TESTS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 10
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
       ARCHITECTURE: x86
+      UNIT_TESTS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 11 2012 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 11
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_amd64
+      UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 12 2013 Win64
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 12
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_amd64
+      UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 14
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_amd64
+      UNIT_TESTS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
       INTEGRATION_TESTS: 1
       VS_COMPILER_VERSION: 15
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
       ARCHITECTURE: x86_amd64
+      UNIT_TESTS: ON
 
 shallow_clone: true
 
@@ -72,13 +78,13 @@ build_script:
     - cmd: call "%VCVARS%" x86_amd64
     - cmd: conan install .. --build missing
     - cmd: echo %CMAKE_GENERATOR%
-    - cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_INSTALL_PREFIX=install ..
+    - cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=%UNIT_TESTS% -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: cmake --build . --config Release
     - cmd: cmake --build . --config Release --target install
 
 after_build:
     - cmd: cd bin
-    - cmd: unit_tests.exe
+    - cmd: if %UNIT_TESTS% == "ON" unit_tests.exe
     - cmd: cd ../../tests/
     - cmd: set EXIV2_EXT=.exe
     - cmd: if %INTEGRATION_TESTS% == "1" c:\Python36\python.exe runner.py -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 9 2008 Win64
+      CMAKE_GENERATOR: Visual Studio 9 2008
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 9
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
       ARCHITECTURE: x86
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 10 2010 Win64
+      CMAKE_GENERATOR: Visual Studio 10 2010
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 10
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     set(USING_CONAN ON)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_set_find_paths()
+    conan_basic_setup(NO_OUTPUT_DIRS KEEP_RPATHS)
 endif()
 
 find_package(Threads REQUIRED)

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,9 +6,11 @@ class Exiv2Conan(ConanFile):
     generators = 'cmake'
     options = {'unitTests': [True, False],
                'xmp': [True, False],
+               'iconv': [True, False],
               }
     default_options = ('unitTests=True',
                        'xmp=False',
+                       'iconv=False',
                       )
 
     def configure(self):
@@ -20,8 +22,9 @@ class Exiv2Conan(ConanFile):
         self.requires('zlib/1.2.11@conan/stable')
         self.requires('libcurl/7.60.0@bincrafters/stable')
 
-        if os_info.is_windows:
-            self.requires('libiconv/1.15@bincrafters/stable')
+        if os_info.is_windows and self.options.xmp:
+            if os_info.detect_windows_subsystem() in ("cygwin", "msys2"):
+                self.requires('libiconv/1.15@bincrafters/stable')
 
         if self.options.unitTests:
             self.requires('gtest/1.8.0@bincrafters/stable')

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -555,6 +555,8 @@ namespace Exiv2 {
         // IntType may be a user-defined type).
 #ifdef _MSC_VER
 #pragma warning( disable : 4146 )
+#undef max
+#undef min
 #endif
         if (n < zero) {
             if (n == std::numeric_limits<IntType>::min()) {

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -370,13 +370,14 @@ namespace Exiv2
                                     bytes[jump]=0               ;
                                     if ( ::strcmp("Nikon",chars) == 0 )
                                     {
-                                        // tag is an embedded tiff
-					std::vector<byte> nikon_bytes(count-jump);
+                                      // tag is an embedded tiff
+                                      std::vector<byte> nikon_bytes(count - jump);
 
-                                        io.read(&nikon_bytes.at(0),nikon_bytes.size());
-					MemIo memIo(&nikon_bytes.at(0),(long)count-jump);  // create a file
-                                        std::cerr << "Nikon makernote" << std::endl;
-                                        // printTiffStructure(memIo,out,option,depth);  TODO: fix it
+                                      io.read(&nikon_bytes.at(0), (long)nikon_bytes.size());
+                                      MemIo memIo(&nikon_bytes.at(0), (long)count - jump); // create a file
+                                      std::cerr << "Nikon makernote" << std::endl;
+                                      // printTiffStructure(memIo,out,option,depth);
+                                      // TODO: fix it
                                     }
                                     else
                                     {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1551,7 +1551,7 @@ namespace {
                               &inbytesleft,
                               &outptr,
                               &outbytesleft);
-            int outbytesProduced = sizeof(outbuf) - outbytesleft;
+            const size_t outbytesProduced = sizeof(outbuf) - outbytesleft;
             if (rc == size_t(-1) && errno != E2BIG) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "iconv: " << strError()

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -155,9 +155,9 @@ static int error(std::string& errors, const char* msg, const char* x, const char
     char buffer[buffer_size];
     memset(buffer, 0, buffer_size);
 #ifdef MSDEV_2003
-	sprintf(buffer,msg,x,y,z);
+    sprintf(buffer,msg,x,y,z);
 #else
-	snprintf(buffer, buffer_size, msg, x, y, z) ;
+    snprintf(buffer, buffer_size, msg, x, y, z) ;
 #endif
     if ( errno ) {
         perror(buffer) ;
@@ -268,7 +268,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 
     ////////////////////////////////////
     // open the socket
-    int     sockfd = socket(AF_INET , SOCK_STREAM,IPPROTO_TCP) ;
+    int     sockfd = (int) socket(AF_INET , SOCK_STREAM,IPPROTO_TCP) ;
     if (    sockfd < 0 ) return error(errors, "unable to create socket\n",NULL,NULL,0) ;
 
     // connect the socket to the server
@@ -310,7 +310,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 #else
     int    n  = snprintf(buffer,buff_l,httpTemplate,verb,page,version,servername,header) ;
 #endif
-	buffer[n] = 0 ;
+    buffer[n] = 0 ;
     response["requestheaders"]=std::string(buffer,n);
 
 
@@ -392,21 +392,21 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 
     if ( n != FINISH || !OK(status) ) {
 #ifdef MSDEV_2003
-		sprintf(buffer,"wsa_error = %d,n = %d,sleep_ = %d status = %d"
+        sprintf(buffer,"wsa_error = %d,n = %d,sleep_ = %d status = %d"
                 ,   WSAGetLastError()
                 ,   n
                 ,   sleep_
                 ,   status
                 ) ;
 #else
-		snprintf(buffer,sizeof buffer,"wsa_error = %d,n = %d,sleep_ = %d status = %d"
+        snprintf(buffer,sizeof buffer,"wsa_error = %d,n = %d,sleep_ = %d status = %d"
                 ,   WSAGetLastError()
                 ,   n
                 ,   sleep_
                 ,   status
                 ) ;
 #endif
-		error(errors,buffer,NULL,NULL,0) ;
+        error(errors,buffer,NULL,NULL,0) ;
     } else if ( bSearching && OK(status) ) {
         if ( end ) {
         //  we finished OK without finding headers, flush the buffer

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -660,7 +660,7 @@ namespace Exiv2 {
                         if (size > 0) {
                             io_->seek(-bufRead, BasicIo::cur);
                             std::vector<byte> xmp(size + 1);
-                            io_->read(xmp.data(), size);
+                            io_->read(&xmp[0], size);
                             int start = 0;
 
                             // http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -152,7 +152,7 @@ namespace Exiv2 {
 
             // compressed string after the compression technique spec
             const byte* compressedText      = data.pData_ + keysize + 2;
-            unsigned int compressedTextSize = data.size_  - keysize - 2;
+            long compressedTextSize = data.size_  - keysize - 2;
             enforce(compressedTextSize < data.size_, kerCorruptedMetadata);
 
             zlibUncompress(compressedText, compressedTextSize, arr);
@@ -171,7 +171,7 @@ namespace Exiv2 {
         else if(type == iTXt_Chunk)
         {
             enforce(data.size_ >= Safe::add(keysize, 3), Exiv2::kerCorruptedMetadata);
-            const int nullSeparators = std::count(&data.pData_[keysize+3], &data.pData_[data.size_], '\0');
+            const size_t nullSeparators = std::count(&data.pData_[keysize+3], &data.pData_[data.size_], '\0');
             enforce(nullSeparators >= 2, Exiv2::kerCorruptedMetadata);
 
             // Extract a deflate compressed or uncompressed UTF-8 text chunk
@@ -188,9 +188,9 @@ namespace Exiv2 {
             const size_t languageTextMaxSize = data.size_ - keysize - 3;
             std::string languageText =
                 string_from_unterminated((const char*)(data.pData_ + Safe::add(keysize, 3)), languageTextMaxSize);
-            const unsigned int languageTextSize = static_cast<unsigned int>(languageText.size());
+            const size_t languageTextSize = languageText.size();
 
-            enforce(data.size_ >= Safe::add(static_cast<unsigned int>(Safe::add(keysize, 4)), languageTextSize),
+            enforce(data.size_ >= Safe::add(static_cast<size_t>(Safe::add(keysize, 4)), languageTextSize),
                     Exiv2::kerCorruptedMetadata);
             // translated keyword string after the language description
             std::string translatedKeyText =
@@ -200,11 +200,11 @@ namespace Exiv2 {
 
             if ((compressionFlag == 0x00) || (compressionFlag == 0x01 && compressionMethod == 0x00)) {
                 enforce(Safe::add(static_cast<unsigned int>(keysize + 3 + languageTextSize + 1),
-                                  Safe::add(translatedKeyTextSize, 1u)) <= data.size_,
+                                  Safe::add(translatedKeyTextSize, 1u)) <= static_cast<unsigned int>(data.size_),
                         Exiv2::kerCorruptedMetadata);
 
                 const byte* text = data.pData_ + keysize + 3 + languageTextSize + 1 + translatedKeyTextSize + 1;
-                const long textsize = data.size_ - (keysize + 3 + languageTextSize + 1 + translatedKeyTextSize + 1);
+                const long textsize = static_cast<long>(data.size_ - (keysize + 3 + languageTextSize + 1 + translatedKeyTextSize + 1));
 
                 if (compressionFlag == 0x00) {
                     // then it's an uncompressed iTXt chunk

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -930,7 +930,7 @@ namespace {
 
     DataBuf decodeBase64(const std::string& src)
     {
-        const unsigned long srcSize = src.size();
+        const size_t srcSize = src.size();
 
         // create decoding table
         unsigned long invalid = 64;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -659,6 +659,9 @@ namespace Exiv2 {
 
     Rational floatToRationalCast(float f)
     {
+#if defined(_MSC_VER) && _MSC_VER < 1800
+        #define isinf(x) (!_finite(x))
+#endif
         if (isinf(f)) {
             return Rational(f > 0 ? 1 : -1, 0);
         }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -45,6 +45,37 @@
 #include <cstdlib>
 #include <ctype.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+__inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+__inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(outBuf, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+
+#endif
+
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {

--- a/unitTests/gtestwrapper.h
+++ b/unitTests/gtestwrapper.h
@@ -5,6 +5,7 @@
         #pragma warning(push)
         #pragma warning(disable : 4251)
         #pragma warning(disable : 4275)
+        #pragma warning(disable : 4996)
 #endif
 #include <gtest/gtest.h>
 #ifdef _MSC_VER

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -42,7 +42,7 @@ TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
 
 TEST(Rational, floatToRationalCast)
 {
-    static const float floats[] = {0.5, 0.015, 0.0000625};
+    static const float floats[] = {0.5f, 0.015f, 0.0000625f};
 
     for (size_t i = 0; i < sizeof(floats) / sizeof(*floats); ++i) {
         const Rational r = floatToRationalCast(floats[i]);

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -1,6 +1,7 @@
 #include <exiv2/types.hpp>
 
-#include <math.h>
+#include <cmath>
+#include <limits>
 
 #include "gtestwrapper.h"
 
@@ -50,11 +51,11 @@ TEST(Rational, floatToRationalCast)
         ASSERT_TRUE(fabs((floats[i] - fraction) / floats[i]) < 0.01f);
     }
 
-    const Rational plus_inf = floatToRationalCast(INFINITY);
+    const Rational plus_inf = floatToRationalCast(std::numeric_limits<float>::infinity());
     ASSERT_EQ(plus_inf.first, 1);
     ASSERT_EQ(plus_inf.second, 0);
 
-    const Rational minus_inf = floatToRationalCast(-1 * INFINITY);
+    const Rational minus_inf = floatToRationalCast(-1 * std::numeric_limits<float>::infinity());
     ASSERT_EQ(minus_inf.first, -1);
     ASSERT_EQ(minus_inf.second, 0);
 }


### PR DESCRIPTION
I managed to enable in Appveyor all the old versions of Visual Studio (2008, 2010, 2012 and 2013). However I had to fight against many issues I discovered during the process:

- Few Integration tests (python suite) fail with all the old versions. Only 4 tests were failing.
- The unit test do not compile with VS2008 and VS2010. The templating code in `unitTests/test_safe_op.cpp` is "too advance" for those old compilers.
- Since the express editions of VS2008 and VS2010 only bring a x86 compiler and I to add some conan configuration to chose different architectures. 
- Surprisingly we were using `std::vector::data()`which should be only available after **C++11**. VS2008 is the only compiler which does not have that functionality.
- I had to deal with few other issues which appeared in old VS versions (see the different commits).

I do not think it is worth to try to fix the integration tests in the old compilers or fix the compilation of the unit tests for VS2008 and VS2010. I just wanted to enable these new compilers for the CI so that we can keep them during the lifetime of the 0.27 branch. However, once we move on and we migrate to modern C++, we will need to remove all these elements from the CI matrix anyway. 
