### PR TITLE
Use isnan(f) as an alternative to isinf()

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -661,6 +661,8 @@ namespace Exiv2 {
     {
 #if defined(_MSC_VER) && _MSC_VER < 1800
         #define isinf(x) (!_finite(x))
+#elif __APPLE__
+        #define isinf(x) (isinf(x) || isnan(x))
 #endif
         if (isinf(f)) {
             return Rational(f > 0 ? 1 : -1, 0);


### PR DESCRIPTION
Fix for #433 

As we discussed on Slack, I tried with `isfinite` but this is only available since C++11. Therefore I went for the isnanf solution.