### PR TITLE
Use PROJECT_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,13 +231,13 @@ endif()
 
 # TODO : We should not include include/exiv2 but only include !!!
 target_include_directories(exiv2lib PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/exiv2>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/exiv2>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
 target_include_directories(exiv2lib_int PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/exiv2>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/exiv2>
 )
 
 if (EXIV2_ENABLE_WEBREADY)

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(xmp
 
 target_include_directories(xmp
     PUBLIC 
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/xmpsdk/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
     PRIVATE 
         ${EXPAT_INCLUDE_DIR}
 )


### PR DESCRIPTION
Using PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR is exactly the same for locating include folders during a standard build. However, using PROJECT_SOURCE_DIR instead allows the Exiv2 to be built as a subproject of other projects using CMake's FetchContent and ExternalProject_Add.  