### PR TITLE
Restore API functions remove in #450

### DIFF
--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -112,6 +112,10 @@ namespace Exiv2 {
         ExifTags& operator=(const ExifTags& rhs);
 
     public:
+        //! Return read-only list of built-in groups
+        static const GroupInfo* groupList();
+        //! Return read-only list of built-in \em groupName tags.
+        static const TagInfo* tagList(const std::string& groupName);
         //! Print a list of all standard Exif tags to output stream
         static void taglist(std::ostream& os);
         //! Print the list of tags for \em groupName

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -178,6 +178,16 @@ namespace Exiv2 {
         return Internal::isExifIfd(ifdId);
     }
 
+    const GroupInfo *ExifTags::groupList()
+    {
+        return Internal::groupList();
+    }
+
+    const TagInfo *ExifTags::tagList(const std::string &groupName)
+    {
+        return Internal::tagList(groupName);
+    }
+
     void ExifTags::taglist(std::ostream& os)
     {
         const TagInfo* ifd = ifdTagList();

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2870,4 +2870,19 @@ namespace Exiv2 {
 
         return os << stringValue;
     }
+
+    const GroupInfo *groupList()
+    {
+        return groupInfo + 1;
+    }
+
+    const TagInfo* tagList(const std::string& groupName)
+    {
+        const GroupInfo* ii = find(groupInfo, GroupInfo::GroupName(groupName));
+        if (ii == 0 || ii->tagList_ == 0) {
+            return 0;
+        }
+        return ii->tagList_();
+    }
+
 } }

--- a/src/tags_int.hpp
+++ b/src/tags_int.hpp
@@ -307,6 +307,9 @@ namespace Exiv2 {
     //! Return read-only list of built-in mfp Tags http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/MPF.html
     const TagInfo* mpfTagList();
 
+    const GroupInfo* groupList();
+    const TagInfo* tagList(const std::string& groupName);
+
     //! Return the group id for a group name
     IfdId groupId(const std::string& groupName);
     //! Return the name of the IFD


### PR DESCRIPTION
This PR is adding back the API functions removed in #450 as we discussed in #465. 

Since I am not very familiar yet with this code and the terminology used, something might be missing. If that's all we need to have I can try to add some tests around this code in order to understand it. 