### PR TITLE
Appveyor: Fix the unit & integration tests execution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
       VS_COMPILER_VERSION: 9
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
       ARCHITECTURE: x86
-      UNIT_TESTS: OFF
+      UNIT_TESTS: 0
       WARNINGS_AS_ERRORS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010
@@ -14,7 +14,7 @@ environment:
       VS_COMPILER_VERSION: 10
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
       ARCHITECTURE: x86
-      UNIT_TESTS: OFF
+      UNIT_TESTS: 0
       WARNINGS_AS_ERRORS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 11 2012 Win64
@@ -22,7 +22,7 @@ environment:
       VS_COMPILER_VERSION: 11
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_64
-      UNIT_TESTS: ON
+      UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 12 2013 Win64
@@ -30,7 +30,7 @@ environment:
       VS_COMPILER_VERSION: 12
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_64
-      UNIT_TESTS: ON
+      UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
@@ -38,7 +38,7 @@ environment:
       VS_COMPILER_VERSION: 14
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
       ARCHITECTURE: x86_64
-      UNIT_TESTS: ON
+      UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 15 2017 Win64
@@ -46,7 +46,7 @@ environment:
       VS_COMPILER_VERSION: 15
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
       ARCHITECTURE: x86_64
-      UNIT_TESTS: ON
+      UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
 
 shallow_clone: true
@@ -87,13 +87,11 @@ build_script:
     - cmd: cmake -G "%CMAKE_GENERATOR%" -DEXIV2_TEAM_WARNINGS_AS_ERRORS=%WARNINGS_AS_ERRORS% -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=%UNIT_TESTS% -DCMAKE_INSTALL_PREFIX=install ..
     - cmd: cmake --build . --config Release
     - cmd: cmake --build . --config Release --target install
-
-after_build:
     - cmd: cd bin
-    - cmd: if %UNIT_TESTS% == "ON" unit_tests.exe
+    - cmd: if %UNIT_TESTS% == 1 unit_tests.exe
     - cmd: cd ../../tests/
     - cmd: set EXIV2_EXT=.exe
-    - cmd: if %INTEGRATION_TESTS% == "1" c:\Python36\python.exe runner.py -v
+    - cmd: if %INTEGRATION_TESTS% == 1 c:\Python36\python.exe runner.py -v
 
 cache:
     - envs                          # Conan installation


### PR DESCRIPTION
I accidentally found out that the UNIT and INTEGRATION tests were not running on Appveyor. This change fixes the situation. Luckily none of the tests broke during the downtime.