### PR TITLE
Add EXIV2_TEAM_PACKAGING cmake variable to add CPack configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentatio
 option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
 option( EXIV2_TEAM_WARNINGS_AS_ERRORS "Treat warnings as errors"                              OFF )
 option( EXIV2_TEAM_USE_SANITIZERS     "Enable ASAN and UBSAN when available"                  OFF )
+option( EXIV2_TEAM_PACKAGING          "Additional stuff for generating packages"              OFF )
 set(EXTRA_COMPILE_FLAGS " ")
 
 mark_as_advanced(
@@ -95,7 +96,10 @@ if( EXIV2_BUILD_PO )
     add_subdirectory( po )
 endif()
 
-include(cmake/packaging.cmake)
+if (EXIV2_TEAM_PACKAGING)
+    include(cmake/packaging.cmake)
+endif()
+
 include(cmake/printSummary.cmake)
 
 # That's all Folks!


### PR DESCRIPTION
Thanks to this change we will not add additional **install()** commands to normal builds.