### PR TITLE
Fix infinite loop in getopt.cpp

### DIFF
--- a/src/getopt.cpp
+++ b/src/getopt.cpp
@@ -105,8 +105,13 @@ namespace Util {
 
         for (;;) {
             int c = Util::getopt(argc, argv, optstring.c_str());
-            if (c == -1) break;
+            if (c == -1) {
+                break;
+            }
             errcnt_ += option(c, Util::optarg == 0 ? "" : Util::optarg, Util::optopt);
+            if (c == '?' ) {
+                break;
+            }
         }
         for (int i = Util::optind; i < argc; i++) {
             errcnt_ += nonoption(argv[i]);


### PR DESCRIPTION
Note that the getopt code was looping forever when one of the argument options was incorrect. Example:

```
./exiv2 -A 20:00:00 -Y 2018 -O 11 -D 01 ad myImage.tiff
```
Since both of the proposed solutions at #510 were working, I think it is better to change the code in the `Getopt` class and leave the `getopt` snippet unchanged (since this snippet was taken from somewhere else). 