### PR TITLE
Clean conan compiler flags

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     set(USING_CONAN ON)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup(NO_OUTPUT_DIRS KEEP_RPATHS)
+    conan_basic_setup(NO_OUTPUT_DIRS KEEP_RPATHS TARGETS)
 endif()
 
 find_package(Threads REQUIRED)

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -41,3 +41,7 @@ target_compile_definitions(unit_tests
 set_target_properties( unit_tests PROPERTIES
     COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
 )
+
+if (USING_CONAN)
+    target_compile_definitions(unit_tests PRIVATE ${CONAN_COMPILE_DEFINITIONS_GTEST})
+endif()


### PR DESCRIPTION
I recently noticed that we were adding more things than needed for compiling the library translation units, and this was due to the wrong usage of conan in CMake.

By running ` cmake ../ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` we can obtain a file **compile_commands.json** that looks like this:

```
[
{
  "directory": "F:/projects/exiv2/buildShared",
  "command": "C:\\PROGRA~2\\MICROS~2\\2017\\COMMUN~1\\VC\\Tools\\MSVC\\1415~1.267\\bin\\Hostx64\\x64\\cl.exe  /nologo /TP -DEXV_HAVE_STDINT_H -DXML_STATIC -IC:\\Users\\pipon\\.conan\\data\\zlib\\1.2.11\\conan\\stable\\package\\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7\\include -IC:\\Users\\pipon\\.conan\\data\\gtest\\1.8.0\\bincrafters\\stable\\package\\a35f8fa327837a5f1466eaf165e1b6347f6e1e51\\include -IC:\\Users\\pipon\\.conan\\data\\Expat\\2.2.5\\pix4d\\stable\\package\\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7\\include -I. -I..\\xmpsdk\\include  /DWIN32 /D_WINDOWS /W3 /GR /EHsc   /MP /MDd /Zi /Ob0 /Od /RTC1    -DXML_STATIC -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DGTEST_LANG_CXX11=1 -DGTEST_HAS_TR1_TUPLE=0 /Foxmpsdk\\CMakeFiles\\xmp.dir\\src\\ExpatAdapter.cpp.obj /FdTARGET_COMPILE_PDB /FS -c F:\\projects\\exiv2\\xmpsdk\\src\\ExpatAdapter.cpp",
  "file": "F:/projects/exiv2/xmpsdk/src/ExpatAdapter.cpp"
},
{
  "directory": "F:/projects/exiv2/buildShared",
  "command": "C:\\PROGRA~2\\MICROS~2\\2017\\COMMUN~1\\VC\\Tools\\MSVC\\1415~1.267\\bin\\Hostx64\\x64\\cl.exe  /nologo /TP -DEXV_HAVE_STDINT_H -DXML_STATIC -IC:\\Users\\pipon\\.conan\\data\\zlib\\1.2.11\\conan\\stable\\package\\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7\\include -IC:\\Users\\pipon\\.conan\\data\\gtest\\1.8.0\\bincrafters\\stable\\package\\a35f8fa327837a5f1466eaf165e1b6347f6e1e51\\include -IC:\\Users\\pipon\\.conan\\data\\Expat\\2.2.5\\pix4d\\stable\\package\\6cc50b139b9c3d27b3e9042d5f5372d327b3a9f7\\include -I. -I..\\xmpsdk\\include  /DWIN32 /D_WINDOWS /W3 /GR /EHsc   /MP /MDd /Zi /Ob0 /Od /RTC1    -DXML_STATIC -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DGTEST_LANG_CXX11=1 -DGTEST_HAS_TR1_TUPLE=0 /Foxmpsdk\\CMakeFiles\\xmp.dir\\src\\MD5.cpp.obj /FdTARGET_COMPILE_PDB /FS -c F:\\projects\\exiv2\\xmpsdk\\src\\MD5.cpp",
  "file": "F:/projects/exiv2/xmpsdk/src/MD5.cpp"
},
...
```
The flags that got my attention were:
```
-DXML_STATIC -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DGTEST_LANG_CXX11=1 -DGTEST_HAS_TR1_TUPLE=0
```

That were even used in the translation units that were not part of the **unit_tests** target.

The culprit of this situation was the call to **conan_basic_setup** which is trying to be smart about the flags, inclusions and definitions to include to compile the project. However, I do not like to add definitions which are not needed for the library targets (xmp and libexiv2) and the samples and exiv2 application. By just adding the argument `TARGET` into the **conan_basic_setup** call we can prevent this behaviour. 