### PR TITLE
CI: Update conan version to 1.9.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ before_build:
     - cmd: cd envs
     - cmd: python -m virtualenv conan
     - cmd: conan/Scripts/activate
-    - cmd: python -m pip install conan==1.6.1
+    - cmd: python -m pip install conan==1.9.0
     - cmd: cd ..
     - cmd: conan --version
     - cmd: conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -31,7 +31,7 @@ fi
 
 python --version
 pip install urllib3[secure] -U #Should solve SSL issues
-pip install conan==1.6.1
+pip install conan==1.9.0
 pip install codecov
 conan --version
 conan config set storage.path=~/conanData


### PR DESCRIPTION
The cache in the Appveyor images we use to compile the project seems to be corrupted for some reason. I decided to take this opportunity to update the Conan version we use in the CI jobs (and this action will clean conan cache in the images). 