### PR TITLE
Fix issues reported by cppcheck

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -270,7 +270,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Constructor, takes a BasicIo reference
-        IoCloser(BasicIo& bio) : bio_(bio) {}
+        explicit IoCloser(BasicIo& bio) : bio_(bio) {}
         //! Destructor, closes the BasicIo reference
         virtual ~IoCloser() { close(); }
         //@}
@@ -307,7 +307,7 @@ namespace Exiv2 {
               therefore never failes.
           @param path The full path of a file
          */
-        FileIo(const std::string& path);
+        explicit FileIo(const std::string& path);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like FileIo(const std::string& path) but accepts a
@@ -778,7 +778,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Default constructor that reads data from stdin/data uri path and writes them to the temp file.
-        XPathIo(const std::string& orgPath);
+        explicit XPathIo(const std::string& orgPath);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like XPathIo(const std::string& orgPath) but accepts a

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -827,60 +827,6 @@ namespace Exiv2 {
     }; // class XPathIo
 #endif
 
-    /*!
-      @brief Utility class provides the block mapping to the part of data. This avoids allocating
-            a single contiguous block of memory to the big data.
-     */
-    class EXIV2API BlockMap {
-    public:
-        //! the status of the block.
-        enum    blockType_e {bNone, bKnown, bMemory};
-        //! @name Creators
-        //@{
-        //! Default constructor. the init status of the block is bNone.
-        BlockMap():type_(bNone), data_(NULL),size_(0) {}
-        //! Destructor. Releases all managed memory.
-        virtual ~BlockMap() {
-            if (data_) {std::free(data_); data_ = NULL;}
-        }
-        //@}
-        //! @name Manipulators
-        //@{
-        /*!
-          @brief Populate the block.
-          @param source The data populate to the block
-          @param num The size of data
-         */
-        void    populate (byte* source, size_t num) {
-            size_ = num;
-            data_ = (byte*) std::malloc(size_);
-            type_ = bMemory;
-            std::memcpy(data_, source, size_);
-        }
-        /*!
-          @brief Change the status to bKnow. bKnow blocks do not contain the data,
-                but they keep the size of data. This avoids allocating memory for parts
-                of the file that contain image-date (non-metadata/pixel data) which never change in exiv2.
-          @param num The size of the data
-         */
-        void    markKnown(size_t num) {
-            type_ = bKnown;
-            size_ = num;
-        }
-        //@}
-        //! @name Accessors
-        //@{
-        bool    isNone()  {return type_ == bNone;}
-        bool    isInMem ()  {return type_ == bMemory;}
-        bool    isKnown ()  {return type_ == bKnown;}
-        byte*   getData ()  {return data_;}
-        size_t  getSize ()  {return size_;}
-        //@}
-    private:
-        blockType_e type_;
-        byte*       data_;
-        size_t      size_;
-    }; // class BlockMap
 
     /*!
         @brief Provides remote binary file IO by implementing the BasicIo interface. This is an

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -77,7 +77,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        BmpImage(BasicIo::AutoPtr io);
+        explicit BmpImage(BasicIo::AutoPtr io);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -236,7 +236,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Constructor.
-        ExifThumbC(const ExifData& exifData);
+        explicit ExifThumbC(const ExifData& exifData);
         //@}
 
         //! @name Accessors
@@ -305,7 +305,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Constructor.
-        ExifThumb(ExifData& exifData);
+        explicit ExifThumb(ExifData& exifData);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -78,7 +78,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        GifImage(BasicIo::AutoPtr io);
+        explicit GifImage(BasicIo::AutoPtr io);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/ini.hpp
+++ b/include/exiv2/ini.hpp
@@ -140,7 +140,7 @@ public:
     /*! @brief Construct INIReader and parse given filename. See ini.h for more info
        about the parsing.
     */
-    INIReader(std::string filename);
+    explicit INIReader(const std::string& filename);
 
     /*! @brief Return the result of ini_parse(), i.e., 0 on success, line number of
         first error on parse error, or -1 on file open error.

--- a/include/exiv2/preview.hpp
+++ b/include/exiv2/preview.hpp
@@ -174,7 +174,7 @@ namespace Exiv2 {
         //! @name Constructors
         //@{
         //! Constructor.
-        PreviewManager(const Image& image);
+        explicit PreviewManager(const Image& image);
         //@}
 
         //! @name Accessors

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -76,14 +76,14 @@ namespace Exiv2 {
         //! For comparison with prefix
         struct Prefix {
             //! Constructor.
-            Prefix(const std::string& prefix);
+            explicit Prefix(const std::string& prefix);
             //! The prefix string.
             std::string prefix_;
         };
         //! For comparison with namespace
         struct Ns {
             //! Constructor.
-            Ns(const std::string& ns);
+            explicit Ns(const std::string& ns);
             //! The namespace string
             std::string ns_;
         };

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -79,7 +79,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        PsdImage(BasicIo::AutoPtr io);
+        explicit PsdImage(BasicIo::AutoPtr io);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        Rw2Image(BasicIo::AutoPtr io);
+        explicit Rw2Image(BasicIo::AutoPtr io);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/rwlock.hpp
+++ b/include/exiv2/rwlock.hpp
@@ -90,7 +90,7 @@ namespace Exiv2 {
         {
         public:
             //! constructor (acquires the lock)
-            RWLock(const pthread_rwlockattr_t *attr = 0)
+            explicit RWLock(const pthread_rwlockattr_t *attr = 0)
             {
                 pthread_rwlock_init(&rwlock_, attr);
             }
@@ -151,7 +151,7 @@ namespace Exiv2 {
         {
         public:
             //! constructor - locks the object
-            ScopedReadLock(RWLock &rwlock):
+            explicit ScopedReadLock(RWLock &rwlock):
                 rwlock_(rwlock)
             {
                 rwlock_.rdlock();
@@ -173,7 +173,7 @@ namespace Exiv2 {
         {
         public:
             //! constructor - locks the object
-            ScopedWriteLock(RWLock &rwlock):
+            explicit ScopedWriteLock(RWLock &rwlock):
                 rwlock_(rwlock)
             {
                 rwlock_.wrlock();

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -73,7 +73,7 @@ namespace Exiv2 {
 
     //! Search key to find a GroupInfo by its group name.
     struct GroupInfo::GroupName {
-        GroupName(const std::string& groupName); //!< Constructor
+        explicit GroupName(const std::string& groupName);
         std::string g_;                          //!< Group name
     };
 
@@ -176,7 +176,8 @@ namespace Exiv2 {
           @throw Error if the key cannot be constructed from the tag number
                  and group name.
          */
-        ExifKey(const TagInfo& ti);
+        explicit ExifKey(const TagInfo& ti);
+
         //! Copy constructor
         ExifKey(const ExifKey& rhs);
         //! Destructor

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -79,7 +79,7 @@ namespace Exiv2 {
               instance after it is passed to this method.  Use the Image::io()
               method to get a temporary reference.
          */
-        TgaImage(BasicIo::AutoPtr io);
+        explicit TgaImage(BasicIo::AutoPtr io);
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -195,7 +195,7 @@ namespace Exiv2 {
      */
     struct EXIV2API DataBufRef {
         //! Constructor
-        DataBufRef(std::pair<byte*, long> rhs) : p(rhs) {}
+        explicit DataBufRef(std::pair<byte*, long> rhs) : p(rhs) {}
         //! Pointer to a byte array and its size
         std::pair<byte*, long> p;
     };

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -264,7 +264,7 @@ namespace Exiv2 {
           See http://www.josuttis.com/libbook/auto_ptr.html for a discussion.
          */
         //@{
-        DataBuf(DataBufRef rhs);
+        DataBuf(const DataBufRef& rhs);
         DataBuf& operator=(DataBufRef rhs);
         operator DataBufRef();
         //@}

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -546,7 +546,7 @@ namespace Exiv2 {
     {
         std::istringstream is(s);
         T tmp;
-        ok = is >> tmp ? true : false;
+        ok = (is >> tmp) ? true : false;
         std::string rest;
         is >> std::skipws >> rest;
         if (!rest.empty()) ok = false;

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -921,10 +921,9 @@ namespace Jzon
 		std::string valueBuffer;
 		bool saveBuffer;
 
-		char c = '\0';
 		for (; cursor < jsonSize; ++cursor)
 		{
-			c = json.at(cursor);
+            char c = json.at(cursor);
 
 			if (IsWhitespace(c))
 				continue;
@@ -1218,10 +1217,10 @@ namespace Jzon
 	void Parser::jumpToCommentEnd()
 	{
 		++cursor;
-		char c1 = '\0', c2 = '\0';
+        char c1 = '\0';
 		for (; cursor < jsonSize; ++cursor)
 		{
-			c2 = json.at(cursor);
+            char c2 = json.at(cursor);
 
 			if (c1 == '*' && c2 == '/')
 				break;
@@ -1239,10 +1238,10 @@ namespace Jzon
 
 		++cursor;
 
-		char c1 = '\0', c2 = '\0';
+        char c1 = '\0';
 		for (; cursor < jsonSize; ++cursor)
 		{
-			c2 = json.at(cursor);
+            char c2 = json.at(cursor);
 
 			if (c1 != '\\' && c2 == '"')
 			{

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -282,7 +282,7 @@ time_t Position::deltaMax_ = 60 ;
 class UserData
 {
 public:
-    UserData(Options& options):
+    explicit UserData(Options& options):
         indent(0)
       , count(0)
       , nTrkpt(0)

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -656,12 +656,14 @@ int readFile(const char* path,Options /* options */)
     FILE* f     = fopen(path,"r");
     int nResult = f ? typeFile : typeUnknown;
     if (  f ) {
-        const char* docs[] = { ".doc",".txt", NULL };
-        const char* code[] = { ".cpp",".h"  ,".pl" ,".py" ,".pyc", NULL };
         const char*  ext   = strstr(path,".");
         if  ( ext ) {
-            if ( sina(ext,docs) ) nResult = typeDoc;
-            if ( sina(ext,code) ) nResult = typeCode;
+            const char* docs[] = { ".doc",".txt", NULL };
+            const char* code[] = { ".cpp",".h"  ,".pl" ,".py" ,".pyc", NULL };
+            if ( sina(ext,docs) )
+                nResult = typeDoc;
+            if ( sina(ext,code) )
+                nResult = typeCode;
         }
     }
     if ( f ) fclose(f) ;

--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -45,7 +45,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Default constructor
-        Cr2Header(ByteOrder byteOrder =littleEndian);
+        explicit Cr2Header(ByteOrder byteOrder =littleEndian);
         //! Destructor.
         ~Cr2Header();
         //@}

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -70,7 +70,7 @@ namespace Exiv2 {
      * @throws nothing
      */
     template <typename T>
-    std::ostream& operator<<(std::ostream& stream, const binaryToStringHelper<T>& binToStr) throw()
+    std::ostream& operator<<(std::ostream& stream, const binaryToStringHelper<T>& binToStr)
     {
         for (size_t i = 0; i < binToStr.buf_.size(); ++i) {
             int c = static_cast<int>(binToStr.buf_.at(i));

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -92,7 +92,7 @@ namespace Exiv2 {
         {
         }
 
-        friend std::ostream& operator<<<T>(std::ostream& stream, const binaryToStringHelper<T>& binToStr) throw();
+        friend std::ostream& operator<<<T>(std::ostream& stream, const binaryToStringHelper<T>& binToStr);
 
         // the Slice is stored by value to avoid dangling references, in case we
         // invoke:

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -208,7 +208,7 @@ int Exiv2::ini_parse(const char* filename, ini_handler handler, void* user)
     return error;
 }
 
-INIReader::INIReader(string filename)
+INIReader::INIReader(const std::string &filename)
 {
     _error = ini_parse(filename.c_str(), ValueHandler, this);
 }

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -340,7 +340,7 @@ namespace Exiv2 {
         return sizeof(signature_);
     }
 
-    FujiMnHeader::FujiMnHeader()
+    FujiMnHeader::FujiMnHeader() : start_(0)
     {
         read(signature_, sizeOfSignature(), byteOrder_);
     }
@@ -402,7 +402,7 @@ namespace Exiv2 {
         return sizeof(signature_);
     }
 
-    Nikon2MnHeader::Nikon2MnHeader()
+    Nikon2MnHeader::Nikon2MnHeader() : start_(0)
     {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
@@ -525,7 +525,7 @@ namespace Exiv2 {
         return sizeof(signature_);
     }
 
-    PanasonicMnHeader::PanasonicMnHeader()
+    PanasonicMnHeader::PanasonicMnHeader(): start_(0)
     {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
@@ -707,7 +707,7 @@ namespace Exiv2 {
         return sizeof(signature1_);
     }
 
-    SigmaMnHeader::SigmaMnHeader()
+    SigmaMnHeader::SigmaMnHeader(): start_(0)
     {
         read(signature1_, sizeOfSignature(), invalidByteOrder);
     }
@@ -755,7 +755,7 @@ namespace Exiv2 {
         return sizeof(signature_);
     }
 
-    SonyMnHeader::SonyMnHeader()
+    SonyMnHeader::SonyMnHeader(): start_(0)
     {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
@@ -803,7 +803,7 @@ namespace Exiv2 {
         return sizeof(signature_);
     }
 
-    Casio2MnHeader::Casio2MnHeader()
+    Casio2MnHeader::Casio2MnHeader(): start_(0)
     {
         read(signature_, sizeOfSignature(), invalidByteOrder );
     }

--- a/src/minoltamn_int.cpp
+++ b/src/minoltamn_int.cpp
@@ -2049,16 +2049,21 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0x1c;
             long index  = 0;
 
             std::string model   = getKeyString("Exif.Image.Model"    ,metadata);
             std::string lens    = getKeyString("Exif.Photo.LensModel",metadata);
 
-            if ( model == "SLT-A77V" && lens == "100mm F2.8 Macro" ) index=2;
+            if ( model == "SLT-A77V" && lens == "100mm F2.8 Macro" ) {
+                index=2;
+            }
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
-        } catch (...) {}
+            if ( index > 0 ) {
+                const long lensID = 0x1c;
+                return resolvedLens(os,lensID,index);
+            }
+        } catch (...) {
+        }
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);
     }
 
@@ -2066,16 +2071,22 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0x29;
             long index  = 0;
 
             std::string model   = getKeyString("Exif.Image.Model"    ,metadata);
             std::string lens    = getKeyString("Exif.Photo.LensModel",metadata);
 
-            if ( model == "SLT-A77V" && lens == "DT 11-18mm F4.5-5.6" ) index=2;
+            if ( model == "SLT-A77V" && lens == "DT 11-18mm F4.5-5.6" ) {
+                index=2;
+            }
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
-        } catch (...) {}
+            if ( index > 0 ) {
+                const long lensID = 0x29;
+                return resolvedLens(os,lensID,index);
+            }
+        } catch (...) {
+
+        }
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);
     }
 
@@ -2083,7 +2094,6 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0x34;
             long index  = 0;
 
             std::string model       = getKeyString("Exif.Image.Model"            ,metadata);
@@ -2091,11 +2101,19 @@ namespace Exiv2 {
             long        focalLength = getKeyLong  ("Exif.Photo.FocalLength"      ,metadata);
             std::string F2_8        = "760/256" ;
 
-            if ( model == "SLT-A77V" && maxAperture == F2_8           ) index=4;
-            if ( model == "SLT-A77V" && inRange(focalLength,70,300)   ) index=3;
+            if ( model == "SLT-A77V" && maxAperture == F2_8           ) {
+                index=4;
+            }
+            if ( model == "SLT-A77V" && inRange(focalLength,70,300)   ) {
+                index=3;
+            }
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
-        } catch (...) {}
+            if ( index > 0 ) {
+                const long lensID = 0x34;
+                return resolvedLens(os,lensID,index);
+            }
+        } catch (...) {
+        }
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);
     }
 
@@ -2103,7 +2121,6 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0x80;
             long index  = 0;
 
             std::string model       = getKeyString("Exif.Image.Model"    ,metadata);
@@ -2111,9 +2128,14 @@ namespace Exiv2 {
             long        focalLength = getKeyLong  ("Exif.Photo.FocalLength"      ,metadata);
             std::string F4          = "1024/256";
 
-            if ( model == "SLT-A77V" && maxAperture == F4  && inRange(focalLength,18,200) ) index=2;
+            if ( model == "SLT-A77V" && maxAperture == F4  && inRange(focalLength,18,200) ) {
+                index=2;
+            }
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
+            if ( index > 0 ) {
+                const long lensID = 0x80;
+                return resolvedLens(os,lensID,index);
+            }
         } catch (...) {}
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);
     }
@@ -2122,7 +2144,6 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0xff;
             long index  = 0   ;
 
             std::string model       = getKeyString("Exif.Image.Model"            ,metadata);
@@ -2130,10 +2151,16 @@ namespace Exiv2 {
             std::string maxAperture = getKeyString("Exif.Photo.MaxApertureValue" ,metadata);
             std::string F2_8        = "760/256" ;
 
-            if ( model == "SLT-A77V" && maxAperture == F2_8 && inRange(focalLength,17,50) ) index = 1 ;
+            if ( model == "SLT-A77V" && maxAperture == F2_8 && inRange(focalLength,17,50) ) {
+                index = 1 ;
+            }
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
-        } catch (...) {}
+            if ( index > 0 ) {
+                const long lensID = 0xff;
+                return resolvedLens(os,lensID,index);
+            }
+        } catch (...) {
+        }
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);
     }
 
@@ -2141,7 +2168,6 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            long lensID = 0xffff;
             long index  = 1   ;
 
             // #1153
@@ -2170,7 +2196,10 @@ namespace Exiv2 {
                 if ( inRange(focalRatio,145,155) ) index = 3 ;
             } catch (...) {}
 
-            if ( index > 0 ) return resolvedLens(os,lensID,index);
+            if ( index > 0 ) {
+                const long lensID = 0xffff;
+                return resolvedLens(os,lensID,index);
+            }
         } catch (...) {}
 
         return EXV_PRINT_TAG(minoltaSonyLensID)(os, value, metadata);

--- a/src/orfimage_int.hpp
+++ b/src/orfimage_int.hpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Default constructor
-        OrfHeader(ByteOrder byteOrder =littleEndian);
+        explicit OrfHeader(ByteOrder byteOrder =littleEndian);
         //! Destructor.
         ~OrfHeader();
         //@}

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1124,14 +1124,12 @@ namespace Exiv2 {
 
         if (value.count() == 2) {
             long l1 = value.toLong(1);
-            long type;
-            long range;
             os << " (";
             if (l1 == 0) {
                 os << _("No extended bracketing");
             } else {
-                type = l1 >> 8;
-                range = l1 & 0xff;
+                long type = l1 >> 8;
+                long range = l1 & 0xff;
                 switch (type) {
                     case 1:
                         os << _("WB-BA");
@@ -1221,16 +1219,18 @@ namespace Exiv2 {
                                                  const ExifData* metadata)
     {
         try {
-            unsigned long lensID    = 0x32c;
             unsigned long index     = 0;
 
             long        focalLength = getKeyLong  ("Exif.Photo.FocalLength",metadata);
             bool        bFL10_20    = 10 <= focalLength && focalLength <= 20;
 
             // std::cout << "model,focalLength = " << model << "," << focalLength << std::endl;
-            if ( bFL10_20 ) index = 1;
+            if ( bFL10_20 ) {
+                index = 1;
+            }
 
             if ( index > 0 )  {
+                const unsigned long lensID    = 0x32c;
                 const TagDetails* td = find(pentaxLensType, lensID);
                 os << exvGettext(td[index].label_);
                 return os;
@@ -1247,7 +1247,6 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------
     {
         try {
-            unsigned long lensID = 0x3ff;
             unsigned long index  = 0;
 
             // http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Pentax.html#LensData
@@ -1291,6 +1290,7 @@ namespace Exiv2 {
             }
 
             if ( index > 0 )  {
+                const unsigned long lensID = 0x3ff;
                 const TagDetails* td = find(pentaxLensType, lensID);
                 os << exvGettext(td[index].label_);
                 return os;
@@ -1306,7 +1306,6 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------
     {
         try {
-            unsigned long lensID = 0x8ff;
             unsigned long index  = 0;
 
             const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
@@ -1319,6 +1318,7 @@ namespace Exiv2 {
             }
 
             if ( index > 0 )  {
+                const unsigned long lensID = 0x8ff;
                 const TagDetails* td = find(pentaxLensType, lensID);
                 os << exvGettext(td[index].label_);
                 return os;
@@ -1334,7 +1334,6 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------
     {
         try {
-            unsigned long lensID = 0x319;
             unsigned long index  = 0;
 
             const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
@@ -1355,6 +1354,7 @@ namespace Exiv2 {
             }
 
             if ( index > 0 )  {
+                const unsigned long lensID = 0x319;
                 const TagDetails* td = find(pentaxLensType, lensID);
                 os << exvGettext(td[index].label_);
                 return os;

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -114,9 +114,8 @@ namespace Exiv2 {
 namespace Exiv2 {
 
     //! @cond IGNORE
-    GroupInfo::GroupName::GroupName(const std::string& groupName)
+    GroupInfo::GroupName::GroupName(const std::string& groupName): g_(groupName)
     {
-        g_ = groupName;
     }
     //! @endcond
 

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -476,7 +476,7 @@ namespace Exiv2 {
     class FindExifdatum {
     public:
         //! Constructor, initializes the object with the IfdId to look for.
-        FindExifdatum(Exiv2::Internal::IfdId ifdId) : ifdId_(ifdId) {}
+        explicit FindExifdatum(Exiv2::Internal::IfdId ifdId) : ifdId_(ifdId) {}
         //! Returns true if IFD id matches.
         bool operator()(const Exiv2::Exifdatum& md) const { return ifdId_ == md.ifdId(); }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -192,7 +192,7 @@ namespace Exiv2 {
         size_ = p.second;
     }
 
-    DataBuf::DataBuf(DataBufRef rhs) : pData_(rhs.p.first), size_(rhs.p.second) {}
+    DataBuf::DataBuf(const DataBufRef &rhs) : pData_(rhs.p.first), size_(rhs.p.second) {}
 
     DataBuf &DataBuf::operator=(DataBufRef rhs) { reset(rhs.p); return *this; }
 


### PR DESCRIPTION
Following the suggestion made by @cgilles I decided to give another cppcheck pass to Exiv2.

Each category of issues have been committed in a different commit (to ease the review process).

Something that I found interesting is that the class **BlockMap** is exported in the API while it seems like a implementation detail only used inside `basicio.cpp`. I was tempted to move the declaration of the class inside the .cpp file but I was not sure if this class could be used by external projects.

Apart from that, the rest of the changes should be inoffensive.

In the future I would like to add another CI check to make sure that the number of issues reported by cppcheck does not increase when PRs are submitted. 