### PR TITLE
conan: copy 3rd party dlls only if the conanDlls folder exists

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -54,9 +54,3 @@ if( BUILD_WITH_CCACHE )
     endif()
 endif()
 
-# On Windows we are interested in placing the DLLs together to the binaries in the install/bin
-# folder, at the installation step. On other platforms we do not care about that, since the
-# RPATHs will point the locations where the libraries where found.
-if (USING_CONAN AND WIN32)
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/conanDlls/ DESTINATION bin)
-endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,10 +254,16 @@ if(EXIV2_BUILD_EXIV2_COMMAND)
         target_include_directories(exiv2lib PRIVATE ${Intl_INCLUDE_DIRS})
     endif()
 
-    # Copy DLLs from conan packages to the bin folder
-    if (USING_CONAN AND WIN32)
+    if (USING_CONAN AND WIN32 AND EXISTS ${PROJECT_BINARY_DIR}/conanDlls)
+        # In case of using conan recipes with their 'shared' option turned on, we will have dlls of
+        # the 3rd party dependencies in the conanDlls folder.
+
+        # Copy 3rd party DLLs the bin folder. [build step]
         add_custom_command(TARGET exiv2 POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/conanDlls ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+        # Copy 3rd party DLLs the bin folder. [install step]
+        install(DIRECTORY ${PROJECT_BINARY_DIR}/conanDlls/ DESTINATION bin)
     endif()
 
     install(TARGETS exiv2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This PR is related to #184.

While working on which it will be the official conan recipe for exiv2 ([here](https://github.com/piponazo/conan-exiv2)) I noticed that there was a problem on Windows.

When bringing the 3rd party dependencies with conan in their static version (to simplify the final packages of exiv2), the folder **conanDlls** is not generated and the CMake installation step was failing because the line:

```
        install(DIRECTORY ${PROJECT_BINARY_DIR}/conanDlls/ DESTINATION bin)
```
Was assuming the existence of DLLs in that folder. This change only calls to such CMake **install()** command in case the **conanDlls** folder is present (which it would indicate that at least one of the conan packages has been configured with its **shared** option equal to True).

Once this is merged into master, the conan-exiv2 recipe will be ready and I will take the needed actions to try to publish it in the public conan repository:
https://bintray.com/conan/conan-center

Note that thanks to this recipe, exiv2 will be also tested in a more wide range of compilers. You can check here all the combinations of Operative Systems and Compilers for which we are compiling exiv2:

https://travis-ci.org/piponazo/conan-exiv2
https://ci.appveyor.com/project/piponazo/conan-exiv2