### PR TITLE
Fix alpha bit detection in VP8L chunks

### DIFF
--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -237,7 +237,7 @@ namespace Exiv2 {
 
             /* Chunk with with lossless image data. */
             if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8L) && !has_alpha) {
-                if ((payload.pData_[5] & WEBP_VP8X_ALPHA_BIT) == WEBP_VP8X_ALPHA_BIT) {
+                if ((payload.pData_[4] & WEBP_VP8X_ALPHA_BIT) == WEBP_VP8X_ALPHA_BIT) {
                     has_alpha = true;
                 }
             }


### PR DESCRIPTION
As per the spec ([1]), the alpha_bit is located on the 4th byte of the payload, just after the height.

This seems to fix the bug reported on GIMP ([2]) where an incorrect file was generated.



[1] https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification#2_riff_header
[2] https://gitlab.gnome.org/GNOME/gimp/issues/1818