### PR TITLE
Update to expat 226

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -166,7 +166,7 @@ if(MSVC)
                  string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
              endif()
          endforeach()
-     endif()
+    endif()
 
     # remove /Ob2 and /Ob1 - they cause linker issues
     set(obs /Ob2 /Ob1)

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,7 +35,7 @@ class Exiv2Conan(ConanFile):
         if self.options.xmp:
             self.requires('XmpSdk/2016.7@piponazo/stable') # from conan-piponazo
         else:
-            self.requires('Expat/2.2.5@pix4d/stable')
+            self.requires('Expat/2.2.6@pix4d/stable')
 
     def imports(self):
         self.copy('*.dll', dst='conanDlls', src='bin')

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -38,6 +38,10 @@ target_include_directories(xmp
         ${EXPAT_INCLUDE_DIR}
 )
 
+if (MSVC)
+    target_compile_definitions(xmp PRIVATE XML_STATIC)
+endif()
+
 check_include_file( "stdint.h"  EXV_HAVE_STDINT_H )
 if (EXV_HAVE_STDINT_H)
     target_compile_definitions(xmp PRIVATE EXV_HAVE_STDINT_H)

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -38,9 +38,6 @@ target_include_directories(xmp
         ${EXPAT_INCLUDE_DIR}
 )
 
-# TODO : We should only add this definition for Windows
-target_compile_definitions(xmp PRIVATE XML_STATIC)
-
 check_include_file( "stdint.h"  EXV_HAVE_STDINT_H )
 if (EXV_HAVE_STDINT_H)
     target_compile_definitions(xmp PRIVATE EXV_HAVE_STDINT_H)

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -1,34 +1,30 @@
-# CMakeLists.txt exiv2/xmpsdk
-
-# list files to be use to build XMPsdk
-set(XMPSRC src/ExpatAdapter.cpp
-           src/MD5.cpp
-           src/ParseRDF.cpp
-           src/UnicodeConversions.cpp
-           src/WXMPIterator.cpp
-           src/WXMPMeta.cpp
-           src/WXMPUtils.cpp
-           src/XML_Node.cpp
-           src/XMPCore_Impl.cpp
-           src/XMPIterator.cpp
-           src/XMPMeta-GetSet.cpp
-           src/XMPMeta-Parse.cpp
-           src/XMPMeta-Serialize.cpp
-           src/XMPMeta.cpp
-           src/XMPUtils-FileInfo.cpp
-           src/XMPUtils.cpp
-           include/MD5.h
-           include/TXMPIterator.hpp
-           include/TXMPMeta.hpp
-           include/TXMPUtils.hpp
-           include/XMP_Const.h
-           include/XMP_Environment.h
-           include/XMP.incl_cpp
-           include/XMPSDK.hpp
-           include/XMP_Version.h
+add_library(xmp STATIC
+    src/ExpatAdapter.cpp
+    src/MD5.cpp
+    src/ParseRDF.cpp
+    src/UnicodeConversions.cpp
+    src/WXMPIterator.cpp
+    src/WXMPMeta.cpp
+    src/WXMPUtils.cpp
+    src/XML_Node.cpp
+    src/XMPCore_Impl.cpp
+    src/XMPIterator.cpp
+    src/XMPMeta-GetSet.cpp
+    src/XMPMeta-Parse.cpp
+    src/XMPMeta-Serialize.cpp
+    src/XMPMeta.cpp
+    src/XMPUtils-FileInfo.cpp
+    src/XMPUtils.cpp
+    include/MD5.h
+    include/TXMPIterator.hpp
+    include/TXMPMeta.hpp
+    include/TXMPUtils.hpp
+    include/XMP_Const.h
+    include/XMP_Environment.h
+    include/XMP.incl_cpp
+    include/XMPSDK.hpp
+    include/XMP_Version.h
 )
-
-add_library(xmp STATIC ${XMPSRC})
 
 target_link_libraries(xmp 
     PRIVATE 
@@ -59,6 +55,3 @@ install(TARGETS xmp EXPORT exiv2Config
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-
-# That's all Folks!
-##


### PR DESCRIPTION
As described in #494, we were having some issues when building exiv2 on windows and static mode, that are solved when using expat 2.2.6 with the proper configuration.

As a side effect of this change, I have updated the public libexpat recipe to its 2.2.6 version (packages available in conan-center):
https://github.com/Pix4D/conan-expat

Note that this change does not enforce the usage of expat 2.2.6. Linux/OSX users can still get expat from their system packages in older versions and exiv2 will compile correctly. However, when using conan, it will bring the latest version of the library. 