### PR TITLE
CMake: Supress MSVC PDB warnings

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -80,6 +80,10 @@ if( EXPAT_FOUND )
         target_compile_definitions(geotag PRIVATE XML_STATIC)
     endif()
 
+    if (MSVC)
+        set_target_properties(geotag PROPERTIES LINK_FLAGS "/ignore:4099")
+    endif()
+
     install( TARGETS       geotag    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,10 @@ set_target_properties( exiv2lib PROPERTIES
     COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
 )
 
+if (MSVC)
+    set_target_properties(exiv2lib PROPERTIES LINK_FLAGS "/ignore:4099")
+endif()
+
 set_target_properties( exiv2lib_int PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     COMPILE_DEFINITIONS exiv2lib_STATIC

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -40,10 +40,14 @@ target_compile_definitions(unit_tests
         GTEST_LINKED_AS_SHARED_LIBRARY=1
 )
 
-set_target_properties( unit_tests PROPERTIES
+set_target_properties(unit_tests PROPERTIES
     COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
 )
 
 if (USING_CONAN)
     target_compile_definitions(unit_tests PRIVATE ${CONAN_COMPILE_DEFINITIONS_GTEST})
+endif()
+
+if (MSVC)
+    set_target_properties(unit_tests PROPERTIES LINK_FLAGS "/ignore:4099")
 endif()


### PR DESCRIPTION
With this change we will ignore the warnings reported by the MSVC linker complaining about the lack of the PDB files files of external libraries. Example:

```
pipon@DesktopWin10 MINGW64 /f/projects/exiv2/buildDebug (testsPsdImage)
$ ninja unit_tests
[98/99] Linking CXX shared library bin\exiv2.dll
LINK : bin\exiv2.dll not found or not built by the last incremental link; performing full link
zlib.lib(compress.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(compress.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(uncompr.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(uncompr.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(crc32.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(crc32.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(deflate.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(deflate.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inflate.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inflate.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(adler32.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(adler32.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(zutil.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(zutil.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(trees.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(trees.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inftrees.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inftrees.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inffast.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inffast.obj)' or at 'F:\projects\exiv2\buildDebug\src\zlibstatic.pdb'; linking object as if no debug info
expatd.lib(xmlparse.obj) : warning LNK4099: PDB 'expat.pdb' was not found with 'expatd.lib(xmlparse.obj)' or at 'F:\projects\exiv2\buildDebug\src\expat.pdb'; linking object as if no debug info
expatd.lib(xmltok.obj) : warning LNK4099: PDB 'expat.pdb' was not found with 'expatd.lib(xmltok.obj)' or at 'F:\projects\exiv2\buildDebug\src\expat.pdb'; linking object as if no debug info
expatd.lib(xmlrole.obj) : warning LNK4099: PDB 'expat.pdb' was not found with 'expatd.lib(xmlrole.obj)' or at 'F:\projects\exiv2\buildDebug\src\expat.pdb'; linking object as if no debug info
expatd.lib(loadlibrary.obj) : warning LNK4099: PDB 'expat.pdb' was not found with 'expatd.lib(loadlibrary.obj)' or at 'F:\projects\exiv2\buildDebug\src\expat.pdb'; linking object as if no debug info
   Creating library lib\exiv2.lib and object lib\exiv2.exp
[99/99] Linking CXX executable bin\unit_tests.exe
LINK : bin\unit_tests.exe not found or not built by the last incremental link; performing full link
zlib.lib(compress.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(compress.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(uncompr.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(uncompr.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(crc32.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(crc32.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(deflate.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(deflate.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inflate.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inflate.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(adler32.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(adler32.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(zutil.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(zutil.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(trees.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(trees.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inftrees.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inftrees.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
zlib.lib(inffast.obj) : warning LNK4099: PDB 'zlibstatic.pdb' was not found with 'zlib.lib(inffast.obj)' or at 'F:\projects\exiv2\buildDebug\bin\zlibstatic.pdb'; linking object as if no debug info
(conan)
```