### PR TITLE
video width/height values propogated to base class pixel{Height,Width}_

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -516,7 +516,7 @@ namespace Exiv2 {
 
         if(stream == 2) {
             xmpData_["Xmp.video.Width"] = temp;
-            width_ = temp;
+            pixelWidth_ = width_ = temp;
         }
         else if(stream == 1) {
             xmpData_["Xmp.audio.Codec"] = test->printAudioEncoding(temp);
@@ -532,7 +532,7 @@ namespace Exiv2 {
 
         if(stream == 2) {
             xmpData_["Xmp.video.Height"] = temp;
-            height_ = temp;
+            pixelHeight_ = height_ = temp;
         }
         else if(stream == 1) {
             xmpData_["Xmp.audio.SampleRate"] = temp;

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -592,10 +592,10 @@ namespace Exiv2 {
             xmpData_[mt->label_] = returnValue(buf, size);
 
             if (mt->val_ == 0x0030 || mt->val_ == 0x14b0) {
-                width_ = returnValue(buf, size);
+                pixelWidth_ = width_ = returnValue(buf, size);
             }
             else if (mt->val_ == 0x003a || mt->val_ == 0x14ba) {
-                height_ = returnValue(buf, size);
+                pixelHeight_ = height_ = returnValue(buf, size);
             }
             break;
 

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -1537,14 +1537,14 @@ namespace Exiv2 {
                 if(currentStream_ == Video) {
                     temp = returnBufValue(buf, 2) + static_cast<int64_t>((buf.pData_[2] * 256 + buf.pData_[3]) * 0.01);
                     xmpData_["Xmp.video.Width"] = temp;
-                    width_ = temp;
+                    pixelWidth_ = width_ = temp;
                 }
                 break;
             case ImageHeight:
                 if(currentStream_ == Video) {
                     temp = returnBufValue(buf, 2) + static_cast<int64_t>((buf.pData_[2] * 256 + buf.pData_[3]) * 0.01);
                     xmpData_["Xmp.video.Height"] = temp;
-                    height_ = temp;
+                    pixelHeight_ = height_ = temp;
                 }
                 break;
             default:

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -1082,10 +1082,12 @@ namespace Exiv2 {
                 break;
             case imageWidth_h:
                 width = Exiv2::getULong(buf.pData_, littleEndian);
+                pixelWidth_ = width;
                 xmpData_["Xmp.video.Width"] = width;
                 break;
             case imageHeight_h:
                 height = Exiv2::getULong(buf.pData_, littleEndian);
+                pixelHeight_ = height;
                 xmpData_["Xmp.video.Height"] = height;
                 break;
             }


### PR DESCRIPTION
bug fix proposal for issue: https://github.com/Exiv2/exiv2/issues/586

`Image` object's `width` and `height` values incorrect/not set for `*Video` subclasses