### PR TITLE
Deprecate relics

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,6 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 9 2008
-      INTEGRATION_TESTS: 0
-      VS_COMPILER_VERSION: 9
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86
-      UNIT_TESTS: 0
-      WARNINGS_AS_ERRORS: OFF
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 10

--- a/cmake/compilerFlagsExiv2.cmake
+++ b/cmake/compilerFlagsExiv2.cmake
@@ -3,6 +3,7 @@
 if (MINGW OR UNIX) # MINGW, Linux, APPLE, CYGWIN
     if ( EXIV2_TEAM_WARNINGS_AS_ERRORS )
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
     endif ()
 endif()
 

--- a/cmake/mainSetup.cmake
+++ b/cmake/mainSetup.cmake
@@ -5,6 +5,14 @@ include(GNUInstallDirs)
 include(CheckFunctionExists)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
+include(WriteCompilerDetectionHeader)
+
+write_compiler_detection_header(
+    FILE exiv2lib_compiler_detection.h
+    PREFIX EXIV2
+    COMPILERS GNU Clang AppleClang MSVC
+    FEATURES cxx_attribute_deprecated
+)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cmake/printSummary.cmake
+++ b/cmake/printSummary.cmake
@@ -65,5 +65,8 @@ OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC            
 OptionOutput( "Building with coverage flags:       " BUILD_WITH_COVERAGE             )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
 
+message( STATUS "------------------------------------------------------------------" )
+
+message(STATUS " WARNING: Deprecated features: EPS, Video, Ssh")
 
 message( STATUS "------------------------------------------------------------------" )

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -31,6 +31,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
+#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 namespace Exiv2 {
@@ -46,7 +47,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access ASF video files.
      */
-    class EXIV2API AsfVideo:public Image
+    class EXIV2_DEPRECATED EXIV2API AsfVideo:public Image
     {
     public:
         //! @name Creators
@@ -169,10 +170,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Windows Asf Video.
-    EXIV2API bool isAsfType(BasicIo& iIo, bool advance);
+    EXIV2_DEPRECATED EXIV2API bool isAsfType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -27,6 +27,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
+#include "exiv2lib_compiler_detection.h"
 #include "types.hpp"
 
 // + standard includes
@@ -1112,7 +1113,7 @@ namespace Exiv2 {
         @brief Provides the ssh read/write access and sftp read access for the RemoteIo.
             This class is based on libssh.
     */
-    class EXIV2API SshIo : public RemoteIo {
+    class EXIV2_DEPRECATED EXIV2API SshIo : public RemoteIo {
     public:
         //! @name Creators
         //@{

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -38,6 +38,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
+#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -56,7 +57,7 @@ namespace Exiv2
     /*!
       @brief Class to access EPS images.
      */
-    class EXIV2API EpsImage : public Image {
+    class EXIV2_DEPRECATED EXIV2API EpsImage : public Image {
     public:
         //! @name Creators
         //@{
@@ -114,10 +115,10 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2API Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a EPS image.
-    EXIV2API bool isEpsType(BasicIo& iIo, bool advance);
+    EXIV2_DEPRECATED EXIV2API bool isEpsType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -31,6 +31,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
+#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -49,7 +50,7 @@ namespace Exiv2 {
     /*!
       @brief Helper structure for the Matroska tags lookup table.
      */
-    struct MatroskaTags {
+    struct EXIV2_DEPRECATED MatroskaTags {
         uint64_t val_;                          //!< Tag value
         const char* label_;                     //!< Translation of the tag value
 
@@ -60,7 +61,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access Matroska video files.
      */
-    class EXIV2API MatroskaVideo : public Image {
+    class EXIV2_DEPRECATED EXIV2API MatroskaVideo : public Image {
     public:
         //! @name Creators
         //@{
@@ -145,10 +146,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Matroska Video.
-    EXIV2API bool isMkvType(BasicIo& iIo, bool advance);
+    EXIV2_DEPRECATED EXIV2API bool isMkvType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access QuickTime video files.
      */
-    class EXIV2API QuickTimeVideo:public Image
+    class EXIV2_DEPRECATED EXIV2API QuickTimeVideo:public Image
     {
     public:
         //! @name Creators
@@ -242,10 +242,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Quick Time Video.
-    EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);
+    EXIV2_DEPRECATED EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -32,6 +32,7 @@
 
 // included header files
 #include "exif.hpp"
+#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -49,7 +50,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access RIFF video files.
      */
-    class EXIV2API RiffVideo:public Image
+    class EXIV2_DEPRECATED EXIV2API RiffVideo:public Image
     {
     public:
         //! @name Creators
@@ -210,10 +211,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2API Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Riff Video.
-    EXIV2API bool isRiffType(BasicIo& iIo, bool advance);
+    EXIV2_DEPRECATED EXIV2API bool isRiffType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/ssh.hpp
+++ b/include/exiv2/ssh.hpp
@@ -28,7 +28,9 @@
 #include <libssh/sftp.h>
 #include <sys/stat.h>
 #include <string>
+
 #include "error.hpp"
+#include "exiv2lib_compiler_detection.h"
 #include "types.hpp"
 #include "futils.hpp"
 
@@ -38,7 +40,7 @@ namespace Exiv2 {
             It makes the libssh transparent. The functions in this class can
             be used without the requirement of understanding libssh.
      */
-    class EXIV2API SSH {
+    class EXIV2_DEPRECATED EXIV2API SSH {
     public:
         //! @name Creators
         //@{

--- a/include/exiv2/utilsvideo.hpp
+++ b/include/exiv2/utilsvideo.hpp
@@ -18,6 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifndef UTILSVIDEO_HPP_
+#define UTILSVIDEO_HPP_
+
+#include "exiv2lib_compiler_detection.h"
 
 namespace Exiv2
 {
@@ -25,7 +29,7 @@ namespace Exiv2
     /*!
       @brief Class of utility functions used by the video code.
      */
-    class UtilsVideo
+    class EXIV2_DEPRECATED UtilsVideo
     {
     public:
         /*!
@@ -56,3 +60,5 @@ namespace Exiv2
     }; // class UtilsVideo
 
 } // namespace Exiv2
+
+#endif                                  // #ifndef UTILSVIDEO_HPP_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,6 @@ add_library( exiv2lib
     ../include/exiv2/exiv2.hpp
     ../include/exiv2/rwlock.hpp
     ../include/exiv2/slice.hpp
-    asfvideo.cpp            ../include/exiv2/asfvideo.hpp
     basicio.cpp             ../include/exiv2/basicio.hpp
     bigtiffimage.cpp
     bmpimage.cpp            ../include/exiv2/bmpimage.hpp
@@ -64,7 +63,6 @@ add_library( exiv2lib
     iptc.cpp                ../include/exiv2/iptc.hpp
     jp2image.cpp            ../include/exiv2/jp2image.hpp
     jpgimage.cpp            ../include/exiv2/jpgimage.hpp
-    matroskavideo.cpp       ../include/exiv2/matroskavideo.hpp
     metadatum.cpp           ../include/exiv2/metadatum.hpp
     mrwimage.cpp            ../include/exiv2/mrwimage.hpp
     orfimage.cpp            ../include/exiv2/orfimage.hpp
@@ -72,15 +70,12 @@ add_library( exiv2lib
     preview.cpp             ../include/exiv2/preview.hpp
     properties.cpp          ../include/exiv2/properties.hpp
     psdimage.cpp            ../include/exiv2/psdimage.hpp
-    quicktimevideo.cpp      ../include/exiv2/quicktimevideo.hpp
     rafimage.cpp            ../include/exiv2/rafimage.hpp
-    riffvideo.cpp           ../include/exiv2/riffvideo.hpp
     rw2image.cpp            ../include/exiv2/rw2image.hpp
     tags.cpp                ../include/exiv2/tags.hpp
     tgaimage.cpp            ../include/exiv2/tgaimage.hpp
     tiffimage.cpp           ../include/exiv2/tiffimage.hpp
     types.cpp               ../include/exiv2/types.hpp
-    utilsvideo.cpp          ../include/exiv2/utilsvideo.hpp
     value.cpp               ../include/exiv2/value.hpp
     version.cpp             ../include/exiv2/version.hpp
     webpimage.cpp           ../include/exiv2/webpimage.hpp
@@ -115,6 +110,16 @@ endif()
 if( EXIV2_ENABLE_PNG )
     target_sources(exiv2lib_int PRIVATE pngchunk_int.cpp)
     target_sources(exiv2lib PRIVATE pngimage.cpp ../include/exiv2/pngimage.hpp)
+endif()
+
+if( EXIV2_ENABLE_VIDEO )
+    target_sources(exiv2lib PRIVATE 
+        asfvideo.cpp            ../include/exiv2/asfvideo.hpp
+        matroskavideo.cpp       ../include/exiv2/matroskavideo.hpp
+        quicktimevideo.cpp      ../include/exiv2/quicktimevideo.hpp
+        riffvideo.cpp           ../include/exiv2/riffvideo.hpp
+        utilsvideo.cpp          ../include/exiv2/utilsvideo.hpp
+    )
 endif()
 
 # Other library target properties


### PR DESCRIPTION
After the discussion we had in #603 about deprecating some relics in the code, and #611 about having a proper deprecation cycle, I decided to create this PR where I did the following:

- Provide the CMake magic to have a `EXIV2_DEPRECATED` definition which will be replaced for the needed code in each compiler to provide deprecation warnings.
- Deprecate the features discussed in #603: EPS, Video, SSH. (I am not sure what is the FTP code, @clanmills could you tell me what to deprecate related with FTP?).
- Compile the video sources only if `EXIV2_ENABLE_VIDEO` is enabled. Before we were compiling those sources even if `EXIV2_ENABLE_VIDEO` was disabled.
- `EXIV2_TEAM_WARNINGS_AS_ERRORS` had to be disabled on our CI jobs so that the deprecation warnings are not treated as errors. Note that this is disabled only in the branch 0.27. The idea is that we will remove that code from master so that we can keep `EXIV2_TEAM_WARNINGS_AS_ERRORS` enabled. 