### PR TITLE
xmpsdk: Build with -DBanAllEntityUsage=1

### DIFF
--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -38,6 +38,10 @@ target_include_directories(exiv2-xmp
         ${EXPAT_INCLUDE_DIR}
 )
 
+# Prevent a denial-service-attack related to XML entity expansion
+# ("billion laughs attack").
+# See https://bugzilla.redhat.com/show_bug.cgi?id=888769
+target_compile_definitions(exiv2-xmp PRIVATE BanAllEntityUsage=1)
 if (MSVC)
     target_compile_definitions(exiv2-xmp PRIVATE XML_STATIC)
 endif()

--- a/xmpsdk/src/ExpatAdapter.cpp
+++ b/xmpsdk/src/ExpatAdapter.cpp
@@ -484,7 +484,10 @@ static void CommentHandler ( void * userData, XMP_StringPtr comment )
 static void StartDoctypeDeclHandler ( void * userData, XMP_StringPtr doctypeName,
 									  XMP_StringPtr sysid, XMP_StringPtr pubid, int has_internal_subset )
 {
-	IgnoreParam(userData);
+	IgnoreParam(doctypeName);
+	IgnoreParam(sysid);
+	IgnoreParam(pubid);
+	IgnoreParam(has_internal_subset);
 
 	ExpatAdapter * thiz = (ExpatAdapter*)userData;
 


### PR DESCRIPTION
Prevent a denial-service-attack related to XML entity expansion
("billion laughs attack").
See https://bugzilla.redhat.com/show_bug.cgi?id=888769

Search for BanAllEntityUsage in xmpsdk/src/ExpatAdapter.cpp

Signed-off-by: Andreas Schneider <asn@cryptomilk.org>