### PR TITLE
Reliable detection of strerror_r variants (master)

### DIFF
--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -27,6 +27,9 @@
 // Define if you have the strerror_r function.
 #cmakedefine EXV_HAVE_STRERROR_R
 
+// Define if the strerror_r function returns char*.
+#cmakedefine EXV_STRERROR_R_CHAR_P
+
 // Define to enable the Windows unicode path support.
 #cmakedefine EXV_UNICODE_PATH
 

--- a/cmake/generateConfigFile.cmake
+++ b/cmake/generateConfigFile.cmake
@@ -1,4 +1,5 @@
 include(CheckIncludeFile)
+include(CheckCXXSourceCompiles)
 
 # Note that the scope of the EXV_ variables in local
 if (${EXIV2_ENABLE_WEBREADY})
@@ -27,6 +28,14 @@ check_function_exists( gmtime_r EXV_HAVE_GMTIME_R )
 check_function_exists( mmap     EXV_HAVE_MMAP )
 check_function_exists( munmap   EXV_HAVE_MUNMAP )
 check_function_exists( strerror_r   EXV_HAVE_STRERROR_R )
+
+check_cxx_source_compiles( "
+#include <string.h>
+int main() {
+    char buff[100];
+    const char* c = strerror_r(0,buff,100);
+    return 0;
+}" EXV_STRERROR_R_CHAR_P )
 
 check_include_file( "unistd.h"  EXV_HAVE_UNISTD_H )
 check_include_file( "sys/mman.h"    EXV_HAVE_SYS_MMAN_H )

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -53,14 +53,6 @@
 #include <algorithm>
 #include <stdexcept>
 
-#ifdef EXV_HAVE_STRERROR_R
-#if defined(__GLIBC__) && defined(_GNU_SOURCE)
-extern char *strerror_r(int errnum, char *buf, size_t n);
-#else
-extern int strerror_r(int errnum, char *buf, size_t n);
-#endif
-#endif
-
 namespace Exiv2 {
     const char* ENVARDEF[] = {"/exiv2.php", "40"}; //!< @brief default URL for http exiv2 handler and time-out
     const char* ENVARKEY[] = {"EXIV2_HTTP_POST", "EXIV2_TIMEOUT"}; //!< @brief request keys for http exiv2 handler and time-out
@@ -345,7 +337,7 @@ namespace Exiv2 {
         std::ostringstream os;
 #ifdef EXV_HAVE_STRERROR_R
         const size_t n = 1024;
-#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+#ifdef EXV_STRERROR_R_CHAR_P
         char *buf = 0;
         char buf2[n];
         std::memset(buf2, 0x0, n);


### PR DESCRIPTION
This PR should fix #616.

As @clanmills pointed out, in 0.26 we had some CMake code dealing with this. I now remember that at some point I tried to simplify things over there, and clearly I did not consider the cross-compilation cases. I am sorry for the inconveniences that decision has caused.

@clanmills It would be great if you could try out this solution on the Alpine VM you have. 

Let's see if the CI jobs can compile this in all the different distributions ...

If this patch works on master (where #633 was failing), I'll apply this to the 0.27 branch.