### PR TITLE
Include exiv2lib_export.h where needed and cleanup headers

### DIFF
--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -31,7 +31,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
 #include "image.hpp"
 
 namespace Exiv2 {

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -28,6 +28,8 @@
 #define ASFVIDEO_HPP
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "image.hpp"

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -28,15 +28,9 @@
 
 // included header files
 #include "types.hpp"
-#include "futils.hpp"
 
 // + standard includes
-#include <string>
 #include <memory>       // for std::auto_ptr
-#include <fstream>      // write the temporary file
-#include <fcntl.h>      // _O_BINARY in FileIo::FileIo
-#include <ctime>        // timestamp for the name of temporary file
-#include <cstring>      // std::memcpy
 
 // The way to handle data from stdin or data uri path. If EXV_XPATH_MEMIO = 1,
 // it uses MemIo. Otherwises, it uses FileIo.

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -24,6 +24,8 @@
 #define BASICIO_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "futils.hpp"

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -28,6 +28,8 @@
 #define BMPIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -31,13 +31,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
-#include "iptc.hpp"
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/convert.hpp
+++ b/include/exiv2/convert.hpp
@@ -30,6 +30,8 @@
 #ifndef CONVERT_HPP_
 #define CONVERT_HPP_
 
+#include "exiv2lib_export.h"
+
 // included header files
 #include "config.h"
 

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -28,6 +28,8 @@
 #define CR2IMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -32,11 +32,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -30,6 +30,8 @@
 #define CRWIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "image.hpp"

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -33,13 +33,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "types.hpp"
 #include "image.hpp"
-#include "basicio.hpp"
-
-// + standard includes
-#include <iosfwd>
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -30,14 +30,9 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "types.hpp"
 #include "metadatum.hpp"
 
 // + standard includes
-#include <string>
-#include <utility>                              // for std::pair
-#include <iosfwd>
-#include <memory>
 #include <set>
 #include <vector>
 #include <map>

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -27,6 +27,8 @@
 #define DATASETS_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "metadatum.hpp"

--- a/include/exiv2/easyaccess.hpp
+++ b/include/exiv2/easyaccess.hpp
@@ -27,6 +27,8 @@
 #define EASYACCESS_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -39,10 +39,6 @@
 
 // included header files
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -35,6 +35,8 @@
 #define EPSIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "types.hpp"

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -29,6 +29,8 @@
 #define ERROR_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -37,8 +37,6 @@
 // + standard includes
 #include <exception>
 #include <string>
-#include <iosfwd>
-#include <sstream>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -28,6 +28,8 @@
 #define EXIF_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "metadatum.hpp"
 #include "tags.hpp"

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -33,13 +33,9 @@
 // included header files
 #include "metadatum.hpp"
 #include "tags.hpp"
-#include "value.hpp"
-#include "types.hpp"
 
 // + standard includes
-#include <string>
 #include <list>
-#include <memory>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -28,8 +28,8 @@
 #ifndef FUTILS_HPP_
 #define FUTILS_HPP_
 
-#include "config.h"
 #include "exiv2lib_export.h"
+#include "config.h"
 
 #include <string>
 

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -32,13 +32,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
-#include "iptc.hpp"
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -29,6 +29,8 @@
 #define GIFIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/http.hpp
+++ b/include/exiv2/http.hpp
@@ -3,12 +3,9 @@
 
 #include "exiv2lib_export.h"
 
-#include "config.h"
 #include "datasets.hpp"
 
 #include <string>
-#include <map>
-#include <algorithm>
 
 
 namespace Exiv2 {

--- a/include/exiv2/http.hpp
+++ b/include/exiv2/http.hpp
@@ -1,12 +1,15 @@
 #ifndef HTTP_HPP_
 #define HTTP_HPP_
 
+#include "exiv2lib_export.h"
+
 #include "config.h"
+#include "datasets.hpp"
+
 #include <string>
 #include <map>
 #include <algorithm>
 
-#include "datasets.hpp"
 
 namespace Exiv2 {
     /*!

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -27,7 +27,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "types.hpp"
 #include "basicio.hpp"
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -24,6 +24,8 @@
 #define IMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -32,14 +32,7 @@
 
 // included header files
 #include "metadatum.hpp"
-#include "types.hpp"
-#include "error.hpp"
-#include "value.hpp"
 #include "datasets.hpp"
-
-// + standard includes
-#include <string>
-#include <vector>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -28,6 +28,8 @@
 #define IPTC_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "metadatum.hpp"
 #include "types.hpp"

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -29,13 +29,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
-#include "iptc.hpp"
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -26,6 +26,8 @@
 #define JP2IMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -34,6 +34,8 @@
 #define JPGIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -38,11 +38,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -31,7 +31,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
 #include "image.hpp"
 
 // *****************************************************************************

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -28,6 +28,8 @@
 #define MATROSKAVIDEO_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "image.hpp"

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -32,6 +32,8 @@
 #define METADATUM_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "value.hpp"

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -35,12 +35,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "types.hpp"
 #include "value.hpp"
-
-// + standard includes
-#include <string>
-#include <memory>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -33,11 +33,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -29,6 +29,8 @@
 #define MRWIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -28,6 +28,8 @@
 #define ORFIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "tiffimage.hpp"

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -31,13 +31,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "image.hpp"
 #include "tiffimage.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -35,11 +35,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -31,6 +31,8 @@
 #define PGFIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -32,6 +32,8 @@
 #define PNGIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -36,11 +36,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/preview.hpp
+++ b/include/exiv2/preview.hpp
@@ -28,6 +28,8 @@
 #define PREVIEW_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "image.hpp"

--- a/include/exiv2/preview.hpp
+++ b/include/exiv2/preview.hpp
@@ -30,13 +30,7 @@
 // *****************************************************************************
 #include "exiv2lib_export.h"
 
-// included header files
-#include "types.hpp"
 #include "image.hpp"
-#include "basicio.hpp"
-
-#include <string>
-#include <vector>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -32,6 +32,8 @@
 #define PROPERTIES_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 #include "metadatum.hpp"

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -35,16 +35,8 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "types.hpp"
-#include "metadatum.hpp"
-#include "tags.hpp"
 #include "datasets.hpp"
 #include "rwlock.hpp"
-
-// + standard includes
-#include <string>
-#include <iosfwd>
-#include <memory>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -34,13 +34,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
-#include "iptc.hpp"
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -31,6 +31,8 @@
 #define PSDIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -28,6 +28,8 @@
 #define QUICKTIMEVIDEO_HPP
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "image.hpp"

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -28,6 +28,8 @@
 #define RAFIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -28,6 +28,8 @@
 #define RIFFVIDEO_HPP
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "image.hpp"

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -28,6 +28,8 @@
 #define RW2IMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -32,11 +32,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -33,7 +33,6 @@
 
 // included header files
 #include "metadatum.hpp"
-#include "types.hpp"
 
 // + standard includes
 #include <string>

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -29,6 +29,8 @@
 #define TAGS_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "metadatum.hpp"
 #include "types.hpp"

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -30,6 +30,8 @@
 #define TGAIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "iptc.hpp"

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -33,13 +33,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
-#include "iptc.hpp"
 #include "image.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -25,6 +25,8 @@
 #define TIFFIMAGE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -29,11 +29,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -29,18 +29,16 @@
 #ifndef TYPES_HPP_
 #define TYPES_HPP_
 
+#include "exiv2lib_export.h"
+
 // included header files
 #include "config.h"
-#include "slice.hpp"
-#include "exiv2lib_export.h"
 #include "slice.hpp"
 
 // + standard includes
 #include <string>
 #include <vector>
-#include <iosfwd>
 #include <limits>
-#include <utility>
 #include <algorithm>
 #include <sstream>
 

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -36,12 +36,8 @@
 #include "types.hpp"
 
 // + standard includes
-#include <string>
-#include <vector>
 #include <map>
-#include <iostream>
 #include <iomanip>
-#include <sstream>
 #include <memory>
 #include <cstring>
 #include <climits>

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -30,6 +30,8 @@
 #define VALUE_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "types.hpp"
 

--- a/include/exiv2/version.hpp
+++ b/include/exiv2/version.hpp
@@ -30,8 +30,8 @@
 #ifndef VERSION_HPP_
 #define VERSION_HPP_
 
-#include "exv_conf.h"
 #include "exiv2lib_export.h"
+#include "exv_conf.h"
 
 // *****************************************************************************
 // included header files

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -28,6 +28,8 @@
 #define WEBPIMAGE_HPP
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "exif.hpp"
 #include "image.hpp"

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -31,7 +31,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exif.hpp"
 #include "image.hpp"
 
 // *****************************************************************************

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -28,6 +28,8 @@
 #define XMP_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "metadatum.hpp"
 #include "properties.hpp"

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -33,14 +33,6 @@
 // included header files
 #include "metadatum.hpp"
 #include "properties.hpp"
-#include "value.hpp"
-#include "types.hpp"
-#include "datasets.hpp"
-#include "properties.hpp"
-
-// + standard includes
-#include <string>
-#include <vector>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -28,6 +28,8 @@
 #define XMPSIDECAR_HPP_
 
 // *****************************************************************************
+#include "exiv2lib_export.h"
+
 // included header files
 #include "image.hpp"
 #include "basicio.hpp"

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -32,11 +32,6 @@
 
 // included header files
 #include "image.hpp"
-#include "basicio.hpp"
-#include "types.hpp"
-
-// + standard includes
-#include <string>
 
 // *****************************************************************************
 // namespace extensions

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -2,10 +2,12 @@
 // mrwthumb.cpp
 // Sample program to extract a Minolta thumbnail from the makernote
 
-#include <cassert>
 #include "error.hpp"
 #include "exif.hpp"
 #include "image.hpp"
+
+#include <cassert>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 {

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -5,6 +5,8 @@
 #include <cassert>
 #include <iostream>
 #include <string>
+
+#include "error.hpp"
 #include "image.hpp"
 
 int main(int argc, char* const argv[])

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -30,15 +30,7 @@
 
 // *****************************************************************************
 // included header files
-
-// + standard includes
-#include <string>
-#include <map>
-
 #include "exiv2app.hpp"
-#include "image.hpp"
-#include "exif.hpp"
-#include "iptc.hpp"
 
 // *****************************************************************************
 // class declarations

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #ifdef EXV_ENABLE_VIDEO
+#include "error.hpp"
 #include "tags.hpp"
 #include "tags_int.hpp"
 #include "asfvideo.hpp"

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -35,10 +35,13 @@
 #include <string>
 #include <memory>
 #include <iostream>
-#include <cstring>
+#include <cstring>                      // std::memcpy
 #include <cassert>
+#include <fstream>                      // write the temporary file
+#include <fcntl.h>                      // _O_BINARY in FileIo::FileIo
 #include <cstdio>                       // for remove, rename
 #include <cstdlib>                      // for alloc, realloc, free
+#include <ctime>                        // timestamp for the name of temporary file
 #include <sys/types.h>                  // for stat, chmod
 #include <sys/stat.h>                   // for stat, chmod
 

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -1,8 +1,4 @@
-
 #include "bigtiffimage.hpp"
-
-#include <cassert>
-#include <limits>
 
 #include "safe_op.hpp"
 #include "exif.hpp"
@@ -10,6 +6,9 @@
 #include "image_int.hpp"
 #include "enforce.hpp"
 
+#include <cassert>
+#include <limits>
+#include <iostream>
 
 namespace Exiv2
 {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -28,6 +28,7 @@
 // included header files
 #include "config.h"
 #include "types.hpp"
+#include "error.hpp"
 #include "exif.hpp"
 #include "iptc.hpp"
 #include "xmp_exiv2.hpp"

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -3,8 +3,10 @@
 #include "i18n.h"                // NLS support.
 #include "timegm.h"
 #include "unused.h"
+#include "error.hpp"
 
 #include <cassert>
+#include <ctime>
 
 // *****************************************************************************
 // local declarations

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <algorithm>
 #include <iterator>
+#include <fstream>      // write the temporary file
 
 // *****************************************************************************
 namespace {

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <cassert>
 #include <stdexcept>
+#include <iostream>
 
 // *****************************************************************************
 // class member definitions

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -29,6 +29,7 @@
 
 #ifdef EXV_ENABLE_VIDEO
 #include "matroskavideo.hpp"
+#include "error.hpp"
 #include "futils.hpp"
 #include "basicio.hpp"
 #include "tags.hpp"

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #ifdef EXV_ENABLE_VIDEO
+#include "error.hpp"
 #include "tags.hpp"
 #include "tags_int.hpp"
 #include "quicktimevideo.hpp"

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #ifdef EXV_ENABLE_VIDEO
+#include "error.hpp"
 #include "riffvideo.hpp"
 #include "futils.hpp"
 #include "basicio.hpp"

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1,5 +1,6 @@
 #include "tiffimage_int.hpp"
 
+#include "error.hpp"
 #include "makernote_int.hpp"
 #include "tiffvisitor_int.hpp"
 #include "i18n.h"                // NLS support.


### PR DESCRIPTION
This PR fixes #636.

Furthermore I took the opportunity to cleanup the useless inclusions in the public headers of Exiv2. This might look like a scary change, but the CI jobs are building in all the platforms and many linux distributions. 

Nonetheless, I decided to add @cgilles in the list of reviewers to check if he might see any problem with Exiv2 consumers such as Digikam. 