### PR TITLE
Fix644 on 0.27

### DIFF
--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -260,7 +260,7 @@ namespace Exiv2 {
              provided to print errors to a stream.
      */
     template<typename charT>
-    class BasicError : public AnyError {
+    class EXIV2API BasicError : public AnyError {
     public:
         //! @name Creators
         //@{


### PR DESCRIPTION
This change produces linker warnings on MacOS-X

```
[ 50%] Linking CXX shared library ../lib/libexiv2.dylib
ld: warning: direct access in function 'Exiv2::Internal::CiffEntry::doAdd(std::__1::auto_ptr<Exiv2::Internal::CiffComponent>)' from file 'CMakeFiles/exiv2lib_int.dir/crwimage_int.cpp.o' to global weak symbol 'typeinfo for Exiv2::BasicError<char>' from file 'CMakeFiles/exiv2lib.dir/basicio.cpp.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

We've seen this message before (around the time of Exiv2 v0.27 RC3) and didn't know what it meant.  I'll open another issue to investigate this.  The fix for 644 is a build-breaker for Suse, the linking message is ugly and probably benign.