### PR TITLE
Add configuration file for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,40 @@
+pull_request_rules:
+  - name: backport patches to 0.27 branch
+    conditions:
+      - base=master
+      - label=backport-to-0.27
+    actions:
+      backport:
+        branches:
+          - "0.27"
+
+  - name: backport patches to 0.26 branch
+    conditions:
+      - base=master
+      - label=backport-to-0.26
+    actions:
+      backport:
+        branches:
+          - "0.26"
+
+  - name: forward-port patches to master
+    conditions:
+      - base=0.27
+      - label=to-master
+    actions:
+      backport:
+        branches:
+          - master
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}
+
+  - name: remove outdated reviews
+    conditions: []
+    actions:
+      dismiss_reviews:
+        approved: True
+        changes_requested: False


### PR DESCRIPTION
Actions for mergify:
- backport from master to 0.27 when the PR gets the label `backport-to-0.27`
- backport from master to 0.26 when the PR gets the label `backport-to-0.26`
- forward port from  0.27 to master when the PR gets the label `to-master`
- automatically delete the PR's branch after it got merged (this should **not** delete the branch when the PR got closed, but we should test that)
- Automatically dismiss approvals only of PRs that got changed. This one could end up being quite annoying, as we sometimes rebase PRs quite often. However, it is imho *in principle* a good idea.

I have explicitly not allowed mergify to actually merge any pull request, or do other stuff. The bot can do the following things:
- merge PRs
- comment on PRs
- add labels to PRs
- close PRs
- delete the branch after a merge
- dismiss reviews
- backport PRs
(see https://doc.mergify.io/actions.html)

All of that under certain, user-defined conditions, like "number of reviewers >= 2 and travis passes and appveyor passes" add the label: `MERGE and don't wait for gitlab!!!`

This closes #669.