### PR TITLE
Buildfix and cleanup

### DIFF
--- a/cmake/mainSetup.cmake
+++ b/cmake/mainSetup.cmake
@@ -5,14 +5,6 @@ include(GNUInstallDirs)
 include(CheckFunctionExists)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
-include(WriteCompilerDetectionHeader)
-
-write_compiler_detection_header(
-    FILE exiv2lib_compiler_detection.h
-    PREFIX EXIV2
-    COMPILERS GNU Clang AppleClang MSVC
-    FEATURES cxx_attribute_deprecated
-)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -31,7 +31,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 namespace Exiv2 {
@@ -47,7 +46,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access ASF video files.
      */
-    class EXIV2_DEPRECATED EXIV2API AsfVideo:public Image
+    class EXIV2LIB_DEPRECATED_EXPORT AsfVideo:public Image
     {
     public:
         //! @name Creators
@@ -170,10 +169,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Windows Asf Video.
-    EXIV2_DEPRECATED EXIV2API bool isAsfType(BasicIo& iIo, bool advance);
+    EXIV2LIB_DEPRECATED_EXPORT bool isAsfType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -27,7 +27,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exiv2lib_compiler_detection.h"
 #include "types.hpp"
 
 // + standard includes
@@ -1113,7 +1112,7 @@ namespace Exiv2 {
         @brief Provides the ssh read/write access and sftp read access for the RemoteIo.
             This class is based on libssh.
     */
-    class EXIV2_DEPRECATED EXIV2API SshIo : public RemoteIo {
+    class EXIV2LIB_DEPRECATED_EXPORT SshIo : public RemoteIo {
     public:
         //! @name Creators
         //@{

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -38,7 +38,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -57,7 +56,7 @@ namespace Exiv2
     /*!
       @brief Class to access EPS images.
      */
-    class EXIV2_DEPRECATED EXIV2API EpsImage : public Image {
+    class EXIV2LIB_DEPRECATED_EXPORT EpsImage : public Image {
     public:
         //! @name Creators
         //@{
@@ -115,10 +114,10 @@ namespace Exiv2
              Caller owns the returned object and the auto-pointer ensures that
              it will be deleted.
      */
-    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a EPS image.
-    EXIV2_DEPRECATED EXIV2API bool isEpsType(BasicIo& iIo, bool advance);
+    EXIV2LIB_DEPRECATED_EXPORT bool isEpsType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -31,7 +31,6 @@
 #include "exiv2lib_export.h"
 
 // included header files
-#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -50,7 +49,7 @@ namespace Exiv2 {
     /*!
       @brief Helper structure for the Matroska tags lookup table.
      */
-    struct EXIV2_DEPRECATED MatroskaTags {
+    struct EXIV2LIB_DEPRECATED MatroskaTags {
         uint64_t val_;                          //!< Tag value
         const char* label_;                     //!< Translation of the tag value
 
@@ -61,7 +60,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access Matroska video files.
      */
-    class EXIV2_DEPRECATED EXIV2API MatroskaVideo : public Image {
+    class EXIV2LIB_DEPRECATED_EXPORT MatroskaVideo : public Image {
     public:
         //! @name Creators
         //@{
@@ -146,10 +145,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Matroska Video.
-    EXIV2_DEPRECATED EXIV2API bool isMkvType(BasicIo& iIo, bool advance);
+    EXIV2LIB_DEPRECATED_EXPORT bool isMkvType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access QuickTime video files.
      */
-    class EXIV2_DEPRECATED EXIV2API QuickTimeVideo:public Image
+    class EXIV2LIB_DEPRECATED_EXPORT QuickTimeVideo:public Image
     {
     public:
         //! @name Creators
@@ -242,10 +242,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Quick Time Video.
-    EXIV2_DEPRECATED EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);
+    EXIV2LIB_DEPRECATED_EXPORT bool isQTimeType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -32,7 +32,6 @@
 
 // included header files
 #include "exif.hpp"
-#include "exiv2lib_compiler_detection.h"
 #include "image.hpp"
 
 // *****************************************************************************
@@ -50,7 +49,7 @@ namespace Exiv2 {
     /*!
       @brief Class to access RIFF video files.
      */
-    class EXIV2_DEPRECATED EXIV2API RiffVideo:public Image
+    class EXIV2LIB_DEPRECATED_EXPORT RiffVideo:public Image
     {
     public:
         //! @name Creators
@@ -211,10 +210,10 @@ namespace Exiv2 {
           Caller owns the returned object and the auto-pointer ensures that
           it will be deleted.
      */
-    EXIV2_DEPRECATED EXIV2API Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
+    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
 
     //! Check if the file iIo is a Riff Video.
-    EXIV2_DEPRECATED EXIV2API bool isRiffType(BasicIo& iIo, bool advance);
+    EXIV2LIB_DEPRECATED_EXPORT bool isRiffType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2
 

--- a/include/exiv2/ssh.hpp
+++ b/include/exiv2/ssh.hpp
@@ -30,7 +30,6 @@
 #include <string>
 
 #include "error.hpp"
-#include "exiv2lib_compiler_detection.h"
 #include "types.hpp"
 #include "futils.hpp"
 
@@ -40,7 +39,7 @@ namespace Exiv2 {
             It makes the libssh transparent. The functions in this class can
             be used without the requirement of understanding libssh.
      */
-    class EXIV2_DEPRECATED EXIV2API SSH {
+    class EXIV2LIB_DEPRECATED_EXPORT SSH {
     public:
         //! @name Creators
         //@{

--- a/include/exiv2/utilsvideo.hpp
+++ b/include/exiv2/utilsvideo.hpp
@@ -21,7 +21,9 @@
 #ifndef UTILSVIDEO_HPP_
 #define UTILSVIDEO_HPP_
 
-#include "exiv2lib_compiler_detection.h"
+#include "exiv2lib_export.h"
+
+#include "exif.hpp"
 
 namespace Exiv2
 {
@@ -29,7 +31,7 @@ namespace Exiv2
     /*!
       @brief Class of utility functions used by the video code.
      */
-    class EXIV2_DEPRECATED UtilsVideo
+    class EXIV2LIB_DEPRECATED_EXPORT UtilsVideo
     {
     public:
         /*!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,7 +236,6 @@ install(TARGETS exiv2lib EXPORT exiv2Config
 install(FILES
     ${CMAKE_BINARY_DIR}/exv_conf.h
     ${CMAKE_BINARY_DIR}/exiv2lib_export.h
-    ${CMAKE_BINARY_DIR}/exiv2lib_compiler_detection.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
 install(EXPORT exiv2Config DESTINATION "${CMAKE_INSTALL_LIBDIR}/exiv2/cmake")

--- a/src/utilsvideo.cpp
+++ b/src/utilsvideo.cpp
@@ -25,6 +25,9 @@
   @date    16-Aug-14, AB: created
  */
 // *****************************************************************************
+
+#include "config.h"
+
 #ifdef EXV_ENABLE_VIDEO
 #include "utilsvideo.hpp"
 


### PR DESCRIPTION
Combining two macros before class definition can cause build problems if one of them expands to [[deprecated]] and other one to __attribute__()