### PR TITLE
Use uninitialized buffers for string formatting functions

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1365,7 +1365,8 @@ namespace {
 
     bool mb2wc(UINT cp, std::string& str)
     {
-        if (str.empty()) return true;
+        if (str.empty())
+            return true;
         int len = MultiByteToWideChar(cp, 0, str.c_str(), (int)str.size(), 0, 0);
         if (len == 0) {
 #ifdef DEBUG
@@ -1374,21 +1375,22 @@ namespace {
             return false;
         }
         std::vector<std::string::value_type> out;
-        out.resize(len * 2);
-        int ret = MultiByteToWideChar(cp, 0, str.c_str(), (int)str.size(), (LPWSTR)&out[0], len * 2);
+        out.reserve(len * 2);
+        int ret = MultiByteToWideChar(cp, 0, str.c_str(), (int)str.size(), (LPWSTR)out.data(), len * 2);
         if (ret == 0) {
 #ifdef DEBUG
             EXV_DEBUG << "mb2wc: Failed to convert the input string to a wide character string.\n";
 #endif
             return false;
         }
-        str.assign(out.begin(), out.end());
+        str.assign(out.data(), static_cast<size_t>(len) * 2);
         return true;
     }
 
     bool wc2mb(UINT cp, std::string& str)
     {
-        if (str.empty()) return true;
+        if (str.empty())
+            return true;
         if (str.size() & 1) {
 #ifdef DEBUG
             EXV_DEBUG << "wc2mb: Size " << str.size() << " of input string is not even.\n";
@@ -1403,15 +1405,15 @@ namespace {
             return false;
         }
         std::vector<std::string::value_type> out;
-        out.resize(len);
-        int ret = WideCharToMultiByte(cp, 0, (LPCWSTR)str.data(), (int)str.size() / 2, (LPSTR)&out[0], len, 0, 0);
+        out.reserve(len);
+        int ret = WideCharToMultiByte(cp, 0, (LPCWSTR)str.data(), (int)str.size() / 2, (LPSTR)out.data(), len, 0, 0);
         if (ret == 0) {
 #ifdef DEBUG
             EXV_DEBUG << "wc2mb: Failed to convert the input string to a multi byte string.\n";
 #endif
             return false;
         }
-        str.assign(out.begin(), out.end());
+        str.assign(out.data(), static_cast<size_t>(len));
         return true;
     }
 

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -32,28 +32,30 @@ namespace Exiv2
         std::string stringFormat(const char* format, ...)
         {
             std::string result;
-            std::vector<char> buffer;
-            size_t need = std::strlen(format)*8;  // initial guess
-            int rc = -1;
+            std::vector<std::string::value_type> buffer;
+            size_t need = std::strlen(format) * 8;  // initial guess
+            int len = -1;
 
             // vsnprintf writes at most size (2nd parameter) bytes (including \0)
             //           returns the number of bytes required for the formatted string excluding \0
             // the following loop goes through:
-            // one iteration (if 'need' was large enough for the for formatted string)
+            // one iteration (if 'need' was large enough for the formatted string)
             // or two iterations (after the first call to vsnprintf we know the required length)
             do {
-                buffer.resize(need + 1);
+                buffer.reserve(need + 1);
                 va_list args;            // variable arg list
                 va_start(args, format);  // args start after format
-                rc = vsnprintf(&buffer[0], buffer.size(), format, args);
+                len = vsnprintf(buffer.data(), need + 1, format, args);
                 va_end(args);     // free the args
-                assert(rc >= 0);  // rc < 0 => we have made an error in the format string
-                if (rc > 0)
-                    need = static_cast<size_t>(rc);
-            } while (buffer.size() <= need);
+                assert(len >= 0);  // len < 0 => we have made an error in the format string
+                if (len > static_cast<int>(need))
+                    need = static_cast<size_t>(len);
+                else
+                    break;
+            } while (true);
 
-            if (rc > 0)
-                result = std::string(&buffer[0], need);
+            if (len > 0)
+                result.assign(buffer.data(), static_cast<size_t>(len));
             return result;
         }
 

--- a/unitTests/test_image_int.cpp
+++ b/unitTests/test_image_int.cpp
@@ -34,7 +34,7 @@ TEST(binaryToString, zeroStart)
     // should result in the same as previously, as trailing zero is ignored
     checkBinaryToString(makeSlice(buf, 0, 9), "abc...e.");
 
-    // ensure that the function does not overread when last element != 0
+    // ensure that the function does not overflow when last element != 0
     checkBinaryToString(makeSlice(buf, 0, sizeof(buf)), "abc...e..a");
 }
 
@@ -45,4 +45,11 @@ TEST(binaryToString, nonZeroStart)
 
     // start @ index 3, read until end
     checkBinaryToString(makeSlice(buf, 3, sizeof(buf)), "...e..a");
+}
+
+TEST(stringFormat, badInitialGuessOfBufferSize)
+{
+    const char fmt[] = "%s";
+    const char str[] = "Long string with more than 16 characters.";
+    ASSERT_EQ(stringFormat(fmt, str), std::string(str));
 }


### PR DESCRIPTION
* Can use `reserve` for vector buffer to allocate capacity only, but not require `resize`, which also initializes the buffer
* Use C++11 `data` consistently on vector buffers