### PR TITLE
Fix missing libintl include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,7 @@ endif()
 if( EXIV2_ENABLE_NLS )
     target_link_libraries(exiv2lib PRIVATE ${Intl_LIBRARIES})
     target_include_directories(exiv2lib PRIVATE ${Intl_INCLUDE_DIRS})
+    target_include_directories(exiv2lib_int PRIVATE ${Intl_INCLUDE_DIRS})
     # Definition needed for translations
     target_compile_definitions(exiv2lib PUBLIC EXV_LOCALEDIR="/../${CMAKE_INSTALL_LOCALEDIR}")
 endif()
@@ -263,7 +264,7 @@ if(EXIV2_BUILD_EXIV2_COMMAND)
 
     if( EXIV2_ENABLE_NLS )
         target_link_libraries(exiv2 PRIVATE ${Intl_LIBRARIES})
-        target_include_directories(exiv2lib PRIVATE ${Intl_INCLUDE_DIRS})
+        target_include_directories(exiv2 PRIVATE ${Intl_INCLUDE_DIRS})
     endif()
 
     if (USING_CONAN AND WIN32 AND EXISTS ${PROJECT_BINARY_DIR}/conanDlls)


### PR DESCRIPTION
This PR fixes an issue where `exiv2lib_int` and `exiv2` were not being passed the `libintl` include directories. This lead to build errors (missing includes) when `gettext` was installed to a non-standard search path.

See #684 