### PR TITLE
Rework installed CMake configs to auto-find dependencies

### DIFF
--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -1,0 +1,46 @@
+@PACKAGE_INIT@
+
+# Setup for dependency management
+include(CMakeFindDependencyMacro)
+### Setup search path for custom FindXXX.cmake modules ###
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/Modules/")
+
+###
+# Dependencies: This section should mirror findDependencies.cmake
+# Reasoning about this described here:
+# https://cmake.org/pipermail/cmake-developers/2015-April/025034.html
+
+find_dependency(Threads)
+
+if( @EXIV2_ENABLE_PNG@ )
+    find_dependency( ZLIB )
+endif( )
+
+if( @EXIV2_ENABLE_WEBREADY@ )
+    if( @EXIV2_ENABLE_CURL@ )
+        find_dependency(CURL)
+    endif()
+
+    if( @EXIV2_ENABLE_SSH@ )
+        find_dependency( SSH )
+    endif( )
+endif( )
+
+if (@EXIV2_ENABLE_XMP@)
+    find_dependency(EXPAT)
+elseif (@EXIV2_ENABLE_EXTERNAL_XMP@)
+    find_dependency(XmpSdk)
+endif ()
+
+
+if (@EXIV2_ENABLE_NLS@)
+    find_dependency(Intl)
+endif( )
+
+find_dependency(Iconv)
+
+#####################################################################
+
+### Include exiv2 targets ###
+include("${CMAKE_CURRENT_LIST_DIR}/exiv2Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -42,5 +42,7 @@ find_dependency(Iconv)
 #####################################################################
 
 ### Include exiv2 targets ###
-include("${CMAKE_CURRENT_LIST_DIR}/exiv2Targets.cmake")
+if(NOT TARGET exiv2lib)
+    include("${CMAKE_CURRENT_LIST_DIR}/exiv2Targets.cmake")
+endif()
 check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,20 +233,18 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
 # CMake configs
-set(export_dir "${CMAKE_BINARY_DIR}/export")
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${export_dir}/exiv2ConfigVersion.cmake" COMPATIBILITY AnyNewerVersion
-)
+write_basic_package_version_file("exiv2ConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
 
 configure_package_config_file(
     "${CMAKE_SOURCE_DIR}/cmake/exiv2Config.cmake.in"
-    "${export_dir}/exiv2Config.cmake"
+    "exiv2Config.cmake"
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 
-install(
-    FILES "${export_dir}/exiv2Config.cmake" "${export_dir}/exiv2ConfigVersion.cmake"
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/exiv2ConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -242,15 +242,15 @@ write_basic_package_version_file(
 configure_package_config_file(
     "${CMAKE_SOURCE_DIR}/cmake/exiv2Config.cmake.in"
     "${export_dir}/exiv2Config.cmake"
-    INSTALL_DESTINATION "share/exiv2/cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 
 install(
     FILES "${export_dir}/exiv2Config.cmake" "${export_dir}/exiv2ConfigVersion.cmake"
-    DESTINATION "share/exiv2/cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 
-install(EXPORT exiv2Targets DESTINATION "share/exiv2/cmake")
+install(EXPORT exiv2Targets DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2")
 
 # ******************************************************************************
 # exiv2 application
@@ -295,4 +295,3 @@ if(EXIV2_BUILD_EXIV2_COMMAND)
         set_target_properties(exiv2 PROPERTIES LINK_FLAGS "/ignore:4099")
     endif()
 endif()
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,7 +221,7 @@ if( ICONV_FOUND )
 endif()
 
 
-install(TARGETS exiv2lib EXPORT exiv2Config
+install(TARGETS exiv2lib EXPORT exiv2Targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -232,7 +232,25 @@ install(FILES
     ${CMAKE_BINARY_DIR}/exiv2lib_export.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
-install(EXPORT exiv2Config DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2")
+# CMake configs
+set(export_dir "${CMAKE_BINARY_DIR}/export")
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${export_dir}/exiv2ConfigVersion.cmake" COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+    "${CMAKE_SOURCE_DIR}/cmake/exiv2Config.cmake.in"
+    "${export_dir}/exiv2Config.cmake"
+    INSTALL_DESTINATION "share/exiv2/cmake"
+)
+
+install(
+    FILES "${export_dir}/exiv2Config.cmake" "${export_dir}/exiv2ConfigVersion.cmake"
+    DESTINATION "share/exiv2/cmake"
+)
+
+install(EXPORT exiv2Targets DESTINATION "share/exiv2/cmake")
 
 # ******************************************************************************
 # exiv2 application

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -56,7 +56,7 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 # 1119  Install libxmp.a for use by third party applications (Thanks, Emmanuel)
-install(TARGETS exiv2-xmp EXPORT exiv2Config
+install(TARGETS exiv2-xmp EXPORT exiv2Targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
The current CMake system correctly transfers `exiv2` targets and their dependencies to downstream projects. However, the onus is on those downstream projects to make the appropriate `find_package` calls for `exiv2` dependencies.

This PR reworks the installed exiv2 CMake configs so that dependencies are automatically found by downstream projects using the `find_dependency` macro.

This is a process for dependency management that I've only used in one of my own, private projects, so it might have problems I haven't foreseen. If someone has a better solution than mirroring the `findDependencies.cmake` file, I'm open to alternatives.