### PR TITLE
(CI) Enable NLS for macOS builds

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -13,7 +13,7 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
     source conan/bin/activate
 else
     brew update
-    brew install md5sha1sum pyenv-virtualenv
+    brew install md5sha1sum pyenv-virtualenv gettext
     export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS"
     export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
     pyenv install $PYTHON

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -21,7 +21,7 @@ fi
 if [[ "$(uname -s)" == 'Linux' ]]; then
     source conan/bin/activate
 else
-    export CMAKE_OPTIONS="$CMAKE_OPTIONS -DEXIV2_ENABLE_NLS=OFF"
+    export CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_PREFIX_PATH=/usr/local/opt/gettext/"
     export PYENV_VERSION=$PYTHON
     export PATH="/Users/travis/.pyenv/shims:${PATH}"
     eval "$(pyenv init -)"
@@ -55,4 +55,3 @@ popd
 if [ -n "$WITH_COVERAGE" ]; then
     bash <(curl -s https://codecov.io/bash)
 fi
-


### PR DESCRIPTION
When developing #687, it was noted that NLS isn't enabled on the macOS Travis CI builds. 
This PR:
1) Installs `gettext` via Homebrew
2) Removes the `EXIV2_ENABLE_NLS=OFF` CMake option
3) Since `gettext` is keg-only, it sets the `CMAKE_PREFIX_PATH` to the `gettext` install location