### PR TITLE
C++11: Avoid implicit copy/move assignment/construction

### DIFF
--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -50,15 +50,12 @@ namespace Exiv2 {
           read width and height.
      */
     class EXIV2API BmpImage : public Image {
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        BmpImage(const BmpImage& rhs);
-        //! Assignment operator
-        BmpImage& operator=(const BmpImage& rhs);
-        //@}
-
     public:
+        BmpImage& operator=(const BmpImage& rhs) = delete;
+        BmpImage& operator=(const BmpImage&& rhs) = delete;
+        BmpImage(const BmpImage& rhs) = delete;
+        BmpImage(const BmpImage&& rhs) = delete;
+
         //! @name Creators
         //@{
         /*!

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -96,15 +96,10 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        Cr2Image(const Cr2Image& rhs);
-        //! Assignment operator
-        Cr2Image& operator=(const Cr2Image& rhs);
-        //@}
-
+        Cr2Image& operator=(const Cr2Image& rhs) = delete;
+        Cr2Image& operator=(const Cr2Image&& rhs) = delete;
+        Cr2Image(const Cr2Image& rhs) = delete;
+        Cr2Image(const Cr2Image&& rhs) = delete;
     }; // class Cr2Image
 
     /*!

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -96,15 +96,10 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        CrwImage(const CrwImage& rhs);
-        //! Assignment operator
-        CrwImage& operator=(const CrwImage& rhs);
-        //@}
-
+        CrwImage& operator=(const CrwImage& rhs) = delete;
+        CrwImage& operator=(const CrwImage&& rhs) = delete;
+        CrwImage(const CrwImage& rhs) = delete;
+        CrwImage(const CrwImage&& rhs) = delete;
     }; // class CrwImage
 
     /*!

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -172,15 +172,12 @@ namespace Exiv2 {
         static const uint16_t Preview                = 202;
         //@}
 
-    private:
-        //! Prevent construction: not implemented.
-        IptcDataSets() {}
-        //! Prevent copy-construction: not implemented.
-        IptcDataSets(const IptcDataSets& rhs);
-        //! Prevent assignment: not implemented.
-        IptcDataSets& operator=(const IptcDataSets& rhs);
+        IptcDataSets() = delete;
+        IptcDataSets& operator=(const IptcDataSets& rhs) = delete;
+        IptcDataSets& operator=(const IptcDataSets&& rhs) = delete;
+        IptcDataSets(const IptcDataSets& rhs) = delete;
+        IptcDataSets(const IptcDataSets&& rhs) = delete;
 
-    public:
         /*!
           @brief Return the name of the dataset.
           @param number The dataset number

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -73,11 +73,12 @@ namespace Exiv2 {
              make that call any logic that always needs to be executed.
      */
     class EXIV2API LogMsg {
-        //! Prevent copy-construction: not implemented.
-        LogMsg(const LogMsg&);
-        //! Prevent assignment: not implemented.
-        LogMsg& operator=(const LogMsg&);
     public:
+        LogMsg& operator=(const LogMsg& rhs) = delete;
+        LogMsg& operator=(const LogMsg&& rhs) = delete;
+        LogMsg(const LogMsg& rhs) = delete;
+        LogMsg(const LogMsg&& rhs) = delete;
+
         /*!
           @brief Defined log levels. To suppress all log messages, either set the
                  log level to \c mute or set the log message handler to 0.

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -51,15 +51,12 @@ namespace Exiv2 {
              directly.
      */
     class EXIV2API GifImage : public Image {
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        GifImage(const GifImage& rhs);
-        //! Assignment operator
-        GifImage& operator=(const GifImage& rhs);
-        //@}
-
     public:
+        GifImage& operator=(const GifImage& rhs) = delete;
+        GifImage& operator=(const GifImage&& rhs) = delete;
+        GifImage(const GifImage& rhs) = delete;
+        GifImage(const GifImage&& rhs) = delete;
+
         //! @name Creators
         //@{
         /*!

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -501,15 +501,13 @@ namespace Exiv2 {
         //! Return tag type for given tag id.
         const char* typeName(uint16_t tag) const;
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        Image(const Image& rhs);
-        //! Assignment operator
-        Image& operator=(const Image& rhs);
-        //@}
+    public:
+        Image& operator=(const Image& rhs) = delete;
+        Image& operator=(const Image&& rhs) = delete;
+        Image(const Image& rhs) = delete;
+        Image(const Image&& rhs) = delete;
 
+    private:
         // DATA
         int               imageType_;         //!< Image type
         uint16_t          supportedMetadata_; //!< Bitmap with all supported metadata types
@@ -709,16 +707,11 @@ namespace Exiv2 {
         */
         static bool checkType(int type, BasicIo& io, bool advance);
 
-    private:
-        //! @name Creators
-        //@{
-        //! Prevent construction: not implemented.
-        ImageFactory();
-        //! Prevent copy construction: not implemented.
-        ImageFactory(const ImageFactory& rhs);
-        //@}
-
-    }; // class ImageFactory
+        ImageFactory& operator=(const ImageFactory& rhs) = delete;
+        ImageFactory& operator=(const ImageFactory&& rhs) = delete;
+        ImageFactory(const ImageFactory& rhs) = delete;
+        ImageFactory(const ImageFactory&& rhs) = delete;
+    };  // class ImageFactory
 
 // *****************************************************************************
 // template, inline and free functions

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -94,13 +94,12 @@ namespace Exiv2
         std::string mimeType() const override;
         //@}
 
+        Jp2Image& operator=(const Jp2Image& rhs) = delete;
+        Jp2Image& operator=(const Jp2Image&& rhs) = delete;
+        Jp2Image(const Jp2Image& rhs) = delete;
+        Jp2Image(const Jp2Image&& rhs) = delete;
+
     private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        Jp2Image(const Jp2Image& rhs);
-        //! Assignment operator
-        Jp2Image& operator=(const Jp2Image& rhs);
         /*!
           @brief Provides the main implementation of writeMetadata() by
                 writing all buffered metadata to the provided BasicIo.

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -249,17 +249,13 @@ namespace Exiv2 {
         static const char xmpId_[];             //!< XMP packet identifier
         static const char iccId_[];             //!< ICC profile identifier
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Default constructor.
-        JpegBase();
-        //! Copy constructor
-        JpegBase(const JpegBase& rhs);
-        //! Assignment operator
-        JpegBase& operator=(const JpegBase& rhs);
-        //@}
+        JpegBase() = delete;
+        JpegBase& operator=(const JpegBase& rhs) = delete;
+        JpegBase& operator=(const JpegBase&& rhs) = delete;
+        JpegBase(const JpegBase& rhs) = delete;
+        JpegBase(const JpegBase&& rhs) = delete;
 
+    private:
         //! @name Manipulators
         //@{
         /*!
@@ -348,14 +344,12 @@ namespace Exiv2 {
         static const byte soi_;          // SOI marker
         static const byte blank_[];      // Minimal Jpeg image
 
-        // NOT Implemented
-        //! Default constructor
-        JpegImage();
-        //! Copy constructor
-        JpegImage(const JpegImage& rhs);
-        //! Assignment operator
-        JpegImage& operator=(const JpegImage& rhs);
-
+    public:
+        JpegImage() = delete;
+        JpegImage& operator=(const JpegImage& rhs) = delete;
+        JpegImage& operator=(const JpegImage&& rhs) = delete;
+        JpegImage(const JpegImage& rhs) = delete;
+        JpegImage(const JpegImage&& rhs) = delete;
     }; // class JpegImage
 
     //! Helper class to access %Exiv2 files
@@ -401,15 +395,13 @@ namespace Exiv2 {
         static const char exiv2Id_[];    // EXV identifier
         static const byte blank_[];      // Minimal exiv2 file
 
-        // NOT Implemented
-        //! Default constructor
-        ExvImage();
-        //! Copy constructor
-        ExvImage(const ExvImage& rhs);
-        //! Assignment operator
-        ExvImage& operator=(const ExvImage& rhs);
-
-    }; // class ExvImage
+    public:
+        ExvImage() = delete;
+        ExvImage& operator=(const ExvImage& rhs) = delete;
+        ExvImage& operator=(const ExvImage&& rhs) = delete;
+        ExvImage(const ExvImage& rhs) = delete;
+        ExvImage(const ExvImage&& rhs) = delete;
+    };  // class ExvImage
 
 // *****************************************************************************
 // template, inline and free functions

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -104,16 +104,11 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        MrwImage(const MrwImage& rhs);
-        //! Assignment operator
-        MrwImage& operator=(const MrwImage& rhs);
-        //@}
-
-    }; // class MrwImage
+        MrwImage& operator=(const MrwImage& rhs) = delete;
+        MrwImage& operator=(const MrwImage&& rhs) = delete;
+        MrwImage(const MrwImage& rhs) = delete;
+        MrwImage(const MrwImage&& rhs) = delete;
+    };  // class MrwImage
 
 // *****************************************************************************
 // template, inline and free functions

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -90,16 +90,11 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        OrfImage(const OrfImage& rhs);
-        //! Assignment operator
-        OrfImage& operator=(const OrfImage& rhs);
-        //@}
-
-    }; // class OrfImage
+        OrfImage& operator=(const OrfImage& rhs) = delete;
+        OrfImage& operator=(const OrfImage&& rhs) = delete;
+        OrfImage(const OrfImage& rhs) = delete;
+        OrfImage(const OrfImage&& rhs) = delete;
+    };  // class OrfImage
 
     /*!
       @brief Stateless parser class for data in ORF format. Images use this

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -87,14 +87,13 @@ namespace Exiv2
         std::string mimeType() const override { return "image/pgf"; }
         //@}
 
+        PgfImage& operator=(const PgfImage& rhs) = delete;
+        PgfImage& operator=(const PgfImage&& rhs) = delete;
+        PgfImage(const PgfImage& rhs) = delete;
+        PgfImage(const PgfImage&& rhs) = delete;
+
     private:
         bool bSwap_; // true for bigEndian hardware, else false
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        PgfImage(const PgfImage& rhs);
-        //! Assignment operator
-        PgfImage& operator=(const PgfImage& rhs);
         /*!
           @brief Provides the main implementation of writeMetadata() by
                 writing all buffered metadata to the provided BasicIo.

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -96,13 +96,12 @@ namespace Exiv2
         std::string mimeType() const override;
         //@}
 
+        PngImage& operator=(const PngImage& rhs) = delete;
+        PngImage& operator=(const PngImage&& rhs) = delete;
+        PngImage(const PngImage& rhs) = delete;
+        PngImage(const PngImage&& rhs) = delete;
+
     private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        PngImage(const PngImage& rhs);
-        //! Assignment operator
-        PngImage& operator=(const PngImage& rhs);
         /*!
           @brief Provides the main implementation of writeMetadata() by
                 writing all buffered metadata to the provided BasicIo.

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -94,19 +94,17 @@ namespace Exiv2 {
 
     //! XMP property reference, implemented as a static class.
     class EXIV2API XmpProperties {
-        //! Prevent construction: not implemented.
-        XmpProperties();
-        //! Prevent copy-construction: not implemented.
-        XmpProperties(const XmpProperties& rhs);
-        //! Prevent assignment: not implemented.
-        XmpProperties& operator=(const XmpProperties& rhs);
-
-      private:
         static const XmpNsInfo* nsInfoUnsafe(const std::string& prefix);
         static void unregisterNsUnsafe(const std::string& ns);
         static const XmpNsInfo* lookupNsRegistryUnsafe(const XmpNsInfo::Prefix& prefix);
 
     public:
+        XmpProperties() = delete;
+        XmpProperties& operator=(const XmpProperties& rhs) = delete;
+        XmpProperties& operator=(const XmpProperties&& rhs) = delete;
+        XmpProperties(const XmpProperties& rhs) = delete;
+        XmpProperties(const XmpProperties&& rhs) = delete;
+
         /*!
           @brief Return the title (label) of the property.
           @param key The property key

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -52,15 +52,12 @@ namespace Exiv2 {
       @brief Class to access raw Photoshop images.
      */
     class EXIV2API PsdImage : public Image {
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        PsdImage(const PsdImage& rhs);
-        //! Assignment operator
-        PsdImage& operator=(const PsdImage& rhs);
-        //@}
-
     public:
+        PsdImage& operator=(const PsdImage& rhs) = delete;
+        PsdImage& operator=(const PsdImage&& rhs) = delete;
+        PsdImage(const PsdImage& rhs) = delete;
+        PsdImage(const PsdImage&& rhs) = delete;
+
         //! @name Creators
         //@{
         /*!

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -109,16 +109,11 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        RafImage(const RafImage& rhs);
-        //! Assignment operator
-        RafImage& operator=(const RafImage& rhs);
-        //@}
-
-    }; // class RafImage
+        RafImage& operator=(const RafImage& rhs) = delete;
+        RafImage& operator=(const RafImage&& rhs) = delete;
+        RafImage(const RafImage& rhs) = delete;
+        RafImage(const RafImage&& rhs) = delete;
+    };  // class RafImage
 
 // *****************************************************************************
 // template, inline and free functions

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -102,16 +102,11 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor
-        Rw2Image(const Rw2Image& rhs);
-        //! Assignment operator
-        Rw2Image& operator=(const Rw2Image& rhs);
-        //@}
-
-    }; // class Rw2Image
+        Rw2Image& operator=(const Rw2Image& rhs) = delete;
+        Rw2Image& operator=(const Rw2Image&& rhs) = delete;
+        Rw2Image(const Rw2Image& rhs) = delete;
+        Rw2Image(const Rw2Image&& rhs) = delete;
+    };  // class Rw2Image
 
     /*!
       @brief Stateless parser class for data in RW2 format. Images use this

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -105,14 +105,13 @@ namespace Exiv2 {
 
     //! Access to Exif group and tag lists and misc. tag reference methods, implemented as a static class.
     class EXIV2API ExifTags {
-        //! Prevent construction: not implemented.
-        ExifTags();
-        //! Prevent copy-construction: not implemented.
-        ExifTags(const ExifTags& rhs);
-        //! Prevent assignment: not implemented.
-        ExifTags& operator=(const ExifTags& rhs);
-
     public:
+        ExifTags() = delete;
+        ExifTags& operator=(const ExifTags& rhs) = delete;
+        ExifTags& operator=(const ExifTags&& rhs) = delete;
+        ExifTags(const ExifTags& rhs) = delete;
+        ExifTags(const ExifTags&& rhs) = delete;
+
         //! Return read-only list of built-in groups
         static const GroupInfo* groupList();
         //! Return read-only list of built-in \em groupName tags.

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -52,15 +52,12 @@ namespace Exiv2 {
           read width and height.
      */
     class EXIV2API TgaImage : public Image {
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        TgaImage(const TgaImage& rhs);
-        //! Assignment operator
-        TgaImage& operator=(const TgaImage& rhs);
-        //@}
-
     public:
+        TgaImage& operator=(const TgaImage& rhs) = delete;
+        TgaImage& operator=(const TgaImage&& rhs) = delete;
+        TgaImage(const TgaImage& rhs) = delete;
+        TgaImage(const TgaImage&& rhs) = delete;
+
         //! @name Creators
         //@{
         /*!

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -101,15 +101,12 @@ namespace Exiv2 {
         int pixelHeight() const override;
         //@}
 
-    private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        TiffImage(const TiffImage& rhs);
-        //! Assignment operator
-        TiffImage& operator=(const TiffImage& rhs);
-        //@}
+        TiffImage& operator=(const TiffImage& rhs) = delete;
+        TiffImage& operator=(const TiffImage&& rhs) = delete;
+        TiffImage(const TiffImage& rhs) = delete;
+        TiffImage(const TiffImage&& rhs) = delete;
 
+    private:
         //! @name Accessors
         //@{
         //! Return the group name of the group with the primary image.

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -146,14 +146,13 @@ namespace Exiv2 {
 
     //! Type information lookup functions. Implemented as a static class.
     class EXIV2API TypeInfo {
-        //! Prevent construction: not implemented.
-        TypeInfo();
-        //! Prevent copy-construction: not implemented.
-        TypeInfo(const TypeInfo& rhs);
-        //! Prevent assignment: not implemented.
-        TypeInfo& operator=(const TypeInfo& rhs);
-
     public:
+        TypeInfo() = delete;
+        TypeInfo& operator=(const TypeInfo& rhs) = delete;
+        TypeInfo& operator=(const TypeInfo&& rhs) = delete;
+        TypeInfo(const TypeInfo& rhs) = delete;
+        TypeInfo(const TypeInfo&& rhs) = delete;
+
         //! Return the name of the type, 0 if unknown.
         static const char* typeName(TypeId typeId);
         //! Return the type id for a type name

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -530,14 +530,13 @@ namespace Exiv2 {
 
         //! Charset information lookup functions. Implemented as a static class.
         class EXIV2API CharsetInfo {
-            //! Prevent construction: not implemented.
-            CharsetInfo() {}
-            //! Prevent copy-construction: not implemented.
-            CharsetInfo(const CharsetInfo&);
-            //! Prevent assignment: not implemented.
-            CharsetInfo& operator=(const CharsetInfo&);
-
         public:
+            CharsetInfo() = delete;
+            CharsetInfo& operator=(const CharsetInfo& rhs) = delete;
+            CharsetInfo& operator=(const CharsetInfo&& rhs) = delete;
+            CharsetInfo(const CharsetInfo& rhs) = delete;
+            CharsetInfo(const CharsetInfo&& rhs) = delete;
+ 
             //! Return the name for a charset id
             static const char* name(CharsetId charsetId);
             //! Return the code for a charset id

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -85,6 +85,11 @@ namespace Exiv2 {
         std::string mimeType() const override;
         //@}
 
+        WebPImage& operator=(const WebPImage& rhs) = delete;
+        WebPImage& operator=(const WebPImage&& rhs) = delete;
+        WebPImage(const WebPImage& rhs) = delete;
+        WebPImage(const WebPImage&& rhs) = delete;
+
     private:
         void doWriteMetadata(BasicIo& outIo);
         //! @name NOT Implemented
@@ -97,11 +102,6 @@ namespace Exiv2 {
         void inject_VP8X(BasicIo& iIo, bool has_xmp, bool has_exif,
                          bool has_alpha, bool has_icc, int width,
                          int height);
-
-        //! Copy constructor
-        WebPImage(const WebPImage& rhs);
-        //! Assignment operator
-        WebPImage& operator=(const WebPImage& rhs);
         //@}
 
     private:

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -84,15 +84,12 @@ namespace Exiv2 {
         std::string mimeType() const override;
         //@}
 
-    private:
-        //! @name NOT Implemented
-        //@{
-        //! Copy constructor
-        XmpSidecar(const XmpSidecar& rhs);
-        //! Assignment operator
-        XmpSidecar& operator=(const XmpSidecar& rhs);
-        //@}
+        XmpSidecar& operator=(const XmpSidecar& rhs) = delete;
+        XmpSidecar& operator=(const XmpSidecar&& rhs) = delete;
+        XmpSidecar(const XmpSidecar& rhs) = delete;
+        XmpSidecar(const XmpSidecar&& rhs) = delete;
 
+    private:
         Exiv2::Dictionary dates_;
 
     }; // class XmpSidecar

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -132,9 +132,14 @@ namespace Action {
     private:
         //! Prevent construction other than through instance().
         TaskFactory();
-        //! Prevent copy construction: not implemented.
-        TaskFactory(const TaskFactory& rhs);
 
+    public:
+        TaskFactory& operator=(const TaskFactory& rhs) = delete;
+        TaskFactory& operator=(const TaskFactory&& rhs) = delete;
+        TaskFactory(const TaskFactory& rhs) = delete;
+        TaskFactory(const TaskFactory&& rhs) = delete;
+
+    private:
         //! Pointer to the one and only instance of this class.
         static TaskFactory* instance_;
         //! Type used to store Task prototype classes

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -143,11 +143,10 @@ namespace Exiv2 {
         DWORD winNumberOfLinks() const;
 #endif
 
-    private:
-        // NOT IMPLEMENTED
-        Impl(const Impl& rhs);                         //!< Copy constructor
-        Impl& operator=(const Impl& rhs);              //!< Assignment
-
+        Impl& operator=(const Impl& rhs) = delete;
+        Impl& operator=(const Impl&& rhs) = delete;
+        Impl(const Impl& rhs) = delete;
+        Impl(const Impl&& rhs) = delete;
     }; // class FileIo::Impl
 
     FileIo::Impl::Impl(const std::string& path)
@@ -1069,12 +1068,11 @@ namespace Exiv2 {
         // METHODS
         void reserve(long wcount);         //!< Reserve memory
 
-    private:
-        // NOT IMPLEMENTED
-        Impl(const Impl& rhs);             //!< Copy constructor
-        Impl& operator=(const Impl& rhs);  //!< Assignment
-
-    }; // class MemIo::Impl
+        Impl& operator=(const Impl& rhs) = delete;
+        Impl& operator=(const Impl&& rhs) = delete;
+        Impl(const Impl& rhs) = delete;
+        Impl(const Impl&& rhs) = delete;
+    };  // class MemIo::Impl
 
     MemIo::Impl::Impl()
         : data_(0),
@@ -2047,11 +2045,12 @@ namespace Exiv2 {
           @throw Error if it fails.
          */
         void writeRemote(const byte* data, size_t size, long from, long to);
-    protected:
-        // NOT IMPLEMENTED
-        HttpImpl(const HttpImpl& rhs); //!< Copy constructor
-        HttpImpl& operator=(const HttpImpl& rhs); //!< Assignment
-    }; // class HttpIo::HttpImpl
+
+        HttpImpl& operator=(const HttpImpl& rhs) = delete;
+        HttpImpl& operator=(const HttpImpl&& rhs) = delete;
+        HttpImpl(const HttpImpl& rhs) = delete;
+        HttpImpl(const HttpImpl&& rhs) = delete;
+    };  // class HttpIo::HttpImpl
 
     HttpIo::HttpImpl::HttpImpl(const std::string& url, size_t blockSize)
         : Impl(url, blockSize)
@@ -2218,10 +2217,12 @@ namespace Exiv2 {
                 http://dev.exiv2.org/wiki/exiv2
          */
         void writeRemote(const byte* data, size_t size, long from, long to);
-    protected:
-        // NOT IMPLEMENTED
-        CurlImpl(const CurlImpl& rhs); //!< Copy constructor
-        CurlImpl& operator=(const CurlImpl& rhs); //!< Assignment
+
+        CurlImpl& operator=(const CurlImpl& rhs) = delete;
+        CurlImpl& operator=(const CurlImpl&& rhs) = delete;
+        CurlImpl(const CurlImpl& rhs) = delete;
+        CurlImpl(const CurlImpl&& rhs) = delete;
+
     private:
         long timeout_; //!< The number of seconds to wait while trying to connect.
     }; // class RemoteIo::Impl
@@ -2466,11 +2467,11 @@ namespace Exiv2 {
          */
         void writeRemote(const byte* data, size_t size, long from, long to);
 
-    protected:
-        // NOT IMPLEMENTED
-        SshImpl(const SshImpl& rhs); //!< Copy constructor
-        SshImpl& operator=(const SshImpl& rhs); //!< Assignment
-    }; // class RemoteIo::Impl
+        SshImpl& operator=(const SshImpl& rhs) = delete;
+        SshImpl& operator=(const SshImpl&& rhs) = delete;
+        SshImpl(const SshImpl& rhs) = delete;
+        SshImpl(const SshImpl&& rhs) = delete;
+    };  // class RemoteIo::Impl
 
     SshIo::SshImpl::SshImpl(const std::string& url, size_t blockSize):Impl(url, blockSize)
     {

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -572,13 +572,9 @@ namespace Exiv2 {
              to image metadata and vice versa
      */
     class CrwMap {
-        //! @name Not implemented
-        //@{
-        //! Default constructor
-        CrwMap();
-        //@}
-
     public:
+        CrwMap() = delete;
+
         /*!
           @brief Decode image metadata from a CRW entry, convert and add it
                  to the image metadata. This function converts only one CRW

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -293,9 +293,13 @@ private:
         yodAdjust_[yodDay]   = emptyYodAdjust_[yodDay];
     }
 
-    //! Prevent copy-construction: not implemented.
-    Params(const Params& rhs);
+public:
+    Params& operator=(const Params& rhs) = delete;
+    Params& operator=(const Params&& rhs) = delete;
+    Params(const Params& rhs) = delete;
+    Params(const Params&& rhs) = delete;
 
+private:
     //! Destructor, frees any allocated regexes in greps_
     ~Params();
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -530,13 +530,10 @@ namespace Exiv2 {
                                     TiffType  tiffType,
                                     ByteOrder byteOrder);
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Assignment operator.
-        TiffEntryBase& operator=(const TiffEntryBase& rhs);
-        //@}
+    public:
+        TiffEntryBase& operator=(const TiffEntryBase& rhs) = delete;
 
+    private:
         // DATA
         TiffType tiffType_;   //!< Field TIFF type
         uint32_t count_;      //!< The number of values of the indicated type
@@ -931,13 +928,10 @@ namespace Exiv2 {
         uint32_t doSizeImage() const override;
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Assignment operator.
-        TiffDirectory& operator=(const TiffDirectory& rhs);
-        //@}
+    public:
+        TiffDirectory& operator=(const TiffDirectory& rhs) = delete;
 
+    private:
         //! @name Private Accessors
         //@{
         //! Write a binary directory entry for a TIFF component.
@@ -1030,13 +1024,10 @@ namespace Exiv2 {
         uint32_t doSizeImage() const override;
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Assignment operator.
-        TiffSubIfd& operator=(const TiffSubIfd& rhs);
-        //@}
+    public:
+        TiffSubIfd& operator=(const TiffSubIfd& rhs) = delete;
 
+    private:
         //! A collection of TIFF directories (IFDs)
         typedef std::vector<TiffDirectory*> Ifds;
 
@@ -1103,15 +1094,13 @@ namespace Exiv2 {
         // Using doSizeImage from base class
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Copy constructor.
-        TiffMnEntry(const TiffMnEntry& rhs);
-        //! Assignment operator.
-        TiffMnEntry& operator=(const TiffMnEntry& rhs);
-        //@}
+    public:
+        TiffMnEntry& operator=(const TiffMnEntry& rhs) = delete;
+        TiffMnEntry& operator=(const TiffMnEntry&& rhs) = delete;
+        TiffMnEntry(const TiffMnEntry& rhs) = delete;
+        TiffMnEntry(const TiffMnEntry&& rhs) = delete;
 
+    private:
         // DATA
         IfdId          mnGroup_;             //!< New group for concrete mn
         TiffComponent* mn_;                  //!< The Makernote
@@ -1257,21 +1246,14 @@ namespace Exiv2 {
         uint32_t doSizeImage() const override;
         //@}
 
+    public:
+        TiffIfdMakernote& operator=(const TiffIfdMakernote& rhs) = delete;
+
+        TiffIfdMakernote& operator=(const TiffIfdMakernote&& rhs) = delete;
+        TiffIfdMakernote(const TiffIfdMakernote& rhs) = delete;
+        TiffIfdMakernote(const TiffIfdMakernote&& rhs) = delete;
+
     private:
-        /*!
-          @name NOT implemented
-
-          Implementing the copy constructor and assignment operator will require
-          cloning the header, i.e., clone() functionality on the MnHeader
-          hierarchy.
-         */
-        //@{
-        //! Copy constructor.
-        TiffIfdMakernote(const TiffIfdMakernote& rhs);
-        //! Assignment operator.
-        TiffIfdMakernote& operator=(const TiffIfdMakernote& rhs);
-        //@}
-
         // DATA
         MnHeader*     pHeader_;                 //!< Makernote header
         TiffDirectory ifd_;                     //!< Makernote IFD
@@ -1446,13 +1428,12 @@ namespace Exiv2 {
         // Using doSizeImage from base class
         //@}
 
-    private:
-        //! @name NOT implemented
-        //@{
-        //! Assignment operator.
-        TiffBinaryArray& operator=(const TiffBinaryArray& rhs);
-        //@}
+    public:
+        TiffBinaryArray& operator=(const TiffBinaryArray& rhs) = delete;
+        TiffBinaryArray& operator=(const TiffBinaryArray&& rhs) = delete;
+        TiffBinaryArray(const TiffBinaryArray&& rhs) = delete;
 
+    private:
         // DATA
         const CfgSelFct cfgSelFct_; //!< Pointer to a function to determine which cfg to use (may be 0)
         const ArraySet* arraySet_;  //!< Pointer to the array set, if any (may be 0)

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -1026,6 +1026,8 @@ namespace Exiv2 {
 
     public:
         TiffSubIfd& operator=(const TiffSubIfd& rhs) = delete;
+        TiffSubIfd& operator=(const TiffSubIfd&& rhs) = delete;
+        TiffSubIfd(const TiffSubIfd&& rhs) = delete;
 
     private:
         //! A collection of TIFF directories (IFDs)


### PR DESCRIPTION
This is for #214. Hope I caught them all.