### PR TITLE
exiv2-xmp linked privately

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -72,7 +72,11 @@ install( TARGETS metacopy pathtest exiv2json RUNTIME DESTINATION ${CMAKE_INSTALL
 if( EXPAT_FOUND )
     add_executable(        geotag    geotag.cpp)
     list(APPEND APPLICATIONS geotag)
-    target_link_libraries( geotag    PRIVATE ${EXPAT_LIBRARIES})
+    target_link_libraries(geotag 
+        PRIVATE
+            exiv2-xmp
+            ${EXPAT_LIBRARIES}
+    )
     target_include_directories(geotag PRIVATE ${EXPAT_INCLUDE_DIR})
     target_include_directories(geotag PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find unused.h
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,7 @@ target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
 target_include_directories(exiv2lib PRIVATE ${ZLIB_INCLUDE_DIR})
 
 if (EXIV2_ENABLE_XMP)
-    target_link_libraries(exiv2lib PUBLIC exiv2-xmp)
+    target_link_libraries(exiv2lib PRIVATE exiv2-xmp)
 elseif(EXIV2_ENABLE_EXTERNAL_XMP)
     target_link_libraries(exiv2lib PUBLIC ${XMPSDK_LIBRARY})
     target_include_directories(exiv2lib PUBLIC ${XMPSDK_INCLUDE_DIR})


### PR DESCRIPTION
Thanks to the discussion we had in #688 we discovered that we can link against exiv2-xmp in a private way. In that way, we'll simplify the dependencies that are written down automatically in the cmake configuration files. 