### PR TITLE
Run upgrade in Archlinux container

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -34,7 +34,7 @@ case "$distro_id" in
         ;;
 
     'arch')
-        pacman --noconfirm -Sy
+        pacman --noconfirm -Syu
         pacman --noconfirm -S gcc clang cmake make ccache expat zlib libssh curl gtest python dos2unix which diffutils
         ;;
 


### PR DESCRIPTION
Archlinux is rolling release and occasionally the container image contains older libraries than would be required by the packages that we install. When that occurs, builds fail due to missing dynamic libraries, like this one: https://gitlab.com/D4N/exiv2/-/jobs/160300883.

Simple fix: run `pacman -Syu` before the install.

I have not enabled any sort of upgrade on the other distros, as they typically don't show these kind of issues and it keeps the build times down.