### PR TITLE
Fix slices

### DIFF
--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -20,7 +20,7 @@
  */
 /*!
   @file    slice.hpp
-  @brief   Simple implementation of slices (=views) for STL containers and C-arrays
+  @brief   Simple implementation of slices for STL containers and C-arrays
   @author  Dan Čermák (D4N)
            <a href="mailto:dan.cermak@cgc-instruments.com">dan.cermak@cgc-instruments.com</a>
   @date    30-March-18, D4N: created
@@ -33,689 +33,549 @@
 #include <cstddef>
 #include <iterator>
 #include <stdexcept>
+#include <type_traits>
 
 namespace Exiv2
 {
+#ifndef PARSED_BY_DOXYGEN
     namespace Internal
     {
-        // TODO: remove these custom implementations once we have C++11
-        template <class T>
-        struct remove_const
-        {
-            typedef T type;
-        };
-
-        template <class T>
-        struct remove_const<const T>
-        {
-            typedef T type;
-        };
-
-        template <class T>
-        struct remove_volatile
-        {
-            typedef T type;
-        };
-        template <class T>
-        struct remove_volatile<volatile T>
-        {
-            typedef T type;
-        };
-        template <class T>
-        struct remove_cv
-        {
-            typedef typename remove_const<typename remove_volatile<T>::type>::type type;
-        };
-
-        template <class T>
-        struct remove_pointer
-        {
-            typedef T type;
-        };
-
-        template <class T>
-        struct remove_pointer<T*>
-        {
-            typedef T type;
-        };
-
-        template <class T>
-        struct remove_pointer<T* const>
-        {
-            typedef T type;
-        };
-
-        /*!
-         * Common base class of all slice implementations.
-         *
-         * Implements only the most basic functions, which do not require any
-         * knowledge about the stored data.
-         */
+        /// Common base class of all slice implementations.
+        ///
+        /// Implements only the most basic functions, which do not require any
+        /// knowledge about the stored data.
         struct SliceBase
         {
-            inline SliceBase(size_t begin, size_t end) : begin_(begin), end_(end)
+            SliceBase(size_t begin, size_t end) : begin_(begin), end_(end)
             {
                 if (begin >= end) {
                     throw std::out_of_range("Begin must be smaller than end");
                 }
             }
 
-            /*!
-             * Return the number of elements in the slice.
-             */
-            inline size_t size() const noexcept
+            /// Return the number of elements in the slice.
+            size_t size() const noexcept
             {
                 // cannot underflow, as we know that begin < end
                 return end_ - begin_;
             }
 
         protected:
-            /*!
-             * Throw an exception when index is too large.
-             *
-             * @throw std::out_of_range when `index` will access an element
-             * outside of the slice
-             */
-            inline void rangeCheck(size_t index) const
+            /// Throw an exception when index is too large.
+            ///
+            /// @throw std::out_of_range when `index` will access an element
+            ///     outside of the slice
+            void rangeCheck(size_t index) const
             {
                 if (index >= size()) {
                     throw std::out_of_range("Index outside of the slice");
                 }
             }
 
-            /*!
-             * lower and upper bounds of the slice with respect to the
-             * container/array stored in storage_
-             */
+            /// Modify begin & end in-place so that they are the correct bounds
+            /// of the new sub-slice.
+            ///
+            /// This is a helper function for the subSlice() member functions: it
+            /// calculates the bounds with respect to the original
+            /// container/pointer.
+            ///
+            /// @param[in,out] begin, end new bounds of a subSlice, this function
+            ///     adds the current `begin_` and `end_` to these safely.
+            ///
+            /// @throw std::out_of_range when `begin` or `end` will access an
+            ///     element outside of the slice
+            void calculateSubSliceBounds(size_t& begin, size_t& end) const
+            {
+                // end == size() is a legal value, since end is the first element beyond the slice
+                // end == 0 is not a legal value
+                if ((begin >= size()) || (end > size()) || (begin > end)) {
+                    throw std::out_of_range("sub-Slice index invalid");
+                }
+
+                // additions are safe, begin and end are smaller than size()
+                begin += this->begin_;
+                end += this->begin_;
+
+                // end <= size() = end_ - begin_
+                // => new_end = end + begin_ <= end_
+                // => value is safe
+                assert(end <= this->end_);
+            }
+
+            /// lower and upper bounds of the slice with respect to the
+            /// container/array stored in storage_
             const size_t begin_, end_;
         };
+    }   // namespace Internal
+#endif  // PARSED_BY_DOXYGEN
 
-        /*!
-         * @brief This class provides the public-facing const-qualified methods
-         * of a slice.
-         *
-         * The public methods are implemented in a generic fashion using a
-         * storage_type. This type contains the actual reference to the data to
-         * which the slice points and provides the following methods:
-         *
-         * - (const) value_type& unsafeAt(size_t index) (const)
-         *   Return the value at the given index of the underlying container,
-         *   without promising to perform a range check and without any
-         *   knowledge of the slices' size
-         *
-         * - const_iterator/iterator unsafeGetIteratorAt(size_t index) (const)
-         *   Return a (constant) iterator at the given index of the underlying
-         *   container. Again, no range checks are promised.
-         *
-         * - Constructor(data_type& data, size_t begin, size_t end)
-         *   Can use `begin` & `end` to perform range checks on `data`, but
-         *   should not store both values. Must not take ownership of `data`!
-         *
-         * - Must save data as a public member named `data_`.
-         *
-         * - Must provide appropriate typedefs for iterator, const_iterator and
-         *   value_type
-         */
-        template <template <typename data_type> class storage_type, typename data_type>
-        struct ConstSliceBase : SliceBase
-        {
-            typedef typename storage_type<data_type>::iterator iterator;
-            typedef typename storage_type<data_type>::const_iterator const_iterator;
-            typedef typename storage_type<data_type>::value_type value_type;
-
-            /*!
-             * Default contructor, requires begin to be smaller than end,
-             * otherwise an exception is thrown. Also forwards all parameters to
-             * the constructor of storage_
-             */
-            ConstSliceBase(data_type& data, size_t begin, size_t end)
-                : SliceBase(begin, end), storage_(data, begin, end)
-            {
-            }
-
-            /*!
-             * Obtain a constant reference to the element with the specified
-             * index in the slice.
-             *
-             * @throw std::out_of_range when index is out of bounds of the slice
-             */
-            const value_type& at(size_t index) const
-            {
-                rangeCheck(index);
-                // we know: begin_ < end <= size() <= SIZE_T_MAX
-                // and: index < end - begin
-                // thus: index + begin < end <= SIZE_T_MAX
-                // => no overflow is possible
-                return storage_.unsafeAt(begin_ + index);
-            }
-
-            /*!
-             * Obtain a constant iterator to the first element in the slice.
-             */
-            const_iterator cbegin() const noexcept
-            {
-                return storage_.unsafeGetIteratorAt(begin_);
-            }
-
-            /*!
-             * Obtain a constant iterator to the first beyond the slice.
-             */
-            const_iterator cend() const noexcept
-            {
-                return storage_.unsafeGetIteratorAt(end_);
-            }
-
-            /*!
-             * Create a constant sub-slice with the given bounds (with respect
-             * to the current slice).
-             *
-             * @tparam slice_type  Type of the slice that this function shall
-             * return. Provide it with the type of the class that derives from
-             * mutable_slice_base.
-             */
-            template <typename slice_type>
-            slice_type subSlice(size_t begin, size_t end) const
-            {
-                this->rangeCheck(begin);
-                // end == size() is a legal value, since end is the first
-                // element beyond the slice
-                // end == 0 is not a legal value (subtraction will underflow and
-                // throw an exception)
-                this->rangeCheck(end - 1);
-                // additions are safe, begin and end are smaller than size()
-                const size_t new_begin = begin + this->begin_;
-                const size_t new_end = this->begin_ + end;
-                if (new_end > this->end_) {
-                    throw std::out_of_range("Invalid input parameters to slice");
-                }
-                return slice_type(storage_.data_, new_begin, new_end);
-            }
-
-        protected:
-            /*!
-             * Stores a reference to the actual data.
-             */
-            storage_type<data_type> storage_;
-        };
-
-        /*!
-         * This class provides all public-facing non-const-qualified methods of
-         * slices. It only re-implements the const-qualified versions as
-         * non-const.
-         */
-        template <template <typename> class storage_type, typename data_type>
-        struct MutableSliceBase : public ConstSliceBase<storage_type, data_type>
-        {
-            typedef typename ConstSliceBase<storage_type, data_type>::iterator iterator;
-            typedef typename ConstSliceBase<storage_type, data_type>::const_iterator const_iterator;
-            typedef typename ConstSliceBase<storage_type, data_type>::value_type value_type;
-
-            /*!
-             * Forwards everything to the constructor of const_slice_base
-             *
-             * @todo use using once we have C++11
-             */
-            MutableSliceBase(data_type& data, size_t begin, size_t end)
-                : ConstSliceBase<storage_type, data_type>(data, begin, end)
-            {
-            }
-
-            /*!
-             * Obtain a reference to the element with the specified index in the
-             * slice.
-             *
-             * @throw std::out_of_range when index is out of bounds of the slice
-             */
-            value_type& at(size_t index)
-            {
-                this->rangeCheck(index);
-                return this->storage_.unsafeAt(this->begin_ + index);
-            }
-
-            const value_type& at(size_t index) const
-            {
-                // TODO: use using base_type::at once we have C++11
-                return base_type::at(index);
-            }
-
-            /*!
-             * Obtain an iterator to the first element in the slice.
-             */
-            iterator begin() noexcept
-            {
-                return this->storage_.unsafeGetIteratorAt(this->begin_);
-            }
-
-            /*!
-             * Obtain an iterator to the first element beyond the slice.
-             */
-            iterator end() noexcept
-            {
-                return this->storage_.unsafeGetIteratorAt(this->end_);
-            }
-
-        protected:
-            /*!
-             * Explicitly convert this instance into a base-class of the
-             * appropriate constant version of this slice.
-             *
-             * This function is required to properly implement the `subSlice()
-             * const` function for mutable slices. The problem here is, that a
-             * slice<T> and a slice<const T> actually don't share the same base
-             * class `ConstSliceBase<storage_type, T>`. Instead `slice<T>`
-             * inherits from `ConstSliceBase<storage_type, T>` and `slice<const
-             * T>` inherits from `ConstSliceBase<storage_type, const T>`.
-             *
-             * Now, `slice<T>` can call the `subSlice() const` method from its
-             * base class, but that will return a mutable `slice<T>`! Instead we
-             * use this function to convert the ``slice<T>` into the parent of
-             * the appropriate `slice<const T>` and call its `subSlice() const`,
-             * which returns the correct type.
-             */
-            ConstSliceBase<storage_type, const data_type> to_const_base() const noexcept
-            {
-                return ConstSliceBase<storage_type, const data_type>(this->storage_.data_, this->begin_, this->end_);
-            }
-
-            typedef ConstSliceBase<storage_type, data_type> base_type;
-
-            /*!
-             * Create a mutable sub-slice with the given bounds (with respect to
-             * the current slice).
-             *
-             * @tparam slice_type  Type of the slice that this function shall
-             * return. Provide it with the type of the class that derives from
-             * mutable_slice_base.
-             */
-            template <typename slice_type>
-            slice_type subSlice(size_t begin, size_t end)
-            {
-                this->rangeCheck(begin);
-                // end == size() is a legal value, since end is the first
-                // element beyond the slice
-                // end == 0 is not a legal value (subtraction will underflow and
-                // throw an exception)
-                this->rangeCheck(end - 1);
-
-                // additions are safe, begin & end are smaller than size()
-                const size_t new_begin = begin + this->begin_;
-                const size_t new_end = this->begin_ + end;
-                if (new_end > this->end_) {
-                    throw std::out_of_range("Invalid input parameters to slice");
-                }
-                return slice_type(this->storage_.data_, new_begin, new_end);
-            }
-        };
-
-        /*!
-         * Implementation of the storage concept for STL-containers.
-         *
-         * @tparam container  Type of the STL-container.
-         */
-        template <typename container>
-        struct ContainerStorage
-        {
-            typedef typename container::iterator iterator;
-
-            typedef typename container::const_iterator const_iterator;
-
-            typedef typename Internal::remove_cv<typename container::value_type>::type value_type;
-
-            /*!
-             * @throw std::out_of_range when end is larger than the container's
-             * size.
-             */
-            ContainerStorage(container& data, size_t /* begin*/, size_t end) : data_(data)
-            {
-                if (end > data.size()) {
-                    throw std::out_of_range("Invalid input parameters to slice");
-                }
-            }
-
-            /*!
-             * Obtain a constant reference to the element with the given `index`
-             * in the container.
-             *
-             * @throw whatever container::at() throws
-             */
-            const value_type& unsafeAt(size_t index) const
-            {
-                return data_.at(index);
-            }
-
-            value_type& unsafeAt(size_t index)
-            {
-                return data_.at(index);
-            }
-
-            /*!
-             * Obtain an iterator at the position of the element with the given
-             * index in the container.
-             *
-             * @throw whatever container::begin() and std::advance() throw
-             */
-            iterator unsafeGetIteratorAt(size_t index)
-            {
-                // we are screwed if the container got changed => try to catch it
-                assert(index <= data_.size());
-
-                iterator it = data_.begin();
-                std::advance(it, index);
-                return it;
-            }
-
-            const_iterator unsafeGetIteratorAt(size_t index) const
-            {
-                assert(index <= data_.size());
-
-                const_iterator it = data_.begin();
-                std::advance(it, index);
-                return it;
-            }
-
-            container& data_;
-        };
-
-        /*!
-         * @brief Implementation of the storage concept for slices of C arrays.
-         *
-         * @tparam storage_type  Type as which the C-array should be stored. Use
-         * this parameter to save constant arrays as `const` and mutable ones as
-         * non-`const`.
-         */
-        template <typename storage_type>
-        struct PtrSliceStorage
-        {
-            typedef typename remove_cv<typename remove_pointer<storage_type>::type>::type value_type;
-            typedef value_type* iterator;
-            typedef const value_type* const_iterator;
-
-            /*!
-             * Stores ptr and checks that it is not `nullptr`. The slice's bounds
-             * are ignored, as we do not know the array's length.
-             *
-             * @throw std::invalid_argument when ptr is `nullptr`
-             */
-            PtrSliceStorage(storage_type ptr, size_t /*begin*/, size_t /*end*/) : data_(ptr)
-            {
-                if (ptr == nullptr) {
-                    throw std::invalid_argument("Null pointer passed to slice constructor");
-                }
-            }
-
-            /*!
-             * Obtain a reference to the element with the given `index` in the
-             * array.
-             *
-             * @throw nothing
-             */
-            value_type& unsafeAt(size_t index) noexcept
-            {
-                return data_[index];
-            }
-
-            const value_type& unsafeAt(size_t index) const noexcept
-            {
-                return data_[index];
-            }
-
-            /*!
-             * Obtain an iterator (=pointer) at the position of the element with
-             * the given index in the container.
-             *
-             * @throw nothing
-             */
-            iterator unsafeGetIteratorAt(size_t index) noexcept
-            {
-                return data_ + index;
-            }
-
-            const_iterator unsafeGetIteratorAt(size_t index) const noexcept
-            {
-                return data_ + index;
-            }
-
-            storage_type data_;
-        };
-
-    }  // namespace Internal
-
-    /*!
-     * @brief Slice (= view) for STL containers.
-     *
-     * This is a very simple implementation of slices (i.e. views of sub-arrays)
-     * for STL containers that support O(1) element access and random access
-     * iterators (like std::vector, std::array and std::string).
-     *
-     * A slice represents the semi-open interval [begin, end) and provides a
-     * (mutable) view, it does however not own the data! It can be used to
-     * conveniently pass parts of containers into functions without having to use
-     * iterators or offsets.
-     *
-     * In contrast to C++20's std::span<T> it is impossible to read beyond the
-     * container's bounds and unchecked access is not-possible (by design).
-     *
-     * Example usage:
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-     * std::vector<int> vec = {0, 1, 2, 3, 4};
-     * slice<std::vector<int> > one_two(vec, 1, 3);
-     * assert(one_two.size() == 2);
-     * assert(one_two.at(0) == 1 && one_two.at(1) == 2);
-     * // mutate the contents:
-     * one_two.at(0) *= 2;
-     * one_two.at(1) *= 3;
-     * assert(one_two.at(0) == 2 && one_two.at(1) == 6);
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~
-     *
-     * Slices also offer access via iterators of the same type as the underlying
-     * container, so that they can be used in a comparable fashion:
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-     * std::vector<int> vec = {0, 1, 2, 3, 4};
-     * slice<std::vector<int>> three_four(vec, 3, 5);
-     * assert(*three_four.begin() == 3 && *three_four.end() == 4);
-     * // this prints:
-     * // 3
-     * // 4
-     * for (const auto & elem : three_four) {
-     *     std::cout << elem << std::endl;
-     * }
-     * ~~~~~~~~~~~~~~~~~~~~~~~~~
-     *
-     * @tparam container A STL container type, like vector or array. Must support
-     * array-like access via the `at()` method.
-     */
+    /// @brief Slice (= view) for STL containers.
+    ///
+    /// This is a very simple implementation of slices (i.e. views of sub-arrays)
+    /// for STL containers that support O(1) element access and random access
+    /// iterators (like std::vector, std::array and std::string).
+    ///
+    /// A slice represents the semi-open interval [begin, end) and provides a
+    /// (mutable) view, it does however not own the data! It can be used to
+    /// conveniently pass parts of containers into functions without having to use
+    /// iterators or offsets.
+    ///
+    /// In contrast to C++20's std::span<T> it is impossible to read beyond the
+    /// container's bounds and unchecked access is not-possible (by design).
+    ///
+    /// Example usage:
+    /// ~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+    /// std::vector<int> vec = {0, 1, 2, 3, 4};
+    /// slice<std::vector<int> > one_two(vec, 1, 3);
+    /// assert(one_two.size() == 2);
+    /// assert(one_two.at(0) == 1 && one_two.at(1) == 2);
+    /// // mutate the contents:
+    /// one_two.at(0) *= 2;
+    /// one_two.at(1) *= 3;
+    /// assert(one_two.at(0) == 2 && one_two.at(1) == 6);
+    /// ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ///
+    /// Slices also offer access via iterators of the same type as the underlying
+    /// container, so that they can be used in a comparable fashion:
+    /// ~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+    /// std::vector<int> vec = {0, 1, 2, 3, 4};
+    /// slice<std::vector<int>> three_four(vec, 3, 5);
+    /// assert(*three_four.begin() == 3 && *three_four.end() == 4);
+    /// // this prints:
+    /// // 3
+    /// // 4
+    /// for (const auto & elem : three_four) {
+    ///     std::cout << elem << std::endl;
+    /// }
+    /// ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ///
+    /// @tparam container  A STL container type, like vector or array. Must
+    ///     support array-like access via the `at()` and the methods `(c)begin()`
+    ///     and `(c)end()` which return a (constant) iterator to the beginning or
+    ///     the end of the container, respectively.
     template <typename container>
-    struct Slice : public Internal::MutableSliceBase<Internal::ContainerStorage, container>
+    struct Slice
+#ifndef PARSED_BY_DOXYGEN
+        : Internal::SliceBase
+#endif
     {
+        /// Type of the standard (mutable) iterator
         typedef typename container::iterator iterator;
 
+        /// Type of the constant iterator (does not provide mutable access)
         typedef typename container::const_iterator const_iterator;
 
-        typedef typename Internal::remove_cv<typename container::value_type>::type value_type;
+        /// Type of the individual elements inside the slice
+        typedef typename std::remove_cv<typename container::value_type>::type value_type;
 
-        /*!
-         * @brief Construct a slice of the container `cont` starting at `begin`
-         * (including) and ending before `end`.
-         *
-         * @param[in] cont Reference to the container
-         * @param[in] begin First element of the slice.
-         * @param[in] end First element beyond the slice.
-         *
-         * @throws std::out_of_range For invalid slice bounds: when end is not
-         * larger than begin or when the slice's bounds are larger than the
-         * container's size.
-         *
-         * Please note that due to the requirement that `end` must be larger
-         * than `begin` (they cannot be equal) it is impossible to construct a
-         * slice with zero length.
-         */
-        Slice(container& cont, size_t begin, size_t end)
-            : Internal::MutableSliceBase<Internal::ContainerStorage, container>(cont, begin, end)
+        /// Construct a slice of the container `cont` starting at `begin`
+        /// (including) and ending before `end`.
+        ///
+        /// @param[in] cont  Reference to the container
+        /// @param[in] begin  First element of the slice.
+        /// @param[in] end  First element beyond the slice.
+        ///
+        /// @throws std::out_of_range  For invalid slice bounds: when end is not
+        ///     larger than begin or when the slice's bounds are larger than the
+        ///     container's size.
+        ///
+        /// Please note that due to the requirement that `end` must be larger
+        /// than `begin` (they cannot be equal) it is impossible to construct a
+        /// slice with zero length. This limitation is included by design.
+        Slice(container& cont, size_t begin, size_t end) : Internal::SliceBase(begin, end), cont_(cont)
         {
+            if (end > cont.size()) {
+                throw std::out_of_range("End must not be larger than the container.");
+            }
         }
 
-        /*!
-         * Construct a sub-slice of this slice with the given bounds. The bounds
-         * are evaluated with respect to the current slice.
-         *
-         * @param[in] begin  First element in the new slice.
-         * @param[in] end  First element beyond the new slice.
-         *
-         * @throw std::out_of_range when begin or end are invalid
-         */
-        Slice subSlice(size_t begin, size_t end)
+#ifdef PARSED_BY_DOXYGEN
+        /// Return the number of elements in the slice.
+        size_t size() const noexcept
         {
-            return Internal::MutableSliceBase<Internal::ContainerStorage, container>::template subSlice<Slice>(begin,
-                                                                                                               end);
+        }
+#endif
+
+        /// Obtain a constant reference to the element with the given `index` in
+        /// the slice.
+        ///
+        /// @throw  std::out_of_range when `index` is out of bounds of the slice
+        ///     or anything that container::at() throws
+        const value_type& at(size_t index) const
+        {
+            rangeCheck(index);
+            // we know: begin_ < end <= size() <= SIZE_T_MAX
+            // and: index < end - begin
+            // thus: index + begin < end <= SIZE_T_MAX
+            // => no overflow is possible
+            return cont_.at(begin_ + index);
         }
 
-        /*!
-         * Constructs a new constant subSlice. Behaves otherwise exactly like
-         * the non-const version.
-         */
-        Slice<const container> subSlice(size_t begin, size_t end) const
+        /// Obtain a mutable reference to the element with the given `index` in
+        /// the slice.
+        ///
+        /// Please note that this function is unavailable when `container` is a
+        /// constant type.
+        ///
+        /// @throw  std::out_of_range when `index` is out of bounds of the slice
+        ///     or anything that container::at() throws
+#ifdef PARSED_BY_DOXYGEN
+        value_type&
+#else
+        template <typename Dummy = container>
+        typename std::enable_if<!std::is_const<Dummy>::value, value_type>::type&
+#endif
+        at(size_t index)
         {
-            return this->to_const_base().template subSlice<Slice<const container> >(begin, end);
+            rangeCheck(index);
+            // we know: begin_ < end <= size() <= SIZE_T_MAX
+            // and: index < end - begin
+            // thus: index + begin < end <= SIZE_T_MAX
+            // => no overflow is possible
+            return cont_.at(begin_ + index);
         }
+
+#ifndef PARSED_BY_DOXYGEN
+#define RETURN_ITERATOR(getter_method, offset) \
+    auto iter = cont_.getter_method();         \
+    std::advance(iter, offset);                \
+    return iter
+#endif
+
+        /// Return a constant iterator to the beginning of the slice.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::cbegin()` and `const_iterator++` don't throw.
+        const_iterator cbegin() const
+        {
+            RETURN_ITERATOR(cbegin, this->begin_);
+        }
+
+        /// Return an iterator to the beginning of the slice.
+        ///
+        /// Note: this function is not available when `container` is a constant
+        /// type.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::begin()` and `iterator++` don't throw.
+#ifdef PARSED_BY_DOXYGEN
+        iterator
+#else
+        template <typename Dummy = container>
+        typename std::enable_if<!std::is_const<Dummy>::value, iterator>::type
+#endif
+        begin()
+        {
+            RETURN_ITERATOR(begin, this->begin_);
+        }
+
+        /// Return a constant iterator to the beginning of the slice.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::begin()` and `iterator++` don't throw.
+        const_iterator begin() const
+        {
+            RETURN_ITERATOR(begin, this->begin_);
+        }
+
+        /// Return a constant iterator to the first element beyond the slice.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::cbegin()` and `iterator++` don't throw.
+        const_iterator cend() const
+        {
+            RETURN_ITERATOR(cbegin, this->end_);
+        }
+
+        /// Return an iterator to the first element beyond the slice.
+        ///
+        /// Note: this function is not available when `container` is a constant
+        /// type.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::begin()` and `iterator++` don't throw.
+#ifdef PARSED_BY_DOXYGEN
+        iterator
+#else
+        template <typename Dummy = container>
+        typename std::enable_if<!std::is_const<Dummy>::value, iterator>::type
+#endif
+        end()
+        {
+            RETURN_ITERATOR(begin, this->end_);
+        }
+
+        /// Return a constant iterator to the first element beyond the slice.
+        ///
+        /// @throw  This function does not throw anything, as long as
+        ///     `container::begin()` and `iterator++` don't throw.
+        const_iterator end() const
+        {
+            RETURN_ITERATOR(begin, this->end_);
+        }
+
+#ifndef PARSED_BY_DOXYGEN
+#undef RETURN_ITERATOR
+#endif
+
+        /// Construct a sub-slice of this slice with the given bounds. The bounds
+        /// are evaluated with respect to the current slice.
+        ///
+        /// Note: the non-const overload is only available when the container is
+        /// also not constant.
+        ///
+        /// Example:
+        /// ~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+        /// std::vector<int> vec = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        /// slice<std::vector<int>> center = Slice(vec, 3, 7);
+        /// // center_vals = {3, 4, 5, 6}
+        /// auto middle = center_vals.subSlice(1, 3);
+        /// // middle = {4, 5}
+        /// // the following throws:
+        /// center_vals.subSlice(1, 5);
+        /// ~~~~~~~~~~~~~~~~~~~~~~~~
+        ///
+        /// @param[in] begin  First element in the new slice.
+        /// @param[in] end  First element beyond the new slice.
+        ///
+        /// @throw  std::out_of_range when begin or end are out of bounds of the
+        ///     current slice
+#ifdef PARSED_BY_DOXYGEN
+        Slice<container>
+#else
+        template <typename Dummy = container>
+        typename std::enable_if<!std::is_const<Dummy>::value, Slice<container> >::type
+#endif
+        subSlice(size_t begin, size_t end)
+        {
+            this->calculateSubSliceBounds(begin, end);
+            return Slice<container>(cont_, begin, end);
+        }
+
+        /// Constructs a new constant subSlice. Behaves otherwise exactly like
+        /// the non-const version.
+        Slice<container> subSlice(size_t begin, size_t end) const
+        {
+            this->calculateSubSliceBounds(begin, end);
+            return Slice<container>(cont_, begin, end);
+        }
+
+    private:
+        container& cont_;
     };
 
-    /*!
-     * @brief Specialization of slices for constant containers.
-     */
-    template <typename container>
-    struct Slice<const container> : public Internal::ConstSliceBase<Internal::ContainerStorage, const container>
-    {
-        typedef typename container::iterator iterator;
-
-        typedef typename container::const_iterator const_iterator;
-
-        typedef typename Internal::remove_cv<typename container::value_type>::type value_type;
-
-        Slice(const container& cont, size_t begin, size_t end)
-            : Internal::ConstSliceBase<Internal::ContainerStorage, const container>(cont, begin, end)
-        {
-        }
-
-        Slice subSlice(size_t begin, size_t end) const
-        {
-            return Internal::ConstSliceBase<Internal::ContainerStorage,
-                                            const container>::template subSlice<Slice<const container> >(begin, end);
-        }
-    };
-
-    /*!
-     * Specialization of slices for constant C-arrays.
-     *
-     * These have exactly the same interface as the slices for STL-containers,
-     * with the *crucial* exception, that the slice's constructor *cannot* make
-     * a proper bounds check! It can only verify that you didn't accidentally
-     * swap begin and end!
-     */
+    /// Specialization of @ref Slice for C-arrays.
+    ///
+    /// These have exactly the same interface as the slices for STL-containers,
+    /// with the *crucial* exception, that the slice's constructor *cannot* make
+    /// a proper bounds check. It can only verify that you didn't accidentally
+    /// swap begin and end.
     template <typename T>
-    struct Slice<const T*> : public Internal::ConstSliceBase<Internal::PtrSliceStorage, const T*>
+    struct Slice<T*>
+#ifndef PARSED_BY_DOXYGEN
+        : Internal::SliceBase
+#endif
     {
-        /*!
-         * Constructor.
-         *
-         * @param[in] ptr  C-array of which a slice should be constructed. Must
-         *     not be a null pointer.
-         * @param[in] begin  Index of the first element in the slice.
-         * @param[in] end  Index of the first element that is no longer in the
-         *     slice.
-         *
-         * Please note that the constructor has no way how to verify that
-         * `begin` and `end` are not out of bounds of the provided array!
-         */
-        Slice(const T* ptr, size_t begin, size_t end)
-            : Internal::ConstSliceBase<Internal::PtrSliceStorage, const T*>(ptr, begin, end)
+        /// Type of the individual elements inside the slice
+        typedef typename std::remove_cv<T>::type value_type;
+
+        /// Type of the constant iterator (does not provide mutable access)
+        typedef typename std::conditional<std::is_const<T>::value, typename std::add_const<value_type>::type*,
+                                          value_type*>::type iterator;
+
+        /// Type of the standard (mutable) iterator
+        typedef const typename std::remove_cv<T>::type* const_iterator;
+
+        /// Constructor.
+        ///
+        /// @param[in] ptr  C-array of which a Slice should be constructed. Must
+        ///     not be a null pointer.
+        /// @param[in] begin  Index of the first element in the slice.
+        /// @param[in] end  Index of the first element that is no longer in the
+        ///     slice.
+        ///
+        /// Please note that the constructor has no way how to verify that
+        /// `begin` and `end` are not out of bounds of the provided array!
+        Slice(T* ptr, size_t begin, size_t end) : Internal::SliceBase(begin, end), ptr_(ptr)
         {
-            // TODO: use using in C++11
+            if (ptr == nullptr) {
+                throw std::invalid_argument("ptr must not be null.");
+            }
         }
 
+#ifdef PARSED_BY_DOXYGEN
+        /// Return the number of elements in the slice.
+        size_t size() const noexcept
+        {
+            static_assert(false,
+                          "This code is only present for documentation purposes. Do not define the macro "
+                          "PARSED_BY_DOXYGEN for building");
+        }
+#endif
+
+        /// Obtain a constant reference to the element with the given `index` in
+        /// the slice.
+        ///
+        /// @throw  std::out_of_range when `index` is out of bounds of the slice
+        const value_type& at(size_t index) const
+        {
+            rangeCheck(index);
+            // we know: begin_ < end <= size() <= SIZE_T_MAX
+            // and: index < end - begin
+            // thus: index + begin < end <= SIZE_T_MAX
+            // => no overflow is possible
+            return ptr_[begin_ + index];
+        }
+
+        /// Obtain a mutable reference to the element with the given `index` in
+        /// the slice.
+        ///
+        /// Please note that this function is unavailable when `T` is a
+        /// constant type.
+        ///
+        /// @throw  std::out_of_range when `index` is out of bounds of the slice
+#ifdef PARSED_BY_DOXYGEN
+        value_type&
+#else
+        template <typename Dummy = T>
+        typename std::enable_if<!std::is_const<Dummy>::value, value_type>::type&
+#endif
+        at(size_t index)
+        {
+            rangeCheck(index);
+            // we know: begin_ < end <= size() <= SIZE_T_MAX
+            // and: index < end - begin
+            // thus: index + begin < end <= SIZE_T_MAX
+            // => no overflow is possible
+            return ptr_[begin_ + index];
+        }
+
+        /// Return a constant iterator to the beginning of the slice.
+        const_iterator cbegin() const noexcept
+        {
+            return ptr_ + begin_;
+        }
+
+        /// Return an iterator to the beginning of the slice.
+        ///
+        /// Note: this function is not available when `T` is a constant type.
+#ifdef PARSED_BY_DOXYGEN
+        iterator
+#else
+        template <typename Dummy = T>
+        typename std::enable_if<!std::is_const<Dummy>::value, iterator>::type
+#endif
+        begin() noexcept
+        {
+            return ptr_ + begin_;
+        }
+
+        /// Return a constant iterator to the beginning of the slice.
+        const_iterator begin() const noexcept
+        {
+            return ptr_ + begin_;
+        }
+
+        /// Return a constant iterator to the first element beyond the slice.
+        const_iterator cend() const noexcept
+        {
+            return ptr_ + end_;
+        }
+
+        /// Return an iterator to the first element beyond the slice.
+        ///
+        /// Note: this function is not available when `T` is a constant type.
+#ifdef PARSED_BY_DOXYGEN
+        iterator
+#else
+        template <typename Dummy = T>
+        typename std::enable_if<!std::is_const<Dummy>::value, iterator>::type
+#endif
+        end() noexcept
+        {
+            return ptr_ + end_;
+        }
+
+        /// Return a constant iterator to the first element beyond the slice.
+        const_iterator end() const noexcept
+        {
+            return ptr_ + end_;
+        }
+
+        /// Construct a sub-slice of this slice with the given bounds. The bounds
+        /// are evaluated with respect to the current slice.
+        ///
+        /// @param[in] begin  First element in the new slice.
+        /// @param[in] end  First element beyond the new slice.
+        ///
+        /// @throw  std::out_of_range when begin or end are out of bounds of the
+        ///     current slice
+#ifdef PARSED_BY_DOXYGEN
+        Slice<T*>
+#else
+        template <typename Dummy = T>
+        typename std::enable_if<!std::is_const<Dummy>::value, Slice<T*> >::type
+#endif
+        subSlice(size_t begin, size_t end)
+        {
+            this->calculateSubSliceBounds(begin, end);
+            return Slice<T*>(ptr_, begin, end);
+        }
+
+        /// Constructs a new constant subSlice. Behaves otherwise exactly like
+        /// the non-const version.
         Slice<const T*> subSlice(size_t begin, size_t end) const
         {
-            return Internal::ConstSliceBase<Internal::PtrSliceStorage, const T*>::template subSlice<Slice<const T*> >(
-                begin, end);
+            this->calculateSubSliceBounds(begin, end);
+            return Slice<const T*>(ptr_, begin, end);
         }
+
+    private:
+        T* ptr_;
     };
 
-    /*!
-     * Specialization of slices for (mutable) C-arrays.
-     */
+    /// @brief Return a new slice with the given bounds.
+    ///
+    /// Convenience wrapper around the slice's constructor for automatic template
+    /// parameter deduction.
     template <typename T>
-    struct Slice<T*> : public Internal::MutableSliceBase<Internal::PtrSliceStorage, T*>
-    {
-        Slice(T* ptr, size_t begin, size_t end)
-            : Internal::MutableSliceBase<Internal::PtrSliceStorage, T*>(ptr, begin, end)
-        {
-            // TODO: use using in C++11
-        }
-
-        Slice<T*> subSlice(size_t begin, size_t end)
-        {
-            return Internal::MutableSliceBase<Internal::PtrSliceStorage, T*>::template subSlice<Slice<T*> >(begin, end);
-        }
-
-        Slice<const T*> subSlice(size_t begin, size_t end) const
-        {
-            return this->to_const_base().template subSlice<Slice<const T*> >(begin, end);
-        }
-    };
-
-    /*!
-     * @brief Return a new slice with the given bounds.
-     *
-     * Convenience wrapper around the slice's constructor for automatic template
-     * parameter deduction.
-     */
-    template <typename T>
-    inline Slice<T> makeSlice(T& cont, size_t begin, size_t end)
+    Slice<T> makeSlice(T& cont, size_t begin, size_t end)
     {
         return Slice<T>(cont, begin, end);
     }
 
-    /*!
-     * Overload of makeSlice for slices of C-arrays.
-     */
+    /// Overload of makeSlice for slices of C-arrays.
     template <typename T>
-    inline Slice<T*> makeSlice(T* ptr, size_t begin, size_t end)
+    Slice<T*> makeSlice(T* ptr, size_t begin, size_t end)
     {
         return Slice<T*>(ptr, begin, end);
     }
 
-    /*!
-     * @brief Return a new slice spanning the whole container.
-     */
+    /// @brief Return a new slice spanning the whole container.
     template <typename container>
-    inline Slice<container> makeSlice(container& cont)
+    Slice<container> makeSlice(container& cont)
     {
         return Slice<container>(cont, 0, cont.size());
     }
 
-    /*!
-     * @brief Return a new slice spanning from begin until the end of the
-     * container.
-     */
+    /// @brief Return a new slice spanning from begin until the end of the
+    /// container.
     template <typename container>
-    inline Slice<container> makeSliceFrom(container& cont, size_t begin)
+    Slice<container> makeSliceFrom(container& cont, size_t begin)
     {
         return Slice<container>(cont, begin, cont.size());
     }
 
-    /*!
-     * @brief Return a new slice spanning until `end`.
-     */
+    /// @brief Return a new slice spanning until `end`.
     template <typename container>
-    inline Slice<container> makeSliceUntil(container& cont, size_t end)
+    Slice<container> makeSliceUntil(container& cont, size_t end)
     {
         return Slice<container>(cont, 0, end);
     }
 
-    /*!
-     * Overload of makeSliceUntil for pointer based slices.
-     */
+    /// Overload of makeSliceUntil for pointer based slices.
     template <typename T>
-    inline Slice<T*> makeSliceUntil(T* ptr, size_t end)
+    Slice<T*> makeSliceUntil(T* ptr, size_t end)
     {
         return Slice<T*>(ptr, 0, end);
     }

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -120,6 +120,14 @@ TYPED_TEST_P(slice, atAccess)
     }
 }
 
+TYPED_TEST_P(slice, atOutOfBoundsAccess)
+{
+    Slice<TypeParam> sl = this->getTestSlice();
+
+    ASSERT_THROW(sl.at(sl.size()), std::out_of_range);
+    ASSERT_THROW(sl.at(sl.size() + 1), std::out_of_range);
+}
+
 TYPED_TEST_P(slice, iteratorAccess)
 {
     Slice<TypeParam> sl = this->getTestSlice();
@@ -128,14 +136,16 @@ TYPED_TEST_P(slice, iteratorAccess)
     for (typename Slice<TypeParam>::const_iterator it = sl.cbegin(); it < sl.cend(); ++it, ++vec_it) {
         ASSERT_EQ(*it, *vec_it);
     }
+}
 
-    auto vec_it_second = this->vec_.begin() + 1;
+TYPED_TEST_P(slice, rangeBasedForLoop)
+{
+    auto sl = this->getTestSlice();
+    auto vec_iter = this->vec_.begin() + 1;
     for (const auto& val : sl) {
-        ASSERT_EQ(val, *vec_it_second);
-        ++vec_it_second;
+        ASSERT_EQ(val, *vec_iter);
+        ++vec_iter;
     }
-
-    ASSERT_THROW(sl.at(sl.size()), std::out_of_range);
 }
 
 TYPED_TEST_P(slice, constructionFailsFromInvalidRange)
@@ -429,10 +439,10 @@ TYPED_TEST_P(dataBufSlice, failedConstruction)
 //
 // GTest boilerplate to get the tests running for all the different types
 //
-REGISTER_TYPED_TEST_CASE_P(slice, atAccess, iteratorAccess, constructionFailsFromInvalidRange,
-                           constructionFailsWithZeroLength, subSliceSuccessfulConstruction, subSliceFunctions,
-                           subSliceFailedConstruction, subSliceConstructionOverflowResistance,
-                           constMethodsPreserveConst);
+REGISTER_TYPED_TEST_CASE_P(slice, atAccess, atOutOfBoundsAccess, iteratorAccess, rangeBasedForLoop,
+                           constructionFailsFromInvalidRange, constructionFailsWithZeroLength,
+                           subSliceSuccessfulConstruction, subSliceFunctions, subSliceFailedConstruction,
+                           subSliceConstructionOverflowResistance, constMethodsPreserveConst);
 
 typedef ::testing::Types<const std::vector<int>, std::vector<int>, int*, const int*> test_types_t;
 INSTANTIATE_TYPED_TEST_CASE_P(, slice, test_types_t);

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -11,44 +11,24 @@ template <typename T>
 class slice;
 
 /*!
- * This namespace contains the helper-function get_test_data. It is intented
- * to be used for test with the slice fixture: it returns the appropriate
+ * This namespace contains the helper-function getTestData. It is intented
+ * to be used for tests with the slice fixture: it returns the appropriate
  * data to the constructor of slice. For (const) T==std::vector it returns the
- * fixtures meber vec_, for (const) T==int* it returns vec_.data()
+ * fixtures member vec_, for (const) T==int* it returns vec_.data()
  *
- * Due to C++98's limitations, this requires a separate traits class, that
- * specifies the return type *and* a specialization of get_test_data for each
- * case (maybe some can be reduced with SFINAE, but that ain't improving
- * readability either).
- *
- * Unfortunately, C++11 will probably only make the return_type_traits go away,
- * but not the template specializations of get_test_data (for that we need
- * C++17, so see you in 2025).
+ * As we don't have C++17 and can't use a single function with a big `constexpr
+ * if`, we instead overload getTestData for the four types that we test.
  */
-namespace cpp_98_boilerplate
+namespace cpp_pre_17_boilerplate
 {
-    template <typename T>
-    struct return_type_traits
-    {
-        typedef T type;
-    };
+    int* getTestData(slice<int*>& st);
 
-    template <typename U>
-    struct return_type_traits<std::vector<U> >
-    {
-        typedef typename std::vector<U>& type;
-    };
+    const int* getTestData(slice<const int*>& st);
 
-    template <typename U>
-    struct return_type_traits<const std::vector<U> >
-    {
-        typedef const typename std::vector<U>& type;
-    };
+    std::vector<int>& getTestData(slice<std::vector<int> >& st);
 
-    template <typename T>
-    typename return_type_traits<T>::type get_test_data(slice<T>& st);
-
-}  // namespace cpp_98_boilerplate
+    const std::vector<int>& getTestData(slice<const std::vector<int> >& st);
+}  // namespace cpp_pre_17_boilerplate
 
 /*!
  * Fixture for slice testing. Has one public vector of ints with size vec_size
@@ -77,41 +57,37 @@ public:
 
     Slice<T> getTestSlice(size_t begin = 1, size_t end = vec_size - 1)
     {
-        return Slice<T>(cpp_98_boilerplate::get_test_data<T>(*this), begin, end);
+        return Slice<T>(cpp_pre_17_boilerplate::getTestData(*this), begin, end);
     }
 
     // TODO: once we have C++11: use initializer list
     std::vector<int> vec_;
 };
 
-// specializations of get_test_data are provided here, since they must have the
-// full definition of slice available
-namespace cpp_98_boilerplate
+// implementation of the overloads of getTestData are provided here, since
+// they must have the full definition of slice available
+namespace cpp_pre_17_boilerplate
 {
-    template <>
-    int* get_test_data<int*>(slice<int*>& st)
+    int* getTestData(slice<int*>& st)
     {
         return st.vec_.data();
     }
 
-    template <>
-    const int* get_test_data<const int*>(slice<const int*>& st)
+    const int* getTestData(slice<const int*>& st)
     {
         return st.vec_.data();
     }
 
-    template <>
-    std::vector<int>& get_test_data<std::vector<int> >(slice<std::vector<int> >& st)
+    std::vector<int>& getTestData(slice<std::vector<int> >& st)
     {
         return st.vec_;
     }
 
-    template <>
-    const std::vector<int>& get_test_data<const std::vector<int> >(slice<const std::vector<int> >& st)
+    const std::vector<int>& getTestData(slice<const std::vector<int> >& st)
     {
         return st.vec_;
     }
-}  // namespace cpp_98_boilerplate
+}  // namespace cpp_pre_17_boilerplate
 
 /*!
  * Fixture to run test for mutable slices.

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -8,7 +8,7 @@
 using namespace Exiv2;
 
 template <typename T>
-class slice;
+class ASlice;
 
 /*!
  * This namespace contains the helper-function getTestData. It is intented
@@ -21,13 +21,13 @@ class slice;
  */
 namespace cpp_pre_17_boilerplate
 {
-    int* getTestData(slice<int*>& st);
+    int* getTestData(ASlice<int*>& st);
 
-    const int* getTestData(slice<const int*>& st);
+    const int* getTestData(ASlice<const int*>& st);
 
-    std::vector<int>& getTestData(slice<std::vector<int> >& st);
+    std::vector<int>& getTestData(ASlice<std::vector<int> >& st);
 
-    const std::vector<int>& getTestData(slice<const std::vector<int> >& st);
+    const std::vector<int>& getTestData(ASlice<const std::vector<int> >& st);
 }  // namespace cpp_pre_17_boilerplate
 
 /*!
@@ -42,7 +42,7 @@ namespace cpp_pre_17_boilerplate
  * @tparam T  Type that is used to construct a slice for testing.
  */
 template <typename T>
-class slice : public ::testing::Test
+class ASlice : public ::testing::Test
 {
 public:
     static const size_t vec_size = 10;
@@ -59,22 +59,22 @@ public:
 // they must have the full definition of slice available
 namespace cpp_pre_17_boilerplate
 {
-    int* getTestData(slice<int*>& st)
+    int* getTestData(ASlice<int*>& st)
     {
         return st.vec_.data();
     }
 
-    const int* getTestData(slice<const int*>& st)
+    const int* getTestData(ASlice<const int*>& st)
     {
         return st.vec_.data();
     }
 
-    std::vector<int>& getTestData(slice<std::vector<int> >& st)
+    std::vector<int>& getTestData(ASlice<std::vector<int> >& st)
     {
         return st.vec_;
     }
 
-    const std::vector<int>& getTestData(slice<const std::vector<int> >& st)
+    const std::vector<int>& getTestData(ASlice<const std::vector<int> >& st)
     {
         return st.vec_;
     }
@@ -87,7 +87,7 @@ namespace cpp_pre_17_boilerplate
  * different tests on it.
  */
 template <typename T>
-class mutableSlice : public slice<T>
+class mutableSlice : public ASlice<T>
 {
 };
 
@@ -106,55 +106,55 @@ static_assert(std::is_same<Slice<const int*>::iterator, int const*>::value,
 static_assert(std::is_same<Slice<const int*>::const_iterator, int const*>::value,
               "Slice<const int*>::iterator is not int const*");
 
-TYPED_TEST_CASE_P(slice);
+TYPED_TEST_CASE_P(ASlice);
 TYPED_TEST_CASE_P(mutableSlice);
 
-TYPED_TEST_P(slice, atAccess)
+TYPED_TEST_P(ASlice, atAccess)
 {
-    Slice<TypeParam> sl = this->getTestSlice();
+    Slice<TypeParam> slice = this->getTestSlice();
 
-    ASSERT_EQ(this->vec_.size() - 2, sl.size());
+    ASSERT_EQ(this->vec_.size() - 2, slice.size());
 
-    for (unsigned int i = 0; i < sl.size(); ++i) {
-        ASSERT_EQ(this->vec_.at(i + 1), sl.at(i));
+    for (unsigned int i = 0; i < slice.size(); ++i) {
+        ASSERT_EQ(this->vec_.at(i + 1), slice.at(i));
     }
 }
 
-TYPED_TEST_P(slice, atOutOfBoundsAccess)
+TYPED_TEST_P(ASlice, atOutOfBoundsAccess)
 {
-    Slice<TypeParam> sl = this->getTestSlice();
+    Slice<TypeParam> slice = this->getTestSlice();
 
-    ASSERT_THROW(sl.at(sl.size()), std::out_of_range);
-    ASSERT_THROW(sl.at(sl.size() + 1), std::out_of_range);
+    ASSERT_THROW(slice.at(slice.size()), std::out_of_range);
+    ASSERT_THROW(slice.at(slice.size() + 1), std::out_of_range);
 }
 
-TYPED_TEST_P(slice, iteratorAccess)
+TYPED_TEST_P(ASlice, iteratorAccess)
 {
-    Slice<TypeParam> sl = this->getTestSlice();
+    Slice<TypeParam> slice = this->getTestSlice();
 
     auto vec_it = this->vec_.begin() + 1;
-    for (typename Slice<TypeParam>::const_iterator it = sl.cbegin(); it < sl.cend(); ++it, ++vec_it) {
+    for (typename Slice<TypeParam>::const_iterator it = slice.cbegin(); it < slice.cend(); ++it, ++vec_it) {
         ASSERT_EQ(*it, *vec_it);
     }
 }
 
-TYPED_TEST_P(slice, rangeBasedForLoop)
+TYPED_TEST_P(ASlice, rangeBasedForLoop)
 {
-    auto sl = this->getTestSlice();
+    auto slice = this->getTestSlice();
     auto vec_iter = this->vec_.begin() + 1;
-    for (const auto& val : sl) {
+    for (const auto& val : slice) {
         ASSERT_EQ(val, *vec_iter);
         ++vec_iter;
     }
 }
 
-TYPED_TEST_P(slice, constructionFailsFromInvalidRange)
+TYPED_TEST_P(ASlice, constructionFailsFromInvalidRange)
 {
     // start > end
     ASSERT_THROW(this->getTestSlice(2, 1), std::out_of_range);
 }
 
-TYPED_TEST_P(slice, constructionFailsWithZeroLength)
+TYPED_TEST_P(ASlice, constructionFailsWithZeroLength)
 {
     ASSERT_THROW(this->getTestSlice(1, 1), std::out_of_range);
 }
@@ -162,7 +162,7 @@ TYPED_TEST_P(slice, constructionFailsWithZeroLength)
 /*!
  * Test the construction of subSlices and their behavior.
  */
-TYPED_TEST_P(slice, subSliceSuccessfulConstruction)
+TYPED_TEST_P(ASlice, subSliceSuccessfulConstruction)
 {
     typedef Slice<TypeParam> slice_t;
 
@@ -176,7 +176,7 @@ TYPED_TEST_P(slice, subSliceSuccessfulConstruction)
     ASSERT_NO_THROW(center_vals.subSlice(1, center_vals.size()));
 }
 
-TYPED_TEST_P(slice, subSliceFunctions)
+TYPED_TEST_P(ASlice, subSliceFunctions)
 {
     Slice<TypeParam> middle = this->getTestSlice(3, 7).subSlice(1, 3);
 
@@ -184,7 +184,7 @@ TYPED_TEST_P(slice, subSliceFunctions)
     ASSERT_EQ(middle.at(1), static_cast<typename Slice<TypeParam>::value_type>(5));
 }
 
-TYPED_TEST_P(slice, subSliceFailedConstruction)
+TYPED_TEST_P(ASlice, subSliceFailedConstruction)
 {
     // 0 1 2 3 4 5 6 7 8 9
     //       |     |       middle
@@ -202,7 +202,7 @@ TYPED_TEST_P(slice, subSliceFailedConstruction)
 }
 
 /*! try to cause integer overflows in a sub-optimal implementation */
-TYPED_TEST_P(slice, subSliceConstructionOverflowResistance)
+TYPED_TEST_P(ASlice, subSliceConstructionOverflowResistance)
 {
     Slice<TypeParam> center_vals = this->getTestSlice(3, 7);
 
@@ -215,9 +215,9 @@ TYPED_TEST_P(slice, subSliceConstructionOverflowResistance)
  * constant reference.
  */
 template <typename T>
-void checkConstSliceValueAt(const Slice<T>& sl, typename Slice<T>::value_type value, size_t index)
+void checkConstSliceValueAt(const Slice<T>& slice, typename Slice<T>::value_type value, size_t index)
 {
-    ASSERT_EQ(sl.at(index), value);
+    ASSERT_EQ(slice.at(index), value);
 }
 
 /*!
@@ -225,29 +225,29 @@ void checkConstSliceValueAt(const Slice<T>& sl, typename Slice<T>::value_type va
  * loop.
  */
 template <typename T>
-void checkConstSliceIterator(const Slice<T>& sl, typename Slice<T>::value_type first_value)
+void checkConstSliceIterator(const Slice<T>& slice, typename Slice<T>::value_type first_value)
 {
     auto first_value_copy = first_value;
 
-    for (typename Slice<T>::const_iterator it = sl.cbegin(); it < sl.cend(); ++it) {
+    for (typename Slice<T>::const_iterator it = slice.cbegin(); it < slice.cend(); ++it) {
         ASSERT_EQ(*it, first_value++);
     }
 
-    for (const auto& it : sl) {
+    for (const auto& it : slice) {
         ASSERT_EQ(it, first_value_copy++);
     }
 }
 
 template <typename T>
-void checkSubSlice(const Slice<T>& sl)
+void checkSubSlice(const Slice<T>& slice)
 {
-    ASSERT_EQ(sl.at(1), sl.subSlice(1, sl.size()).at(0));
+    ASSERT_EQ(slice.at(1), slice.subSlice(1, slice.size()).at(0));
 }
 
 /*!
  * Test that all slices can be also passed as const references and still work
  */
-TYPED_TEST_P(slice, constMethodsPreserveConst)
+TYPED_TEST_P(ASlice, constMethodsPreserveConst)
 {
     typedef Slice<TypeParam> slice_t;
 
@@ -269,19 +269,19 @@ TYPED_TEST_P(slice, constMethodsPreserveConst)
 TYPED_TEST_P(mutableSlice, iterators)
 {
     typedef Slice<TypeParam> slice_t;
-    slice_t sl = this->getTestSlice();
+    slice_t slice = this->getTestSlice();
 
-    ASSERT_EQ(*sl.begin(), static_cast<typename slice_t::value_type>(1));
-    ASSERT_EQ(*sl.end(), static_cast<typename slice_t::value_type>(this->vec_size - 1));
+    ASSERT_EQ(*slice.begin(), static_cast<typename slice_t::value_type>(1));
+    ASSERT_EQ(*slice.end(), static_cast<typename slice_t::value_type>(this->vec_size - 1));
 
-    for (typename slice_t::iterator it = sl.begin(); it < sl.end(); ++it) {
+    for (typename slice_t::iterator it = slice.begin(); it < slice.end(); ++it) {
         *it = 2 * (*it);
     }
 
     ASSERT_EQ(this->vec_.at(0), 0);
     for (size_t j = 1; j < this->vec_size - 1; ++j) {
         ASSERT_EQ(this->vec_.at(j), static_cast<typename slice_t::value_type>(2 * j));
-        ASSERT_EQ(this->vec_.at(j), sl.at(j - 1));
+        ASSERT_EQ(this->vec_.at(j), slice.at(j - 1));
     }
     ASSERT_EQ(this->vec_.at(this->vec_size - 1), static_cast<typename slice_t::value_type>(this->vec_size - 1));
 }
@@ -291,14 +291,14 @@ TYPED_TEST_P(mutableSlice, iterators)
  */
 TYPED_TEST_P(mutableSlice, rangeBasedForLoop)
 {
-    Slice<TypeParam> sl = this->getTestSlice();
+    Slice<TypeParam> slice = this->getTestSlice();
 
     // revert the changes again
-    for (auto& val : sl) {
+    for (auto& val : slice) {
         val *= 2;
     }
     size_t i = 1;
-    for (const auto& val : sl) {
+    for (const auto& val : slice) {
         ASSERT_EQ(val, 2 * i);
         ++i;
     }
@@ -310,10 +310,10 @@ TYPED_TEST_P(mutableSlice, rangeBasedForLoop)
 TYPED_TEST_P(mutableSlice, at)
 {
     typedef Slice<TypeParam> slice_t;
-    slice_t sl = this->getTestSlice(2, 4);
+    slice_t slice = this->getTestSlice(2, 4);
 
-    sl.at(0) = 6;
-    sl.at(1) = 12;
+    slice.at(0) = 6;
+    slice.at(1) = 12;
 
     ASSERT_EQ(this->vec_.at(2), 6);
     ASSERT_EQ(this->vec_.at(3), 12);
@@ -439,13 +439,13 @@ TYPED_TEST_P(dataBufSlice, failedConstruction)
 //
 // GTest boilerplate to get the tests running for all the different types
 //
-REGISTER_TYPED_TEST_CASE_P(slice, atAccess, atOutOfBoundsAccess, iteratorAccess, rangeBasedForLoop,
+REGISTER_TYPED_TEST_CASE_P(ASlice, atAccess, atOutOfBoundsAccess, iteratorAccess, rangeBasedForLoop,
                            constructionFailsFromInvalidRange, constructionFailsWithZeroLength,
                            subSliceSuccessfulConstruction, subSliceFunctions, subSliceFailedConstruction,
                            subSliceConstructionOverflowResistance, constMethodsPreserveConst);
 
 typedef ::testing::Types<const std::vector<int>, std::vector<int>, int*, const int*> test_types_t;
-INSTANTIATE_TYPED_TEST_CASE_P(, slice, test_types_t);
+INSTANTIATE_TYPED_TEST_CASE_P(, ASlice, test_types_t);
 
 REGISTER_TYPED_TEST_CASE_P(mutableSlice, iterators, rangeBasedForLoop, at);
 typedef ::testing::Types<std::vector<int>, int*> mut_test_types_t;

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -169,11 +169,17 @@ TYPED_TEST_P(slice, subSliceFunctions)
 TYPED_TEST_P(slice, subSliceFailedConstruction)
 {
     // 0 1 2 3 4 5 6 7 8 9
-    //         | |         middle
-    Slice<TypeParam> middle = this->getTestSlice(4, 6);
+    //       |     |       middle
+    Slice<TypeParam> middle = this->getTestSlice(3, 7);
 
+    ASSERT_EQ(middle.size(), 4);
+
+    // these are all invalid
+    ASSERT_THROW(middle.subSlice(1, 6), std::out_of_range);
     ASSERT_THROW(middle.subSlice(1, 5), std::out_of_range);
-    ASSERT_THROW(middle.subSlice(2, 1), std::out_of_range);
+    ASSERT_THROW(middle.subSlice(5, 1), std::out_of_range);
+
+    // rejected by Slice constructor
     ASSERT_THROW(middle.subSlice(2, 2), std::out_of_range);
 }
 


### PR DESCRIPTION
The previous `Slice` implementation relied on inheritance to expose the correct const and non-const methods. Unfortunately, this was broken by the transition to C++11 which showed that this approach was a bad idea from the start. See for instance #703, where the old implementation breaks. Also, the inheritance approach was hard to understand and pretty bad in hindsight.

The new implementation instead uses SFINAE to hide non-const member functions when the slice holds const data. Since the problematic member functions are not template functions themselves (they depend on the same template parameter as the class itself), we cannot use classical SFINAE. Instead we use the Dummy template parameter trick described e.g. here: https://foonathan.net/blog/2016/12/21/conditionally-removing-functions.html

Additionally this PR adds a `PARSED_BY_DOXYGEN` macro to conditionally hide implementation details from the API documentation. Furthermore, the unit tests of slices were simplified a little bit and are not using & testing C++11 features.

TODO:

- [x] Add documentation
- [x] Check doxygen output
- [x] increase code coverage