### PR TITLE
[ci] Run upgrade in Archlinux container

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -34,7 +34,7 @@ case "$distro_id" in
         ;;
 
     'arch')
-        pacman --noconfirm -Sy
+        pacman --noconfirm -Syu
         pacman --noconfirm -S gcc clang cmake make ccache expat zlib libssh curl gtest python dos2unix which diffutils
         ;;
 


### PR DESCRIPTION
This is a backport of #705 that mergify didn't pick up and which should solve the current failure of the pipeline on Github for 0.27.