### PR TITLE
[CI] Fix name of the OpenSUSE Tumbleweed container for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,7 @@ CentOS:
   <<: *distro_build
 
 OpenSUSE:
-  image: opensuse:tumbleweed
+  image: opensuse/tumbleweed
   <<: *default_config
   <<: *distro_build
 


### PR DESCRIPTION
The container name changed and the gitlab builds of today were all failing. This should fix that.