### PR TITLE
[CI] Fix name of the OpenSUSE Tumbleweed container for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ CentOS:
   <<: *distro_build
 
 OpenSUSE:
-  image: opensuse:tumbleweed
+  image: opensuse/tumbleweed
   <<: *default_config
   <<: *distro_build
 


### PR DESCRIPTION
Backport of #723.