### PR TITLE
Replace check_function_exists by check_cxx_symbol_exist

### DIFF
--- a/cmake/generateConfigFile.cmake
+++ b/cmake/generateConfigFile.cmake
@@ -1,5 +1,6 @@
-include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
+include(CheckCXXSymbolExists)
 
 # Note that the scope of the EXV_ variables in local
 if (${EXIV2_ENABLE_WEBREADY})
@@ -21,11 +22,10 @@ set(EXV_HAVE_ICONV       ${ICONV_FOUND})
 set(EXV_HAVE_LIBZ        ${ZLIB_FOUND})
 set(EXV_UNICODE_PATH     ${EXIV2_ENABLE_WIN_UNICODE})
 
-# TODO: Try to use the cmake function check_symbol_exists which is more robust
-check_function_exists( gmtime_r EXV_HAVE_GMTIME_R )
-check_function_exists( mmap     EXV_HAVE_MMAP )
-check_function_exists( munmap   EXV_HAVE_MUNMAP )
-check_function_exists( strerror_r   EXV_HAVE_STRERROR_R )
+check_cxx_symbol_exists(gmtime_r    time.h         EXV_HAVE_GMTIME_R)
+check_cxx_symbol_exists(mmap        sys/mman.h     EXV_HAVE_MMAP )
+check_cxx_symbol_exists(munmap      sys/mman.h     EXV_HAVE_MUNMAP )
+check_cxx_symbol_exists(strerror_r  string.h       EXV_HAVE_STRERROR_R )
 
 check_cxx_source_compiles( "
 #include <string.h>
@@ -35,10 +35,10 @@ int main() {
     return 0;
 }" EXV_STRERROR_R_CHAR_P )
 
-check_include_file( "unistd.h"  EXV_HAVE_UNISTD_H )
-check_include_file( "sys/mman.h"    EXV_HAVE_SYS_MMAN_H )
+check_include_file_cxx( "unistd.h"  EXV_HAVE_UNISTD_H )
+check_include_file_cxx( "sys/mman.h"    EXV_HAVE_SYS_MMAN_H )
 if ( NOT MINGW AND NOT MSYS AND NOT MSVC )
-check_include_file( "regex.h"       EXV_HAVE_REGEX_H )
+check_include_file_cxx( "regex.h"       EXV_HAVE_REGEX_H )
 endif()
 
 set(EXV_ENABLE_NLS ${EXIV2_ENABLE_NLS})


### PR DESCRIPTION
In this PR I am doing a tiny improvement in the CMake code (I wrote a TODO there a long time ago).

In the CMake documentation I noticed that they recommend to use **check_cxx_symbol_exists** over **check_function_exists**:
 
https://cmake.org/cmake/help/v3.13/module/CheckFunctionExists.html

I also think that we should be using **check_include_file_cxx** over **check_include_file**. 