### PR TITLE
Enum class for image types

### DIFF
--- a/include/exiv2/CMakeLists.txt
+++ b/include/exiv2/CMakeLists.txt
@@ -15,6 +15,7 @@ install(FILES
             gifimage.hpp
             http.hpp
             image.hpp
+            image_types.hpp
             ini.hpp
             iptc.hpp
             jp2image.hpp

--- a/include/exiv2/bigtiffimage.hpp
+++ b/include/exiv2/bigtiffimage.hpp
@@ -5,11 +5,6 @@
 namespace Exiv2
 {
 
-namespace ImageType
-{
-    const int bigtiff = 25;
-}
-
 Image::UniquePtr newBigTiffInstance(BasicIo::UniquePtr, bool);
 bool isBigTiffType(BasicIo &, bool);
 

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add Windows Bitmap (BMP) to the supported image formats
-    namespace ImageType {
-        const int bmp = 14; //!< Windows bitmap (bmp) image type (see class BmpImage)
-    }
-
     /*!
       @brief Class to access Windows bitmaps. This is just a stub - we only
           read width and height.

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add CR2 to the supported image formats
-    namespace ImageType {
-        const int cr2 = 7;          //!< CR2 image type (see class Cr2Image)
-    }
-
     /*!
       @brief Class to access raw Canon CR2 images.  Exif metadata
           is supported directly, IPTC is read from the Exif data, if present.

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -47,11 +47,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add CRW to the supported image formats
-    namespace ImageType {
-        const int crw = 3;          //!< CRW image type (see class CrwImage)
-    }
-
     /*!
       @brief Class to access raw Canon CRW images. Only Exif metadata and a
              comment are supported. CRW format does not contain IPTC metadata.

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -41,11 +41,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add GIF to the supported image formats
-    namespace ImageType {
-        const int gif = 11;          //!< GIF image type (see class GifImage)
-    }
-
     /*!
       @brief Class to access raw GIF images. Exif/IPTC metadata are supported
              directly.

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -30,6 +30,7 @@
 #include "basicio.hpp"
 #include "exif.hpp"
 #include "iptc.hpp"
+#include "image_types.hpp"
 #include "xmp_exiv2.hpp"
 
 // + standard includes
@@ -42,11 +43,6 @@ namespace Exiv2 {
 
 // *****************************************************************************
 // class definitions
-
-    //! Supported image formats
-    namespace ImageType {
-        const int none = 0;         //!< Not an image
-    }
 
     //! Native preview information. This is meant to be used only by the PreviewManager.
     struct NativePreview {
@@ -90,9 +86,7 @@ namespace Exiv2 {
               metadata types and an auto-pointer that owns an IO instance.
               See subclass constructor doc.
          */
-        Image(int              imageType,
-              uint16_t         supportedMetadata,
-              BasicIo::UniquePtr io);
+        Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io);
         //! Virtual Destructor
         virtual ~Image();
         //@}
@@ -471,16 +465,14 @@ namespace Exiv2 {
         //@}
 
         //! set type support for this image format
-        void setTypeSupported(
-            int              imageType,
-            uint16_t         supportedMetadata
-        ) {
+        void setTypeSupported(ImageType imageType, uint16_t supportedMetadata)
+        {
             imageType_         = imageType;
             supportedMetadata_ = supportedMetadata;
         }
 
         //! set type support for this image format
-        int imageType() const { return imageType_; }
+        ImageType imageType() const { return imageType_; }
 
     protected:
         // DATA
@@ -509,7 +501,7 @@ namespace Exiv2 {
 
     private:
         // DATA
-        int               imageType_;         //!< Image type
+        ImageType        imageType_;         //!< Image type
         uint16_t          supportedMetadata_; //!< Bitmap with all supported metadata types
         bool              writeXmpFromPacket_;//!< Determines the source when writing XMP
         ByteOrder         byteOrder_;         //!< Byte order
@@ -614,13 +606,13 @@ namespace Exiv2 {
               type.
           @throw Error If the image type is not supported.
          */
-        static Image::UniquePtr create(int type, const std::string& path);
+        static Image::UniquePtr create(ImageType type, const std::string& path);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like create() but accepts a unicode path in an std::wstring.
           @note This function is only available on Windows.
          */
-        static Image::UniquePtr create(int type, const std::wstring& wpath);
+        static Image::UniquePtr create(ImageType type, const std::wstring& wpath);
 #endif
         /*!
           @brief Create an Image subclass of the requested type by creating a
@@ -630,7 +622,8 @@ namespace Exiv2 {
               type.
           @throw Error If the image type is not supported
          */
-        static Image::UniquePtr create(int type);
+        static Image::UniquePtr create(ImageType type);
+
         /*!
           @brief Create an Image subclass of the requested type by writing a
               new image to a BasicIo instance. If the BasicIo instance already
@@ -645,20 +638,22 @@ namespace Exiv2 {
           @return An auto-pointer that owns an Image instance of the requested
               type. If the image type is not supported, the pointer is 0.
          */
-        static Image::UniquePtr create(int type, BasicIo::UniquePtr io);
+
+        static Image::UniquePtr create(ImageType type, BasicIo::UniquePtr io);
         /*!
           @brief Returns the image type of the provided file.
           @param path %Image file. The contents of the file are tested to
               determine the image type. File extension is ignored.
           @return %Image type or Image::none if the type is not recognized.
          */
-        static int getType(const std::string& path);
+        static ImageType getType(const std::string& path);
+
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like getType() but accepts a unicode path in an std::wstring.
           @note This function is only available on Windows.
          */
-        static int getType(const std::wstring& wpath);
+        static ImageType getType(const std::wstring& wpath);
 #endif
         /*!
           @brief Returns the image type of the provided data buffer.
@@ -667,7 +662,7 @@ namespace Exiv2 {
           @param size Number of bytes pointed to by \em data.
           @return %Image type or Image::none if the type is not recognized.
          */
-        static int getType(const byte* data, long size);
+        static ImageType getType(const byte* data, long size);
         /*!
           @brief Returns the image type of data provided by a BasicIo instance.
               The passed in \em io instance is (re)opened by this method.
@@ -675,7 +670,7 @@ namespace Exiv2 {
               of the image data are tested to determine the type.
           @return %Image type or Image::none if the type is not recognized.
          */
-        static int getType(BasicIo& io);
+        static ImageType getType(BasicIo& io);
         /*!
           @brief Returns the access mode or supported metadata functions for an
               image type and a metadata type.
@@ -684,7 +679,7 @@ namespace Exiv2 {
           @return Access mode for the requested image type and metadata identifier.
           @throw Error(kerUnsupportedImageType) if the image type is not supported.
          */
-        static AccessMode checkMode(int type, MetadataId metadataId);
+        static AccessMode checkMode(ImageType type, MetadataId metadataId);
         /*!
           @brief Determine if the content of \em io is an image of \em type.
 
@@ -705,7 +700,7 @@ namespace Exiv2 {
           @return  true  if the data matches the type of this class;<BR>
                    false if the data does not match
         */
-        static bool checkType(int type, BasicIo& io, bool advance);
+        static bool checkType(ImageType type, BasicIo& io, bool advance);
 
         ImageFactory& operator=(const ImageFactory& rhs) = delete;
         ImageFactory(const ImageFactory& rhs) = delete;

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -708,9 +708,7 @@ namespace Exiv2 {
         static bool checkType(int type, BasicIo& io, bool advance);
 
         ImageFactory& operator=(const ImageFactory& rhs) = delete;
-        ImageFactory& operator=(const ImageFactory&& rhs) = delete;
         ImageFactory(const ImageFactory& rhs) = delete;
-        ImageFactory(const ImageFactory&& rhs) = delete;
     };  // class ImageFactory
 
 // *****************************************************************************

--- a/include/exiv2/image_types.hpp
+++ b/include/exiv2/image_types.hpp
@@ -1,0 +1,56 @@
+// ***************************************************************** -*- C++ -*-
+/*
+ * Copyright (C) 2004-2019 Exiv2 authors
+ * This program is part of the Exiv2 distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef IMAGE_TYPES_H
+#define IMAGE_TYPES_H
+
+namespace Exiv2 {
+    /// Supported Image Formats
+    enum class ImageType{
+        none,       ///<
+        jpeg,       ///<
+        exv,        ///<
+        crw,        ///<
+        tiff,       ///<
+        dng,
+        nef,
+        pef,
+        arw,
+        sr2,
+        srw,
+        mrw,        ///<
+        png,        ///<
+        cr2,        ///<
+        raf,        ///<
+        orf,        ///<
+        xmp,        ///< XMP sidecar files
+        gif,        ///< GIF
+        psd,        ///< Photoshop (PSD)
+        tga,        ///<
+        bmp,        ///< Windows bitmap
+        jp2,        ///< JPEG-2000
+        rw2,        ///<
+        pgf,        ///<
+        webp,       ///<
+        bigtiff,    ///<
+    };
+}
+
+#endif // IMAGE_TYPES_H

--- a/include/exiv2/image_types.hpp
+++ b/include/exiv2/image_types.hpp
@@ -21,36 +21,38 @@
 #ifndef IMAGE_TYPES_H
 #define IMAGE_TYPES_H
 
-namespace Exiv2 {
+namespace Exiv2
+{
     /// Supported Image Formats
-    enum class ImageType{
-        none,       ///<
-        jpeg,       ///<
-        exv,        ///<
-        crw,        ///<
-        tiff,       ///<
-        dng,
-        nef,
-        pef,
+    enum class ImageType
+    {
+        none,
         arw,
+        bigtiff,
+        bmp,        ///< Windows bitmap
+        cr2,
+        crw,
+        dng,
+        exv,
+        gif,        ///< GIF
+        jp2,        ///< JPEG-2000
+        jpeg,
+        mrw,
+        nef,
+        orf,
+        pef,
+        png,
+        pgf,
+        psd,        ///< Photoshop (PSD)
+        raf,
+        rw2,
         sr2,
         srw,
-        mrw,        ///<
-        png,        ///<
-        cr2,        ///<
-        raf,        ///<
-        orf,        ///<
+        tga,
+        tiff,
+        webp,
         xmp,        ///< XMP sidecar files
-        gif,        ///< GIF
-        psd,        ///< Photoshop (PSD)
-        tga,        ///<
-        bmp,        ///< Windows bitmap
-        jp2,        ///< JPEG-2000
-        rw2,        ///<
-        pgf,        ///<
-        webp,       ///<
-        bigtiff,    ///<
     };
-}
+}  // namespace Exiv2
 
-#endif // IMAGE_TYPES_H
+#endif  // IMAGE_TYPES_H

--- a/include/exiv2/image_types.hpp
+++ b/include/exiv2/image_types.hpp
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef IMAGE_TYPES_H
-#define IMAGE_TYPES_H
+#ifndef INCLUDE_EXIV2_IMAGE_TYPES_H
+#define INCLUDE_EXIV2_IMAGE_TYPES_H
 
 namespace Exiv2
 {
@@ -55,4 +55,4 @@ namespace Exiv2
     };
 }  // namespace Exiv2
 
-#endif  // IMAGE_TYPES_H
+#endif  // INCLUDE_EXIV2_IMAGE_TYPES_H

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -39,12 +39,6 @@ namespace Exiv2
 // *****************************************************************************
 // class definitions
 
-    // Add JPEG-2000 to the supported image formats
-    namespace ImageType
-    {
-        const int jp2 = 15;                     //!< JPEG-2000 image type
-    }
-
     /*!
       @brief Class to access JPEG-2000 images.
      */

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -46,12 +46,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Supported JPEG image formats
-    namespace ImageType {
-        const int jpeg = 1;         //!< JPEG image type (see class JpegImage)
-        const int exv  = 2;         //!< EXV image type (see class ExvImage)
-    }
-
     /*!
       @brief Helper class, has methods to deal with %Photoshop "Information
              Resource Blocks" (IRBs).
@@ -178,7 +172,7 @@ namespace Exiv2 {
               valid image of the calling subclass.
           @param dataSize Size of initData in bytes.
          */
-        JpegBase(int              type,
+        JpegBase(ImageType       type,
                  BasicIo::UniquePtr io,
                  bool             create,
                  const byte       initData[],

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -41,11 +41,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add MRW to the supported image formats
-    namespace ImageType {
-        const int mrw = 5;          //!< MRW image type (see class MrwImage)
-    }
-
     /*!
       @brief Class to access raw Minolta MRW images. Exif metadata is supported
              directly, IPTC is read from the Exif data, if present.

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add ORF to the supported image formats
-    namespace ImageType {
-        const int orf = 9;          //!< ORF image type (see class OrfImage)
-    }
-
     /*!
       @brief Class to access raw Olympus ORF images. Exif metadata is supported
              directly, IPTC is read from the Exif data, if present.

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -44,12 +44,6 @@ namespace Exiv2
 // *****************************************************************************
 // class definitions
 
-    // Add PGF to the supported image formats
-    namespace ImageType
-    {
-        const int pgf = 17;          //!< PGF image type (see class PgfImage)
-    }
-
     /*!
       @brief Class to access PGF images. Exif and IPTC metadata are supported
           directly.

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -45,12 +45,6 @@ namespace Exiv2
 // *****************************************************************************
 // class definitions
 
-    // Add PNG to the supported image formats
-    namespace ImageType
-    {
-        const int png = 6;          //!< PNG image type (see class PngImage)
-    }
-
     /*!
       @brief Class to access PNG images. Exif and IPTC metadata are supported
           directly.

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -43,11 +43,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add PSD to the supported image formats
-    namespace ImageType {
-        const int psd = 12; //!< Photoshop (PSD) image type (see class PsdImage)
-    }
-
     /*!
       @brief Class to access raw Photoshop images.
      */

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -45,11 +45,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add RAF to the supported image formats
-    namespace ImageType {
-        const int raf = 8;          //!< RAF image type (see class RafImage)
-    }
-
     /*!
       @brief Class to access raw Fujifilm RAF images. Exif metadata is
           supported directly, IPTC is read from the Exif data, if present.

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add RW2 to the supported image formats
-    namespace ImageType {
-        const int rw2 = 16;             //!< RW2 image type (see class Rw2Image)
-    }
-
     /*!
       @brief Class to access raw Panasonic RW2 images.  Exif metadata is
           supported directly, IPTC and XMP are read from the Exif data, if

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -42,11 +42,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add TARGA to the supported image formats
-    namespace ImageType {
-        const int tga = 13; //!< Truevision TARGA (tga) image type (see class TgaImage)
-    }
-
     /*!
       @brief Class to access raw TARGA images. This is just a stub - we only
           read width and height.

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -37,17 +37,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add TIFF to the supported image formats
-    namespace ImageType {
-        const int tiff = 4;          //!< TIFF image type (see class TiffImage)
-        const int dng = 4;           //!< DNG image type (see class TiffImage)
-        const int nef = 4;           //!< NEF image type (see class TiffImage)
-        const int pef = 4;           //!< PEF image type (see class TiffImage)
-        const int arw = 4;           //!< ARW image type (see class TiffImage)
-        const int sr2 = 4;           //!< SR2 image type (see class TiffImage)
-        const int srw = 4;           //!< SRW image type (see class TiffImage)
-    }
-
     /*!
       @brief Class to access TIFF images. Exif metadata is
           supported directly, IPTC is read from the Exif data, if present.

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -488,7 +488,7 @@ namespace Exiv2 {
     const T* find(T (&src)[N], const K& key)
     {
         const T* rc = std::find(src, src + N, key);
-        return rc == src + N ? 0 : rc;
+        return rc == src + N ? nullptr : rc;
     }
 
     //! Template used in the COUNTOF macro to determine the size of an array

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -90,16 +90,39 @@ namespace Exiv2 {
     typedef std::pair<int32_t, int32_t> Rational;
 
     //! Type to express the byte order (little or big endian)
-    enum ByteOrder { invalidByteOrder, littleEndian, bigEndian };
+    enum ByteOrder
+    {
+        invalidByteOrder,
+        littleEndian,
+        bigEndian,
+    };
 
     //! Type to indicate write method used by TIFF parsers
-    enum WriteMethod { wmIntrusive, wmNonIntrusive };
+    enum WriteMethod
+    {
+        wmIntrusive,
+        wmNonIntrusive,
+    };
 
     //! An identifier for each type of metadata
-    enum MetadataId { mdNone=0, mdExif=1, mdIptc=2, mdComment=4, mdXmp=8, mdIccProfile=16 };
+    enum MetadataId
+    {
+        mdNone = 0,
+        mdExif = 1,
+        mdIptc = 2,
+        mdComment = 4,
+        mdXmp = 8,
+        mdIccProfile = 16,
+    };
 
     //! An identifier for each mode of metadata support
-    enum AccessMode { amNone=0, amRead=1, amWrite=2, amReadWrite=3 };
+    enum AccessMode
+    {
+        amNone = 0,
+        amRead = 1,
+        amWrite = 2,
+        amReadWrite = 3,
+    };
 
     /*!
       @brief %Exiv2 value type identifiers.

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add WEBP to the supported image formats
-    namespace ImageType {
-        const int webp = 23; //!< Treating webp as an image type>
-    }
-
     /*!
       @brief Class to access WEBP video files.
      */

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -40,11 +40,6 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    // Add XMP to the supported image formats
-    namespace ImageType {
-        const int xmp = 10;          //!< XMP sidecar files (see class XmpSidecar)
-    }
-
     /*!
       @brief Class to access XMP sidecar files. They contain only XMP metadata.
      */

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -115,7 +115,7 @@ namespace {
     */
     int metacopy(const std::string& source,
                  const std::string& target,
-                 int targetType,
+                 Exiv2::ImageType targetType,
                  bool preserve);
 
     /*!
@@ -2073,7 +2073,7 @@ namespace {
 
     int metacopy(const std::string& source,
                  const std::string& tgt,
-                 int targetType,
+                 Exiv2::ImageType targetType,
                  bool preserve)
     {
 #ifdef DEBUG

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1369,9 +1369,13 @@ namespace Exiv2 {
     {
         long avail = EXV_MAX(p_->size_ - p_->idx_, 0);
         long allow = EXV_MIN(rcount, avail);
+        if (p_->data_ == nullptr) {
+            throw Error(kerCallFailed, "std::memcpy with src == nullptr");
+        }
         std::memcpy(buf, &p_->data_[p_->idx_], allow);
         p_->idx_ += allow;
-        if (rcount > avail) p_->eof_ = true;
+        if (rcount > avail)
+            p_->eof_ = true;
         return allow;
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -803,7 +803,7 @@ namespace Exiv2 {
     }
 
 #ifdef EXV_UNICODE_PATH
-    int ImageFactory::getType(const std::wstring& wpath)
+    ImageType ImageFactory::getType(const std::wstring& wpath)
     {
         FileIo fileIo(wpath);
         return getType(fileIo);
@@ -944,7 +944,7 @@ namespace Exiv2 {
         fileIo->close();
         BasicIo::UniquePtr io(std::move(fileIo));
         Image::UniquePtr image = create(type, std::move(io));
-        if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+        if (image.get() == 0) throw Error(kerUnsupportedImageType, static_cast<int>(type));
         return image;
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -916,8 +916,7 @@ namespace Exiv2 {
         return Image::UniquePtr();
     } // ImageFactory::open
 
-    Image::UniquePtr ImageFactory::create(ImageType type,
-                                        const std::string& path)
+    Image::UniquePtr ImageFactory::create(ImageType type, const std::string& path)
     {
         std::unique_ptr<FileIo> fileIo(new FileIo(path));
         // Create or overwrite the file, then close it
@@ -963,10 +962,12 @@ namespace Exiv2 {
     {
         // BasicIo instance does not need to be open
         const Registry* r = find(registry, type);
-        if (0 != r) {
-            return r->newInstance_(std::move(io), true);
+
+        if (r == nullptr || type == ImageType::none) {
+            return Image::UniquePtr();
         }
-        return Image::UniquePtr();
+
+        return r->newInstance_(std::move(io), true);
     } // ImageFactory::create
 
 // *****************************************************************************

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -95,6 +95,7 @@ namespace {
         AccessMode     commentSupport_;
     };
 
+    /// \todo Use std::unordered_map for implementing the registry. Avoid to use ImageType::none
     const Registry registry[] = {
         //image type       creation fct     type check  Exif mode    IPTC mode    XMP mode     Comment mode
         //---------------  ---------------  ----------  -----------  -----------  -----------  ------------

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -793,7 +793,7 @@ namespace Exiv2 {
             return r->isThisType_(io, advance);
         }
         return false;
-    } // ImageFactory::checkType
+    }
 
     ImageType ImageFactory::getType(const std::string& path)
     {
@@ -854,7 +854,7 @@ namespace Exiv2 {
         return BasicIo::UniquePtr(new FileIo(path));
 
         (void)(useCurl);
-    } // ImageFactory::createIo
+    }
 
 #ifdef EXV_UNICODE_PATH
     BasicIo::UniquePtr ImageFactory::createIo(const std::wstring& wpath, bool useCurl)
@@ -877,7 +877,7 @@ namespace Exiv2 {
         if (fProt == pStdin || fProt == pDataUri)
             return BasicIo::UniquePtr(new XPathIo(wpath)); // may throw
         return BasicIo::UniquePtr(new FileIo(wpath));
-    } // ImageFactory::createIo
+    }
 #endif
     Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
     {
@@ -914,7 +914,7 @@ namespace Exiv2 {
             }
         }
         return Image::UniquePtr();
-    } // ImageFactory::open
+    }
 
     Image::UniquePtr ImageFactory::create(ImageType type, const std::string& path)
     {
@@ -968,7 +968,7 @@ namespace Exiv2 {
         }
 
         return r->newInstance_(std::move(io), true);
-    } // ImageFactory::create
+    }
 
 // *****************************************************************************
 // template, inline and free functions
@@ -984,6 +984,6 @@ namespace Exiv2 {
             blob.resize(size + len);
             std::memcpy(&blob[size], buf, len);
         }
-    } // append
+    }
 
 }                                       // namespace Exiv2

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -301,7 +301,7 @@ namespace Exiv2 {
 
     } // Photoshop::setIptcIrb
 
-    JpegBase::JpegBase(int type, BasicIo::UniquePtr io, bool create,
+    JpegBase::JpegBase(ImageType type, BasicIo::UniquePtr io, bool create,
                        const byte initData[], long dataSize)
         : Image(type, mdExif | mdIptc | mdXmp | mdComment, std::move(io))
     {

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_helper_functions.cpp
     test_slice.cpp
     test_image_int.cpp
+    test_ImageFactory.cpp
     $<TARGET_OBJECTS:exiv2lib_int>
 )
 

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -18,7 +18,11 @@ add_executable(unit_tests mainTestRunner.cpp
     $<TARGET_OBJECTS:exiv2lib_int>
 )
 
-#TODO Use GTest::GTest once we upgrade the minimum CMake version required
+target_compile_definitions(unit_tests
+    PRIVATE
+        TESTDATA_PATH="${PROJECT_SOURCE_DIR}/test/data"
+)
+
 target_link_libraries(unit_tests
     PRIVATE
         exiv2lib

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -9,47 +9,47 @@ using namespace Exiv2;
 TEST(TheImageFactory, createsInstancesForFewSupportedTypesInMemory)
 {
     // Note that the constructor of these Image classes take an 'create' argument
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::exv));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::png));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::jp2));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::jpeg));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::exv));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::pgf));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::png));
 }
 
 TEST(TheImageFactory, cannotCreateInstancesForMostTypesInMemory)
 {
     // Note that the constructor of these Image classes does not take an 'create' argument
 
-    EXPECT_THROW(ImageFactory::create(ImageType::bmp), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::cr2), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::crw), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::gif), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::mrw), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::orf), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::psd), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::raf), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::rw2), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::webp), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::bmp), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::cr2), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::crw), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::gif), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::mrw), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::orf), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::psd), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::raf), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::rw2), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::tga), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::webp), Error);
 
     // TIFF
-    EXPECT_THROW(ImageFactory::create(ImageType::tiff), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::dng), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::nef), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::pef), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::arw), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::sr2), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::srw), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::tiff), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::dng), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::nef), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::pef), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::arw), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::sr2), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::srw), Error);
 }
 
 TEST(TheImageFactory, throwsWithImageTypeNone)
 {
-    EXPECT_THROW(ImageFactory::create(ImageType::none), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::none), Error);
 }
 
 TEST(TheImageFactory, throwsWithNonExistingImageTypes)
 {
-    EXPECT_THROW(ImageFactory::create(static_cast<ImageType>(666)), Error);
+    ASSERT_THROW(ImageFactory::create(static_cast<ImageType>(666)), Error);
 }
 
 
@@ -58,13 +58,13 @@ TEST(TheImageFactory, createsInstancesForFewSupportedTypesInFiles)
     const std::string filePath("./here");
 
     // Note that the constructor of these Image classes take an 'create' argument
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2, filePath));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, filePath));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath));
-    EXPECT_NO_THROW(ImageFactory::create(ImageType::png, filePath));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::jp2, filePath));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::exv, filePath));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath));
+    ASSERT_NO_THROW(ImageFactory::create(ImageType::png, filePath));
 
-    EXPECT_EQ(0, std::remove(filePath.c_str()));
+    ASSERT_EQ(0, std::remove(filePath.c_str()));
 }
 
 TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles)
@@ -72,26 +72,26 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles)
     const std::string filePath("./here");
 
     // Note that the constructor of these Image classes does not take an 'create' argument
-    EXPECT_THROW(ImageFactory::create(ImageType::bmp, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::cr2, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::crw, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::gif, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::mrw, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::orf, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::psd, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::raf, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::rw2, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::tga, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::webp, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::bmp, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::cr2, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::crw, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::gif, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::mrw, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::orf, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::psd, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::raf, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::rw2, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::tga, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::webp, filePath), Error);
 
     // TIFF
-    EXPECT_THROW(ImageFactory::create(ImageType::tiff, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::dng, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::nef, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::pef, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::arw, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::sr2, filePath), Error);
-    EXPECT_THROW(ImageFactory::create(ImageType::srw, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::tiff, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::dng, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::nef, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::pef, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::arw, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::sr2, filePath), Error);
+    ASSERT_THROW(ImageFactory::create(ImageType::srw, filePath), Error);
 }
 
 TEST(TheImageFactory, loadInstancesDifferentImageTypes)
@@ -99,297 +99,297 @@ TEST(TheImageFactory, loadInstancesDifferentImageTypes)
     /// \todo use filesystem library with C++17
     std::string testData(TESTDATA_PATH);
 
-    EXPECT_EQ(ImageType::jpeg, ImageFactory::getType(testData + "/DSC_3079.jpg"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/DSC_3079.jpg", false));
+    ASSERT_EQ(ImageType::jpeg, ImageFactory::getType(testData + "/DSC_3079.jpg"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/DSC_3079.jpg", false));
 
-    EXPECT_EQ(ImageType::exv, ImageFactory::getType(testData + "/exiv2-bug1108.exv"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1108.exv", false));
+    ASSERT_EQ(ImageType::exv, ImageFactory::getType(testData + "/exiv2-bug1108.exv"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1108.exv", false));
 
-    EXPECT_EQ(ImageType::crw, ImageFactory::getType(testData + "/exiv2-canon-powershot-s40.crw"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-canon-powershot-s40.crw", false));
+    ASSERT_EQ(ImageType::crw, ImageFactory::getType(testData + "/exiv2-canon-powershot-s40.crw"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/exiv2-canon-powershot-s40.crw", false));
 
-    EXPECT_EQ(ImageType::tiff, ImageFactory::getType(testData + "/exiv2-bug1044.tif"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1044.tif", false));
+    ASSERT_EQ(ImageType::tiff, ImageFactory::getType(testData + "/exiv2-bug1044.tif"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1044.tif", false));
 
-    EXPECT_EQ(ImageType::png, ImageFactory::getType(testData + "/exiv2-bug1074.png"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1074.png", false));
+    ASSERT_EQ(ImageType::png, ImageFactory::getType(testData + "/exiv2-bug1074.png"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1074.png", false));
 
-    EXPECT_EQ(ImageType::xmp, ImageFactory::getType(testData + "/BlueSquare.xmp"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/BlueSquare.xmp", false));
+    ASSERT_EQ(ImageType::xmp, ImageFactory::getType(testData + "/BlueSquare.xmp"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/BlueSquare.xmp", false));
 
-    EXPECT_EQ(ImageType::psd, ImageFactory::getType(testData + "/exiv2-photoshop.psd"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-photoshop.psd", false));
+    ASSERT_EQ(ImageType::psd, ImageFactory::getType(testData + "/exiv2-photoshop.psd"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/exiv2-photoshop.psd", false));
 
-    EXPECT_EQ(ImageType::webp, ImageFactory::getType(testData + "/cve_2017_1000126_stack-oob-read.webp"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/cve_2017_1000126_stack-oob-read.webp", false));
+    ASSERT_EQ(ImageType::webp, ImageFactory::getType(testData + "/cve_2017_1000126_stack-oob-read.webp"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/cve_2017_1000126_stack-oob-read.webp", false));
 
-    EXPECT_EQ(ImageType::pgf, ImageFactory::getType(testData + "/imagemagick.pgf"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/imagemagick.pgf", false));
+    ASSERT_EQ(ImageType::pgf, ImageFactory::getType(testData + "/imagemagick.pgf"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/imagemagick.pgf", false));
 
-    EXPECT_EQ(ImageType::jp2, ImageFactory::getType(testData + "/Reagan.jp2"));
-    EXPECT_NO_THROW(ImageFactory::open(testData + "/Reagan.jp2", false));
+    ASSERT_EQ(ImageType::jp2, ImageFactory::getType(testData + "/Reagan.jp2"));
+    ASSERT_NO_THROW(ImageFactory::open(testData + "/Reagan.jp2", false));
 }
 
 TEST(TheImageFactory, getsExpectedModesForJp2Images)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForJpegImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdXmp));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdXmp));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForExvImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdXmp));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdXmp));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForPgfImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdXmp));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdXmp));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdIccProfile));
 }
 
 #ifdef EXV_HAVE_LIBZ
 TEST(TheImageFactory, getsExpectedModesForPngImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdXmp));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdXmp));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdIccProfile));
 }
 #endif
 
 TEST(TheImageFactory, getsExpectedModesForBmpImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdNone));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIptc));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdNone));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIptc));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForCr2Images)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForCrwImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIptc));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdXmp));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIptc));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdXmp));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForGifImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdNone));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIptc));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdNone));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIptc));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForMrwImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForOrfImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForPsdImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForRafImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForRw2Images)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForTgaImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdNone));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIptc));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdNone));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIptc));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForWebpImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForTiffImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForDngImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForNefImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForPefImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForArwImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForSr2Images)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForSrwImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForXmpImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdNone));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdExif));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdIptc));
-    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdNone));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdExif));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdIptc));
+    ASSERT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForBigTiffImages)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdNone));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdExif));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdIptc));
-    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdNone));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdExif));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdIptc));
+    ASSERT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdIccProfile));
 }
 
 TEST(TheImageFactory, getsExpectedModesForNoneValue)
 {
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdNone));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdExif));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIptc));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdXmp));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdComment));
-    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIccProfile));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdNone));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdExif));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIptc));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdXmp));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdComment));
+    ASSERT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIccProfile));
 }
 
 /// \todo check why JpegBase is taking ImageType in the constructor

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -1,0 +1,103 @@
+#include <image.hpp> // Unit under test
+
+/// \todo we should not need to include all these headers to be able to use the Factory
+#include <jpgimage.hpp>
+#include <bmpimage.hpp>
+#include <cr2image.hpp>
+#include <crwimage.hpp>
+#include <gifimage.hpp>
+#include <jp2image.hpp>
+#include <mrwimage.hpp>
+#include <orfimage.hpp>
+#include <pgfimage.hpp>
+#include <pngimage.hpp>
+#include <psdimage.hpp>
+#include <rafimage.hpp>
+#include <rw2image.hpp>
+#include <tgaimage.hpp>
+#include <tiffimage.hpp>
+#include <webpimage.hpp>
+
+#include <error.hpp> // Need to include this header for the Exiv2::Error exception
+
+#include <gtest/gtest.h>
+
+using namespace Exiv2;
+
+TEST(TheImageFactory, createsInstancesForSupportedTypesInMemory)
+{
+    // Note that the constructor of these Image classes take an 'create' argument
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::exv));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::png));
+}
+
+TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInMemory)
+{
+    // Note that the constructor of these Image classes does not take an 'create' argument
+
+    EXPECT_THROW(ImageFactory::create(ImageType::bmp), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::cr2), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::crw), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::gif), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::mrw), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::orf), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::psd), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::raf), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::rw2), Error);
+//    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error); // This one crashes badly
+    EXPECT_THROW(ImageFactory::create(ImageType::webp), Error);
+
+    // TIFF
+    EXPECT_THROW(ImageFactory::create(ImageType::tiff), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::dng), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::nef), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::pef), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::arw), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::sr2), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::srw), Error);
+}
+
+
+TEST(TheImageFactory, createsInstancesForSupportedTypesInFiles)
+{
+    const std::string filePath("./here");
+
+    // Note that the constructor of these Image classes take an 'create' argument
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2, filePath));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, filePath));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath));
+    EXPECT_NO_THROW(ImageFactory::create(ImageType::png, filePath));
+
+    EXPECT_EQ(0, std::remove(filePath.c_str()));
+}
+
+TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles)
+{
+    const std::string filePath("./here");
+
+    // Note that the constructor of these Image classes does not take an 'create' argument
+    EXPECT_THROW(ImageFactory::create(ImageType::bmp, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::cr2, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::crw, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::gif, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::mrw, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::orf, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::psd, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::raf, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::rw2, filePath), Error);
+//    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error); // This one crashes badly
+    EXPECT_THROW(ImageFactory::create(ImageType::webp, filePath), Error);
+
+    // TIFF
+    EXPECT_THROW(ImageFactory::create(ImageType::tiff, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::dng, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::nef, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::pef, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::arw, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::sr2, filePath), Error);
+    EXPECT_THROW(ImageFactory::create(ImageType::srw, filePath), Error);
+}

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -42,6 +42,11 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInMemory)
     EXPECT_THROW(ImageFactory::create(ImageType::srw), Error);
 }
 
+TEST(TheImageFactory, throwsWithNonExistingImageTypes)
+{
+    EXPECT_THROW(ImageFactory::create(static_cast<ImageType>(666)), Error);
+}
+
 
 TEST(TheImageFactory, createsInstancesForSupportedTypesInFiles)
 {

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -129,3 +129,267 @@ TEST(TheImageFactory, loadInstancesDifferentImageTypes)
     EXPECT_EQ(ImageType::jp2, ImageFactory::getType(testData + "/Reagan.jp2"));
     EXPECT_NO_THROW(ImageFactory::open(testData + "/Reagan.jp2", false));
 }
+
+TEST(TheImageFactory, getsExpectedModesForJp2Images)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jp2, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jp2, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForJpegImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdXmp));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::jpeg, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::jpeg, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForExvImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdXmp));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::exv, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::exv, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForPgfImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdXmp));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pgf, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pgf, mdIccProfile));
+}
+
+#ifdef EXV_HAVE_LIBZ
+TEST(TheImageFactory, getsExpectedModesForPngImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdXmp));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::png, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::png, mdIccProfile));
+}
+#endif
+
+TEST(TheImageFactory, getsExpectedModesForBmpImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdNone));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIptc));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bmp, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForCr2Images)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::cr2, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::cr2, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForCrwImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIptc));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdXmp));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::crw, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::crw, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForGifImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdNone));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIptc));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::gif, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForMrwImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::mrw, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::mrw, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForOrfImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::orf, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::orf, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForPsdImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::psd, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::psd, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForRafImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::raf, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::raf, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForRw2Images)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::rw2, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::rw2, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForTgaImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdNone));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIptc));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tga, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForWebpImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::webp, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::webp, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForTiffImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::tiff, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::tiff, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForDngImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::dng, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::dng, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForNefImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::nef, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::nef, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForPefImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::pef, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::pef, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForArwImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::arw, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::arw, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForSr2Images)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::sr2, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::sr2, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForSrwImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::srw, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::srw, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForXmpImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdNone));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdExif));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdIptc));
+    EXPECT_EQ(amReadWrite, ImageFactory::checkMode(ImageType::xmp, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForBigTiffImages)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdNone));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdExif));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdIptc));
+    EXPECT_EQ(amRead, ImageFactory::checkMode(ImageType::bigtiff, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::bigtiff, mdIccProfile));
+}
+
+TEST(TheImageFactory, getsExpectedModesForNoneValue)
+{
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdNone));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdExif));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIptc));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdXmp));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdComment));
+    EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIccProfile));
+}
+
+/// \todo check why JpegBase is taking ImageType in the constructor

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -1,23 +1,5 @@
 #include <image.hpp> // Unit under test
 
-/// \todo we should not need to include all these headers to be able to use the Factory
-#include <jpgimage.hpp>
-#include <bmpimage.hpp>
-#include <cr2image.hpp>
-#include <crwimage.hpp>
-#include <gifimage.hpp>
-#include <jp2image.hpp>
-#include <mrwimage.hpp>
-#include <orfimage.hpp>
-#include <pgfimage.hpp>
-#include <pngimage.hpp>
-#include <psdimage.hpp>
-#include <rafimage.hpp>
-#include <rw2image.hpp>
-#include <tgaimage.hpp>
-#include <tiffimage.hpp>
-#include <webpimage.hpp>
-
 #include <error.hpp> // Need to include this header for the Exiv2::Error exception
 
 #include <gtest/gtest.h>

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -6,7 +6,7 @@
 
 using namespace Exiv2;
 
-TEST(TheImageFactory, createsInstancesForSupportedTypesInMemory)
+TEST(TheImageFactory, createsInstancesForFewSupportedTypesInMemory)
 {
     // Note that the constructor of these Image classes take an 'create' argument
     EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2));
@@ -16,7 +16,7 @@ TEST(TheImageFactory, createsInstancesForSupportedTypesInMemory)
     EXPECT_NO_THROW(ImageFactory::create(ImageType::png));
 }
 
-TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInMemory)
+TEST(TheImageFactory, cannotCreateInstancesForMostTypesInMemory)
 {
     // Note that the constructor of these Image classes does not take an 'create' argument
 
@@ -29,7 +29,7 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInMemory)
     EXPECT_THROW(ImageFactory::create(ImageType::psd), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::raf), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::rw2), Error);
-//    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error); // This one crashes badly
+    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::webp), Error);
 
     // TIFF
@@ -53,7 +53,7 @@ TEST(TheImageFactory, throwsWithNonExistingImageTypes)
 }
 
 
-TEST(TheImageFactory, createsInstancesForSupportedTypesInFiles)
+TEST(TheImageFactory, createsInstancesForFewSupportedTypesInFiles)
 {
     const std::string filePath("./here");
 
@@ -81,7 +81,7 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles)
     EXPECT_THROW(ImageFactory::create(ImageType::psd, filePath), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::raf, filePath), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::rw2, filePath), Error);
-//    EXPECT_THROW(ImageFactory::create(ImageType::tga), Error); // This one crashes badly
+    EXPECT_THROW(ImageFactory::create(ImageType::tga, filePath), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::webp, filePath), Error);
 
     // TIFF
@@ -92,4 +92,40 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles)
     EXPECT_THROW(ImageFactory::create(ImageType::arw, filePath), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::sr2, filePath), Error);
     EXPECT_THROW(ImageFactory::create(ImageType::srw, filePath), Error);
+}
+
+TEST(TheImageFactory, loadInstancesDifferentImageTypes)
+{
+    /// \todo use filesystem library with C++17
+    std::string testData(TESTDATA_PATH);
+
+    EXPECT_EQ(ImageType::jpeg, ImageFactory::getType(testData + "/DSC_3079.jpg"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/DSC_3079.jpg", false));
+
+    EXPECT_EQ(ImageType::exv, ImageFactory::getType(testData + "/exiv2-bug1108.exv"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1108.exv", false));
+
+    EXPECT_EQ(ImageType::crw, ImageFactory::getType(testData + "/exiv2-canon-powershot-s40.crw"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-canon-powershot-s40.crw", false));
+
+    EXPECT_EQ(ImageType::tiff, ImageFactory::getType(testData + "/exiv2-bug1044.tif"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1044.tif", false));
+
+    EXPECT_EQ(ImageType::png, ImageFactory::getType(testData + "/exiv2-bug1074.png"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-bug1074.png", false));
+
+    EXPECT_EQ(ImageType::xmp, ImageFactory::getType(testData + "/BlueSquare.xmp"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/BlueSquare.xmp", false));
+
+    EXPECT_EQ(ImageType::psd, ImageFactory::getType(testData + "/exiv2-photoshop.psd"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/exiv2-photoshop.psd", false));
+
+    EXPECT_EQ(ImageType::webp, ImageFactory::getType(testData + "/cve_2017_1000126_stack-oob-read.webp"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/cve_2017_1000126_stack-oob-read.webp", false));
+
+    EXPECT_EQ(ImageType::pgf, ImageFactory::getType(testData + "/imagemagick.pgf"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/imagemagick.pgf", false));
+
+    EXPECT_EQ(ImageType::jp2, ImageFactory::getType(testData + "/Reagan.jp2"));
+    EXPECT_NO_THROW(ImageFactory::open(testData + "/Reagan.jp2", false));
 }

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -42,6 +42,11 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInMemory)
     EXPECT_THROW(ImageFactory::create(ImageType::srw), Error);
 }
 
+TEST(TheImageFactory, throwsWithImageTypeNone)
+{
+    EXPECT_THROW(ImageFactory::create(ImageType::none), Error);
+}
+
 TEST(TheImageFactory, throwsWithNonExistingImageTypes)
 {
     EXPECT_THROW(ImageFactory::create(static_cast<ImageType>(666)), Error);


### PR DESCRIPTION
After the first positive impressions gathered in #732, I have created this PR in which I just focus in the addition of the **enum class** `ImageType` to replace the previous namespace in which we were adding global constant values.

Note that the characterisation tests have revealed some bugs that I also fixed in this branch.

If you are happy with the changes, and somebody approves the PR, feel free to merge the branch. I will not be available for some days. 