### PR TITLE
Enable support for msvc 2015

### DIFF
--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -152,7 +152,9 @@ namespace Exiv2 {
         { 0xffff, 0xffff }
     };
 
+#ifndef _MSC_VER
     constexpr char CiffHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
+#endif
 
     CiffHeader::~CiffHeader()
     {

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -227,7 +227,23 @@ namespace Exiv2 {
         return 0;
     }
 
-    constexpr byte OlympusMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
+#ifndef _MSC_VER
+    /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
+    constexpr byte OlympusMnHeader::signature_[]; 
+    constexpr byte Nikon3MnHeader::signature_[];
+    constexpr byte Olympus2MnHeader::signature_[];
+    constexpr byte FujiMnHeader::signature_[];
+    constexpr ByteOrder FujiMnHeader::byteOrder_;
+    constexpr byte Nikon2MnHeader::signature_[];
+    constexpr byte PanasonicMnHeader::signature_[];
+    constexpr byte PentaxDngMnHeader::signature_[];
+    constexpr byte PentaxMnHeader::signature_[];
+    constexpr byte SigmaMnHeader::signature1_[];
+    constexpr byte SigmaMnHeader::signature2_[];
+    constexpr byte SonyMnHeader::signature_[];
+    constexpr byte Casio2MnHeader::signature_[];
+    constexpr ByteOrder Casio2MnHeader::byteOrder_;
+#endif
 
     constexpr uint32_t OlympusMnHeader::sizeOfSignature()
     {
@@ -274,7 +290,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // OlympusMnHeader::write
 
-    constexpr byte Olympus2MnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t Olympus2MnHeader::sizeOfSignature()
     {
@@ -326,8 +341,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // Olympus2MnHeader::write
 
-    constexpr byte FujiMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
-    constexpr ByteOrder FujiMnHeader::byteOrder_; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t FujiMnHeader::sizeOfSignature()
     {
@@ -387,7 +400,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // FujiMnHeader::write
 
-    constexpr byte Nikon2MnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t Nikon2MnHeader::sizeOfSignature()
     {
@@ -432,7 +444,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // Nikon2MnHeader::write
 
-    constexpr byte Nikon3MnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t Nikon3MnHeader::sizeOfSignature()
     {
@@ -505,7 +516,6 @@ namespace Exiv2 {
         byteOrder_ = byteOrder;
     }
 
-    constexpr byte PanasonicMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t PanasonicMnHeader::sizeOfSignature()
     {
@@ -550,7 +560,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // PanasonicMnHeader::write
 
-    constexpr byte PentaxDngMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
     constexpr uint32_t PentaxDngMnHeader::sizeOfSignature()
     {
         return sizeof(signature_);
@@ -601,7 +610,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // PentaxDngMnHeader::write
 
-    constexpr byte PentaxMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t PentaxMnHeader::sizeOfSignature()
     {
@@ -676,8 +684,6 @@ namespace Exiv2 {
         return 0;
     } // SamsungMnHeader::write
 
-    constexpr byte SigmaMnHeader::signature1_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
-    constexpr byte SigmaMnHeader::signature2_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t SigmaMnHeader::sizeOfSignature()
     {
@@ -724,7 +730,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // SigmaMnHeader::write
 
-    constexpr byte SonyMnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t SonyMnHeader::sizeOfSignature()
     {
@@ -769,8 +774,6 @@ namespace Exiv2 {
         return sizeOfSignature();
     } // SonyMnHeader::write
 
-    constexpr byte Casio2MnHeader::signature_[]; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
-    constexpr ByteOrder Casio2MnHeader::byteOrder_; /// \todo Required in C++11, but deprecated in C++17. Remove this line when we move to C++17.
 
     constexpr uint32_t Casio2MnHeader::sizeOfSignature()
     {


### PR DESCRIPTION
This minor change will enable back the support for msvc 2015.

I will also add another job in Appveyor to check that we do not break that. However, I wanted to check first that it is not breaking anything else. 