### PR TITLE
Changes for v0.27.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.3.2 )
 
 project(exiv2
-    VERSION 0.27.1.19
+    VERSION 0.27.1.1
     LANGUAGES CXX C
 )
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ write, delete and modify Exif, IPTC, XMP and ICC image metadata.
 |:------                      |:----     |
 | Project Homepage            | [https://github.com/Exiv2/exiv2](https://github.com/Exiv2/exiv2) |
 | Downloads and Documentation | [https://exiv2.org](https://exiv2.org) |
-| Prereleases:                | [https://prerelease.exiv2.org](https://prerelease.exiv2.org) |
+| Prereleases:                | [https://pre-release.exiv2.org](https://pre-release.exiv2.org) |
 | License (GPLv2)             | [COPYING](COPYING) |
 | CMake Downloads             | [https://cmake.org/download/](https://cmake.org/download/) |
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ write, delete and modify Exif, IPTC, XMP and ICC image metadata.
 | Exiv2 Resource              | Location |
 |:------                      |:----     |
 | Project Homepage            | [https://github.com/Exiv2/exiv2](https://github.com/Exiv2/exiv2) |
-| Downloads and Documentation | [http://exiv2.dyndns.org](http://exiv2.dyndns.org:8080) |
-| BuildServer:                | [http://exiv2.dyndns.org:8080](http://exiv2.dyndns.org:8080) |
-| License (GPLv2)             | [license.txt](license.txt) |
+| Downloads and Documentation | [https://exiv2.org](https://exiv2.org) |
+| Prereleases:                | [https://prerelease.exiv2.org](https://prerelease.exiv2.org) |
+| License (GPLv2)             | [COPYING](COPYING) |
 | CMake Downloads             | [https://cmake.org/download/](https://cmake.org/download/) |
 
 The file ReadMe.txt in a Build bundle describes how to install the library on the platform.  ReadMe.txt also documents how to compile and link code on the platform.
@@ -77,7 +77,7 @@ To execute the exiv2 command line program, you should update your path to search
 $ export PATH="/usr/local/bin:$PATH"
 ```
 
- you'll also need to locate libexiv2 at run time:
+You will also need to locate libexiv2 at run time:
 
 ```bash
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"      # Linux, Cygwin, MinGW/msys2
@@ -202,7 +202,6 @@ $
 
 The default cmake Generator is usually appropriate for your platform.  Additional information concerning Generators for Visual Studio in [README-CONAN](README-CONAN.md)
 
-
 [TOC](#TOC)
 <name id="2-7">
 ### 2.7 Using pkg-config to compile and link your code with Exiv2
@@ -301,16 +300,12 @@ $
 
 Open a new issue on https://github.com/exiv2/exiv2 and attach the file po/xy/exiv2.po
 
-
 [TOC](#TOC)
 <name id="2-9">
 ### 2.9 Building Exiv2 Documentation
 
 Building documentation requires installing special tools.  You will probably prefer to
-read the documentation on-line from the project website: http://exiv2.dyndns.org
-
-Additionally, complete copies of the project website are archived on the buildserver
-and can be downloaded for off-line use.  http://exiv2.dyndns.org:8080/userContent/builds/Website/
+read the documentation on-line from the project website: https://exiv2.org
 
 To build documentation, use the CMake option **`-DEXIV2_BUILD_DOC=On`**.
 Additionally, you will require an additional build step to actually build the documentation.
@@ -352,7 +347,7 @@ $ cmake --build . --config Release
 [100%] Built target addmoddel
 $ make package
 ...
-CPack: - package: /path/to/exiv2/build/exiv2-0.27.0.1-Linux.tar.gz generated.
+CPack: - package: /path/to/exiv2/build/exiv2-0.27.1-Linux.tar.gz generated.
 ```
 
 2) Source Package
@@ -361,11 +356,10 @@ CPack: - package: /path/to/exiv2/build/exiv2-0.27.0.1-Linux.tar.gz generated.
 $ make package_source
 Run CPack packaging tool for source...
 ...
-CPack: - package: /path/to/exiv2/build/exiv2-0.27.0.1-Source.tar.gz generated.
+CPack: - package: /path/to/exiv2/build/exiv2-0.27.1-Source.tar.gz generated.
 ```
 
 You may prefer to run `$ cmake --build . --config Release --target package_source`
-
 
 [TOC](#TOC)
 <name id="2-11">
@@ -390,7 +384,7 @@ You can check that you have generated a debug build with the command:
 
 ```bash
 $ exiv2 -vVg debug
-exiv2 0.27.0.3
+exiv2 0.27.1
 debug=1
 $
 ```
@@ -736,7 +730,7 @@ The exiv2 command line program provides an option **`--grep`** to filter output.
 
 ```bash
 $ exiv2 -vVg regex
-exiv2 0.27.0.3
+exiv2 0.27.1
 have_regex=1
 $
 ```
@@ -770,7 +764,6 @@ set "PS1=\! CYGWIN64:\u@\h:\w \$ "
 bash.exe -norc
 ```
 
-
 [TOC](#TOC)
 <name id="5-5">
 ### 5.5 Microsoft Visual C++
@@ -795,4 +788,4 @@ cmd
 
 [TOC](#TOC)
 
-Written by Robin Mills<br>robin@clanmills.com<br>Updated: 2018-12-01
+Written by Robin Mills<br>robin@clanmills.com<br>Revised: 2019-03-29

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ g++ -std=c++98 myprog.cpp -o myprog -I/usr/local/include -L/usr/local/lib -lex
 <name id="2-6">
 ### 2.6 Consuming Exiv2 with CMake
 
-When exiv2 is installed, the files required to consume Exiv2 are installed in `${CMAKE_INSTALL_PREFIX}/share/exiv2/cmake/`
+When exiv2 is installed, the files required to consume Exiv2 are installed in `${CMAKE_INSTALL_PREFIX}/lib/exiv2/cmake/`
 
 You can build samples/exifprint.cpp as follows:
 
@@ -189,9 +189,9 @@ project(exifprint VERSION 0.0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(exiv2 REQUIRED CONFIG NAMES exiv2)    # search ${CMAKE_INSTALL_PREFIX}/share/exiv2/cmake/
+find_package(exiv2 REQUIRED CONFIG NAMES exiv2)    # search ${CMAKE_INSTALL_PREFIX}/lib/exiv2/cmake/
 add_executable(exifprint ../samples/exifprint.cpp) # compile this
-target_link_libraries(exifprint exiv2)             # link exiv2
+target_link_libraries(exifprint exiv2lib)          # link exiv2lib
 
 $ cmake .                                          # generate the makefile
 $ make                                             # build the code

--- a/releasenotes/CYGWIN/ReadMe.txt
+++ b/releasenotes/CYGWIN/ReadMe.txt
@@ -1,24 +1,25 @@
-CYGWIN Exiv2 v0.27 Release Bundle
----------------------------------
+CYGWIN Exiv2 v0.27.1 Release Bundle
+-----------------------------------
 
 Structure of the bundle:
 ------------------------
 
-bin/exiv2.exe                             exiv2 and sample applications
-bin/cygexiv2-27.dll                       DLL
-lib/libexiv2.dll.a & libxmp.a             link libraries
-lib/pkgconfig/exiv2.pc                    pkg-config file
-share/man                                 man pages
-share/exiv2/cmake                         consume CMake files
-samples/exifprint.cpp                     sample code
-logs                                      build and test logs
+bin/exiv2.exe                                 exiv2 and sample applications
+bin/cygexiv2-27.dll                           DLL
+lib/libexiv2.dll.a & libexiv2-xmp.a           link libraries
+lib/exiv2/cmake/                              CMake support/consume files
+lib/pkgconfig/exiv2.pc                        pkg-config file
+share/man/                                    man pages
+share/locale/                                 localisation files
+samples/exifprint.cpp                         sample code
+logs                                          build and test logs
 
-ReadMe.txt                                This file
-license.txt                               GPLv2.0 Software License
-releasenotes.txt                          Late breaking news
-README.md                                 Developer Manual
-README-CONAN.md                           Developer Manual Appendix
-exiv2.png                                 Exiv2 Logo
+ReadMe.txt                                    This file
+exiv2.png                                     Exiv2 Logo
+license.txt                                   GPLv2.0 Software License
+README.md                                     Developer Manual
+README-CONAN.md                               Developer Manual Appendix
+releasenotes.txt                              Late breaking news
 
 To run exiv2 from the bundle
 ----------------------------
@@ -41,7 +42,7 @@ $ cd <bundle>
 $ g++ -std=gnu++98 samples/exifprint.cpp -I/usr/local/include -L/usr/local/lib -lexiv2 -o exifprint
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 $ ./exifprint --version
-exiv2=0.27.0
+exiv2=0.27.1
 ...
 xmlns=xmpidq:http://ns.adobe.com/xmp/Identifier/qual/1.0/
 $
@@ -60,7 +61,7 @@ To compile and link your own code using installed library and include files
 $ g++ -std=gnu++98 samples/exifprint.cpp -I/usr/include -I/usr/local/include -L/usr/local/lib -lexiv2 -o exifprint
 $ export PATH="/usr/local/bin:$PATH"
 $ ./exifprint --version
-exiv2=0.27.0
+exiv2=0.27.1
 ...
 xmlns=xmpidq:http://ns.adobe.com/xmp/Identifier/qual/1.0/
 $

--- a/releasenotes/Darwin/ReadMe.txt
+++ b/releasenotes/Darwin/ReadMe.txt
@@ -1,24 +1,25 @@
-MacOS-X (Darwin) Exiv2 v0.27 Release Bundle
--------------------------------------------
+MacOS-X (Darwin) Exiv2 v0.27.1 Release Bundle
+---------------------------------------------
 
 Structure of the bundle
 -----------------------
 
-bin/exiv2                                 exiv2 and sample applications
-lib/libexiv2.0.27.0.0.dylib & libxmp.a    libraries
-lib/pkgconfig/exiv2.pc                    pkg-config file
-include/exiv2/                            include files
-share/man                                 man pages
-share/exiv2/cmake                         consume CMake files
-samples/exifprint.cpp                     sample code
-logs                                      build and test logs
+bin/exiv2                                     exiv2 and sample applications
+lib/libexiv2.0.27.1.0.dylib & libexiv2-xmp.a  libraries
+lib/pkgconfig/exiv2.pc                        pkg-config file
+lib/exiv2/cmake/                              CMake support/consume files
+include/exiv2/                                include files
+share/man/                                    man pages
+share/locale/                                 localisation files
+samples/exifprint.cpp                         sample code
+logs/                                         build and test logs
 
-ReadMe.txt                                This file
-license.txt                               GPLv2.0 Software License
-releasenotes.txt                          Late breaking news
-README.md                                 Developer Manual
-README-CONAN.md                           Developer Manual Appendix
-exiv2.png                                 Exiv2 Logo
+ReadMe.txt                                    This file
+exiv2.png                                     Exiv2 Logo
+license.txt                                   GPLv2.0 Software License
+README.md                                     Developer Manual
+README-CONAN.md                               Developer Manual Appendix
+releasenotes.txt                              Late breaking news
 
 To run exiv2 from the bundle
 ----------------------------
@@ -39,7 +40,7 @@ To compile and link your own code using installed library and include files
 Method 1: Explicitly set include and linking options
 $ g++ -std=c++98 samples/exifprint.cpp -I/usr/local/include -L/usr/local/lib -lexiv2 -o exifprint
 $ ./exifprint --version
-exiv2=0.27.0
+exiv2=0.27.1
 ...
 xmlns=xmpidq:http://ns.adobe.com/xmp/Identifier/qual/1.0/
 $
@@ -47,7 +48,10 @@ $
 Method 2: Use pkg-config to set include and linking options
 $ cd <bundle>
 $ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
-$ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 $ g++ -std=c++98 samples/exifprint.cpp -o exifprint $(pkg-config exiv2 --libs --cflags)
 $ ./exifprint
+
+Method 3: Use the CMake support/consume files
+See file: README.md Section: 2.6 "Consuming Exiv2 with CMake"
+
 

--- a/releasenotes/Linux/ReadMe.txt
+++ b/releasenotes/Linux/ReadMe.txt
@@ -1,23 +1,25 @@
-Linux Exiv2 v0.27 Release Bundle
---------------------------------
+Linux Exiv2 v0.27.1 Release Bundle
+----------------------------------
 
 Structure of the bundle:
 ------------------------
 
-bin/exiv2                                 exiv2 and sample applications
-lib/libexiv2.so.0.27.0.0 & libxmp.a       libraries
-lib/pkgconfig/exiv2.pc                    pkg-config file
-include/exiv2/                            include files
-share/                                    man pages
-samples/exifprint.cpp                     sample code
-logs                                      build and test logs
+bin/exiv2                                     exiv2 and sample applications
+lib/libexiv2.so.0.27.1.0 & libexiv2-xmp.a     libraries
+lib/pkgconfig/exiv2.pc                        pkg-config file
+lib/exiv2/cmake/                              CMake support/consume files
+include/exiv2/                                include files
+share/man/                                    man pages
+share/locale/                                 localisation files
+samples/exifprint.cpp                         sample code
+logs/                                         build and test logs
 
-ReadMe.txt                                This file
-license.txt                               GPLv2.0 Software License
-releasenotes.txt                          Late breaking news
-README.md                                 Developer Manual
-README-CONAN.md                           Developer Manual Appendix
-exiv2.png                                 Exiv2 Logo
+ReadMe.txt                                    This file
+license.txt                                   GPLv2.0 Software License
+releasenotes.txt                              Late breaking news
+README.md                                     Developer Manual
+README-CONAN.md                               Developer Manual Appendix
+exiv2.png                                     Exiv2 Logo
 
 To run exiv2 from the bundle
 ----------------------------
@@ -40,7 +42,7 @@ $ cd <bundle>
 $ g++ -std=c++98 samples/exifprint.cpp -I/usr/local/include -L/usr/local/lib -lexiv2 -o exifprint
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 $ ./exifprint --version
-exiv2=0.27.0
+exiv2=0.27.1
 ...
 xmlns=xmpidq:http://ns.adobe.com/xmp/Identifier/qual/1.0/
 $
@@ -51,4 +53,7 @@ $ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 $ g++ -std=c++98 samples/exifprint.cpp -o exifprint $(pkg-config exiv2 --libs --cflags)
 $ ./exifprint
+
+Method 3: Use the CMake support/consume files
+See file: README.md Section: 2.6 "Consuming Exiv2 with CMake"
 

--- a/releasenotes/MinGW/ReadMe.txt
+++ b/releasenotes/MinGW/ReadMe.txt
@@ -1,25 +1,26 @@
-MinGW/msys2 Exiv2 v0.27 Release Bundle
---------------------------------------
+MinGW/msys2 Exiv2 v0.27.1 Release Bundle
+----------------------------------------
 
 Structure of the bundle:
 ------------------------
 
-bin/exiv2.exe                             exiv2 and sample applications
-bin/msys-exiv2-27.dll                     exiv2 dll
-lib/libexiv2.dll.a & libxmp.a             link libraries
-lib/pkgconfig/exiv2.pc                    pkg-config file
-include/exiv2/                            include files
-share/man                                 man pages
-share/exiv2/cmake                         consume CMake files
-samples/exifprint.cpp                     sample code
-logs                                      build and test logs
+bin/exiv2.exe                                 exiv2 and sample applications
+bin/msys-exiv2-27.dll                         exiv2 dll
+lib/libexiv2.dll.a & libexiv2-xmp.a           link libraries
+lib/pkgconfig/exiv2.pc                        pkg-config file
+lib/exiv2/cmake/                              CMake support/consume files
+include/exiv2/                                include files
+share/man/                                    man pages
+share/locale/                                 localisation files
+samples/exifprint.cpp                         sample code
+logs                                          build and test logs
 
-ReadMe.txt                                This file
-license.txt                               GPLv2.0 Software License
-releasenotes.txt                          Late breaking news
-README.md                                 Developer Manual
-README-CONAN.md                           Developer Manual Appendix
-exiv2.png                                 Exiv2 Logo
+ReadMe.txt                                    This file
+exiv2.png                                     Exiv2 Logo
+license.txt                                   GPLv2.0 Software License
+README.md                                     Developer Manual
+README-CONAN.md                               Developer Manual Appendix
+releasenotes.txt                              Late breaking news
 
 To run exiv2 from the bundle
 ----------------------------
@@ -30,7 +31,7 @@ To build samples/exiftool.cpp from the bundle
 ---------------------------------------------
 $ cd <bundle>
 $ g++ -std=c++98 samples/exifprint.cpp -Llib -Iinclude -lexiv2 -o exifprint
-$ ./exifprint
+$ env PATH="$PWD/bin:$PATH" ./exifprint
 
 To install for use by all users
 -------------------------------
@@ -44,7 +45,8 @@ $ cd <bundle>
 $ g++ -std=c++98 samples/exifprint.cpp -I/usr/local/include -L/usr/local/lib -lexiv2 -o exifprint
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 $ ./exifprint --version
-exiv2=0.27.0
+exiv2=0.27.1
+platform=msys
 ...
 xmlns=xmpidq:http://ns.adobe.com/xmp/Identifier/qual/1.0/
 $

--- a/releasenotes/msvc/ReadMe.txt
+++ b/releasenotes/msvc/ReadMe.txt
@@ -1,23 +1,24 @@
-Visual Studio 2017 Release DLL Bundle
--------------------------------------
+MinGW/msys2 Exiv2 v0.27.1 Release Bundle
+Visual Studio 2017 Release DLL Exiv2 v0.27.1 Release Bundle
+-----------------------------------------------------------
 
 Structure of the bundle:
 ------------------------
 
-bin/exiv2.exe                             exiv2 and sample applications
-bin/exiv2.dll                             dll
-lib/exiv2.lib & xmp.lib                   link libraries
-include/exiv2/                            include files
-share/exiv2/cmake                         consume CMake files
-samples/exifprint.cpp                     sample code
-logs                                      build and test logs
+bin/exiv2.exe                                 exiv2 and sample applications
+bin/exiv2.dll                                 dll
+lib/exiv2.lib & exiv2-xmp.lib                 link libraries
+lib/exiv2/cmake/                              CMake support/consume files
+include/exiv2/                                include files
+samples/exifprint.cpp                         sample code
+logs/                                         build and test logs
 
-ReadMe.txt                                This file
-license.txt                               GPLv2.0 Software License
-releasenotes.txt                          Late breaking news
-README.md                                 Developer Manual
-README-CONAN.md                           Developer Manual Appendix
-exiv2.png                                 Exiv2 Logo
+ReadMe.txt                                    This file
+license.txt                                   GPLv2.0 Software License
+releasenotes.txt                              Late breaking news
+README.md                                     Developer Manual
+README-CONAN.md                               Developer Manual Appendix
+exiv2.png                                     Exiv2 Logo
 
 +----------------------------------------------------------------------------+
 | Caution: Use a Windows unzip utility such as 7z or winzip                  |

--- a/releasenotes/releasenotes.txt
+++ b/releasenotes/releasenotes.txt
@@ -1,9 +1,73 @@
-Exiv2 v0.27.0
--------------
+Exiv2 v0.27.1.1
+---------------
 
-Thank You to Dan and Luis for their huge contribution this release.
+This is RC1 of the first quarterly "dot" release of Exiv2 v0.27
 
-Contributors: Ben, Freddy, Gilles, Henri, Michal, Phil, Shridar, Toni and Thomas.
+Thank You to Dan, Luis and Thomas for their huge contribution to this release.
+Contributors: Andreas S, Freddie, Gilles, Michal, Phil.
+
+exiv2.org in being transfered to a new host
+The web-site exiv2.org.uk is being HostPresto.com in England.
+Thank You Elliot at HostPresto.com
+Thank You Nehal for server support and skills.
+Thank You Andreas H for assisting with this transition.
+
+Headline Features of Exiv2 v0.27.1
+----------------------------------
+
+1) Bug and security fixes.
+2) Deprecation warnings for Video, EPS and SSH support.
+3) Relocating exiv2.org to a new host.
+4) Branch 0.27-maintenance for "dots" to avoid confusion with tag 0.27 (== 0.27.0 code).
+5) Support for cross-compiling for MinGW from Linux.
+
+Known Issues with v0.27.1 RC1
+-----------------------------
+
+#745 Review/fix documentation concerning CMake support files.
+
+Changes since 0.27.0
+--------------------
+https://github.com/Exiv2/exiv2/milestone/3?closed=1
+
+#744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
+#740 Tests for jp2image.
+#726 Doxygen improvements.
+#706 Fix access to null pointer in TiffParser.
+#700 exiv2-xmp linked privately.
+#684 gettext include issue on macOS.
+#661 Development of v0.27 dots moved to branch 0.27-maintenance.
+#660 Install new file exiv2lib_compiler_detection.h
+#644 Xcode fails with Exiv2::BasicError<char>
+#644 Old issue tracker (Redmine) is being spammed.
+#637 Reliable detection of strerror_r variants.
+#634 Fixes for installing exiv2.
+#629 xmpsdk: Build with -DBanAllEntityUsage=1.
+#628 cmake: Install header files without globbing.
+#625 cmake: Use correct installation dirs for doc and cmake configs.
+#620 0.27 tarball contains cruft.
+#617 Deprecate relics.
+#608 Update Nikon lens database.
+#603 MSVC cmake+conan with -DEXIV2_ENABLE_LIBSSH=On is broken
+#602 MSVC compiler warning with -DEXIV2_ENABLE_VIDEO=On.
+#597 Patch for broken ICC profile in PNG files
+#590 Several bugs in 0.27-rc3
+
+Outstanding issues assigned to 0.27.1 (defer to 0.27.2)
+-------------------------------------------------------
+
+#662 How does the rename (mv) work in case of name clash?
+#646 Exiv2 does not find certain AF tags for the Nikon D850
+#582 Add support for FocusPosition (Tag9402) in Sony RAW files (ARW)
+#547 Insufficient verification(cycle) in function Image::printIFDStructure in image.cpp:335
+
+Robin Mills
+robin@clanmills.com
+2019-03-15
+
+-------------------------
+Release Notes for v0.27.0
+-------------------------
 
 The headline features are:
 
@@ -38,44 +102,6 @@ The code will be modernised to C++11.
 
 C++98 compilers such as Visual Studio (<2015) will be supported
 with quarterly Exiv2 v0.27 'dot' (security) releases during 2019 and 2020.
-
-Code changes since RC3
-----------------------
-     None.
-
-Fixes between RC2 and RC3
--------------------------
-#584 Quicktime Video isn't correctly built.
-#575 Unit tests build and execute on all platforms.  Documented in README.md
-#572 Build Server publishes/tests
-     on Cygwin, MinGW, Linux, Darwin and msvc
-     in Release/Debug, 64/32, gcc/clang, static/shared.
-     User can request from Jenkins: exiv2.dyndns.org:8080/job/exiv2/build
-#570 All compiler warnings have been eliminated.
-     Web-site refined and polished.
-     Preparation to rehost exiv2.org
-#557 Updates to documentation concerning Debugging, Clang, ccache and Unit Tests.
-     Build and test logs are stored in build bundles.
-#551 Fix heading install (broken in RC2)
-#532 TAMRON SP 15-30mm F/2.8 Di VC USD A012 len recognition
-#521 Delete XMP XmpBag and XmpSeq
-#425 Security fixes (#425, #547, #558, #564)
-#369 Revised man page exiv2.1.
-#226 Exiv2::Image::xmpPacket() doesn't work on tiff files
-
-Fixes between RC1 and RC2
--------------------------
-#544 Catalonian Language Support
-#541 exiv2 -vVg loops
-#540 CMake Cleanup
-#528 Xcode 10.1 builds samples/taglist.cpp
-#527 Localization Support
-#512 Restore exiv2.pc pkg-config file
-#510 getopt() looping on bad input
-#507 DLL name restored to cygexiv2-27.dll
-#505 Incorrect packaging
-#499 Support for FreeBSD
-
 
 Fixes since v0.26
 -----------------

--- a/releasenotes/releasenotes.txt
+++ b/releasenotes/releasenotes.txt
@@ -6,31 +6,38 @@ This is RC1 of the first quarterly "dot" release of Exiv2 v0.27
 Thank You to Dan, Luis and Thomas for their huge contribution to this release.
 Contributors: Andreas S, Freddie, Gilles, Michal, Phil.
 
-exiv2.org in being transfered to a new host
-The web-site exiv2.org.uk is being HostPresto.com in England.
-Thank You Elliot at HostPresto.com
+Website relocated to https://exiv2.org
 Thank You Nehal for server support and skills.
 Thank You Andreas H for assisting with this transition.
+
+The web-site exiv2.org.uk is being HostPresto.com in England.
+Thank You Elliot at HostPresto.com
 
 Headline Features of Exiv2 v0.27.1
 ----------------------------------
 
 1) Bug and security fixes.
 2) Deprecation warnings for Video, EPS and SSH support.
-3) Relocating exiv2.org to a new host.
+3) Relocated https://exiv2.org
 4) Branch 0.27-maintenance for "dots" to avoid confusion with tag 0.27 (== 0.27.0 code).
-5) Support for cross-compiling for MinGW from Linux.
 
-Known Issues with v0.27.1 RC1
------------------------------
-
-#745 Review/fix documentation concerning CMake support files.
+Remaining Issues with v0.27.1 RC1
+---------------------------------
+The following are not resolved and will either be fixed in v0.27.1 or deferred.
+#744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
+#743 Sigma 24-70mm F2,8 DG OS HSM Art not detected
+#740 Tests for jp2image.cpp
+#662 Documentation to explain how mv works with filename clash
+#646 Exiv2 does not find certain AF tags for the Nikon D850
+#582 Add support for FocusPosition (Tag9402) in Sony RAW files (ARW)
+#547 Insufficient verification(cycle) in function Image::printIFDStructure in image.cpp
 
 Changes since 0.27.0
 --------------------
 https://github.com/Exiv2/exiv2/milestone/3?closed=1
 
-#744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
+#761 Corrections in README.md concerning "Consuming Exiv2 with CMake"
+#745 Review/fix documentation concerning CMake support files.
 #740 Tests for jp2image.
 #726 Doxygen improvements.
 #706 Fix access to null pointer in TiffParser.
@@ -53,17 +60,9 @@ https://github.com/Exiv2/exiv2/milestone/3?closed=1
 #597 Patch for broken ICC profile in PNG files
 #590 Several bugs in 0.27-rc3
 
-Outstanding issues assigned to 0.27.1 (defer to 0.27.2)
--------------------------------------------------------
-
-#662 How does the rename (mv) work in case of name clash?
-#646 Exiv2 does not find certain AF tags for the Nikon D850
-#582 Add support for FocusPosition (Tag9402) in Sony RAW files (ARW)
-#547 Insufficient verification(cycle) in function Image::printIFDStructure in image.cpp:335
-
 Robin Mills
 robin@clanmills.com
-2019-03-15
+2019-03-27
 
 -------------------------
 Release Notes for v0.27.0


### PR DESCRIPTION
This is an WIP "umbrella".   This will include fixes for #743, #744 and #745.  Hope to be ready for review later this week.  I would like to delay v0.27.1.1 (v0.27.1 RC1) until exiv2.org is moved and stable.

Thanks to @piponazo for the following instructions:
```
git checkout 0.27-maintenance # Move to that branch
git pull --rebase                            # Bring latest changes from the remote
git checkout -b 0.27.1-XXX        # Create a new branch 
#Do some work there (commits)
git push --set-upstream origin 0.27.1-XXX # push the branch to the server
```

And thanks to @D4N and @cryptomilk for help with git.  One day I might understand!