### PR TITLE
travis: use newer xcode version and drop the old one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,20 +69,11 @@ matrix:
       env:
         - BUILD_TYPE="Debug"
 
-    - name: "OS X 10.12 - XCode 9.0"
+    - name: "OS X 10.13 - XCode 10.2"
       os: osx
-      osx_image: xcode9
+      osx_image: xcode10.2
       compiler: clang
       env:
-        - PYTHON=3.6.2
-        - BUILD_TYPE="Release"
-
-    - name: "OS X 10.13 - XCode 10.1"
-      os: osx
-      osx_image: xcode10.1
-      compiler: clang
-      env:
-        - PYTHON=3.6.2
         - BUILD_TYPE="Release"
 
 install: ./ci/install.sh

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -13,14 +13,8 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
     source conan/bin/activate
 else
     brew update
-    brew install md5sha1sum pyenv-virtualenv gettext
-    export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS"
-    export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
-    pyenv install $PYTHON
-    # I would expect something like ``pyenv init; pyenv local $PYTHON`` or
-    # ``pyenv shell $PYTHON`` would work, but ``pyenv init`` doesn't seem to
-    # modify the Bash environment. ??? So, I hand-set the variables instead.
-    export PYENV_VERSION=$PYTHON
+    brew install pyenv-virtualenv
+
     export PATH="/Users/travis/.pyenv/shims:${PATH}"
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
@@ -29,7 +23,7 @@ else
 fi
 
 python --version
-pip install urllib3[secure] -U #Should solve SSL issues
+#pip install urllib3[secure] -U #Should solve SSL issues
 pip install conan==1.11.1
 pip install codecov
 conan --version

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -22,7 +22,6 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
     source conan/bin/activate
 else
     export CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_PREFIX_PATH=/usr/local/opt/gettext/"
-    export PYENV_VERSION=$PYTHON
     export PATH="/Users/travis/.pyenv/shims:${PATH}"
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"


### PR DESCRIPTION
This PR is fixing the OS-X builds in travis-CI.

Few other changes were done in this PR to drop things which were not needed anymore.

Note that I will also need to propagate these changes to the 0.27 branch