### PR TITLE
[localization] Add a mutex guarding the global exvGettextInitialized

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -49,6 +49,7 @@
 #include <cstring>
 #include <cmath>
 #include <math.h>
+#include <mutex>
 
 // *****************************************************************************
 namespace {
@@ -722,21 +723,30 @@ namespace Exiv2 {
 }                                       // namespace Exiv2
 
 #ifdef EXV_ENABLE_NLS
+
+namespace
+{
+    bool exvGettextInitialized = false;
+    std::mutex exvGettextInitializedMutex;
+}  // namespace
+
 // Declaration is in i18n.h
 const char* _exvGettext(const char* str)
 {
-    static bool exvGettextInitialized = false;
+    // hold the mutex only as long as necessary
+    {
+        std::lock_guard<std::mutex> lock(exvGettextInitializedMutex);
 
-    if (!exvGettextInitialized) {
-        //bindtextdomain(EXV_PACKAGE_NAME, EXV_LOCALEDIR);
-        const std::string localeDir = Exiv2::getProcessPath() + EXV_LOCALEDIR;
-        bindtextdomain(EXV_PACKAGE_NAME, localeDir.c_str());
-# ifdef EXV_HAVE_BIND_TEXTDOMAIN_CODESET
-        bind_textdomain_codeset (EXV_PACKAGE_NAME, "UTF-8");
-# endif
-        exvGettextInitialized = true;
+        if (!exvGettextInitialized) {
+            // bindtextdomain(EXV_PACKAGE_NAME, EXV_LOCALEDIR);
+            const std::string localeDir = Exiv2::getProcessPath() + EXV_LOCALEDIR;
+            bindtextdomain(EXV_PACKAGE_NAME, localeDir.c_str());
+#ifdef EXV_HAVE_BIND_TEXTDOMAIN_CODESET
+            bind_textdomain_codeset(EXV_PACKAGE_NAME, "UTF-8");
+#endif
+            exvGettextInitialized = true;
+        }
     }
-
     return dgettext(EXV_PACKAGE_NAME, str);
 }
 #endif // EXV_ENABLE_NLS


### PR DESCRIPTION
Split of from #685: add a mutex guard around the global variable `exvGettextInitialized`.