### PR TITLE
Add conversion function from wstring to string

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -29,7 +29,7 @@ case "$distro_id" in
 
     'debian')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev googletest libxml2-utils
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev googletest libxml2-utils locales locales-all
         debian_build_gtest
         ;;
 
@@ -40,7 +40,7 @@ case "$distro_id" in
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libgmock-dev libxml2-utils
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libgmock-dev libxml2-utils locales locales-all
         debian_build_gtest
         ;;
 

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -35,13 +35,12 @@
 #include "slice.hpp"
 
 // + standard includes
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <limits>
-#include <algorithm>
-#include <sstream>
-#include <stdint.h> /// \todo change to cstdint
-
 
 // MSVC macro to convert a string to a wide string
 #ifdef EXV_UNICODE_PATH
@@ -419,12 +418,15 @@ namespace Exiv2 {
      */
     EXIV2API const char* exvGettext(const char* str);
 
-#ifdef EXV_UNICODE_PATH
-    //! Convert an std::string s to a unicode string returned as a std::wstring.
+    //! Convert a std::string s to a wide string returned as a std::wstring.
     EXIV2API std::wstring s2ws(const std::string& s);
-    //! Convert a unicode std::wstring s to an std::string.
+
+    //! Convert a wide std::wstring s to its multibyte representation as a std::string.
+    //!
+    //! @return A narrow byte version of `s` or an empty string if `s`
+    //!     contains invalid characters.
     EXIV2API std::string ws2s(const std::wstring& s);
-#endif
+
     /*!
       @brief Return a \em long set to the value represented by \em s.
 


### PR DESCRIPTION
Another PR split of from #685: here I add a function that converts `std::wstring` to `std::string`, which is intended to be used with unicode paths on Windows, as we had `WError` for that, which should be removed by that PR.

TODO:
- [x] fix the test failure on Windows: ~~an assertion fails here.~~ encoding issues...