### PR TITLE
Changes for v0.27.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.3.2 )
 
 project(exiv2
-    VERSION 0.27.1.1
+    VERSION 0.27.1
     LANGUAGES CXX C
 )
 

--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -189,9 +189,11 @@ cmd
 
 ### Profiles for Visual Studio
 
-You can build Exiv2 with Visual Studio 2019 (version 16), 2017 (version 15) and 2015 (version 14).
+Exiv2 v0.27 can be built with VS 2008, 2010, 2012, 2013, 2015 and 2017.
 
-The following versions are believed to build, however Team Exiv2 will not provide support for 2013 (version 12), 2012 (version 11), 2010 (version 10) or 2008 (version 9).
+Exiv2 v0.27.1 (and later) can be built with VS 2015, 2017 and 2019.  I believe it will build with 2013 and earlier, however we don't actively support those version of Visual Studio.
+
+v0.28 is being "modernised" to C++11 and will not support C++98. We don't expect Exiv2 v0.28 to build with VS 2008, 2010, 2012 or 2013.
 
 You create profiles in %HOMEPATH%\.conan\profiles with a text editor.  For your convenience, you'll find profiles in `<exiv2dir>\cmake/msvc\_conan\_profiles`.  There are 26 in total:
 

--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -189,15 +189,18 @@ cmd
 
 ### Profiles for Visual Studio
 
-You can build Exiv2 with Visual Studio 2017 (version 15), 2015 (version 14), 2013 (version 12), 2012 (version 11), 2010 (version 10) or 2008 (version 9).
-You create profiles in %HOMEPATH%\.conan\profiles with a text editor.  For your convenience, you'll find profiles in **<exiv2dir>/cmake/msvc\_conan\_profiles**.  There are 24 in total:
+You can build Exiv2 with Visual Studio 2019 (version 16), 2017 (version 15) and 2015 (version 14).
+
+The following versions are believed to build, however Team Exiv2 will not provide support for 2013 (version 12), 2012 (version 11), 2010 (version 10) or 2008 (version 9).
+
+You create profiles in %HOMEPATH%\.conan\profiles with a text editor.  For your convenience, you'll find profiles in `<exiv2dir>\cmake/msvc\_conan\_profiles`.  There are 26 in total:
 
 ```
 Profile :=    msvc{Edition}{Type}{Bits}
-Edition :=  { 2017    | 2015  |  2013  |  2012  |  2010  |  2008  }
+Edition :=  { 2019    | 2017  |  2015  }
 Type    :=  { Release | Debug }
-Bits    :=  { 64      | 32    }
-Examples:     msvc2017Release64  msvc2015Debug32
+Bits    :=  { 64      | 32    }   # 32 bit build is not provided for 2019
+Examples:     msvc2019Release msvc2017Release64  msvc2015Debug32
 ```
 
 The profile msvc2017Release64 is as follows:
@@ -217,6 +220,14 @@ os_build=Windows
 [env]
 ```
 
+### Tools for Visual Studio 2019
+
+You will need cmake version 3.14 (and up) and conan 1.14 (and up).  Additionally, when I upgraded to conan 1.14.3, I had to manually update (For me: `%USERPROFILE% == C:\Users\rmills`):
+
+```bat
+copy/y %USERPROFILE%\.conan\settings.yml.new %USERPROFILE%\.conan\settings.yml
+```
+
 ### CMake Generators for Visual Studio
 
 In the step-by-step guide, the command `$ cmake ..` uses
@@ -230,35 +241,35 @@ c:\....\exiv2\build> cmake --build .  --config Release
 
 CMake provides Generators for different editions of Visual Studio.  The 64 and 32 bit Generators have different names:
 
-| Architecture | Visual Studio 2017 | Visual Studio 2015 | Visual Studio 2013 |
-|:---------    |--------------------|--------------------|--------------------|
-| 64 bit       | "Visual Studio 15 2017 Win64" |  "Visual Studio 14 2015 Win64"     | "Visual Studio 12 2013 Win64"  |
-| 32 bit       | "Visual Studio 15 2017"       | "Visual Studio 14 2015"            | "Visual Studio 12 2013 "       |
+| Architecture | Visual Studio 2019 | Visual Studio 2017 | Visual Studio 2015 |
+|:---------    |--------------------|--------------------|--------------------|--------------------|
+| 64 bit       | "Visual Studio 16 2019" | "Visual Studio 15 2017 Win64" |  "Visual Studio 14 2015 Win64"     |
+| 32 bit       | Not provided            | "Visual Studio 15 2017"       | "Visual Studio 14 2015"            |
 
 ### Recommended settings for Visual Studio
 
 ##### 64 bit Release Build
 
-| | Visual Studio 2017 | Visual Studio 2015|
-|:---------|--------------------|--------------------|
-| _**conan install .. --profile**_ | msvc2017Release64 | msvc2015Release64 |
-| _**cmake -G**_                   |  "Visual Studio 15 2017 Win64"    | "Visual Studio 14 2015 Win64" |
-| _**profile**_<br><br><br><br><br><br><br>_ | arch=x86\_64<br>arch\_build=x86\_64<br>build\_type=Release<br>compiler.runtime=MD<br>compiler.version=15<br>compiler=Visual Studio<br>os=Windows<br>os\_build=Windows  | arch=x86\_64<br>arch\_build=x86\_64<br>build\_type=Release<br>compiler.runtime=MD<br>compiler.version=14 <br>compiler=Visual Studio<br>os=Windows<br>os\_build=Windows |
+| | Visual Studio 2017 | Visual Studio 2017 | Visual Studio 2015|
+|:---------|--------------------|--------------------|--------------|
+| _**conan install .. --profile**_ | msvc2019Release | msvc2017Release64 | msvc2015Release64 |
+| _**cmake -G**_                   |  "Visual Studio 16 2019"    |  "Visual Studio 15 2017 Win64"    | "Visual Studio 14 2015 Win64" |
+| _**profile**_<br><br><br><br><br><br><br>_ | arch=x86\_64<br>arch\_build=x86\_64<br>build\_type=Release<br>compiler.runtime=MD<br>compiler.version=16<br>compiler=Visual Studio<br>os=Windows<br>os\_build=Windows  | arch=x86\_64<br>arch\_build=x86\_64<br>build\_type=Release<br>compiler.runtime=MD<br>compiler.version=15<br>compiler=Visual Studio<br>os=Windows<br>os\_build=Windows  | arch=x86\_64<br>arch\_build=x86\_64<br>build\_type=Release<br>compiler.runtime=MD<br>compiler.version=14 <br>compiler=Visual Studio<br>os=Windows<br>os\_build=Windows |
 
 ##### Debug Builds
 
-|| Visual Studio 2017 | Visual Studio 2015 |
-|:-------|-------|------|
-| _**conan install .. --profile**_ | msvc2017Debug64 | msvc2015Debug64 |
-| _**profile**_<br>_ | build\_type=Debug<br>compiler.runtime=MDd | build_type=Debug<br>compiler.runtime=MDd |
+|| Visual Studio 2019 | Visual Studio 2017 | Visual Studio 2015 |
+|:-------|-------|------|--------------|
+| _**conan install .. --profile**_ | msvc2019Debug | msvc2017Debug64 | msvc2015Debug64 |
+| _**profile**_<br>_ | build\_type=Debug<br>compiler.runtime=MDd | build\_type=Debug<br>compiler.runtime=MDd | build_type=Debug<br>compiler.runtime=MDd |
 
 ##### 32bit Builds
 
-|| Visual Studio 2017 | Visual Studio 2015 |
-|:-----------|--------------------|--------------------|
-| _**conan install .. --profile**_ | msvc2017Release32 | msvc2015Release32 |
-| _**cmake -G**_ | "Visual Studio 15 2017" | "Visual Studio 14 2015" |
-| _**profile**_<br>_ | arch=x86<br>arch\_build=x86 | arch=x86<br>arch\_build=x86 |
+|| Visual Studio 2019 | Visual Studio 2017 | Visual Studio 2015 |
+|:-----------|--------------------|--------------------|--------------------|
+| _**conan install .. --profile**_ | Not provided | msvc2017Release32 | msvc2015Release32 |
+| _**cmake -G**_ | Not provided | "Visual Studio 15 2017" | "Visual Studio 14 2015" |
+| _**profile**_<br>_ | Not provided | arch=x86<br>arch\_build=x86 | arch=x86<br>arch\_build=x86 |
 
 ##### Static Builds
 
@@ -278,7 +289,7 @@ If you wish to use the static C run-time library, use the following option in th
 
 ### Changing profile settings with the conan command
 
-It is recommended that you use profiles provided in **<exiv2dir>/cmake/msvc\_conan\_profiles**.
+It is recommended that you use profiles provided in `<exiv2dir>/cmake/msvc\_conan\_profiles'.
 
 You can modify profile settings on the command line.
 The following example demonstrates making substantial changes to profile settings by performing a 32 bit build using Visual Studio 2015 with a 2017 profile!  This example is not considered good practice, it is an illustration to some conan flexibility which be useful when your build environment is automated.
@@ -584,4 +595,4 @@ $ cmake -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_ENABLE_SSH=ON 
 
 [TOC](#TOC)
 
-Written by Robin Mills<br>robin@clanmills.com<br>Updated: 2018-11-22
+Written by Robin Mills<br>robin@clanmills.com<br>Updated: 2019-04-18

--- a/README.md
+++ b/README.md
@@ -674,12 +674,12 @@ I use the following batch file to start the MinGW/msys2 64 bit bash shell from t
 ```bat
 @echo off
 setlocal
-set "PATH=c:\msys64\usr\bin;c:\msys64\usr\local\bin;"
-set "HOME=c:\msys64\home\rmills"
+set "PS1=\! MSYS64:\u@\h:\w \$ "
+set  PATH="/usr/local/bin/:/usr/bin:/mingw64/bin:/bin:/usr/sbin:/sbin"
+set "HOME=c:\msys64\home\%USERNAME%"
 if NOT EXIST %HOME% mkdir %HOME%
 cd  %HOME%
-set "PS1=\! MSYS64:\u@\h:\w \$ "
-bash.exe -norc
+c:\msys64\usr\bin\bash.exe -norc
 ```
 
 #### MinGW/msys2 32 bit
@@ -690,12 +690,12 @@ I use the following batch file to start the MinGW/msys2 32 bit bash shell from t
 ```bat
 @echo off
 setlocal
-set "PATH=c:\msys32\usr\bin;c:\msys32\usr\local\bin;"
-set "HOME=c:\msys32\home\rmills"
+set "PS1=\! MSYS32:\u@\h:\w \$ "
+set  PATH="/usr/local/bin/:/usr/bin:/mingw32/bin:/bin:/usr/sbin:/sbin"
+set "HOME=c:\msys32\home\%USERNAME%"
 if NOT EXIST %HOME% mkdir %HOME%
 cd  %HOME%
-set "PS1=\! MSYS32:\u@\h:\w \$ "
-bash.exe -norc
+c:\msys32\usr\bin\bash.exe -norc
 ```
 
 #### Install MinGW Dependencies

--- a/README.md
+++ b/README.md
@@ -582,15 +582,17 @@ rmills@rmillsmbp-w7 ~/gnu/github/exiv2/exiv2/test $ env EXIV2_BINDIR=${PWD}/../b
 <name id="4-2">
 ### 4.2 Running tests on Visual Studio builds
 
-Use the bash interpreter for MinGW/msys2 to run the test suite.  It's essential to have a DOS Python3 interpreter on your path.  The variables EXIV2\_BINDIR and EXIV2\_EXT enable the test suite to locate the MSVC build artifacts.
+Use the bash interpreter for MinGW/msys2 to run the test suite.  It's essential to have a DOS Python3 interpreter on your path called `python3.exe`  The variables EXIV2\_BINDIR and EXIV2\_EXT enable the test suite to locate the MSVC build artifacts.
 
 ```bash
 $ cd <exiv2dir>/build
 $ cd ../test
-$ PATH="/c/Python36:$PATH"
+$ PATH="/c/Python37:$PATH"
 $ export EXIV2_EXT=.exe
 $ export EXIV2_BINDIR=${PWD}/../build/bin
 ```
+
+**Caution: ** The python3 interpreter must be for DOS and called python3.exe.  I copied `c:\Python37\python.exe c:\Python37\python3.exe`
 
 Once you have modified the PATH and and exported EXIV2\_BINDIR and EXIV2\_EXT, you can execute the test suite as described for UNIX-like systems:
 
@@ -788,4 +790,4 @@ cmd
 
 [TOC](#TOC)
 
-Written by Robin Mills<br>robin@clanmills.com<br>Revised: 2019-03-29
+Written by Robin Mills<br>robin@clanmills.com<br>Revised: 2019-04-18

--- a/cmake/msvc_conan_profiles/msvc2019Debug
+++ b/cmake/msvc_conan_profiles/msvc2019Debug
@@ -1,0 +1,12 @@
+[build_requires]
+[settings]
+arch=x86_64
+build_type=Debug
+compiler=Visual Studio
+compiler.runtime=MDd
+compiler.version=16
+os=Windows
+arch_build=x86_64
+os_build=Windows
+[options]
+[env]

--- a/cmake/msvc_conan_profiles/msvc2019Release
+++ b/cmake/msvc_conan_profiles/msvc2019Release
@@ -1,0 +1,12 @@
+[build_requires]
+[settings]
+arch=x86_64
+build_type=Release
+compiler=Visual Studio
+compiler.runtime=MD
+compiler.version=16
+os=Windows
+arch_build=x86_64
+os_build=Windows
+[options]
+[env]

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,8 +1,10 @@
 Changes from version 0.27 to 0.27.1
 -----------------------------------
 
-https://github.com/Exiv2/exiv2/milestone/3?closed=1 (38)
+https://github.com/Exiv2/exiv2/milestone/3?closed=1 (40)
 
+#781 MinGW exiv2-0.27-Source fails with stdlib.h: No such file or directory.
+#780 Support for Visual Studio 2019 using Conan and CMake.
 #744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
 #745 Review/fix documentation concerning CMake support files
 #761 Corrections in README.md concerning "Consuming Exiv2 with CMake"

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,34 @@
+Changes from version 0.27 to 0.27.1
+-----------------------------------
+
+https://github.com/Exiv2/exiv2/milestone/3?closed=1 (38)
+
+#744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
+#745 Review/fix documentation concerning CMake support files
+#761 Corrections in README.md concerning "Consuming Exiv2 with CMake"
+#745 Review/fix documentation concerning CMake support files.
+#740 Tests for jp2image.
+#726 Doxygen improvements.
+#706 Fix access to null pointer in TiffParser.
+#700 exiv2-xmp linked privately.
+#684 gettext include issue on macOS.
+#661 Development of v0.27 dots moved to branch 0.27-maintenance.
+#660 Install new file exiv2lib_compiler_detection.h
+#644 Xcode fails with Exiv2::BasicError<char>
+#644 Old issue tracker (Redmine) is being spammed.
+#637 Reliable detection of strerror_r variants.
+#634 Fixes for installing exiv2.
+#629 xmpsdk: Build with -DBanAllEntityUsage=1.
+#628 cmake: Install header files without globbing.
+#625 cmake: Use correct installation dirs for doc and cmake configs.
+#620 0.27 tarball contains cruft.
+#617 Deprecate relics.
+#608 Update Nikon lens database.
+#603 MSVC cmake+conan with -DEXIV2_ENABLE_LIBSSH=On is broken
+#602 MSVC compiler warning with -DEXIV2_ENABLE_VIDEO=On.
+#597 Patch for broken ICC profile in PNG files
+#590 Several bugs in 0.27-rc3
+
 Changes from version 0.26 to 0.27
 ---------------------------------
 

--- a/releasenotes/releasenotes.txt
+++ b/releasenotes/releasenotes.txt
@@ -1,7 +1,7 @@
-Exiv2 v0.27.1.1
----------------
+Exiv2 v0.27.1
+-------------
 
-This is RC1 of the first quarterly "dot" release of Exiv2 v0.27
+This is the first quarterly "dot" release of Exiv2 v0.27
 
 Thank You to Dan, Luis and Thomas for their huge contribution to this release.
 Contributors: Andreas S, Freddie, Gilles, Michal, Phil.
@@ -21,16 +21,10 @@ Headline Features of Exiv2 v0.27.1
 3) Relocated https://exiv2.org
 4) Branch 0.27-maintenance for "dots" to avoid confusion with tag 0.27 (== 0.27.0 code).
 
-Remaining Issues with v0.27.1 RC1
----------------------------------
-The following are not resolved and will either be fixed in v0.27.1 or deferred.
+Issues fixed since v0.27.1 RC1
+------------------------------
 #744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
-#743 Sigma 24-70mm F2,8 DG OS HSM Art not detected
-#740 Tests for jp2image.cpp
-#662 Documentation to explain how mv works with filename clash
-#646 Exiv2 does not find certain AF tags for the Nikon D850
-#582 Add support for FocusPosition (Tag9402) in Sony RAW files (ARW)
-#547 Insufficient verification(cycle) in function Image::printIFDStructure in image.cpp
+#745 Review/fix documentation concerning CMake support files
 
 Changes since 0.27.0
 --------------------
@@ -62,7 +56,7 @@ https://github.com/Exiv2/exiv2/milestone/3?closed=1
 
 Robin Mills
 robin@clanmills.com
-2019-03-27
+2019-04-12
 
 -------------------------
 Release Notes for v0.27.0

--- a/releasenotes/releasenotes.txt
+++ b/releasenotes/releasenotes.txt
@@ -20,9 +20,12 @@ Headline Features of Exiv2 v0.27.1
 2) Deprecation warnings for Video, EPS and SSH support.
 3) Relocated https://exiv2.org
 4) Branch 0.27-maintenance for "dots" to avoid confusion with tag 0.27 (== 0.27.0 code).
+5) Support for Visual Studio 2019 using Conan and CMake.
 
 Issues fixed since v0.27.1 RC1
 ------------------------------
+#781 MinGW exiv2-0.27-Source fails with stdlib.h: No such file or directory.
+#780 Support for Visual Studio 2019 using Conan and CMake.
 #744 JP2000 -pS (print Structure) throws Invalid slice bounds specified on all jp2 files.
 #745 Review/fix documentation concerning CMake support files
 
@@ -56,7 +59,7 @@ https://github.com/Exiv2/exiv2/milestone/3?closed=1
 
 Robin Mills
 robin@clanmills.com
-2019-04-12
+2019-04-18
 
 -------------------------
 Release Notes for v0.27.0

--- a/src/exiv2.1
+++ b/src/exiv2.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH EXIV2 1 "Nov 26, 2018"
+.TH EXIV2 1 "Apr 25, 2019"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -656,13 +656,13 @@ requirements of the target format. Some tags copied like this may not
 make sense in the target image.
 .SH SEE ALSO
 .TP
-.I http://exiv2.dyndns.org/sample.html#modify
+.I https://exiv2.org/sample.html#modify
 Sample command files.
 .TP
-.I http://exiv2.dyndns.org/metadata.html
+.I https://exiv2.org/metadata.html
 Taglists with \fIkey\fP and default \fItype\fP values.
 .SH AUTHORS
 .B exiv2
-was written by Andreas Huggel and others.  The Exiv2 project web site is http://exiv2.dyndns.org.  The code is hosted on GitHub at https://github.com/exiv2/exiv2
+was written by Andreas Huggel and others.  The Exiv2 project web site is https://exiv2.org.  The code is hosted on GitHub at https://github.com/exiv2/exiv2
 .PP
 This manual page was originally created for the Debian project by KELEMEN Peter <fuji@debian.org>.

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -199,8 +199,9 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     // add edition in brackets
     // 7.10 = 2003 8.00 = 2005 etc 12.00 = 2013 13.00 = 2015 (yet the installer labels it as 14.0!)
     size_t      edition       = (_MSC_VER-600)/100;
-    const char* editions[]    = { "0","1","2","3","4","5","6","2003", "2005", "2008", "2010", "2012","2013","2015","2017"};
-    if (  edition == 13 && _MSC_VER >= 1910 ) edition++ ; // 2017 _MSC_VAR  == 1910!
+    const char* editions[]    = { "0","1","2","3","4","5","6","2003", "2005", "2008", "2010", "2012","2013","2015","2017","2019"};
+    if (  edition == 13 && _MSC_VER >= 1910 ) edition++ ; // 2017 _MSC_VAR  == 1910
+    if (  edition == 13 && _MSC_VER >= 1920 ) edition++ ; // 2019 _MSC_VAR  == 1920
 
     if  ( edition > lengthof(editions) ) edition = 0 ;
     if  ( edition ) sprintf(version+::strlen(version)," (%s/%s)",editions[edition],bits==64?"x64":"x86");


### PR DESCRIPTION
Gentlemen:

I hope this is v0.27.1.  I haven't had any feedback from users.

I've added support for Visual Studio 2019 and updated README.md concerning an issue with the MinGW/Source build.  I've retained the fix for #744 which was submitted to v0.27-maintenance.  And I've reviewed/revised releasenotes.txt, README.md and README-CONAN.md 

I hope this is good to go.  I'm sure you'll spot more changes.

When it's good, could you tag this as "v0.27.1".  Then I'll get Jenkins to build.  I'll test the builds and publish on https://exiv2.org

Let me know if you'd like to have a meeting (1 hour on-line) to talk together.  I hope to do "v0.27.2 RC1" by 2019-06-15 and v0.27.2 by 2019-06-30.