### PR TITLE
Simplify strError tests to avoid differencies between platforms

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ Archlinux:
   <<: *distro_build
 
 Ubuntu:
-  image: ubuntu:18.04
+  image: ubuntu:18.10
   <<: *default_config
   <<: *distro_build
 
@@ -71,7 +71,7 @@ OpenSUSE:
   <<: *distro_build
 
 Alpine:
-  image: alpine:3.8
+  image: alpine:3.9
   <<: *default_config
   <<: *distro_build
 

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -24,23 +24,23 @@ distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
 
 case "$distro_id" in
     'fedora')
-        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which dos2unix
+        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which dos2unix
         ;;
 
     'debian')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev libxml2-utils
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev googletest libxml2-utils
         debian_build_gtest
         ;;
 
     'arch')
         pacman --noconfirm -Syu
-        pacman --noconfirm -S gcc clang cmake make ccache expat zlib libssh curl gtest python dos2unix which diffutils
+        pacman --noconfirm -S gcc clang cmake make ccache expat zlib libssh curl gtest gmock python dos2unix which diffutils
         ;;
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libxml2-utils
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libgmock-dev libxml2-utils
         debian_build_gtest
         ;;
 
@@ -50,7 +50,7 @@ case "$distro_id" in
         curl https://copr.fedorainfracloud.org/coprs/defolos/devel/repo/epel-7/defolos-devel-epel-7.repo > /etc/yum.repos.d/_copr_defolos-devel.repo
         yum clean all
         yum -y install devtoolset-3-gcc-c++ devtoolset-3-gcc-c++ devtoolset-3-binutils clang cmake3 make ccache \
-            expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which python36 dos2unix
+            expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which python36 dos2unix
         echo source /opt/rh/devtoolset-3/enable >> ~/.bash_profile
         echo export CCACHE_PATH=$HOME/bin:$PATH >> ~/.bash_profile
         mkdir ~/bin
@@ -76,12 +76,12 @@ EOF
 
     'opensuse'|'opensuse-tumbleweed')
         zypper --non-interactive refresh
-        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel libcurl-devel gtest which dos2unix libxml2-tools
+        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel libcurl-devel gtest gmock which dos2unix libxml2-tools
         ;;
 
     'alpine')
         apk update
-        apk add gcc g++ clang cmake make ccache expat-dev zlib-dev libssh-dev curl-dev gtest gtest-dev libintl gettext-dev which dos2unix bash libxml2-utils diffutils
+        apk add gcc g++ clang cmake make ccache expat-dev zlib-dev libssh-dev curl-dev gtest gtest-dev gmock libintl gettext-dev which dos2unix bash libxml2-utils diffutils python3
         ;;
     *)
         echo "Sorry, no predefined dependencies for your distribution $distro_id exist yet"

--- a/contrib/vms/Vagrantfile
+++ b/contrib/vms/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "Ubuntu" do |ubuntu|
-    ubuntu.vm.box = "ubuntu/bionic64"
+    ubuntu.vm.box = "generic/ubuntu1810"
     ubuntu.vm.hostname = "ubuntu-exiv2"
   end
 
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "Alpine" do |alpine|
-    alpine.vm.box = "roboxes/alpine38"
+    alpine.vm.box = "roboxes/alpine39"
     # don't set a custom hostname, this is broken on Alpine
     # alpine.vm.hostname = "alpine-exiv2"
   end

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 using namespace Exiv2;
 
@@ -20,17 +21,8 @@ TEST(strError, returnSuccessAfterClosingFile)
     std::string tmpFile("tmp.dat");
     std::ofstream auxFile(tmpFile.c_str());
     auxFile.close();
-#ifdef _WIN32
-    const char * expectedString = "No error (errno = 0)";
-#elif __APPLE__
-    const char * expectedString = "Undefined error: 0 (errno = 0)";
-#elif ! defined(__GLIBC__)
-    const char * expectedString = "No error information (errno = 0)";
-#else
-    const char * expectedString = "Success (errno = 0)";
-#endif
 
-    ASSERT_STREQ(expectedString, strError().c_str());
+    ASSERT_THAT(strError(), ::testing::EndsWith("(errno = 0)"));
     std::remove(tmpFile.c_str());
 }
 
@@ -43,16 +35,7 @@ TEST(strError, returnNoSuchFileOrDirectoryWhenTryingToOpenNonExistingFile)
 TEST(strError, doNotRecognizeUnknownError)
 {
     errno = 9999;
-#ifdef _WIN32
-    const char * expectedString = "Unknown error (errno = 9999)";
-#elif __APPLE__
-    const char * expectedString = "Unknown error: 9999 (errno = 9999)";
-#elif ! defined(__GLIBC__)
-    const char * expectedString = "No error information (errno = 9999)";
-#else
-    const char * expectedString = "Unknown error 9999 (errno = 9999)";
-#endif
-    ASSERT_STREQ(expectedString, strError().c_str());
+    ASSERT_THAT(strError(), ::testing::EndsWith("(errno = 9999)"));
 }
 
 TEST(getEnv, getsDefaultValueWhenExpectedEnvVariableDoesNotExist)


### PR DESCRIPTION
This PR fixes #763. This PR fixes #803.

I simplified the tests for `strError` so that we do not need to write complex if-else preprocessor conditions to check the slightly different messages in every platform. 