### PR TITLE
Update doxygen style in some classes

### DIFF
--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -17,6 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
+
 /*!
   @file    exif.hpp
   @brief   Encoding and decoding of Exif data
@@ -488,9 +489,9 @@ namespace Exiv2 {
         /// @brief Find the first Exifdatum with the given \em key, return a const iterator to it.
         const_iterator findKey(const ExifKey& key) const;
         //! Return true if there is no Exif metadata
-        bool empty() const { return count() == 0; }
+        bool empty() const;
         //! Get the number of metadata entries
-        long count() const { return static_cast<long>(exifMetadata_.size()); }
+        long count() const;
         //@}
 
     private:

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -43,13 +43,16 @@
   @brief Provides classes and functions to encode and decode Exif and Iptc data.
          The <b>libexiv2</b> API consists of the objects of this namespace.
  */
-namespace Exiv2 {
-
+namespace Exiv2
+{
     class ExifData;
 
     /// @brief An Exif metadatum, consisting of an ExifKey and a Value and methods to manipulate these.
-    class EXIV2API Exifdatum : public Metadatum {
-        template<typename T> friend Exifdatum& setValue(Exifdatum&, const T&);
+    class EXIV2API Exifdatum : public Metadatum
+    {
+        template <typename T>
+        friend Exifdatum& setValue(Exifdatum&, const T&);
+
     public:
         //! @name Creators
         //@{
@@ -59,50 +62,50 @@ namespace Exiv2 {
         /// @param key %ExifKey.
         /// @param pValue Pointer to an %Exifdatum value.
         /// @throw Error if the key cannot be parsed and converted.
-        explicit Exifdatum(const ExifKey& key, const Value* pValue =0);
-        
+        explicit Exifdatum(const ExifKey& key, const Value* pValue = 0);
+
         Exifdatum(const Exifdatum& rhs);
-        
+
         virtual ~Exifdatum();
         //@}
 
         //! @name Manipulators
         //@{
         Exifdatum& operator=(const Exifdatum& rhs);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to UShortValue.
         Exifdatum& operator=(const uint16_t& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to ULongValue.
         Exifdatum& operator=(const uint32_t& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to URationalValue.
         Exifdatum& operator=(const URational& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to ShortValue.
         Exifdatum& operator=(const int16_t& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to LongValue.
         Exifdatum& operator=(const int32_t& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to RationalValue.
         Exifdatum& operator=(const Rational& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. Calls setValue(const std::string&).
         Exifdatum& operator=(const std::string& value);
-        
+
         /// @brief Assign \em value to the %Exifdatum. Calls setValue(const Value*).
         Exifdatum& operator=(const Value& value);
-        
+
         void setValue(const Value* pValue) override;
         /// @brief Set the value to the string \em value.  Uses Value::read(const std::string&).
-        /// 
+        ///
         /// If the %Exifdatum does not have a Value yet, then a %Value of the correct type for this %Exifdatum is
         /// created. An AsciiValue is created for unknown tags. Return 0 if the value was read successfully.
         int setValue(const std::string& value) override;
-        
+
         /// @brief Set the data area by copying (cloning) the buffer pointed to by \em buf.
-        /// 
+        ///
         /// Values may have a data area, which can contain additional information besides the actual value. This method
         /// is used to set such a data area.
         /// @param buf Pointer to the source data area
@@ -126,16 +129,16 @@ namespace Exiv2 {
         const char* ifdName() const;
         //! Return the index (unique id of this key within the original IFD)
         int idx() const;
-        
+
         /// @brief Write value to a data buffer and return the number of bytes written.
-        /// 
+        ///
         /// The user must ensure that the buffer has enough memory. Otherwise the call results in undefined behaviour.
         /// @param buf Data buffer to write to.
         /// @param byteOrder Applicable byte order (little or big endian).
         /// @return Number of characters written.
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const override;
+
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
         //! Return the type id of the value
         TypeId typeId() const override;
         //! Return the name of the type
@@ -149,17 +152,17 @@ namespace Exiv2 {
         //! Return the value as a string.
         std::string toString() const override;
         std::string toString(long n) const override;
-        long toLong(long n =0) const override;
-        float toFloat(long n =0) const override;
-        Rational toRational(long n =0) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
         Value::UniquePtr getValue() const override;
         const Value& value() const override;
         //! Return the size of the data area.
         long sizeDataArea() const;
-        
+
         /// @brief Return a copy of the data area of the value. The caller owns this copy and %DataBuf ensures that it
         /// will be deleted.
-        /// 
+        ///
         /// Values may have a data area, which can contain additional information besides the actual value. This method
         /// is used to access such a data area.
         /// @return A %DataBuf containing a copy of the data area or an empty %DataBuf if the value does not have a
@@ -168,18 +171,18 @@ namespace Exiv2 {
         //@}
 
     private:
-        ExifKey::UniquePtr key_;                  //!< Key
-        Value::UniquePtr   value_;                //!< Value
-
+        ExifKey::UniquePtr key_;  //!< Key
+        Value::UniquePtr value_;  //!< Value
     };
 
-    /// @brief Access to a Exif thumbnail image. 
-    /// 
+    /// @brief Access to a Exif thumbnail image.
+    ///
     /// This class provides higher level accessors to the thumbnail image that is optionally embedded in IFD1 of the
     /// Exif data. These methods do not write to the Exif metadata. Manipulators are provided in subclass ExifThumb.
     /// @note Various other preview and thumbnail images may be contained in an image, depending on its format and the
     /// camera make and model. This class only provides access to the Exif thumbnail as specified in the Exif standard.
-    class EXIV2API ExifThumbC {
+    class EXIV2API ExifThumbC
+    {
     public:
         //! @name Creators
         //@{
@@ -190,15 +193,15 @@ namespace Exiv2 {
         //@{
         /// @brief Return the thumbnail image in a DataBuf. The caller owns the data buffer and %DataBuf.
         DataBuf copy() const;
-        
+
         /// @brief Write the thumbnail image to a file.
-        /// 
+        ///
         /// A filename extension is appended to \em path according to the image type of the thumbnail, so \em path
         /// should not include an extension. The function will overwrite an existing file of the same name.
         /// @param path File name of the thumbnail without extension.
         /// @return The number of bytes written.
         long writeFile(const std::string& path) const;
-        
+
 #ifdef EXV_UNICODE_PATH
         /// @brief Like writeFile() but accepts a unicode path in an std::wstring.
         /// @note This function is only available on Windows.
@@ -206,10 +209,10 @@ namespace Exiv2 {
 #endif
         /// @brief Return the MIME type of the thumbnail, either \c "image/tiff" or \c "image/jpeg".
         const char* mimeType() const;
-        
+
         /// @brief Return the file extension for the format of the thumbnail (".tif" or ".jpg").
         const char* extension() const;
-        
+
 #ifdef EXV_UNICODE_PATH
         /// @brief Like extension() but returns the extension in a wchar_t.
         /// @note This function is only available on Windows.
@@ -218,16 +221,17 @@ namespace Exiv2 {
         //@}
 
     private:
-        const ExifData& exifData_; //!< Const reference to the Exif metadata.
+        const ExifData& exifData_;  //!< Const reference to the Exif metadata.
     };
 
     /// @brief Access and modify an Exif thumbnail image.
-    /// 
+    ///
     /// This class implements manipulators to set and erase the thumbnail image that is optionally embedded in IFD1 of
     /// the Exif data. Accessors are provided by the base class, ExifThumbC.
     /// @note Various other preview and thumbnail images may be contained in an image, depending on its format and the
     /// camera make and model. This class only provides access to the Exif thumbnail as specified in the Exif standard.
-    class EXIV2API ExifThumb : public ExifThumbC {
+    class EXIV2API ExifThumb : public ExifThumbC
+    {
     public:
         //! @name Creators
         //@{
@@ -237,67 +241,67 @@ namespace Exiv2 {
         //! @name Manipulators
         //@{
         /// @brief Set the Exif thumbnail to the JPEG image \em path.
-        /// 
+        ///
         /// Set XResolution, YResolution and ResolutionUnit to \em xres, \em yres and \em unit, respectively. This
         /// results in the minimal thumbnail tags being set for a JPEG thumbnail, as mandated by the Exif standard.
-        /// 
+        ///
         /// @throw Error if reading the file fails.
         /// @note  No checks on the file format or size are performed.
         /// @note  Additional existing Exif thumbnail tags are not modified.
         /// @note  The JPEG image inserted as thumbnail image should not itself contain Exif data (or other metadata),
         /// as existing applications may have problems with that. (The preview application that comes with OS X for
         /// one.) - David Harvey.
-        void setJpegThumbnail(const std::string &path, URational xres, URational yres, uint16_t unit);
-        
+        void setJpegThumbnail(const std::string& path, URational xres, URational yres, uint16_t unit);
+
 #ifdef EXV_UNICODE_PATH
         /// @brief Like setJpegThumbnail() but accepts a unicode path in an std::wstring.
         /// @note This function is only available on Windows.
-        void setJpegThumbnail(const std::wstring &wpath, URational xres, URational yres, uint16_t unit);
+        void setJpegThumbnail(const std::wstring& wpath, URational xres, URational yres, uint16_t unit);
 #endif
-        /// @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf, and size \em size. 
-        /// 
+        /// @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf, and size \em size.
+        ///
         /// Set XResolution, YResolution and ResolutionUnit to \em xres, \em yres and \em unit, respectively. This
         /// results in the minimal thumbnail tags being set for a JPEG thumbnail, as mandated by the Exif standard.
-        /// 
+        ///
         /// @throw Error if reading the file fails.
         /// @note  No checks on the image format or size are performed.
         /// @note  Additional existing Exif thumbnail tags are not modified.
         /// @note  The JPEG image inserted as thumbnail image should not itself contain Exif data (or other metadata),
         /// as existing applications may have problems with that. (The preview application that comes with OS X for
         /// one.) - David Harvey.
-        void setJpegThumbnail(const byte *buf, long size, URational xres, URational yres, uint16_t unit);
-        
+        void setJpegThumbnail(const byte* buf, long size, URational xres, URational yres, uint16_t unit);
+
         /// @brief Set the Exif thumbnail to the JPEG image \em path.
-        /// 
+        ///
         /// This sets only the Compression, JPEGInterchangeFormat and JPEGInterchangeFormatLength tags, which is not
-        /// all the thumbnail Exif information mandatory according to the Exif standard. (But it's enough to work 
+        /// all the thumbnail Exif information mandatory according to the Exif standard. (But it's enough to work
         /// with the thumbnail.)
-        /// 
+        ///
         /// @throw Error if reading the file fails.
         /// @note  No checks on the file format or size are performed.
         /// @note  Additional existing Exif thumbnail tags are not modified.
         void setJpegThumbnail(const std::string& path);
-        
+
 #ifdef EXV_UNICODE_PATH
         /// @brief Like setJpegThumbnail(const std::string& path) but accepts a unicode path in an std::wstring.
         /// @note This function is only available on Windows.
         void setJpegThumbnail(const std::wstring& wpath);
 #endif
         /// @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf, and size \em size.
-        /// 
+        ///
         /// This sets only the Compression, JPEGInterchangeFormat and JPEGInterchangeFormatLength tags, which is not
         /// all the thumbnail Exif information mandatory according to the Exif standard. (But it's enough to work with
         /// the thumbnail.)
         /// @note  No checks on the image format or size are performed.
         /// @note  Additional existing Exif thumbnail tags are not modified.
         void setJpegThumbnail(const byte* buf, long size);
-        
+
         /// @brief Delete the thumbnail from the Exif data. Removes all Exif.%Thumbnail.*, i.e., Exif IFD1 tags.
         void erase();
         //@}
 
     private:
-        ExifData& exifData_;    //!< Reference to the related Exif metadata.
+        ExifData& exifData_;  //!< Reference to the related Exif metadata.
     };
 
     //! Container type to hold all metadata
@@ -313,7 +317,8 @@ namespace Exiv2 {
     /// - write Exif data to JPEG files
     /// - extract Exif metadata to files, insert from these files
     /// - extract and delete Exif thumbnail (JPEG and TIFF thumbnails)
-    class EXIV2API ExifData {
+    class EXIV2API ExifData
+    {
     public:
         //! ExifMetadata iterator type
         typedef ExifMetadata::iterator iterator;
@@ -355,10 +360,16 @@ namespace Exiv2 {
         void sortByTag();
 
         //! Begin of the metadata
-        iterator begin() { return exifMetadata_.begin(); }
+        iterator begin()
+        {
+            return exifMetadata_.begin();
+        }
 
         //! End of the metadata
-        iterator end() { return exifMetadata_.end(); }
+        iterator end()
+        {
+            return exifMetadata_.end();
+        }
 
         /// @brief Find the first Exifdatum with the given \em key, return an iterator to it.
         iterator findKey(const ExifKey& key);
@@ -367,9 +378,15 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         //! Begin of the metadata
-        const_iterator begin() const { return exifMetadata_.begin(); }
+        const_iterator begin() const
+        {
+            return exifMetadata_.begin();
+        }
         //! End of the metadata
-        const_iterator end() const { return exifMetadata_.end(); }
+        const_iterator end() const
+        {
+            return exifMetadata_.end();
+        }
         /// @brief Find the first Exifdatum with the given \em key, return a const iterator to it.
         const_iterator findKey(const ExifKey& key) const;
         //! Return true if there is no Exif metadata
@@ -384,60 +401,61 @@ namespace Exiv2 {
 
     /// @brief Stateless parser class for Exif data. Images use this class to decode and encode binary Exif data.
     /// @note  Encode is lossy and is not the inverse of decode.
-    class EXIV2API ExifParser {
+    class EXIV2API ExifParser
+    {
     public:
-      /// @brief Decode metadata from a buffer \em pData of length \em size with binary Exif data to the provided
-      /// metadata container.
-      /// 
-      /// The buffer must start with a TIFF header. Return byte order in which the data is encoded.
-      /// @param exifData Exif metadata container.
-      /// @param pData Pointer to the data buffer. Must point to data in binary Exif format; no checks are performed.
-      /// @param size  Length of the data buffer
-      /// @return Byte order in which the data is encoded.
-      static ByteOrder decode(ExifData &exifData, const byte *pData, uint32_t size);
-      
-      /// @brief Encode Exif metadata from the provided metadata to binary Exif format.
-      /// 
-      /// The original binary Exif data in the memory block \em pData, \em size is parsed and updated in-place if
-      /// possible ("non-intrusive" writing). If that is not possible (e.g., if new tags were added), the entire Exif
-      /// structure is re-written to the \em blob ("intrusive" writing). The return value indicates which write method
-      /// was used. If it is \c wmNonIntrusive, the original memory \em pData, \em size contains the result and \em blob
-      /// is empty. If the return value is \c wmIntrusive, a new Exif structure was created and returned in \em blob.
-      /// The memory block \em pData, \em size may be partly updated in this case and should not be used anymore.
-      /// 
-      /// Encode is a lossy operation. It attempts to fit the Exif data into a binary block suitable as the payload of
-      /// a JPEG APP1 Exif segment, which can be at most 65527 bytes large. Encode omits IFD0 tags that are "not
-      /// recorded" in compressed images according to the Exif 2.2 specification. It also doesn't write tags in groups
-      /// which do not occur in JPEG images. If the resulting binary block is larger than allowed, it further deletes
-      /// specific large preview tags, unknown tags larger than 4kB and known tags larger than 40kB. The operation
-      /// succeeds even if the end result is still larger than the allowed size. Application should therefore always 
-      /// check the size of the \em blob.
-      /// 
-      /// @param blob Container for the binary Exif data if "intrusive" writing is necessary. Empty otherwise.
-      /// @param pData Pointer to the binary Exif data buffer. Must point to data in Exif format; no checks are
-      /// performed. Will be modified if "non-intrusive" writing is possible.
-      /// @param size      Length of the data buffer.
-      /// @param byteOrder Byte order to use.
-      /// @param exifData  Exif metadata container.
-      /// @return Write method used.
-      static WriteMethod encode(Blob &blob, const byte *pData, uint32_t size,
-                                ByteOrder byteOrder, const ExifData &exifData);
-      
-      /// @brief Encode metadata from the provided metadata to Exif format.
-      /// 
-      /// Encode Exif metadata from the \em ExifData container to binary Exif format in the \em blob, encoded in 
-      /// \em byteOrder.
-      /// 
-      /// This simpler encode method uses "intrusive" writing, i.e., it builds the binary representation of the metadata
-      /// from scratch. It does not attempt "non-intrusive", i.e., in-place updating. It's better to use the other
-      /// encode() method, if the metadata is already available in binary format, in order to allow for "non-intrusive"
-      /// updating of the existing binary representation.
-      ///  
-      /// This is just an inline wrapper for ExifParser::encode(blob, 0, 0, byteOrder, exifData).
-      /// @param blob      Container for the binary Exif data.
-      /// @param byteOrder Byte order to use.
-      /// @param exifData  Exif metadata container.
-      static void encode(Blob &blob, ByteOrder byteOrder, const ExifData &exifData);
+        /// @brief Decode metadata from a buffer \em pData of length \em size with binary Exif data to the provided
+        /// metadata container.
+        ///
+        /// The buffer must start with a TIFF header. Return byte order in which the data is encoded.
+        /// @param exifData Exif metadata container.
+        /// @param pData Pointer to the data buffer. Must point to data in binary Exif format; no checks are performed.
+        /// @param size  Length of the data buffer
+        /// @return Byte order in which the data is encoded.
+        static ByteOrder decode(ExifData& exifData, const byte* pData, uint32_t size);
 
+        /// @brief Encode Exif metadata from the provided metadata to binary Exif format.
+        ///
+        /// The original binary Exif data in the memory block \em pData, \em size is parsed and updated in-place if
+        /// possible ("non-intrusive" writing). If that is not possible (e.g., if new tags were added), the entire Exif
+        /// structure is re-written to the \em blob ("intrusive" writing). The return value indicates which write method
+        /// was used. If it is \c wmNonIntrusive, the original memory \em pData, \em size contains the result and \em
+        /// blob is empty. If the return value is \c wmIntrusive, a new Exif structure was created and returned in \em
+        /// blob. The memory block \em pData, \em size may be partly updated in this case and should not be used
+        /// anymore.
+        ///
+        /// Encode is a lossy operation. It attempts to fit the Exif data into a binary block suitable as the payload of
+        /// a JPEG APP1 Exif segment, which can be at most 65527 bytes large. Encode omits IFD0 tags that are "not
+        /// recorded" in compressed images according to the Exif 2.2 specification. It also doesn't write tags in groups
+        /// which do not occur in JPEG images. If the resulting binary block is larger than allowed, it further deletes
+        /// specific large preview tags, unknown tags larger than 4kB and known tags larger than 40kB. The operation
+        /// succeeds even if the end result is still larger than the allowed size. Application should therefore always
+        /// check the size of the \em blob.
+        ///
+        /// @param blob Container for the binary Exif data if "intrusive" writing is necessary. Empty otherwise.
+        /// @param pData Pointer to the binary Exif data buffer. Must point to data in Exif format; no checks are
+        /// performed. Will be modified if "non-intrusive" writing is possible.
+        /// @param size      Length of the data buffer.
+        /// @param byteOrder Byte order to use.
+        /// @param exifData  Exif metadata container.
+        /// @return Write method used.
+        static WriteMethod encode(Blob& blob, const byte* pData, uint32_t size, ByteOrder byteOrder,
+                                  const ExifData& exifData);
+
+        /// @brief Encode metadata from the provided metadata to Exif format.
+        ///
+        /// Encode Exif metadata from the \em ExifData container to binary Exif format in the \em blob, encoded in
+        /// \em byteOrder.
+        ///
+        /// This simpler encode method uses "intrusive" writing, i.e., it builds the binary representation of the
+        /// metadata from scratch. It does not attempt "non-intrusive", i.e., in-place updating. It's better to use the
+        /// other encode() method, if the metadata is already available in binary format, in order to allow for
+        /// "non-intrusive" updating of the existing binary representation.
+        ///
+        /// This is just an inline wrapper for ExifParser::encode(blob, 0, 0, byteOrder, exifData).
+        /// @param blob      Container for the binary Exif data.
+        /// @param byteOrder Byte order to use.
+        /// @param exifData  Exif metadata container.
+        static void encode(Blob& blob, ByteOrder byteOrder, const ExifData& exifData);
     };
-} // namespace Exiv2
+}  // namespace Exiv2

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -56,7 +56,7 @@ namespace Exiv2
     public:
         //! @name Creators
         //@{
-        /// @brief Constructor for new tags created by an application. The %Exifdatum is created from a \em key / value
+        /// Constructor for new tags created by an application. The %Exifdatum is created from a \em key / value
         /// pair. %Exifdatum copies (clones) the \em key and value if one is provided. Alternatively, a program can
         /// create an 'empty' %Exifdatum with only a key and set the value using setValue().
         /// @param key %ExifKey.

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -418,18 +418,16 @@ namespace Exiv2 {
     //! Container type to hold all metadata
     typedef std::list<Exifdatum> ExifMetadata;
 
-    /*!
-      @brief A container for Exif data.  This is a top-level class of the %Exiv2
-             library. The container holds Exifdatum objects.
-
-      Provide high-level access to the Exif data of an image:
-      - read Exif information from JPEG files
-      - access metadata through keys and standard C++ iterators
-      - add, modify and delete metadata
-      - write Exif data to JPEG files
-      - extract Exif metadata to files, insert from these files
-      - extract and delete Exif thumbnail (JPEG and TIFF thumbnails)
-    */
+    /// @brief A container for EXIF data. This is a top-level class of the library. The container holds Exifdatum
+    /// objects.
+    ///
+    /// Provide high-level access to the Exif data of an image:
+    /// - read Exif information from JPEG files
+    /// - access metadata through keys and standard C++ iterators
+    /// - add, modify and delete metadata
+    /// - write Exif data to JPEG files
+    /// - extract Exif metadata to files, insert from these files
+    /// - extract and delete Exif thumbnail (JPEG and TIFF thumbnails)
     class EXIV2API ExifData {
     public:
         //! ExifMetadata iterator type
@@ -439,60 +437,45 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        /*!
-          @brief Returns a reference to the %Exifdatum that is associated with a
-                 particular \em key. If %ExifData does not already contain such
-                 an %Exifdatum, operator[] adds object \em Exifdatum(key).
-
-          @note  Since operator[] might insert a new element, it can't be a const
-                 member function.
-         */
+        /// @brief Returns a reference to the %Exifdatum that is associated with a particular \em key.
+        /// If %ExifData does not already contain such an %Exifdatum, operator[] adds object \em Exifdatum(key).
+        /// @note  Since operator[] might insert a new element, it can't be a const member function.
         Exifdatum& operator[](const std::string& key);
-        /*!
-          @brief Add an Exifdatum from the supplied key and value pair.  This
-                 method copies (clones) key and value. No duplicate checks are
-                 performed, i.e., it is possible to add multiple metadata with
-                 the same key.
-         */
-        void add(const ExifKey& key, const Value* pValue);
-        /*!
-          @brief Add a copy of the \em exifdatum to the Exif metadata.  No
-                 duplicate checks are performed, i.e., it is possible to add
-                 multiple metadata with the same key.
 
-          @throw Error if the makernote cannot be created
-         */
+        /// @brief Add an Exifdatum from the supplied key and value pair. This method copies (clones) key and value.
+        /// No duplicate checks are performed, i.e., it is possible to add multiple metadata with the same key.
+        void add(const ExifKey& key, const Value* pValue);
+
+        /// @brief Add a copy of the \em exifdatum to the Exif metadata. No duplicate checks are performed, i.e., it is
+        /// possible to add multiple metadata with the same key.
+        /// @throw Error if the makernote cannot be created
         void add(const Exifdatum& exifdatum);
-        /*!
-          @brief Delete the Exifdatum at iterator position \em pos, return the
-                 position of the next exifdatum. Note that iterators into
-                 the metadata, including \em pos, are potentially invalidated
-                 by this call.
-         */
+
+        /// @brief Delete the Exifdatum at iterator position \em pos, return the position of the next exifdatum.
+        /// Note that iterators into the metadata, including \em pos, are potentially invalidated by this call.
         iterator erase(iterator pos);
-        /*!
-          @brief Remove all elements of the range \em beg, \em end, return the
-                 position of the next element. Note that iterators into
-                 the metadata are potentially invalidated by this call.
-         */
+
+        /// @brief Remove all elements of the range \em beg, \em end, return the position of the next element.
+        /// Note that iterators into the metadata are potentially invalidated by this call.
         iterator erase(iterator beg, iterator end);
-        /*!
-          @brief Delete all Exifdatum instances resulting in an empty container.
-                 Note that this also removes thumbnails.
-         */
+
+        /// @brief Delete all Exifdatum instances resulting in an empty container. Note that this also removes
+        /// thumbnails.
         void clear();
+
         //! Sort metadata by key
         void sortByKey();
+
         //! Sort metadata by tag
         void sortByTag();
+
         //! Begin of the metadata
         iterator begin() { return exifMetadata_.begin(); }
+
         //! End of the metadata
         iterator end() { return exifMetadata_.end(); }
-        /*!
-          @brief Find the first Exifdatum with the given \em key, return an
-                 iterator to it.
-         */
+
+        /// @brief Find the first Exifdatum with the given \em key, return an iterator to it.
         iterator findKey(const ExifKey& key);
         //@}
 
@@ -502,10 +485,7 @@ namespace Exiv2 {
         const_iterator begin() const { return exifMetadata_.begin(); }
         //! End of the metadata
         const_iterator end() const { return exifMetadata_.end(); }
-        /*!
-          @brief Find the first Exifdatum with the given \em key, return a const
-                 iterator to it.
-         */
+        /// @brief Find the first Exifdatum with the given \em key, return a const iterator to it.
         const_iterator findKey(const ExifKey& key) const;
         //! Return true if there is no Exif metadata
         bool empty() const { return count() == 0; }

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -45,106 +45,69 @@
  */
 namespace Exiv2 {
 
-// *****************************************************************************
-// class declarations
     class ExifData;
 
-// *****************************************************************************
-// class definitions
-
-    /*!
-      @brief An Exif metadatum, consisting of an ExifKey and a Value and
-             methods to manipulate these.
-     */
+    /// @brief An Exif metadatum, consisting of an ExifKey and a Value and methods to manipulate these.
     class EXIV2API Exifdatum : public Metadatum {
         template<typename T> friend Exifdatum& setValue(Exifdatum&, const T&);
     public:
         //! @name Creators
         //@{
-        /*!
-          @brief Constructor for new tags created by an application. The
-                 %Exifdatum is created from a \em key / value pair. %Exifdatum copies
-                 (clones) the \em key and value if one is provided. Alternatively,
-                 a program can create an 'empty' %Exifdatum with only a key
-                 and set the value using setValue().
-
-          @param key %ExifKey.
-          @param pValue Pointer to an %Exifdatum value.
-          @throw Error if the key cannot be parsed and converted.
-         */
+        /// @brief Constructor for new tags created by an application. The %Exifdatum is created from a \em key / value
+        /// pair. %Exifdatum copies (clones) the \em key and value if one is provided. Alternatively, a program can
+        /// create an 'empty' %Exifdatum with only a key and set the value using setValue().
+        /// @param key %ExifKey.
+        /// @param pValue Pointer to an %Exifdatum value.
+        /// @throw Error if the key cannot be parsed and converted.
         explicit Exifdatum(const ExifKey& key, const Value* pValue =0);
-        //! Copy constructor
+        
         Exifdatum(const Exifdatum& rhs);
-        //! Destructor
+        
         virtual ~Exifdatum();
         //@}
 
         //! @name Manipulators
         //@{
-        //! Assignment operator
         Exifdatum& operator=(const Exifdatum& rhs);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to UShortValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to UShortValue.
         Exifdatum& operator=(const uint16_t& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to ULongValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to ULongValue.
         Exifdatum& operator=(const uint32_t& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to URationalValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to URationalValue.
         Exifdatum& operator=(const URational& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to ShortValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to ShortValue.
         Exifdatum& operator=(const int16_t& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to LongValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to LongValue.
         Exifdatum& operator=(const int32_t& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum. The type of the new Value
-                 is set to RationalValue.
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. The type of the new Value is set to RationalValue.
         Exifdatum& operator=(const Rational& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum.
-                 Calls setValue(const std::string&).
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. Calls setValue(const std::string&).
         Exifdatum& operator=(const std::string& value);
-        /*!
-          @brief Assign \em value to the %Exifdatum.
-                 Calls setValue(const Value*).
-         */
+        
+        /// @brief Assign \em value to the %Exifdatum. Calls setValue(const Value*).
         Exifdatum& operator=(const Value& value);
+        
         void setValue(const Value* pValue) override;
-        /*!
-          @brief Set the value to the string \em value.  Uses Value::read(const
-                 std::string&).  If the %Exifdatum does not have a Value yet,
-                 then a %Value of the correct type for this %Exifdatum is
-                 created. An AsciiValue is created for unknown tags. Return
-                 0 if the value was read successfully.
-         */
+        /// @brief Set the value to the string \em value.  Uses Value::read(const std::string&).
+        /// 
+        /// If the %Exifdatum does not have a Value yet, then a %Value of the correct type for this %Exifdatum is
+        /// created. An AsciiValue is created for unknown tags. Return 0 if the value was read successfully.
         int setValue(const std::string& value) override;
-        /*!
-          @brief Set the data area by copying (cloning) the buffer pointed to
-                 by \em buf.
-
-          Values may have a data area, which can contain additional
-          information besides the actual value. This method is used to set such
-          a data area.
-
-          @param buf Pointer to the source data area
-          @param len Size of the data area
-          @return Return -1 if the %Exifdatum does not have a value yet or the
-                  value has no data area, else 0.
-         */
+        
+        /// @brief Set the data area by copying (cloning) the buffer pointed to by \em buf.
+        /// 
+        /// Values may have a data area, which can contain additional information besides the actual value. This method
+        /// is used to set such a data area.
+        /// @param buf Pointer to the source data area
+        /// @param len Size of the data area
+        /// @return Return -1 if the %Exifdatum does not have a value yet or the value has no data area, else 0.
         int setDataArea(const byte* buf, long len);
         //@}
 
@@ -163,18 +126,15 @@ namespace Exiv2 {
         const char* ifdName() const;
         //! Return the index (unique id of this key within the original IFD)
         int idx() const;
-        /*!
-          @brief Write value to a data buffer and return the number
-                 of bytes written.
-
-          The user must ensure that the buffer has enough memory. Otherwise
-          the call results in undefined behaviour.
-
-          @param buf Data buffer to write to.
-          @param byteOrder Applicable byte order (little or big endian).
-          @return Number of characters written.
-        */
+        
+        /// @brief Write value to a data buffer and return the number of bytes written.
+        /// 
+        /// The user must ensure that the buffer has enough memory. Otherwise the call results in undefined behaviour.
+        /// @param buf Data buffer to write to.
+        /// @param byteOrder Applicable byte order (little or big endian).
+        /// @return Number of characters written.
         long copy(byte* buf, ByteOrder byteOrder) const override;
+        
         std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const override;
         //! Return the type id of the value
         TypeId typeId() const override;
@@ -196,225 +156,149 @@ namespace Exiv2 {
         const Value& value() const override;
         //! Return the size of the data area.
         long sizeDataArea() const;
-        /*!
-          @brief Return a copy of the data area of the value. The caller owns
-                 this copy and %DataBuf ensures that it will be deleted.
-
-          Values may have a data area, which can contain additional
-          information besides the actual value. This method is used to access
-          such a data area.
-
-          @return A %DataBuf containing a copy of the data area or an empty
-                  %DataBuf if the value does not have a data area assigned or the
-                  value is not set.
-         */
+        
+        /// @brief Return a copy of the data area of the value. The caller owns this copy and %DataBuf ensures that it
+        /// will be deleted.
+        /// 
+        /// Values may have a data area, which can contain additional information besides the actual value. This method
+        /// is used to access such a data area.
+        /// @return A %DataBuf containing a copy of the data area or an empty %DataBuf if the value does not have a
+        /// data area assigned or the value is not set.
         DataBuf dataArea() const;
         //@}
 
     private:
-        // DATA
         ExifKey::UniquePtr key_;                  //!< Key
         Value::UniquePtr   value_;                //!< Value
 
-    }; // class Exifdatum
+    };
 
-    /*!
-      @brief Access to a Exif %thumbnail image. This class provides higher level
-             accessors to the thumbnail image that is optionally embedded in IFD1
-             of the Exif data. These methods do not write to the Exif metadata.
-             Manipulators are provided in subclass ExifThumb.
-
-      @note Various other preview and thumbnail images may be contained in an
-            image, depending on its format and the camera make and model. This
-            class only provides access to the Exif thumbnail as specified in the
-            Exif standard.
-     */
+    /// @brief Access to a Exif thumbnail image. 
+    /// 
+    /// This class provides higher level accessors to the thumbnail image that is optionally embedded in IFD1 of the
+    /// Exif data. These methods do not write to the Exif metadata. Manipulators are provided in subclass ExifThumb.
+    /// @note Various other preview and thumbnail images may be contained in an image, depending on its format and the
+    /// camera make and model. This class only provides access to the Exif thumbnail as specified in the Exif standard.
     class EXIV2API ExifThumbC {
     public:
         //! @name Creators
         //@{
-        //! Constructor.
         explicit ExifThumbC(const ExifData& exifData);
         //@}
 
         //! @name Accessors
         //@{
-        /*!
-          @brief Return the thumbnail image in a %DataBuf. The caller owns the
-                 data buffer and %DataBuf ensures that it will be deleted.
-         */
+        /// @brief Return the thumbnail image in a DataBuf. The caller owns the data buffer and %DataBuf.
         DataBuf copy() const;
-        /*!
-          @brief Write the thumbnail image to a file.
-
-          A filename extension is appended to \em path according to the image
-          type of the thumbnail, so \em path should not include an extension.
-          The function will overwrite an existing file of the same name.
-
-          @param path File name of the thumbnail without extension.
-          @return The number of bytes written.
-        */
+        
+        /// @brief Write the thumbnail image to a file.
+        /// 
+        /// A filename extension is appended to \em path according to the image type of the thumbnail, so \em path
+        /// should not include an extension. The function will overwrite an existing file of the same name.
+        /// @param path File name of the thumbnail without extension.
+        /// @return The number of bytes written.
         long writeFile(const std::string& path) const;
+        
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like writeFile() but accepts a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like writeFile() but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         long writeFile(const std::wstring& wpath) const;
 #endif
-        /*!
-          @brief Return the MIME type of the thumbnail, either \c "image/tiff"
-                 or \c "image/jpeg".
-         */
+        /// @brief Return the MIME type of the thumbnail, either \c "image/tiff" or \c "image/jpeg".
         const char* mimeType() const;
-        /*!
-          @brief Return the file extension for the format of the thumbnail
-                 (".tif" or ".jpg").
-         */
+        
+        /// @brief Return the file extension for the format of the thumbnail (".tif" or ".jpg").
         const char* extension() const;
+        
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like extension() but returns the extension in a wchar_t.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like extension() but returns the extension in a wchar_t.
+        /// @note This function is only available on Windows.
         const wchar_t* wextension() const;
 #endif
         //@}
 
     private:
-        // DATA
         const ExifData& exifData_; //!< Const reference to the Exif metadata.
+    };
 
-    }; // class ExifThumb
-
-    /*!
-      @brief Access and modify an Exif %thumbnail image. This class implements
-             manipulators to set and erase the thumbnail image that is optionally
-             embedded in IFD1 of the Exif data. Accessors are provided by the
-             base class, ExifThumbC.
-
-      @note Various other preview and thumbnail images may be contained in an
-            image, depending on its format and the camera make and model. This
-            class only provides access to the Exif thumbnail as specified in the
-            Exif standard.
-     */
+    /// @brief Access and modify an Exif thumbnail image.
+    /// 
+    /// This class implements manipulators to set and erase the thumbnail image that is optionally embedded in IFD1 of
+    /// the Exif data. Accessors are provided by the base class, ExifThumbC.
+    /// @note Various other preview and thumbnail images may be contained in an image, depending on its format and the
+    /// camera make and model. This class only provides access to the Exif thumbnail as specified in the Exif standard.
     class EXIV2API ExifThumb : public ExifThumbC {
     public:
         //! @name Creators
         //@{
-        //! Constructor.
         explicit ExifThumb(ExifData& exifData);
         //@}
 
         //! @name Manipulators
         //@{
-        /*!
-          @brief Set the Exif thumbnail to the JPEG image \em path. Set
-                 XResolution, YResolution and ResolutionUnit to \em xres,
-                 \em yres and \em unit, respectively.
-
-          This results in the minimal thumbnail tags being set for a JPEG
-          thumbnail, as mandated by the Exif standard.
-
-          @throw Error if reading the file fails.
-
-          @note  No checks on the file format or size are performed.
-          @note  Additional existing Exif thumbnail tags are not modified.
-          @note  The JPEG image inserted as thumbnail image should not
-                 itself contain Exif data (or other metadata), as existing
-                 applications may have problems with that. (The preview
-                 application that comes with OS X for one.) - David Harvey.
-         */
-        void setJpegThumbnail(
-            const std::string& path,
-                  URational    xres,
-                  URational    yres,
-                  uint16_t     unit
-        );
+        /// @brief Set the Exif thumbnail to the JPEG image \em path.
+        /// 
+        /// Set XResolution, YResolution and ResolutionUnit to \em xres, \em yres and \em unit, respectively. This
+        /// results in the minimal thumbnail tags being set for a JPEG thumbnail, as mandated by the Exif standard.
+        /// 
+        /// @throw Error if reading the file fails.
+        /// @note  No checks on the file format or size are performed.
+        /// @note  Additional existing Exif thumbnail tags are not modified.
+        /// @note  The JPEG image inserted as thumbnail image should not itself contain Exif data (or other metadata),
+        /// as existing applications may have problems with that. (The preview application that comes with OS X for
+        /// one.) - David Harvey.
+        void setJpegThumbnail(const std::string &path, URational xres, URational yres, uint16_t unit);
+        
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like setJpegThumbnail() but accepts a unicode path in an
-                 std::wstring.
-          @note This function is only available on Windows.
-         */
-        void setJpegThumbnail(
-            const std::wstring& wpath,
-                  URational     xres,
-                  URational     yres,
-                  uint16_t      unit
-        );
+        /// @brief Like setJpegThumbnail() but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
+        void setJpegThumbnail(const std::wstring &wpath, URational xres, URational yres, uint16_t unit);
 #endif
-        /*!
-          @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf,
-                 and size \em size. Set XResolution, YResolution and
-                 ResolutionUnit to \em xres, \em yres and \em unit, respectively.
-
-          This results in the minimal thumbnail tags being set for a JPEG
-          thumbnail, as mandated by the Exif standard.
-
-          @throw Error if reading the file fails.
-
-          @note  No checks on the image format or size are performed.
-          @note  Additional existing Exif thumbnail tags are not modified.
-          @note  The JPEG image inserted as thumbnail image should not
-                 itself contain Exif data (or other metadata), as existing
-                 applications may have problems with that. (The preview
-                 application that comes with OS X for one.) - David Harvey.
-         */
-        void setJpegThumbnail(
-            const byte*     buf,
-                  long      size,
-                  URational xres,
-                  URational yres,
-                  uint16_t  unit
-        );
-        /*!
-          @brief Set the Exif thumbnail to the JPEG image \em path.
-
-          This sets only the Compression, JPEGInterchangeFormat and
-          JPEGInterchangeFormatLength tags, which is not all the thumbnail
-          Exif information mandatory according to the Exif standard. (But it's
-          enough to work with the thumbnail.)
-
-          @throw Error if reading the file fails.
-
-          @note  No checks on the file format or size are performed.
-          @note  Additional existing Exif thumbnail tags are not modified.
-         */
+        /// @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf, and size \em size. 
+        /// 
+        /// Set XResolution, YResolution and ResolutionUnit to \em xres, \em yres and \em unit, respectively. This
+        /// results in the minimal thumbnail tags being set for a JPEG thumbnail, as mandated by the Exif standard.
+        /// 
+        /// @throw Error if reading the file fails.
+        /// @note  No checks on the image format or size are performed.
+        /// @note  Additional existing Exif thumbnail tags are not modified.
+        /// @note  The JPEG image inserted as thumbnail image should not itself contain Exif data (or other metadata),
+        /// as existing applications may have problems with that. (The preview application that comes with OS X for
+        /// one.) - David Harvey.
+        void setJpegThumbnail(const byte *buf, long size, URational xres, URational yres, uint16_t unit);
+        
+        /// @brief Set the Exif thumbnail to the JPEG image \em path.
+        /// 
+        /// This sets only the Compression, JPEGInterchangeFormat and JPEGInterchangeFormatLength tags, which is not
+        /// all the thumbnail Exif information mandatory according to the Exif standard. (But it's enough to work 
+        /// with the thumbnail.)
+        /// 
+        /// @throw Error if reading the file fails.
+        /// @note  No checks on the file format or size are performed.
+        /// @note  Additional existing Exif thumbnail tags are not modified.
         void setJpegThumbnail(const std::string& path);
+        
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like setJpegThumbnail(const std::string& path) but accepts a
-                 unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like setJpegThumbnail(const std::string& path) but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         void setJpegThumbnail(const std::wstring& wpath);
 #endif
-        /*!
-          @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf,
-                 and size \em size.
-
-          This sets only the Compression, JPEGInterchangeFormat and
-          JPEGInterchangeFormatLength tags, which is not all the thumbnail
-          Exif information mandatory according to the Exif standard. (But it's
-          enough to work with the thumbnail.)
-
-          @note  No checks on the image format or size are performed.
-          @note  Additional existing Exif thumbnail tags are not modified.
-         */
+        /// @brief Set the Exif thumbnail to the JPEG image pointed to by \em buf, and size \em size.
+        /// 
+        /// This sets only the Compression, JPEGInterchangeFormat and JPEGInterchangeFormatLength tags, which is not
+        /// all the thumbnail Exif information mandatory according to the Exif standard. (But it's enough to work with
+        /// the thumbnail.)
+        /// @note  No checks on the image format or size are performed.
+        /// @note  Additional existing Exif thumbnail tags are not modified.
         void setJpegThumbnail(const byte* buf, long size);
-        /*!
-          @brief Delete the thumbnail from the Exif data. Removes all
-                 Exif.%Thumbnail.*, i.e., Exif IFD1 tags.
-         */
+        
+        /// @brief Delete the thumbnail from the Exif data. Removes all Exif.%Thumbnail.*, i.e., Exif IFD1 tags.
         void erase();
         //@}
 
     private:
-        // DATA
         ExifData& exifData_;    //!< Reference to the related Exif metadata.
-
-    }; // class ExifThumb
+    };
 
     //! Container type to hold all metadata
     typedef std::list<Exifdatum> ExifMetadata;
@@ -495,111 +379,65 @@ namespace Exiv2 {
         //@}
 
     private:
-        // DATA
         ExifMetadata exifMetadata_;
+    };
 
-    }; // class ExifData
-
-    /*!
-      @brief Stateless parser class for Exif data. Images use this class to
-             decode and encode binary Exif data.
-
-      @note  Encode is lossy and is not the inverse of decode.
-     */
+    /// @brief Stateless parser class for Exif data. Images use this class to decode and encode binary Exif data.
+    /// @note  Encode is lossy and is not the inverse of decode.
     class EXIV2API ExifParser {
     public:
-        /*!
-          @brief Decode metadata from a buffer \em pData of length \em size
-                 with binary Exif data to the provided metadata container.
+      /// @brief Decode metadata from a buffer \em pData of length \em size with binary Exif data to the provided
+      /// metadata container.
+      /// 
+      /// The buffer must start with a TIFF header. Return byte order in which the data is encoded.
+      /// @param exifData Exif metadata container.
+      /// @param pData Pointer to the data buffer. Must point to data in binary Exif format; no checks are performed.
+      /// @param size  Length of the data buffer
+      /// @return Byte order in which the data is encoded.
+      static ByteOrder decode(ExifData &exifData, const byte *pData, uint32_t size);
+      
+      /// @brief Encode Exif metadata from the provided metadata to binary Exif format.
+      /// 
+      /// The original binary Exif data in the memory block \em pData, \em size is parsed and updated in-place if
+      /// possible ("non-intrusive" writing). If that is not possible (e.g., if new tags were added), the entire Exif
+      /// structure is re-written to the \em blob ("intrusive" writing). The return value indicates which write method
+      /// was used. If it is \c wmNonIntrusive, the original memory \em pData, \em size contains the result and \em blob
+      /// is empty. If the return value is \c wmIntrusive, a new Exif structure was created and returned in \em blob.
+      /// The memory block \em pData, \em size may be partly updated in this case and should not be used anymore.
+      /// 
+      /// Encode is a lossy operation. It attempts to fit the Exif data into a binary block suitable as the payload of
+      /// a JPEG APP1 Exif segment, which can be at most 65527 bytes large. Encode omits IFD0 tags that are "not
+      /// recorded" in compressed images according to the Exif 2.2 specification. It also doesn't write tags in groups
+      /// which do not occur in JPEG images. If the resulting binary block is larger than allowed, it further deletes
+      /// specific large preview tags, unknown tags larger than 4kB and known tags larger than 40kB. The operation
+      /// succeeds even if the end result is still larger than the allowed size. Application should therefore always 
+      /// check the size of the \em blob.
+      /// 
+      /// @param blob Container for the binary Exif data if "intrusive" writing is necessary. Empty otherwise.
+      /// @param pData Pointer to the binary Exif data buffer. Must point to data in Exif format; no checks are
+      /// performed. Will be modified if "non-intrusive" writing is possible.
+      /// @param size      Length of the data buffer.
+      /// @param byteOrder Byte order to use.
+      /// @param exifData  Exif metadata container.
+      /// @return Write method used.
+      static WriteMethod encode(Blob &blob, const byte *pData, uint32_t size,
+                                ByteOrder byteOrder, const ExifData &exifData);
+      
+      /// @brief Encode metadata from the provided metadata to Exif format.
+      /// 
+      /// Encode Exif metadata from the \em ExifData container to binary Exif format in the \em blob, encoded in 
+      /// \em byteOrder.
+      /// 
+      /// This simpler encode method uses "intrusive" writing, i.e., it builds the binary representation of the metadata
+      /// from scratch. It does not attempt "non-intrusive", i.e., in-place updating. It's better to use the other
+      /// encode() method, if the metadata is already available in binary format, in order to allow for "non-intrusive"
+      /// updating of the existing binary representation.
+      ///  
+      /// This is just an inline wrapper for ExifParser::encode(blob, 0, 0, byteOrder, exifData).
+      /// @param blob      Container for the binary Exif data.
+      /// @param byteOrder Byte order to use.
+      /// @param exifData  Exif metadata container.
+      static void encode(Blob &blob, ByteOrder byteOrder, const ExifData &exifData);
 
-                 The buffer must start with a TIFF header. Return byte order
-                 in which the data is encoded.
-
-          @param exifData Exif metadata container.
-          @param pData 	  Pointer to the data buffer. Must point to data in
-                          binary Exif format; no checks are performed.
-          @param size 	  Length of the data buffer
-          @return Byte order in which the data is encoded.
-        */
-        static ByteOrder decode(
-                  ExifData& exifData,
-            const byte*     pData,
-                  uint32_t  size
-        );
-        /*!
-          @brief Encode Exif metadata from the provided metadata to binary Exif
-                 format.
-
-          The original binary Exif data in the memory block \em pData, \em size
-          is parsed and updated in-place if possible ("non-intrusive"
-          writing). If that is not possible (e.g., if new tags were added), the
-          entire Exif structure is re-written to the \em blob ("intrusive"
-          writing). The return value indicates which write method was used. If
-          it is \c wmNonIntrusive, the original memory \em pData, \em size
-          contains the result and \em blob is empty. If the return value is
-          \c wmIntrusive, a new Exif structure was created and returned in
-          \em blob. The memory block \em pData, \em size may be partly updated in
-          this case and should not be used anymore.
-
-          Encode is a lossy operation. It attempts to fit the Exif data into a
-          binary block suitable as the payload of a JPEG APP1 Exif segment,
-          which can be at most 65527 bytes large. Encode omits IFD0 tags that
-          are "not recorded" in compressed images according to the Exif 2.2
-          specification. It also doesn't write tags in groups which do not occur
-          in JPEG images. If the resulting binary block is larger than allowed,
-          it further deletes specific large preview tags, unknown tags larger
-          than 4kB and known tags larger than 40kB. The operation succeeds even
-          if the end result is still larger than the allowed size. Application
-          should therefore always check the size of the \em blob.
-
-          @param blob      Container for the binary Exif data if "intrusive"
-                           writing is necessary. Empty otherwise.
-          @param pData     Pointer to the binary Exif data buffer. Must
-                           point to data in Exif format; no checks are
-                           performed. Will be modified if "non-intrusive"
-                           writing is possible.
-          @param size      Length of the data buffer.
-          @param byteOrder Byte order to use.
-          @param exifData  Exif metadata container.
-
-          @return Write method used.
-        */
-        static WriteMethod encode(
-                  Blob&     blob,
-            const byte*     pData,
-                  uint32_t  size,
-                  ByteOrder byteOrder,
-            const ExifData& exifData
-        );
-        /*!
-          @brief Encode metadata from the provided metadata to Exif format.
-
-          Encode Exif metadata from the \em ExifData container to binary Exif
-          format in the \em blob, encoded in \em byteOrder.
-
-          This simpler encode method uses "intrusive" writing, i.e., it builds
-          the binary representation of the metadata from scratch. It does not
-          attempt "non-intrusive", i.e., in-place updating. It's better to use
-          the other encode() method, if the metadata is already available in
-          binary format, in order to allow for "non-intrusive" updating of the
-          existing binary representation.
-
-          This is just an inline wrapper for
-          ExifParser::encode(blob, 0, 0, byteOrder, exifData).
-
-          @param blob      Container for the binary Exif data.
-          @param byteOrder Byte order to use.
-          @param exifData  Exif metadata container.
-        */
-        static void encode(
-                  Blob&     blob,
-                  ByteOrder byteOrder,
-            const ExifData& exifData
-        )
-        {
-            encode(blob, 0, 0, byteOrder, exifData);
-        }
-
-    }; // class ExifParser
-
-}                                       // namespace Exiv2
+    };
+} // namespace Exiv2

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -54,23 +54,17 @@ namespace Exiv2 {
     //! List of native previews. This is meant to be used only by the PreviewManager.
     typedef std::vector<NativePreview> NativePreviewList;
 
-    /*!
-      @brief Options for printStructure
-     */
+    /// @brief Options for printStructure
     typedef enum { kpsNone, kpsBasic, kpsXMP, kpsRecursive
                  , kpsIccProfile    , kpsIptcErase
                  } PrintStructureOption;
 
-    /*!
-      @brief Abstract base class defining the interface for an image. This is
-         the top-level interface to the Exiv2 library.
-
-      Image has containers to store image metadata and subclasses implement
-      read and save metadata from and to specific image formats.<BR>
-      Most client apps will obtain an Image instance by calling a static
-      ImageFactory method. The Image class can then be used to to read, write,
-      and save metadata.
-     */
+    /// @brief Interface for an image. This is the top-level interface to the Exiv2 library.
+    ///
+    /// Image has containers to store image metadata and subclasses implement read and save metadata from and to
+    /// specific image formats.<BR>
+    /// Most clients will obtain an Image instance by calling a static ImageFactory method. The Image class can
+    /// then be used to to read, write, and save metadata.
     class EXIV2API Image {
     public:
         //! Image auto_ptr type
@@ -78,258 +72,190 @@ namespace Exiv2 {
 
         //! @name Creators
         //@{
-        /*!
-          @brief Constructor taking the image type, a bitmap of the supported
-              metadata types and an auto-pointer that owns an IO instance.
-              See subclass constructor doc.
-         */
+
+        /// Constructor taking the image type, a bitmap of the supported metadata types and an auto-pointer that owns
+        /// an IO instance. See subclass constructor doc.
         Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io);
-        //! Virtual Destructor
         virtual ~Image();
         //@}
 
         //! @name Manipulators
         //@{
-        /*!
-          @brief Print out the structure of image file.
-          @throw Error if reading of the file fails or the image data is
-                not valid (does not look like data of the specific image type).
-          @warning This function is not thread safe and intended for exiv2 -pS for debugging.
-          @warning You may need to put the stream into binary mode (see src/actions.cpp)
-         */
+
+        /// @brief Print out the structure of image file.
+        /// @throw Error if reading of the file fails or the image data is not valid (does not look like data of the
+        /// specific image type).
+        /// @warning This function is not thread safe and intended for exiv2 -pS for debugging.
+        /// @warning You may need to put the stream into binary mode (see src/actions.cpp)
         virtual void printStructure(std::ostream& out, PrintStructureOption option =kpsNone, int depth=0);
-        /*!
-          @brief Read all metadata supported by a specific image format from the
-              image. Before this method is called, the image metadata will be
-              cleared.
 
-          This method returns success even if no metadata is found in the
-          image. Callers must therefore check the size of individual metadata
-          types before accessing the data.
-
-          @throw Error if opening or reading of the file fails or the image
-              data is not valid (does not look like data of the specific image
-              type).
-         */
+        /// @brief Read all metadata supported by a specific image format from the image. Before this method is called,
+        /// the image metadata will be cleared.
+        ///
+        /// This method returns success even if no metadata is found in the image. Callers must therefore check the
+        /// size of individual metadata types before accessing the data.
+        ///
+        /// @throw Error if opening or reading of the file fails or the image data is not valid (does not look like
+        /// data of the specific image type).
         virtual void readMetadata() =0;
-        /*!
-          @brief Write metadata back to the image.
 
-          All existing metadata sections in the image are either created,
-          replaced, or erased. If values for a given metadata type have been
-          assigned, a section for that metadata type will either be created or
-          replaced. If no values have been assigned to a given metadata type,
-          any exists section for that metadata type will be removed from the
-          image.
-
-          @throw Error if the operation fails
-         */
+        /// @brief Write metadata back to the image.
+        ///
+        /// All existing metadata sections in the image are either created, replaced, or erased. If values for a
+        /// given metadata type have been assigned, a section for that metadata type will either be created or
+        /// replaced. If no values have been assigned to a given metadata type, any exists section for that metadata
+        /// type will be removed from the image.
+        ///
+        /// @throw Error if the operation fails
         virtual void writeMetadata() =0;
-        /*!
-          @brief Assign new Exif data. The new Exif data is not written
-              to the image until the writeMetadata() method is called.
-          @param exifData An ExifData instance holding Exif data to be copied
-         */
+
+        /// @brief Assign new Exif data. The new Exif data is not written to the image until the writeMetadata()
+        /// method is called.
+        /// @param exifData An ExifData instance holding Exif data to be copied
         virtual void setExifData(const ExifData& exifData);
-        /*!
-          @brief Erase any buffered Exif data. Exif data is not removed from
-              the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase any buffered Exif data. Exif data is not removed from the actual image until the
+        /// writeMetadata() method is called.
         virtual void clearExifData();
-        /*!
-          @brief Assign new IPTC data. The new IPTC data is not written
-              to the image until the writeMetadata() method is called.
-          @param iptcData An IptcData instance holding IPTC data to be copied
-         */
+
+        /// @brief Assign new IPTC data. The new IPTC data is not written to the image until the writeMetadata()
+        /// method is called.
+        /// @param iptcData An IptcData instance holding IPTC data to be copied
         virtual void setIptcData(const IptcData& iptcData);
-        /*!
-          @brief Erase any buffered IPTC data. IPTC data is not removed from
-              the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase any buffered IPTC data. IPTC data is not removed from the actual image until the
+        /// writeMetadata() method is called.
         virtual void clearIptcData();
-        /*!
-          @brief Assign a raw XMP packet. The new XMP packet is not written
-              to the image until the writeMetadata() method is called.
 
-          Subsequent calls to writeMetadata() write the XMP packet from
-          the buffered raw XMP packet rather than from buffered parsed XMP
-          data. In order to write from parsed XMP data again, use
-          either writeXmpFromPacket(false) or setXmpData().
-
-          @param xmpPacket A string containing the raw XMP packet.
-         */
+        /// @brief Assign a raw XMP packet. The new XMP packet is not written to the image until the writeMetadata()
+        /// method is called.
+        ///
+        /// Subsequent calls to writeMetadata() write the XMP packet from the buffered raw XMP packet rather than from
+        /// buffered parsed XMP data. In order to write from parsed XMP data again, use either
+        /// writeXmpFromPacket(false) or setXmpData().
+        /// @param xmpPacket A string containing the raw XMP packet.
         virtual void setXmpPacket(const std::string& xmpPacket);
-        /*!
-          @brief Erase the buffered XMP packet. XMP data is not removed from
-              the actual image until the writeMetadata() method is called.
 
-          This has the same effect as clearXmpData() but operates on the
-          buffered raw XMP packet only, not the parsed XMP data.
-
-          Subsequent calls to writeMetadata() write the XMP packet from
-          the buffered raw XMP packet rather than from buffered parsed XMP
-          data. In order to write from parsed XMP data again, use
-          either writeXmpFromPacket(false) or setXmpData().
-         */
+        /// @brief Erase the buffered XMP packet. XMP data is not removed from the actual image until the
+        /// writeMetadata() method is called.
+        ///
+        /// This has the same effect as clearXmpData() but operates on the buffered raw XMP packet only, not the
+        /// parsed XMP data.
+        /// Subsequent calls to writeMetadata() write the XMP packet from the buffered raw XMP packet rather than from
+        /// buffered parsed XMP data. In order to write from parsed XMP data again, use either
+        /// writeXmpFromPacket(false) or setXmpData().
         virtual void clearXmpPacket();
-        /*!
-          @brief Assign new XMP data. The new XMP data is not written
-              to the image until the writeMetadata() method is called.
 
-          Subsequent calls to writeMetadata() encode the XMP data to
-          a raw XMP packet and write the newly encoded packet to the image.
-          In the process, the buffered raw XMP packet is updated.
-          In order to write directly from the raw XMP packet, use
-          writeXmpFromPacket(true) or setXmpPacket().
-
-          @param xmpData An XmpData instance holding XMP data to be copied
-         */
+        /// @brief Assign new XMP data. The new XMP data is not written to the image until the writeMetadata() method
+        /// is called.
+        ///
+        /// Subsequent calls to writeMetadata() encode the XMP data to a raw XMP packet and write the newly encoded
+        /// packet to the image. In the process, the buffered raw XMP packet is updated. In order to write directly
+        /// from the raw XMP packet, use writeXmpFromPacket(true) or setXmpPacket().
+        /// @param xmpData An XmpData instance holding XMP data to be copied
         virtual void setXmpData(const XmpData& xmpData);
-        /*!
-          @brief Erase any buffered XMP data. XMP data is not removed from
-              the actual image until the writeMetadata() method is called.
 
-          This has the same effect as clearXmpPacket() but operates on the
-          buffered parsed XMP data.
-
-          Subsequent calls to writeMetadata() encode the XMP data to
-          a raw XMP packet and write the newly encoded packet to the image.
-          In the process, the buffered raw XMP packet is updated.
-          In order to write directly from the raw XMP packet, use
-          writeXmpFromPacket(true) or setXmpPacket().
-         */
+        /// @brief Erase any buffered XMP data. XMP data is not removed from the actual image until the writeMetadata()
+        /// method is called.
+        ///
+        /// This has the same effect as clearXmpPacket() but operates on the buffered parsed XMP data.
+        /// Subsequent calls to writeMetadata() encode the XMP data to a raw XMP packet and write the newly encoded
+        /// packet to the image.
+        /// In the process, the buffered raw XMP packet is updated. In order to write directly from the raw XMP packet,
+        /// use writeXmpFromPacket(true) or setXmpPacket().
         virtual void clearXmpData();
-        /*!
-          @brief Set the image comment. The new comment is not written
-              to the image until the writeMetadata() method is called.
-          @param comment String containing comment.
-         */
+
+        /// @brief Set the image comment. The new comment is not written to the image until the writeMetadata() method
+        /// is called.
+        /// @param comment String containing comment.
         virtual void setComment(const std::string& comment);
-        /*!
-          @brief Erase any buffered comment. Comment is not removed
-              from the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase any buffered comment. Comment is not removed from the actual image until the writeMetadata()
+        /// method is called.
         virtual void clearComment();
-        /*!
-          @brief Set the image iccProfile. The new profile is not written
-              to the image until the writeMetadata() method is called.
-          @param iccProfile DataBuf containing profile (binary)
-          @param bTestValid - tests that iccProfile contains credible data
-         */
+
+        /// @brief Set the image iccProfile. The new profile is not written to the image until the writeMetadata()
+        /// method is called.
+        /// @param iccProfile DataBuf containing profile (binary)
+        /// @param bTestValid - tests that iccProfile contains credible data
         virtual void setIccProfile(DataBuf& iccProfile,bool bTestValid=true);
-        /*!
-          @brief Erase iccProfile. the profile is not removed from
-              the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase iccProfile. the profile is not removed from the actual image until the writeMetadata()
+        /// method is called.
         virtual void clearIccProfile();
-        /*!
-          @brief Erase iccProfile. the profile is not removed from
-              the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase iccProfile. the profile is not removed from the actual image until the writeMetadata() method
+        /// is called.
         virtual bool iccProfileDefined() { return iccProfile_.size_?true:false;}
 
-        /*!
-          @brief return iccProfile
-         */
+        /// @brief return iccProfile
         virtual DataBuf* iccProfile() { return &iccProfile_; }
-        /*!
-          @brief Copy all existing metadata from source Image. The data is
-              copied into internal buffers and is not written to the image
-              until the writeMetadata() method is called.
-          @param image Metadata source. All metadata types are copied.
-         */
+
+        /// @brief Copy all existing metadata from source Image. The data is copied into internal buffers and is not
+        /// written to the image until the writeMetadata() method is called.
+        /// @param image Metadata source. All metadata types are copied.
         virtual void setMetadata(const Image& image);
-        /*!
-          @brief Erase all buffered metadata. Metadata is not removed
-              from the actual image until the writeMetadata() method is called.
-         */
+
+        /// @brief Erase all buffered metadata. Metadata is not removed from the actual image until the writeMetadata()
+        /// method is called.
         virtual void clearMetadata();
-        /*!
-          @brief Returns an ExifData instance containing currently buffered
-              Exif data.
 
-          The contained Exif data may have been read from the image by
-          a previous call to readMetadata() or added directly. The Exif
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return modifiable ExifData instance containing Exif values
-         */
+        /// @brief Returns an ExifData instance containing currently buffered Exif data.
+        ///
+        /// The contained Exif data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The Exif data in the returned instance will be written to the image when writeMetadata() is
+        /// called.
+        /// @return modifiable ExifData instance containing Exif values
         virtual ExifData& exifData();
-        /*!
-          @brief Returns an IptcData instance containing currently buffered
-              IPTC data.
 
-          The contained IPTC data may have been read from the image by
-          a previous call to readMetadata() or added directly. The IPTC
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return modifiable IptcData instance containing IPTC values
-         */
+        /// @brief Returns an IptcData instance containing currently buffered IPTC data.
+        ///
+        /// The contained IPTC data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The IPTC data in the returned instance will be written to the image when writeMetadata() is
+        /// called.
+        /// @return modifiable IptcData instance containing IPTC values
         virtual IptcData& iptcData();
-        /*!
-          @brief Returns an XmpData instance containing currently buffered
-              XMP data.
 
-          The contained XMP data may have been read from the image by
-          a previous call to readMetadata() or added directly. The XMP
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return modifiable XmpData instance containing XMP values
-         */
+        /// @brief Returns an XmpData instance containing currently buffered XMP data.
+        ///
+        /// The contained XMP data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The XMP data in the returned instance will be written to the image when writeMetadata() is called.
+        /// @return modifiable XmpData instance containing XMP values
         virtual XmpData& xmpData();
-        /*!
-          @brief Return a modifiable reference to the raw XMP packet.
-         */
+
+        /// @brief Return a modifiable reference to the raw XMP packet.
         virtual std::string& xmpPacket();
-        /*!
-          @brief Determine the source when writing XMP.
 
-          Depending on the setting of this flag, writeMetadata() writes
-          XMP from the buffered raw XMP packet or from parsed XMP data.
-          The default is to write from parsed XMP data. The switch is also
-          set by all functions to set and clear the buffered raw XMP packet
-          and parsed XMP data, so using this function should usually not be
-          necessary.
-
-          If %Exiv2 was compiled without XMP support, the default for this
-          flag is true and it will never be changed in order to preserve
-          access to the raw XMP packet.
-         */
+        /// @brief Determine the source when writing XMP.
+        ///
+        /// Depending on the setting of this flag, writeMetadata() writes XMP from the buffered raw XMP packet or
+        /// from parsed XMP data. The default is to write from parsed XMP data. The switch is also set by all functions
+        /// to set and clear the buffered raw XMP packet and parsed XMP data, so using this function should usually not
+        /// be necessary.
+        ///
+        /// If Exiv2 was compiled without XMP support, the default for this flag is true and it will never be changed
+        /// in order to preserve access to the raw XMP packet.
         void writeXmpFromPacket(bool flag);
-        /*!
-          @brief Set the byte order to encode the Exif metadata in.
 
-          The setting is only used when new Exif metadata is created and may
-          not be applicable at all for some image formats. If the target image
-          already contains Exif metadata, the byte order of the existing data
-          is used. If byte order is not set when writeMetadata() is called,
-          little-endian byte order (II) is used by default.
-         */
+        /// @brief Set the byte order to encode the Exif metadata in.
+        ///
+        /// The setting is only used when new Exif metadata is created and may not be applicable at all for some image
+        /// formats. If the target image already contains Exif metadata, the byte order of the existing data is used.
+        /// If byte order is not set when writeMetadata() is called, little-endian byte order (II) is used by default.
         void setByteOrder(ByteOrder byteOrder);
 
-        /*!
-          @brief Print out the structure of image file.
-          @throw Error if reading of the file fails or the image data is
-                not valid (does not look like data of the specific image type).
-         */
+        /// @brief Print out the structure of image file.
+        /// @throw Error if reading of the file fails or the image data is not valid (does not look like data of the
+        /// specific image type).
         void printTiffStructure(BasicIo& io,std::ostream& out, PrintStructureOption option,int depth,size_t offset=0);
 
-        /*!
-          @brief Print out the structure of a TIFF IFD
-         */
+        /// @brief Print out the structure of a TIFF IFD
         void printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option,uint32_t start,bool bSwap,char c,int depth);
 
-        /*!
-          @brief is the host platform bigEndian
-         */
+        /// @brief is the host platform bigEndian
         bool isBigEndianPlatform();
 
-        /*!
-          @brief is the host platform littleEndian
-         */
+        /// @brief is the host platform littleEndian
         bool isLittleEndianPlatform();
 
         bool isStringType(uint16_t type);
@@ -354,126 +280,96 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        /*!
-          @brief Return the byte order in which the Exif metadata of the image is
-                 encoded. Initially, it is not set (\em invalidByteOrder).
-         */
+
+        /// @brief Return the byte order in which the Exif metadata of the image is encoded. Initially, it is not set
+        /// (\em invalidByteOrder).
         ByteOrder byteOrder() const;
-        /*!
-          @brief Check if the Image instance is valid. Use after object
-              construction.
-          @return true if the Image is in a valid state.
-         */
+
+        /// @brief Check if the Image instance is valid. Use after object construction.
+        /// @return true if the Image is in a valid state.
         bool good() const;
-        /*!
-          @brief Return the MIME type of the image.
 
-          @note For each supported image format, the library knows only one MIME
-          type.  This may not be the most specific MIME type for that format. In
-          particular, several RAW formats are variants of the TIFF format with
-          the same magic as TIFF itself. Class TiffImage handles most of them
-          and thus they all have MIME type "image/tiff", although a more
-          specific MIME type may exist (e.g., "image/x-nikon-nef").
-         */
+        /// @brief Return the MIME type of the image.
+        ///
+        /// @note For each supported image format, the library knows only one MIME type. This may not be the most
+        /// specific MIME type for that format. In particular, several RAW formats are variants of the TIFF format with
+        /// the same magic as TIFF itself. Class TiffImage handles most of them and thus they all have MIME type
+        /// "image/tiff", although a more specific MIME type may exist (e.g., "image/x-nikon-nef").
         virtual std::string mimeType() const =0;
-        /*!
-          @brief Return the pixel width of the image.
-         */
+
+        /// @brief Return the pixel width of the image.
         virtual int pixelWidth() const;
-        /*!
-          @brief Return the pixel height of the image.
-         */
+
+        /// @brief Return the pixel height of the image.
         virtual int pixelHeight() const;
-        /*!
-          @brief Returns an ExifData instance containing currently buffered
-              Exif data.
 
-          The Exif data may have been read from the image by
-          a previous call to readMetadata() or added directly. The Exif
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return read only ExifData instance containing Exif values
-         */
+        /// @brief Returns an ExifData instance containing currently buffered Exif data.
+        ///
+        /// The Exif data may have been read from the image by a previous call to readMetadata() or added directly. The
+        /// Exif data in the returned instance will be written to the image when writeMetadata() is called.
+        /// @return read only ExifData instance containing Exif values
         virtual const ExifData& exifData() const;
-        /*!
-          @brief Returns an IptcData instance containing currently buffered
-              IPTC data.
 
-          The contained IPTC data may have been read from the image by
-          a previous call to readMetadata() or added directly. The IPTC
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return modifiable IptcData instance containing IPTC values
-         */
+        /// @brief Returns an IptcData instance containing currently buffered IPTC data.
+        ///
+        /// The contained IPTC data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The IPTC data in the returned instance will be written to the image when writeMetadata() is
+        /// called.
+        /// @return modifiable IptcData instance containing IPTC values
         virtual const IptcData& iptcData() const;
-        /*!
-          @brief Returns an XmpData instance containing currently buffered
-              XMP data.
 
-          The contained XMP data may have been read from the image by
-          a previous call to readMetadata() or added directly. The XMP
-          data in the returned instance will be written to the image when
-          writeMetadata() is called.
-
-          @return modifiable XmpData instance containing XMP values
-         */
+        /// @brief Returns an XmpData instance containing currently buffered XMP data.
+        ///
+        /// The contained XMP data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The XMP data in the returned instance will be written to the image when writeMetadata() is called.
+        /// @return modifiable XmpData instance containing XMP values
         virtual const XmpData& xmpData() const;
-        /*!
-          @brief Return a copy of the image comment. May be an empty string.
-         */
+
+        /// @brief Return a copy of the image comment. May be an empty string.
         virtual std::string comment() const;
-        /*!
-          @brief Return the raw XMP packet as a string.
-         */
+
+        /// @brief Return the raw XMP packet as a string.
         virtual const std::string& xmpPacket() const;
-        /*!
-          @brief Return a reference to the BasicIo instance being used for Io.
 
-          This refence is particularly useful to reading the results of
-          operations on a MemIo instance. For example after metadata has
-          been modified and the writeMetadata() method has been called,
-          this method can be used to get access to the modified image.
-
-          @return BasicIo instance that can be used to read or write image
-             data directly.
-          @note If the returned BasicIo is used to write to the image, the
-             Image class will not see those changes until the readMetadata()
-             method is called.
-         */
+        /// @brief Return a reference to the BasicIo instance being used for Io.
+        ///
+        /// This refence is particularly useful to reading the results of operations on a MemIo instance. For example
+        /// after metadata has been modified and the writeMetadata() method has been called, this method can be used
+        /// to get access to the modified image.
+        /// @return BasicIo instance that can be used to read or write image data directly.
+        /// @note If the returned BasicIo is used to write to the image, the Image class will not see those changes
+        /// until the readMetadata() method is called.
         virtual BasicIo& io() const;
-        /*!
-          @brief Returns the access mode, i.e., the metadata functions, which
-             this image supports for the metadata type \em metadataId.
-          @param metadataId The metadata identifier.
-          @return Access mode for the requested image type and metadata identifier.
-         */
+
+        /// @brief Returns the access mode, i.e., the metadata functions, which this image supports for the metadata
+        /// type \em metadataId.
+        /// @param metadataId The metadata identifier.
+        /// @return Access mode for the requested image type and metadata identifier.
         AccessMode checkMode(MetadataId metadataId) const;
-        /*!
-          @brief Check if image supports a particular type of metadata.
-             This method is deprecated. Use checkMode() instead.
-         */
+
+        /// @brief Check if image supports a particular type of metadata. This method is deprecated. Use checkMode() instead.
         bool supportsMetadata(MetadataId metadataId) const;
-        //! Return the flag indicating the source when writing XMP metadata.
+
+        /// Return the flag indicating the source when writing XMP metadata.
         bool writeXmpFromPacket() const;
-        //! Return list of native previews. This is meant to be used only by the PreviewManager.
+
+        /// Return list of native previews. This is meant to be used only by the PreviewManager.
         const NativePreviewList& nativePreviews() const;
         //@}
 
-        //! set type support for this image format
+        /// set type support for this image format
         void setTypeSupported(ImageType imageType, uint16_t supportedMetadata)
         {
             imageType_         = imageType;
             supportedMetadata_ = supportedMetadata;
         }
 
-        //! set type support for this image format
+        /// set type support for this image format
         ImageType imageType() const { return imageType_; }
 
     protected:
         // DATA
-        BasicIo::UniquePtr  io_;                //!< Image data IO pointer
+        BasicIo::UniquePtr  io_;              //!< Image data IO pointer
         ExifData          exifData_;          //!< Exif data container
         IptcData          iptcData_;          //!< IPTC data container
         XmpData           xmpData_;           //!< XMP data container
@@ -513,190 +409,140 @@ namespace Exiv2 {
     //! Type for function pointer that checks image types
     typedef bool (*IsThisTypeFct)(BasicIo& iIo, bool advance);
 
-    /*!
-      @brief Returns an Image instance of the specified type.
-
-      The factory is implemented as a static class.
-    */
+    /// @brief Returns an Image instance of the specified type. The factory is implemented as a static class.
     class EXIV2API ImageFactory {
         friend bool Image::good() const;
     public:
-        /*!
-          @brief Create the appropriate class type implemented BasicIo based on the protocol of the input.
-
-          "-" path implies the data from stdin and it is handled by StdinIo.
-          Http path can be handled by either HttpIo or CurlIo. Https, ftp paths
-          are handled by CurlIo. Ssh, sftp paths are handled by SshIo. Others are handled by FileIo.
-
-          @param path %Image file.
-          @param useCurl Indicate whether the libcurl is used or not.
-                If it's true, http is handled by CurlIo. Otherwise it is handled by HttpIo.
-          @return An auto-pointer that owns an BasicIo instance.
-          @throw Error If the file is not found or it is unable to connect to the server to
-                read the remote file.
-         */
+        /// @brief Create the appropriate class type implemented BasicIo based on the protocol of the input.
+        ///
+        /// "-" path implies the data from stdin and it is handled by StdinIo. Http path can be handled by either
+        /// HttpIo or CurlIo. Https, ftp paths are handled by CurlIo. Ssh, sftp paths are handled by SshIo. Others
+        /// are handled by FileIo.
+        /// @param path %Image file.
+        /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
+        /// Otherwise it is handled by HttpIo.
+        /// @return An auto-pointer that owns an BasicIo instance.
+        ///  @throw Error If the file is not found or it is unable to connect to the server to read the remote file.
         static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
+
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like createIo() but accepts a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like createIo() but accepts a unicode path in an std::wstring.
+        ///  @note This function is only available on Windows.
         static BasicIo::UniquePtr createIo(const std::wstring& wpath, bool useCurl = true);
-#endif
-        /*!
-          @brief Create an Image subclass of the appropriate type by reading
-              the specified file. %Image type is derived from the file
-              contents.
-          @param  path %Image file. The contents of the file are tested to
-              determine the image type. File extension is ignored.
-          @param useCurl Indicate whether the libcurl is used or not.
-                If it's true, http is handled by CurlIo. Otherwise it is handled by HttpIo.
-          @return An auto-pointer that owns an Image instance whose type
-              matches that of the file.
-          @throw Error If opening the file fails or it contains data of an
-              unknown image type.
-         */
-        static Image::UniquePtr open(const std::string& path, bool useCurl = true);
-#ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like open() but accepts a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+
+        /// @brief Like open() but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         static Image::UniquePtr open(const std::wstring& wpath, bool useCurl = true);
 #endif
-        /*!
-          @brief Create an Image subclass of the appropriate type by reading
-              the provided memory. %Image type is derived from the memory
-              contents.
-          @param data Pointer to a data buffer containing an image. The contents
-              of the memory are tested to determine the image type.
-          @param size Number of bytes pointed to by \em data.
-          @return An auto-pointer that owns an Image instance whose type
-              matches that of the data buffer.
-          @throw Error If the memory contains data of an unknown image type.
-         */
+        /// @brief Create an Image subclass of the appropriate type by reading the specified file. %Image type is
+        /// derived from the file contents.
+        /// @param  path Image file. The contents of the file are tested to determine the image type. File extension
+        /// is ignored.
+        /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
+        /// Otherwise it is handled by HttpIo.
+        ///  @return An auto-pointer that owns an Image instance whose type matches that of the file.
+        ///  @throw Error If opening the file fails or it contains data of an unknown image type.
+        static Image::UniquePtr open(const std::string& path, bool useCurl = true);
+
+        /// @brief Create an Image subclass of the appropriate type by reading the provided memory. Image type is
+        /// derived from the memory contents.
+        /// @param data Pointer to a data buffer containing an image. The contents of the memory are tested to
+        /// determine the image type.
+        /// @param size Number of bytes pointed to by \em data.
+        /// @return An auto-pointer that owns an Image instance whose type matches that of the data buffer.
+        /// @throw Error If the memory contains data of an unknown image type.
         static Image::UniquePtr open(const byte* data, long size);
-        /*!
-          @brief Create an Image subclass of the appropriate type by reading
-              the provided BasicIo instance. %Image type is derived from the
-              data provided by \em io. The passed in \em io instance is
-              (re)opened by this method.
-          @param io An auto-pointer that owns a BasicIo instance that provides
-              image data. The contents of the image data are tested to determine
-              the type.
-          @note This method takes ownership of the passed
-              in BasicIo instance through the auto-pointer. Callers should not
-              continue to use the BasicIo instance after it is passed to this method.
-              Use the Image::io() method to get a temporary reference.
-          @return An auto-pointer that owns an Image instance whose type
-              matches that of the \em io data. If no image type could be
-              determined, the pointer is 0.
-          @throw Error If opening the BasicIo fails
-         */
+
+        /// @brief Create an Image subclass of the appropriate type by reading the provided BasicIo instance.
+        ///
+        /// Image type is derived from the data provided by \em io. The passed in \em io instance is (re)opened by this
+        /// method.
+        /// @param io An auto-pointer that owns a BasicIo instance that provides image data. The contents of the image
+        /// data are tested to determine the type.
+        /// @note This method takes ownership of the passed in BasicIo instance through the auto-pointer. Callers
+        /// should not continue to use the BasicIo instance after it is passed to this method. Use the Image::io()
+        /// method to get a temporary reference.
+        /// @return An auto-pointer that owns an Image instance whose type matches that of the \em io data. If no
+        /// image type could be determined, the pointer is 0.
+        ///  @throw Error If opening the BasicIo fails
         static Image::UniquePtr open(BasicIo::UniquePtr io);
-        /*!
-          @brief Create an Image subclass of the requested type by creating a
-              new image file. If the file already exists, it will be overwritten.
-          @param type Type of the image to be created.
-          @param path %Image file to create. File extension is ignored.
-          @return An auto-pointer that owns an Image instance of the requested
-              type.
-          @throw Error If the image type is not supported.
-         */
+
+        /// @brief Create an Image subclass of the requested type by creating a new image file. If the file already
+        /// exists, it will be overwritten.
+        /// @param type Type of the image to be created.
+        /// @param path Image file to create. File extension is ignored.
+        /// @return An auto-pointer that owns an Image instance of the requested type.
+        /// @throw Error If the image type is not supported.
         static Image::UniquePtr create(ImageType type, const std::string& path);
+
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like create() but accepts a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like create() but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         static Image::UniquePtr create(ImageType type, const std::wstring& wpath);
 #endif
-        /*!
-          @brief Create an Image subclass of the requested type by creating a
-              new image in memory.
-          @param type Type of the image to be created.
-          @return An auto-pointer that owns an Image instance of the requested
-              type.
-          @throw Error If the image type is not supported
-         */
+        /// @brief Create an Image subclass of the requested type by creating a new image in memory.
+        /// @param type Type of the image to be created.
+        /// @return An auto-pointer that owns an Image instance of the requested type.
+        /// @throw Error If the image type is not supported
         static Image::UniquePtr create(ImageType type);
 
-        /*!
-          @brief Create an Image subclass of the requested type by writing a
-              new image to a BasicIo instance. If the BasicIo instance already
-              contains data, it will be overwritten.
-          @param type Type of the image to be created.
-          @param io An auto-pointer that owns a BasicIo instance that will
-              be written to when creating a new image.
-          @note This method takes ownership of the passed in BasicIo instance
-              through the auto-pointer. Callers should not continue to use the
-              BasicIo instance after it is passed to this method.  Use the
-              Image::io() method to get a temporary reference.
-          @return An auto-pointer that owns an Image instance of the requested
-              type. If the image type is not supported, the pointer is 0.
-         */
-
+        /// @brief Create an Image subclass of the requested type by writing a new image to a BasicIo instance.
+        /// If the BasicIo instance already contains data, it will be overwritten.
+        /// @param type Type of the image to be created.
+        /// @param io An auto-pointer that owns a BasicIo instance that will be written to when creating a new image.
+        /// @note This method takes ownership of the passed in BasicIo instance through the auto-pointer. Callers
+        /// should not continue to use the BasicIo instance after it is passed to this method.  Use the Image::io()
+        /// method to get a temporary reference.
+        /// @return An auto-pointer that owns an Image instance of the requested type. If the image type is not
+        /// supported, the pointer is 0.
         static Image::UniquePtr create(ImageType type, BasicIo::UniquePtr io);
-        /*!
-          @brief Returns the image type of the provided file.
-          @param path %Image file. The contents of the file are tested to
-              determine the image type. File extension is ignored.
-          @return %Image type or Image::none if the type is not recognized.
-         */
+
+        /// @brief Returns the image type of the provided file.
+        /// @param path %Image file. The contents of the file are tested to determine the image type.
+        /// File extension is ignored.
+        /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(const std::string& path);
 
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like getType() but accepts a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like getType() but accepts a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         static ImageType getType(const std::wstring& wpath);
 #endif
-        /*!
-          @brief Returns the image type of the provided data buffer.
-          @param data Pointer to a data buffer containing an image. The contents
-              of the memory are tested to determine the image type.
-          @param size Number of bytes pointed to by \em data.
-          @return %Image type or Image::none if the type is not recognized.
-         */
+
+        /// @brief Returns the image type of the provided data buffer.
+        /// @param data Pointer to a data buffer containing an image. The contents of the memory are tested to
+        /// determine the image type.
+        /// @param size Number of bytes pointed to by \em data.
+        /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(const byte* data, long size);
-        /*!
-          @brief Returns the image type of data provided by a BasicIo instance.
-              The passed in \em io instance is (re)opened by this method.
-          @param io A BasicIo instance that provides image data. The contents
-              of the image data are tested to determine the type.
-          @return %Image type or Image::none if the type is not recognized.
-         */
+
+        /// @brief Returns the image type of data provided by a BasicIo instance. The passed in \em io instance is
+        /// (re)opened by this method.
+        /// @param io A BasicIo instance that provides image data. The contents of the image data are tested to
+        /// determine the type.
+        /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(BasicIo& io);
-        /*!
-          @brief Returns the access mode or supported metadata functions for an
-              image type and a metadata type.
-          @param type       The image type.
-          @param metadataId The metadata identifier.
-          @return Access mode for the requested image type and metadata identifier.
-          @throw Error(kerUnsupportedImageType) if the image type is not supported.
-         */
+
+        /// @brief Returns the access mode or supported metadata functions for an image type and a metadata type.
+        /// @param type       The image type.
+        /// @param metadataId The metadata identifier.
+        /// @return Access mode for the requested image type and metadata identifier.
+        /// @throw Error(kerUnsupportedImageType) if the image type is not supported.
         static AccessMode checkMode(ImageType type, MetadataId metadataId);
-        /*!
-          @brief Determine if the content of \em io is an image of \em type.
 
-          The \em advance flag determines if the read position in the
-          stream is moved (see below). This applies only if the type
-          matches and the function returns true. If the type does not
-          match, the stream position is not changed. However, if
-          reading from the stream fails, the stream position is
-          undefined. Consult the stream state to obtain more
-          information in this case.
-
-          @param type Type of the image.
-          @param io BasicIo instance to read from.
-          @param advance Flag indicating whether the position of the io
-              should be advanced by the number of characters read to
-              analyse the data (true) or left at its original
-              position (false). This applies only if the type matches.
-          @return  true  if the data matches the type of this class;<BR>
-                   false if the data does not match
-        */
+        /// @brief Determine if the content of \em io is an image of \em type.
+        ///
+        ///  The \em advance flag determines if the read position in the stream is moved (see below). This applies
+        /// only if the type matches and the function returns true. If the type does not match, the stream position is
+        /// not changed. However, if reading from the stream fails, the stream position is undefined. Consult the
+        /// stream state to obtain more information in this case.
+        ///
+        /// @param type Type of the image.
+        /// @param io BasicIo instance to read from.
+        /// @param advance Flag indicating whether the position of the io should be advanced by the number of
+        /// characters read to analyse the data (true) or left at its original position (false). This applies only
+        /// if the type matches.
+        /// @return  true  if the data matches the type of this class;<BR> false if the data does not match
         static bool checkType(ImageType type, BasicIo& io, bool advance);
 
         ImageFactory& operator=(const ImageFactory& rhs) = delete;
@@ -708,5 +554,4 @@ namespace Exiv2 {
 
     //! Append \em len bytes pointed to by \em buf to \em blob.
     EXIV2API void append(Exiv2::Blob& blob, const byte* buf, uint32_t len);
-
 }                                       // namespace Exiv2

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -65,6 +65,7 @@ namespace Exiv2 {
     /// specific image formats.<BR>
     /// Most clients will obtain an Image instance by calling a static ImageFactory method. The Image class can
     /// then be used to to read, write, and save metadata.
+    /// @note set/clear methods will not modify the image until writeMetadata() method is called.
     class EXIV2API Image {
     public:
         //! Image auto_ptr type
@@ -109,26 +110,21 @@ namespace Exiv2 {
         /// @throw Error if the operation fails
         virtual void writeMetadata() =0;
 
-        /// @brief Assign new Exif data. The new Exif data is not written to the image until the writeMetadata()
-        /// method is called.
+        /// @brief Assign new Exif data.
         /// @param exifData An ExifData instance holding Exif data to be copied
         virtual void setExifData(const ExifData& exifData);
 
-        /// @brief Erase any buffered Exif data. Exif data is not removed from the actual image until the
-        /// writeMetadata() method is called.
+        /// @brief Erase any buffered Exif data.
         virtual void clearExifData();
 
-        /// @brief Assign new IPTC data. The new IPTC data is not written to the image until the writeMetadata()
-        /// method is called.
+        /// @brief Assign new IPTC data.
         /// @param iptcData An IptcData instance holding IPTC data to be copied
         virtual void setIptcData(const IptcData& iptcData);
 
-        /// @brief Erase any buffered IPTC data. IPTC data is not removed from the actual image until the
-        /// writeMetadata() method is called.
+        /// @brief Erase any buffered IPTC data.
         virtual void clearIptcData();
 
-        /// @brief Assign a raw XMP packet. The new XMP packet is not written to the image until the writeMetadata()
-        /// method is called.
+        /// @brief Assign a raw XMP packet.
         ///
         /// Subsequent calls to writeMetadata() write the XMP packet from the buffered raw XMP packet rather than from
         /// buffered parsed XMP data. In order to write from parsed XMP data again, use either
@@ -136,8 +132,7 @@ namespace Exiv2 {
         /// @param xmpPacket A string containing the raw XMP packet.
         virtual void setXmpPacket(const std::string& xmpPacket);
 
-        /// @brief Erase the buffered XMP packet. XMP data is not removed from the actual image until the
-        /// writeMetadata() method is called.
+        /// @brief Erase the buffered XMP packet.
         ///
         /// This has the same effect as clearXmpData() but operates on the buffered raw XMP packet only, not the
         /// parsed XMP data.
@@ -146,8 +141,7 @@ namespace Exiv2 {
         /// writeXmpFromPacket(false) or setXmpData().
         virtual void clearXmpPacket();
 
-        /// @brief Assign new XMP data. The new XMP data is not written to the image until the writeMetadata() method
-        /// is called.
+        /// @brief Assign new XMP data.
         ///
         /// Subsequent calls to writeMetadata() encode the XMP data to a raw XMP packet and write the newly encoded
         /// packet to the image. In the process, the buffered raw XMP packet is updated. In order to write directly
@@ -155,8 +149,7 @@ namespace Exiv2 {
         /// @param xmpData An XmpData instance holding XMP data to be copied
         virtual void setXmpData(const XmpData& xmpData);
 
-        /// @brief Erase any buffered XMP data. XMP data is not removed from the actual image until the writeMetadata()
-        /// method is called.
+        /// @brief Erase any buffered XMP data.
         ///
         /// This has the same effect as clearXmpPacket() but operates on the buffered parsed XMP data.
         /// Subsequent calls to writeMetadata() encode the XMP data to a raw XMP packet and write the newly encoded
@@ -165,39 +158,32 @@ namespace Exiv2 {
         /// use writeXmpFromPacket(true) or setXmpPacket().
         virtual void clearXmpData();
 
-        /// @brief Set the image comment. The new comment is not written to the image until the writeMetadata() method
-        /// is called.
+        /// @brief Set the image comment.
         /// @param comment String containing comment.
         virtual void setComment(const std::string& comment);
 
-        /// @brief Erase any buffered comment. Comment is not removed from the actual image until the writeMetadata()
-        /// method is called.
+        /// @brief Erase any buffered comment.
         virtual void clearComment();
 
-        /// @brief Set the image iccProfile. The new profile is not written to the image until the writeMetadata()
-        /// method is called.
+        /// @brief Set the image iccProfile.
         /// @param iccProfile DataBuf containing profile (binary)
         /// @param bTestValid - tests that iccProfile contains credible data
         virtual void setIccProfile(DataBuf& iccProfile,bool bTestValid=true);
 
-        /// @brief Erase iccProfile. the profile is not removed from the actual image until the writeMetadata()
-        /// method is called.
+        /// @brief Erase iccProfile.
         virtual void clearIccProfile();
 
-        /// @brief Erase iccProfile. the profile is not removed from the actual image until the writeMetadata() method
-        /// is called.
+        /// @brief Erase iccProfile.
         virtual bool iccProfileDefined() { return iccProfile_.size_?true:false;}
 
         /// @brief return iccProfile
         virtual DataBuf* iccProfile() { return &iccProfile_; }
 
-        /// @brief Copy all existing metadata from source Image. The data is copied into internal buffers and is not
-        /// written to the image until the writeMetadata() method is called.
+        /// @brief Copy all existing metadata from source Image into internal buffers.
         /// @param image Metadata source. All metadata types are copied.
         virtual void setMetadata(const Image& image);
 
-        /// @brief Erase all buffered metadata. Metadata is not removed from the actual image until the writeMetadata()
-        /// method is called.
+        /// @brief Erase all buffered metadata.
         virtual void clearMetadata();
 
         /// @brief Returns an ExifData instance containing currently buffered Exif data.

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -114,13 +114,13 @@ namespace Exiv2 {
         virtual void setExifData(const ExifData& exifData);
 
         /// @brief Erase any buffered Exif data.
-        virtual void clearExifData();
+        void clearExifData();
 
         /// @brief Assign new IPTC data.
         virtual void setIptcData(const IptcData& iptcData);
 
         /// @brief Erase any buffered IPTC data.
-        virtual void clearIptcData();
+        void clearIptcData();
 
         /// @brief Assign a raw XMP packet.
         ///
@@ -136,7 +136,7 @@ namespace Exiv2 {
         /// Subsequent calls to writeMetadata() write the XMP packet from the buffered raw XMP packet rather than from
         /// buffered parsed XMP data. In order to write from parsed XMP data again, use either
         /// writeXmpFromPacket(false) or setXmpData().
-        virtual void clearXmpPacket();
+        void clearXmpPacket();
 
         /// @brief Assign new XMP data.
         ///
@@ -152,13 +152,13 @@ namespace Exiv2 {
         /// packet to the image.
         /// In the process, the buffered raw XMP packet is updated. In order to write directly from the raw XMP packet,
         /// use writeXmpFromPacket(true) or setXmpPacket().
-        virtual void clearXmpData();
+        void clearXmpData();
 
         /// @brief Set the image comment.
         virtual void setComment(const std::string& comment);
 
         /// @brief Erase any buffered comment.
-        virtual void clearComment();
+        void clearComment();
 
         /// @brief Set the image iccProfile.
         /// @param iccProfile DataBuf containing profile (binary)
@@ -166,42 +166,16 @@ namespace Exiv2 {
         virtual void setIccProfile(DataBuf& iccProfile,bool bTestValid=true);
 
         /// @brief Erase iccProfile.
-        virtual void clearIccProfile();
+        void clearIccProfile();
 
         /// @brief return iccProfile
-        virtual DataBuf* iccProfile() { return &iccProfile_; }
+        DataBuf* iccProfile() { return &iccProfile_; }
 
         /// @brief Copy all existing metadata from \b image into internal buffers.
         virtual void setMetadata(const Image& image);
 
         /// @brief Erase all buffered metadata.
-        virtual void clearMetadata();
-
-        /// @brief Returns an ExifData instance containing currently buffered Exif data.
-        ///
-        /// The contained Exif data may have been read from the image by a previous call to readMetadata() or added
-        /// directly. The Exif data in the returned instance will be written to the image when writeMetadata() is
-        /// called.
-        /// @return modifiable ExifData instance containing Exif values
-        virtual ExifData& exifData();
-
-        /// @brief Returns an IptcData instance containing currently buffered IPTC data.
-        ///
-        /// The contained IPTC data may have been read from the image by a previous call to readMetadata() or added
-        /// directly. The IPTC data in the returned instance will be written to the image when writeMetadata() is
-        /// called.
-        /// @return modifiable IptcData instance containing IPTC values
-        virtual IptcData& iptcData();
-
-        /// @brief Returns an XmpData instance containing currently buffered XMP data.
-        ///
-        /// The contained XMP data may have been read from the image by a previous call to readMetadata() or added
-        /// directly. The XMP data in the returned instance will be written to the image when writeMetadata() is called.
-        /// @return modifiable XmpData instance containing XMP values
-        virtual XmpData& xmpData();
-
-        /// @brief Return a modifiable reference to the raw XMP packet.
-        virtual std::string& xmpPacket();
+        void clearMetadata();
 
         /// @brief Determine the source when writing XMP.
         ///
@@ -258,14 +232,6 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
 
-        /// @brief Return the byte order in which the Exif metadata of the image is encoded. Initially, it is not set
-        /// (\em invalidByteOrder).
-        ByteOrder byteOrder() const;
-
-        /// @brief Check if the Image instance is valid. Use after object construction.
-        /// @return true if the Image is in a valid state.
-        bool good() const;
-
         /// @brief Return the MIME type of the image.
         ///
         /// @note For each supported image format, the library knows only one MIME type. This may not be the most
@@ -280,12 +246,24 @@ namespace Exiv2 {
         /// @brief Return the pixel height of the image.
         virtual int pixelHeight() const;
 
+        /// @brief Return the byte order in which the Exif metadata of the image is encoded. Initially, it is not set
+        /// (\em invalidByteOrder).
+        ByteOrder byteOrder() const;
+
+        /// @brief Check if the Image instance is valid. Use after object construction.
+        /// @return true if the Image is in a valid state.
+        bool good() const;
+
         /// @brief Returns an ExifData instance containing currently buffered Exif data.
         ///
-        /// The Exif data may have been read from the image by a previous call to readMetadata() or added directly. The
-        /// Exif data in the returned instance will be written to the image when writeMetadata() is called.
-        /// @return read only ExifData instance containing Exif values
-        virtual const ExifData& exifData() const;
+        /// The contained Exif data may have been read from the image by a previous call to readMetadata() or added
+        /// directly. The Exif data in the returned instance will be written to the image when writeMetadata() is
+        /// called.
+        /// @return modifiable ExifData instance containing Exif values
+        ExifData& exifData();
+
+        /// @brief const version from previous method.
+        const ExifData& exifData() const;
 
         /// @brief Returns an IptcData instance containing currently buffered IPTC data.
         ///
@@ -293,23 +271,31 @@ namespace Exiv2 {
         /// directly. The IPTC data in the returned instance will be written to the image when writeMetadata() is
         /// called.
         /// @return modifiable IptcData instance containing IPTC values
-        virtual const IptcData& iptcData() const;
+        IptcData& iptcData();
+
+        const IptcData& iptcData() const;
 
         /// @brief Returns an XmpData instance containing currently buffered XMP data.
         ///
         /// The contained XMP data may have been read from the image by a previous call to readMetadata() or added
         /// directly. The XMP data in the returned instance will be written to the image when writeMetadata() is called.
         /// @return modifiable XmpData instance containing XMP values
-        virtual const XmpData& xmpData() const;
+        XmpData& xmpData();
+
+        /// @brief const version from previous method.
+        const XmpData& xmpData() const;
 
         /// @brief Return a copy of the image comment. May be an empty string.
-        virtual std::string comment() const;
+        std::string comment() const;
+
+        /// @brief Return a modifiable reference to the raw XMP packet.
+        std::string& xmpPacket();
 
         /// @brief Return the raw XMP packet as a string.
-        virtual const std::string& xmpPacket() const;
+        const std::string& xmpPacket() const;
 
         /// @brief Indicates if the ICC Profile is defined.
-        virtual bool iccProfileDefined() const;
+        bool iccProfileDefined() const;
 
         /// @brief Return a reference to the BasicIo instance being used for Io.
         ///
@@ -319,7 +305,7 @@ namespace Exiv2 {
         /// @return BasicIo instance that can be used to read or write image data directly.
         /// @note If the returned BasicIo is used to write to the image, the Image class will not see those changes
         /// until the readMetadata() method is called.
-        virtual BasicIo& io() const;
+        BasicIo& io() const;
 
         /// @brief Returns the access mode, i.e., the metadata functions, which this image supports for the metadata
         /// type \em metadataId.

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -111,14 +111,12 @@ namespace Exiv2 {
         virtual void writeMetadata() =0;
 
         /// @brief Assign new Exif data.
-        /// @param exifData An ExifData instance holding Exif data to be copied
         virtual void setExifData(const ExifData& exifData);
 
         /// @brief Erase any buffered Exif data.
         virtual void clearExifData();
 
         /// @brief Assign new IPTC data.
-        /// @param iptcData An IptcData instance holding IPTC data to be copied
         virtual void setIptcData(const IptcData& iptcData);
 
         /// @brief Erase any buffered IPTC data.
@@ -129,7 +127,6 @@ namespace Exiv2 {
         /// Subsequent calls to writeMetadata() write the XMP packet from the buffered raw XMP packet rather than from
         /// buffered parsed XMP data. In order to write from parsed XMP data again, use either
         /// writeXmpFromPacket(false) or setXmpData().
-        /// @param xmpPacket A string containing the raw XMP packet.
         virtual void setXmpPacket(const std::string& xmpPacket);
 
         /// @brief Erase the buffered XMP packet.
@@ -146,7 +143,6 @@ namespace Exiv2 {
         /// Subsequent calls to writeMetadata() encode the XMP data to a raw XMP packet and write the newly encoded
         /// packet to the image. In the process, the buffered raw XMP packet is updated. In order to write directly
         /// from the raw XMP packet, use writeXmpFromPacket(true) or setXmpPacket().
-        /// @param xmpData An XmpData instance holding XMP data to be copied
         virtual void setXmpData(const XmpData& xmpData);
 
         /// @brief Erase any buffered XMP data.
@@ -159,7 +155,6 @@ namespace Exiv2 {
         virtual void clearXmpData();
 
         /// @brief Set the image comment.
-        /// @param comment String containing comment.
         virtual void setComment(const std::string& comment);
 
         /// @brief Erase any buffered comment.
@@ -179,8 +174,7 @@ namespace Exiv2 {
         /// @brief return iccProfile
         virtual DataBuf* iccProfile() { return &iccProfile_; }
 
-        /// @brief Copy all existing metadata from source Image into internal buffers.
-        /// @param image Metadata source. All metadata types are copied.
+        /// @brief Copy all existing metadata from \b image into internal buffers.
         virtual void setMetadata(const Image& image);
 
         /// @brief Erase all buffered metadata.
@@ -408,7 +402,7 @@ namespace Exiv2 {
         /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
         /// Otherwise it is handled by HttpIo.
         /// @return An auto-pointer that owns an BasicIo instance.
-        ///  @throw Error If the file is not found or it is unable to connect to the server to read the remote file.
+        /// @throw Error If the file is not found or it is unable to connect to the server to read the remote file.
         static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
 
 #ifdef EXV_UNICODE_PATH
@@ -426,8 +420,8 @@ namespace Exiv2 {
         /// is ignored.
         /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
         /// Otherwise it is handled by HttpIo.
-        ///  @return An auto-pointer that owns an Image instance whose type matches that of the file.
-        ///  @throw Error If opening the file fails or it contains data of an unknown image type.
+        /// @return An auto-pointer that owns an Image instance whose type matches that of the file.
+        /// @throw Error If opening the file fails or it contains data of an unknown image type.
         static Image::UniquePtr open(const std::string& path, bool useCurl = true);
 
         /// @brief Create an Image subclass of the appropriate type by reading the provided memory. Image type is

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -61,10 +61,11 @@ namespace Exiv2
     /// @brief Interface for an image. This is the top-level interface to the Exiv2 library.
     ///
     /// Image has containers to store image metadata and subclasses implement read and save metadata from and to
-    /// specific image formats.<BR>
+    /// specific image formats.
+    ///
     /// Most clients will obtain an Image instance by calling a static ImageFactory method. The Image class can
     /// then be used to to read, write, and save metadata.
-    /// @note set/clear methods will not modify the image until writeMetadata() method is called.
+    /// @note set/clear methods will not modify the image until the writeMetadata() method is called.
     class EXIV2API Image
     {
     public:
@@ -74,8 +75,8 @@ namespace Exiv2
         //! @name Creators
         //@{
 
-        /// Constructor taking the image type, a bitmap of the supported metadata types and an auto-pointer that owns
-        /// an IO instance. See subclass constructor doc.
+        /// Constructor taking the image type, a bitmap of the supported metadata types and a smart pointer that owns
+        /// an IO instance. See the subclasses' constructor documentation.
         Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io);
         virtual ~Image();
         //@}
@@ -85,19 +86,19 @@ namespace Exiv2
 
         /// @brief Print out the structure of image file.
         /// @throw Error if reading of the file fails or the image data is not valid (does not look like data of the
-        /// specific image type).
+        ///     specific image type).
         /// @warning This function is not thread safe and intended for exiv2 -pS for debugging.
         /// @warning You may need to put the stream into binary mode (see src/actions.cpp)
         virtual void printStructure(std::ostream& out, PrintStructureOption option = kpsNone, int depth = 0);
 
         /// @brief Read all metadata supported by a specific image format from the image. Before this method is called,
-        /// the image metadata will be cleared.
+        ///     the image metadata will be cleared.
         ///
         /// This method returns success even if no metadata is found in the image. Callers must therefore check the
         /// size of individual metadata types before accessing the data.
         ///
-        /// @throw Error if opening or reading of the file fails or the image data is not valid (does not look like
-        /// data of the specific image type).
+        /// @throw Error if opening or reading the file fails or the image data is not valid (does not look like
+        ///     data of the specific image type).
         virtual void readMetadata() = 0;
 
         /// @brief Write metadata back to the image.
@@ -200,7 +201,7 @@ namespace Exiv2
 
         /// @brief Print out the structure of image file.
         /// @throw Error if reading of the file fails or the image data is not valid (does not look like data of the
-        /// specific image type).
+        ///     specific image type).
         void printTiffStructure(BasicIo& io, std::ostream& out, PrintStructureOption option, int depth,
                                 size_t offset = 0);
 
@@ -208,10 +209,10 @@ namespace Exiv2
         void printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, uint32_t start,
                                bool bSwap, char c, int depth);
 
-        /// @brief is the host platform bigEndian
+        /// @brief Is the host platform big Endian?
         bool isBigEndianPlatform();
 
-        /// @brief is the host platform littleEndian
+        /// @brief Is the host platform little Endian?
         bool isLittleEndianPlatform();
 
         bool isStringType(uint16_t type);
@@ -252,7 +253,7 @@ namespace Exiv2
         virtual int pixelHeight() const;
 
         /// @brief Return the byte order in which the Exif metadata of the image is encoded. Initially, it is not set
-        /// (\em invalidByteOrder).
+        ///     (\em invalidByteOrder).
         ByteOrder byteOrder() const;
 
         /// @brief Check if the Image instance is valid. Use after object construction.
@@ -264,10 +265,10 @@ namespace Exiv2
         /// The contained Exif data may have been read from the image by a previous call to readMetadata() or added
         /// directly. The Exif data in the returned instance will be written to the image when writeMetadata() is
         /// called.
-        /// @return modifiable ExifData instance containing Exif values
+        /// @return mutable ExifData instance containing Exif values
         ExifData& exifData();
 
-        /// @brief const version from previous method.
+        /// @return immutable ExifData instance containing buffered Exif data
         const ExifData& exifData() const;
 
         /// @brief Returns an IptcData instance containing currently buffered IPTC data.
@@ -284,10 +285,10 @@ namespace Exiv2
         ///
         /// The contained XMP data may have been read from the image by a previous call to readMetadata() or added
         /// directly. The XMP data in the returned instance will be written to the image when writeMetadata() is called.
-        /// @return modifiable XmpData instance containing XMP values
+        /// @return mutable XmpData instance containing XMP values
         XmpData& xmpData();
 
-        /// @brief const version from previous method.
+        /// @return immutable XmpData instance containing buffered XMP data
         const XmpData& xmpData() const;
 
         /// @brief Return a copy of the image comment. May be an empty string.
@@ -313,19 +314,19 @@ namespace Exiv2
         BasicIo& io() const;
 
         /// @brief Returns the access mode, i.e., the metadata functions, which this image supports for the metadata
-        /// type \em metadataId.
+        ///     type \em metadataId.
         /// @param metadataId The metadata identifier.
         /// @return Access mode for the requested image type and metadata identifier.
         AccessMode checkMode(MetadataId metadataId) const;
 
         /// @brief Check if image supports a particular type of metadata. This method is deprecated. Use checkMode()
-        /// instead.
+        ///     instead.
         bool supportsMetadata(MetadataId metadataId) const;
 
-        /// Return the flag indicating the source when writing XMP metadata.
+        /// @return the flag indicating the source when writing XMP metadata.
         bool writeXmpFromPacket() const;
 
-        /// Return list of native previews. This is meant to be used only by the PreviewManager.
+        /// @return list of native previews. This is meant to be used only by the PreviewManager.
         const NativePreviewList& nativePreviews() const;
         //@}
 
@@ -336,7 +337,7 @@ namespace Exiv2
             supportedMetadata_ = supportedMetadata;
         }
 
-        /// set type support for this image format
+        /// get the type support for this image format
         ImageType imageType() const
         {
             return imageType_;
@@ -377,7 +378,7 @@ namespace Exiv2
         std::map<int, std::string> tags_;  //!< Map of tags
         bool init_;                        //!< Flag marking if map of tags needs to be initialized
 
-    };  // class Image
+    };
 
     //! Type for function pointer that creates new Image instances
     typedef Image::UniquePtr (*NewInstanceFct)(BasicIo::UniquePtr io, bool create);
@@ -390,21 +391,21 @@ namespace Exiv2
         friend bool Image::good() const;
 
     public:
-        /// @brief Create the appropriate class type implemented BasicIo based on the protocol of the input.
+        /// @brief Create an appropriate BasicIo instance based on the protocol of the input.
         ///
-        /// "-" path implies the data from stdin and it is handled by StdinIo. Http path can be handled by either
-        /// HttpIo or CurlIo. Https, ftp paths are handled by CurlIo. Ssh, sftp paths are handled by SshIo. Others
+        /// Http paths can be handled by either
+        /// HttpIo or CurlIo. Https, ftp paths are handled by CurlIo. All others
         /// are handled by FileIo.
         /// @param path %Image file.
         /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
-        /// Otherwise it is handled by HttpIo.
-        /// @return An auto-pointer that owns an BasicIo instance.
+        ///     Otherwise it is handled by HttpIo.
+        /// @return A smart-pointer that owns an BasicIo instance.
         /// @throw Error If the file is not found or it is unable to connect to the server to read the remote file.
         static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
 
 #ifdef EXV_UNICODE_PATH
         /// @brief Like createIo() but accepts a unicode path in an std::wstring.
-        ///  @note This function is only available on Windows.
+        /// @note This function is only available on Windows.
         static BasicIo::UniquePtr createIo(const std::wstring& wpath, bool useCurl = true);
 
         /// @brief Like open() but accepts a unicode path in an std::wstring.
@@ -412,35 +413,33 @@ namespace Exiv2
         static Image::UniquePtr open(const std::wstring& wpath, bool useCurl = true);
 #endif
         /// @brief Create an Image subclass of the appropriate type by reading the specified file. %Image type is
-        /// derived from the file contents.
-        /// @param  path Image file. The contents of the file are tested to determine the image type. File extension
-        /// is ignored.
+        ///     derived from the file contents.
+        /// @param  path Image file. The contents of the file are tested to determine the image type. The file extension
+        ///     is ignored.
         /// @param useCurl Indicate whether the libcurl is used or not. If it's true, http is handled by CurlIo.
-        /// Otherwise it is handled by HttpIo.
-        /// @return An auto-pointer that owns an Image instance whose type matches that of the file.
+        ///     Otherwise it is handled by HttpIo.
+        /// @return A smart-pointer that owns an Image instance whose type matches that of the file.
         /// @throw Error If opening the file fails or it contains data of an unknown image type.
         static Image::UniquePtr open(const std::string& path, bool useCurl = true);
 
-        /// @brief Create an Image subclass of the appropriate type by reading the provided memory. Image type is
-        /// derived from the memory contents.
+        /// @brief Create an Image subclass of the appropriate type by reading the provided memory. The image type is
+        ///     derived from the memory contents.
         /// @param data Pointer to a data buffer containing an image. The contents of the memory are tested to
         /// determine the image type.
         /// @param size Number of bytes pointed to by \em data.
-        /// @return An auto-pointer that owns an Image instance whose type matches that of the data buffer.
+        /// @return A smart-pointer that owns an Image instance whose type matches that of the data buffer.
         /// @throw Error If the memory contains data of an unknown image type.
         static Image::UniquePtr open(const byte* data, long size);
 
-        /// @brief Create an Image subclass of the appropriate type by reading the provided BasicIo instance.
+        /// @brief Create an Image subclass of the appropriate type by reading from the provided BasicIo instance.
         ///
-        /// Image type is derived from the data provided by \em io. The passed in \em io instance is (re)opened by this
+        /// The Image type is derived from the data provided by \em io. The passed in \em io instance is (re)opened by this
         /// method.
-        /// @param io An auto-pointer that owns a BasicIo instance that provides image data. The contents of the image
+        /// @param io A smart-pointer that owns a BasicIo instance that provides the image data. The contents of the image
         /// data are tested to determine the type.
-        /// @note This method takes ownership of the passed in BasicIo instance through the auto-pointer. Callers
-        /// should not continue to use the BasicIo instance after it is passed to this method. Use the Image::io()
-        /// method to get a temporary reference.
+        /// @note Use the Image::io() method to get a temporary reference to the BasicIo instance passed to this method.
         /// @return An auto-pointer that owns an Image instance whose type matches that of the \em io data. If no
-        /// image type could be determined, the pointer is 0.
+        ///     image type could be determined, the pointer is a nullptr.
         ///  @throw Error If opening the BasicIo fails
         static Image::UniquePtr open(BasicIo::UniquePtr io);
 
@@ -466,17 +465,15 @@ namespace Exiv2
         /// @brief Create an Image subclass of the requested type by writing a new image to a BasicIo instance.
         /// If the BasicIo instance already contains data, it will be overwritten.
         /// @param type Type of the image to be created.
-        /// @param io An auto-pointer that owns a BasicIo instance that will be written to when creating a new image.
-        /// @note This method takes ownership of the passed in BasicIo instance through the auto-pointer. Callers
-        /// should not continue to use the BasicIo instance after it is passed to this method.  Use the Image::io()
-        /// method to get a temporary reference.
-        /// @return An auto-pointer that owns an Image instance of the requested type. If the image type is not
-        /// supported, the pointer is 0.
+        /// @param io A smart-pointer that owns a BasicIo instance that will be written to when creating a new image.
+        /// @note Use the Image::io() method to get a temporary reference to the BasicIo instance passed to this method.
+        /// @return A smart-pointer that owns an Image instance of the requested type. If the image type is not
+        ///     supported, the pointer is null.
         static Image::UniquePtr create(ImageType type, BasicIo::UniquePtr io);
 
         /// @brief Returns the image type of the provided file.
         /// @param path %Image file. The contents of the file are tested to determine the image type.
-        /// File extension is ignored.
+        ///     The file extension is ignored.
         /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(const std::string& path);
 
@@ -488,15 +485,15 @@ namespace Exiv2
 
         /// @brief Returns the image type of the provided data buffer.
         /// @param data Pointer to a data buffer containing an image. The contents of the memory are tested to
-        /// determine the image type.
+        ///     determine the image type.
         /// @param size Number of bytes pointed to by \em data.
         /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(const byte* data, long size);
 
         /// @brief Returns the image type of data provided by a BasicIo instance. The passed in \em io instance is
-        /// (re)opened by this method.
-        /// @param io A BasicIo instance that provides image data. The contents of the image data are tested to
-        /// determine the type.
+        ///     (re)opened by this method.
+        /// @param io A BasicIo instance that provides the image data. The contents of the image data are tested to
+        ///     determine the type.
         /// @return %Image type or Image::none if the type is not recognized.
         static ImageType getType(BasicIo& io);
 
@@ -507,9 +504,9 @@ namespace Exiv2
         /// @throw Error(kerUnsupportedImageType) if the image type is not supported.
         static AccessMode checkMode(ImageType type, MetadataId metadataId);
 
-        /// @brief Determine if the content of \em io is an image of \em type.
+        /// @brief Check if the contents of \em io is an image of the given \em type.
         ///
-        ///  The \em advance flag determines if the read position in the stream is moved (see below). This applies
+        /// The \em advance flag determines if the read position in the stream is moved (see below). This applies
         /// only if the type matches and the function returns true. If the type does not match, the stream position is
         /// not changed. However, if reading from the stream fails, the stream position is undefined. Consult the
         /// stream state to obtain more information in this case.
@@ -517,8 +514,8 @@ namespace Exiv2
         /// @param type Type of the image.
         /// @param io BasicIo instance to read from.
         /// @param advance Flag indicating whether the position of the io should be advanced by the number of
-        /// characters read to analyse the data (true) or left at its original position (false). This applies only
-        /// if the type matches.
+        ///     characters read to analyze the data (true) or left at its original position (false). This applies only
+        ///     if the type matches.
         /// @return  true  if the data matches the type of this class;<BR> false if the data does not match
         static bool checkType(ImageType type, BasicIo& io, bool advance);
 
@@ -526,8 +523,6 @@ namespace Exiv2
         ImageFactory(const ImageFactory& rhs) = delete;
     };  // class ImageFactory
 
-    // *****************************************************************************
-    // template, inline and free functions
 
     //! Append \em len bytes pointed to by \em buf to \em blob.
     EXIV2API void append(Exiv2::Blob& blob, const byte* buf, uint32_t len);

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -168,9 +168,6 @@ namespace Exiv2 {
         /// @brief Erase iccProfile.
         virtual void clearIccProfile();
 
-        /// @brief Erase iccProfile.
-        virtual bool iccProfileDefined() { return iccProfile_.size_?true:false;}
-
         /// @brief return iccProfile
         virtual DataBuf* iccProfile() { return &iccProfile_; }
 
@@ -310,6 +307,9 @@ namespace Exiv2 {
 
         /// @brief Return the raw XMP packet as a string.
         virtual const std::string& xmpPacket() const;
+
+        /// @brief Indicates if the ICC Profile is defined.
+        virtual bool iccProfileDefined() const;
 
         /// @brief Return a reference to the BasicIo instance being used for Io.
         ///

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -26,8 +26,8 @@
 // included header files
 #include "basicio.hpp"
 #include "exif.hpp"
-#include "iptc.hpp"
 #include "image_types.hpp"
+#include "iptc.hpp"
 #include "xmp_exiv2.hpp"
 
 // + standard includes
@@ -36,28 +36,27 @@
 
 // *****************************************************************************
 // namespace extensions
-namespace Exiv2 {
-
-// *****************************************************************************
-// class definitions
+namespace Exiv2
+{
+    // *****************************************************************************
+    // class definitions
 
     //! Native preview information. This is meant to be used only by the PreviewManager.
-    struct NativePreview {
-        long position_;                         //!< Position
-        uint32_t size_;                         //!< Size
-        uint32_t width_;                        //!< Width
-        uint32_t height_;                       //!< Height
-        std::string filter_;                    //!< Filter
-        std::string mimeType_;                  //!< MIME type
+    struct NativePreview
+    {
+        long position_;         //!< Position
+        uint32_t size_;         //!< Size
+        uint32_t width_;        //!< Width
+        uint32_t height_;       //!< Height
+        std::string filter_;    //!< Filter
+        std::string mimeType_;  //!< MIME type
     };
 
     //! List of native previews. This is meant to be used only by the PreviewManager.
     typedef std::vector<NativePreview> NativePreviewList;
 
     /// @brief Options for printStructure
-    typedef enum { kpsNone, kpsBasic, kpsXMP, kpsRecursive
-                 , kpsIccProfile    , kpsIptcErase
-                 } PrintStructureOption;
+    typedef enum { kpsNone, kpsBasic, kpsXMP, kpsRecursive, kpsIccProfile, kpsIptcErase } PrintStructureOption;
 
     /// @brief Interface for an image. This is the top-level interface to the Exiv2 library.
     ///
@@ -66,7 +65,8 @@ namespace Exiv2 {
     /// Most clients will obtain an Image instance by calling a static ImageFactory method. The Image class can
     /// then be used to to read, write, and save metadata.
     /// @note set/clear methods will not modify the image until writeMetadata() method is called.
-    class EXIV2API Image {
+    class EXIV2API Image
+    {
     public:
         //! Image auto_ptr type
         typedef std::unique_ptr<Image> UniquePtr;
@@ -88,7 +88,7 @@ namespace Exiv2 {
         /// specific image type).
         /// @warning This function is not thread safe and intended for exiv2 -pS for debugging.
         /// @warning You may need to put the stream into binary mode (see src/actions.cpp)
-        virtual void printStructure(std::ostream& out, PrintStructureOption option =kpsNone, int depth=0);
+        virtual void printStructure(std::ostream& out, PrintStructureOption option = kpsNone, int depth = 0);
 
         /// @brief Read all metadata supported by a specific image format from the image. Before this method is called,
         /// the image metadata will be cleared.
@@ -98,7 +98,7 @@ namespace Exiv2 {
         ///
         /// @throw Error if opening or reading of the file fails or the image data is not valid (does not look like
         /// data of the specific image type).
-        virtual void readMetadata() =0;
+        virtual void readMetadata() = 0;
 
         /// @brief Write metadata back to the image.
         ///
@@ -108,7 +108,7 @@ namespace Exiv2 {
         /// type will be removed from the image.
         ///
         /// @throw Error if the operation fails
-        virtual void writeMetadata() =0;
+        virtual void writeMetadata() = 0;
 
         /// @brief Assign new Exif data.
         virtual void setExifData(const ExifData& exifData);
@@ -163,13 +163,16 @@ namespace Exiv2 {
         /// @brief Set the image iccProfile.
         /// @param iccProfile DataBuf containing profile (binary)
         /// @param bTestValid - tests that iccProfile contains credible data
-        virtual void setIccProfile(DataBuf& iccProfile,bool bTestValid=true);
+        virtual void setIccProfile(DataBuf& iccProfile, bool bTestValid = true);
 
         /// @brief Erase iccProfile.
         void clearIccProfile();
 
         /// @brief return iccProfile
-        DataBuf* iccProfile() { return &iccProfile_; }
+        DataBuf* iccProfile()
+        {
+            return &iccProfile_;
+        }
 
         /// @brief Copy all existing metadata from \b image into internal buffers.
         virtual void setMetadata(const Image& image);
@@ -198,10 +201,12 @@ namespace Exiv2 {
         /// @brief Print out the structure of image file.
         /// @throw Error if reading of the file fails or the image data is not valid (does not look like data of the
         /// specific image type).
-        void printTiffStructure(BasicIo& io,std::ostream& out, PrintStructureOption option,int depth,size_t offset=0);
+        void printTiffStructure(BasicIo& io, std::ostream& out, PrintStructureOption option, int depth,
+                                size_t offset = 0);
 
         /// @brief Print out the structure of a TIFF IFD
-        void printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option,uint32_t start,bool bSwap,char c,int depth);
+        void printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, uint32_t start,
+                               bool bSwap, char c, int depth);
 
         /// @brief is the host platform bigEndian
         bool isBigEndianPlatform();
@@ -220,12 +225,12 @@ namespace Exiv2 {
         bool isPrintXMP(uint16_t type, Exiv2::PrintStructureOption option);
         bool isPrintICC(uint16_t type, Exiv2::PrintStructureOption option);
 
-        uint64_t byteSwap(uint64_t value,bool bSwap) const;
-        uint32_t byteSwap(uint32_t value,bool bSwap) const;
-        uint16_t byteSwap(uint16_t value,bool bSwap) const;
-        uint16_t byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) const;
-        uint32_t byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) const;
-        uint64_t byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) const;
+        uint64_t byteSwap(uint64_t value, bool bSwap) const;
+        uint32_t byteSwap(uint32_t value, bool bSwap) const;
+        uint16_t byteSwap(uint16_t value, bool bSwap) const;
+        uint16_t byteSwap2(const DataBuf& buf, size_t offset, bool bSwap) const;
+        uint32_t byteSwap4(const DataBuf& buf, size_t offset, bool bSwap) const;
+        uint64_t byteSwap8(const DataBuf& buf, size_t offset, bool bSwap) const;
 
         //@}
 
@@ -238,7 +243,7 @@ namespace Exiv2 {
         /// specific MIME type for that format. In particular, several RAW formats are variants of the TIFF format with
         /// the same magic as TIFF itself. Class TiffImage handles most of them and thus they all have MIME type
         /// "image/tiff", although a more specific MIME type may exist (e.g., "image/x-nikon-nef").
-        virtual std::string mimeType() const =0;
+        virtual std::string mimeType() const = 0;
 
         /// @brief Return the pixel width of the image.
         virtual int pixelWidth() const;
@@ -313,7 +318,8 @@ namespace Exiv2 {
         /// @return Access mode for the requested image type and metadata identifier.
         AccessMode checkMode(MetadataId metadataId) const;
 
-        /// @brief Check if image supports a particular type of metadata. This method is deprecated. Use checkMode() instead.
+        /// @brief Check if image supports a particular type of metadata. This method is deprecated. Use checkMode()
+        /// instead.
         bool supportsMetadata(MetadataId metadataId) const;
 
         /// Return the flag indicating the source when writing XMP metadata.
@@ -326,25 +332,28 @@ namespace Exiv2 {
         /// set type support for this image format
         void setTypeSupported(ImageType imageType, uint16_t supportedMetadata)
         {
-            imageType_         = imageType;
+            imageType_ = imageType;
             supportedMetadata_ = supportedMetadata;
         }
 
         /// set type support for this image format
-        ImageType imageType() const { return imageType_; }
+        ImageType imageType() const
+        {
+            return imageType_;
+        }
 
     protected:
         // DATA
-        BasicIo::UniquePtr  io_;              //!< Image data IO pointer
-        ExifData          exifData_;          //!< Exif data container
-        IptcData          iptcData_;          //!< IPTC data container
-        XmpData           xmpData_;           //!< XMP data container
-        DataBuf           iccProfile_;        //!< ICC buffer (binary data)
-        std::string       comment_;           //!< User comment
-        std::string       xmpPacket_;         //!< XMP packet
-        int               pixelWidth_;        //!< image pixel width
-        int               pixelHeight_;       //!< image pixel height
-        NativePreviewList nativePreviews_;    //!< list of native previews
+        BasicIo::UniquePtr io_;             //!< Image data IO pointer
+        ExifData exifData_;                 //!< Exif data container
+        IptcData iptcData_;                 //!< IPTC data container
+        XmpData xmpData_;                   //!< XMP data container
+        DataBuf iccProfile_;                //!< ICC buffer (binary data)
+        std::string comment_;               //!< User comment
+        std::string xmpPacket_;             //!< XMP packet
+        int pixelWidth_;                    //!< image pixel width
+        int pixelHeight_;                   //!< image pixel height
+        NativePreviewList nativePreviews_;  //!< list of native previews
 
         //! Return tag name for given tag id.
         const std::string& tagName(uint16_t tag);
@@ -360,15 +369,15 @@ namespace Exiv2 {
 
     private:
         // DATA
-        ImageType        imageType_;         //!< Image type
-        uint16_t          supportedMetadata_; //!< Bitmap with all supported metadata types
-        bool              writeXmpFromPacket_;//!< Determines the source when writing XMP
-        ByteOrder         byteOrder_;         //!< Byte order
+        ImageType imageType_;         //!< Image type
+        uint16_t supportedMetadata_;  //!< Bitmap with all supported metadata types
+        bool writeXmpFromPacket_;     //!< Determines the source when writing XMP
+        ByteOrder byteOrder_;         //!< Byte order
 
-        std::map<int,std::string> tags_;      //!< Map of tags
-        bool                      init_;      //!< Flag marking if map of tags needs to be initialized
+        std::map<int, std::string> tags_;  //!< Map of tags
+        bool init_;                        //!< Flag marking if map of tags needs to be initialized
 
-    }; // class Image
+    };  // class Image
 
     //! Type for function pointer that creates new Image instances
     typedef Image::UniquePtr (*NewInstanceFct)(BasicIo::UniquePtr io, bool create);
@@ -376,8 +385,10 @@ namespace Exiv2 {
     typedef bool (*IsThisTypeFct)(BasicIo& iIo, bool advance);
 
     /// @brief Returns an Image instance of the specified type. The factory is implemented as a static class.
-    class EXIV2API ImageFactory {
+    class EXIV2API ImageFactory
+    {
         friend bool Image::good() const;
+
     public:
         /// @brief Create the appropriate class type implemented BasicIo based on the protocol of the input.
         ///
@@ -515,9 +526,9 @@ namespace Exiv2 {
         ImageFactory(const ImageFactory& rhs) = delete;
     };  // class ImageFactory
 
-// *****************************************************************************
-// template, inline and free functions
+    // *****************************************************************************
+    // template, inline and free functions
 
     //! Append \em len bytes pointed to by \em buf to \em blob.
     EXIV2API void append(Exiv2::Blob& blob, const byte* buf, uint32_t len);
-}                                       // namespace Exiv2
+}  // namespace Exiv2

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -45,10 +45,7 @@ namespace Exiv2 {
 // *****************************************************************************
 // class definitions
 
-    /*!
-      @brief Helper class, has methods to deal with %Photoshop "Information
-             Resource Blocks" (IRBs).
-     */
+    /// @brief Helper class, has methods to deal with %Photoshop "Information Resource Blocks" (IRBs).
     struct EXIV2API Photoshop {
         // Todo: Public for now
         static const char     ps3Id_[]; //!< %Photoshop marker
@@ -57,257 +54,193 @@ namespace Exiv2 {
         static const uint16_t iptc_;    //!< %Photoshop IPTC marker
         static const uint16_t preview_; //!< %Photoshop preview marker
 
-        /*!
-          @brief Checks an IRB
+        /// @brief Checks an IRB
+        /// @param pPsData        Existing IRB buffer
+        /// @param sizePsData     Size of the IRB buffer
+        /// @return true  if the IRB marker is known and the buffer is big enough to check this;<BR> false otherwise
+        static bool isIrb(const byte* pPsData, long sizePsData);
 
-          @param pPsData        Existing IRB buffer
-          @param sizePsData     Size of the IRB buffer
-          @return true  if the IRB marker is known and the buffer is big enough to check this;<BR>
-                  false otherwise
-        */
-        static bool isIrb(const byte* pPsData,
-                          long        sizePsData);
-        /*!
-          @brief Validates all IRBs
+        /// @brief Validates all IRBs
+        /// @param pPsData        Existing IRB buffer
+        /// @param sizePsData     Size of the IRB buffer, may be 0
+        /// @return true  if all IRBs are valid;<BR> false otherwise
+        static bool valid(const byte *pPsData, long sizePsData);
 
-          @param pPsData        Existing IRB buffer
-          @param sizePsData     Size of the IRB buffer, may be 0
-          @return true  if all IRBs are valid;<BR>
-                  false otherwise
-        */
-        static bool valid(const byte* pPsData,
-                          long        sizePsData);
-        /*!
-          @brief Locates the data for a %Photoshop tag in a %Photoshop formated memory
-              buffer. Operates on raw data to simplify reuse.
-          @param pPsData Pointer to buffer containing entire payload of
-              %Photoshop formated data, e.g., from APP13 Jpeg segment.
-          @param sizePsData Size in bytes of pPsData.
-          @param psTag %Tag number of the block to look for.
-          @param record Output value that is set to the start of the
-              data block within pPsData (may not be null).
-          @param sizeHdr Output value that is set to the size of the header
-              within the data block pointed to by record (may not be null).
-          @param sizeData Output value that is set to the size of the actual
-              data within the data block pointed to by record (may not be null).
-          @return 0 if successful;<BR>
-                  3 if no data for psTag was found in pPsData;<BR>
-                 -2 if the pPsData buffer does not contain valid data.
-        */
+        /// @brief Locates the data for a %Photoshop tag in a %Photoshop formated memory buffer. Operates on raw data
+        /// to simplify reuse.
+        /// @param pPsData Pointer to buffer containing entire payload of %Photoshop formated data, e.g., from APP13
+        /// Jpeg segment.
+        /// @param sizePsData Size in bytes of pPsData.
+        /// @param psTag %Tag number of the block to look for.
+        /// @param record Output value that is set to the start of the data block within pPsData (may not be null).
+        /// @param sizeHdr Output value that is set to the size of the header within the data block pointed to by
+        /// record (may not be null).
+        /// @param sizeData Output value that is set to the size of the actual data within the data block pointed to
+        /// by record (may not be null).
+        /// @return 0 if successful;<BR>
+        ///  3 if no data for psTag was found in pPsData;<BR>
+        ///  -2 if the pPsData buffer does not contain valid data.
         static int locateIrb(const byte *pPsData,
                              long sizePsData,
                              uint16_t psTag,
                              const byte **record,
                              uint32_t *const sizeHdr,
                              uint32_t *const sizeData);
-        /*!
-          @brief Forwards to locateIrb() with \em psTag = \em iptc_
-         */
+
+        /// @brief Forwards to locateIrb() with \em psTag = \em iptc_
         static int locateIptcIrb(const byte *pPsData,
                                  long sizePsData,
                                  const byte **record,
                                  uint32_t *const sizeHdr,
                                  uint32_t *const sizeData);
-        /*!
-          @brief Forwards to locatePreviewIrb() with \em psTag = \em preview_
-         */
+
+        /// @brief Forwards to locatePreviewIrb() with \em psTag = \em preview_
         static int locatePreviewIrb(const byte *pPsData,
                                     long sizePsData,
                                     const byte **record,
                                     uint32_t *const sizeHdr,
                                     uint32_t *const sizeData);
-        /*!
-          @brief Set the new IPTC IRB, keeps existing IRBs but removes the
-                 IPTC block if there is no new IPTC data to write.
 
-          @param pPsData    Existing IRB buffer
-          @param sizePsData Size of the IRB buffer, may be 0
-          @param iptcData   Iptc data to embed, may be empty
-          @return A data buffer containing the new IRB buffer, may have 0 size
-        */
-        static DataBuf setIptcIrb(const byte*     pPsData,
-                                  long            sizePsData,
-                                  const IptcData& iptcData);
+        /// @brief Set the new IPTC IRB, keeps existing IRBs but removes the IPTC block if there is no new IPTC data
+        /// to write.
+        ///
+        /// @param pPsData    Existing IRB buffer
+        /// @param sizePsData Size of the IRB buffer, may be 0
+        /// @param iptcData   Iptc data to embed, may be empty
+        /// @return A data buffer containing the new IRB buffer, may have 0 size
+        static DataBuf setIptcIrb(const byte *pPsData, long sizePsData, const IptcData &iptcData);
 
     }; // class Photoshop
 
-    /*!
-      @brief Abstract helper base class to access JPEG images.
-     */
+    /// @brief Abstract helper base class to access JPEG images.
     class EXIV2API JpegBase : public Image {
     public:
-        //! @name Manipulators
-        //@{
         void readMetadata() override;
         void writeMetadata() override;
-
-        /*!
-          @brief Print out the structure of image file.
-          @throw Error if reading of the file fails or the image data is
-                not valid (does not look like data of the specific image type).
-          @warning This function is not thread safe and intended for exiv2 -pS for debugging.
-         */
         void printStructure(std::ostream& out, PrintStructureOption option,int depth) override;
-        //@}
 
     protected:
-        //! @name Creators
-        //@{
-        /*!
-          @brief Constructor that can either open an existing image or create
-              a new image from scratch. If a new image is to be created, any
-              existing data is overwritten.
-          @param type Image type.
-          @param io An auto-pointer that owns a BasicIo instance used for
-              reading and writing image metadata. \b Important: The constructor
-              takes ownership of the passed in BasicIo instance through the
-              auto-pointer. Callers should not continue to use the BasicIo
-              instance after it is passed to this method.  Use the Image::io()
-              method to get a temporary reference.
-          @param create Specifies if an existing image should be read (false)
-              or if a new image should be created (true).
-          @param initData Data to initialize newly created images. Only used
-              when \em create is true. Should contain data for the smallest
-              valid image of the calling subclass.
-          @param dataSize Size of initData in bytes.
-         */
-        JpegBase(ImageType       type,
-                 BasicIo::UniquePtr io,
-                 bool             create,
-                 const byte       initData[],
-                 long             dataSize);
-        //@}
+       //! @name Creators
+       //@{
+       /// @brief Constructor that can either open an existing image or create a new image from scratch. If a new
+       /// image is to be created, any existing data is overwritten.
+       /// @param type Image type.
+       /// @param io An auto-pointer that owns a BasicIo instance used for reading and writing image metadata.
+       /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
+       /// Callers should not continue to use the BasicIo instance after it is passed to this method.  Use the
+       /// Image::io() method to get a temporary reference.
+       /// @param create Specifies if an existing image should be read (false) or if a new image should be created
+       /// (true).
+       /// @param initData Data to initialize newly created images. Only used when \em create is true. Should contain
+       /// data for the smallest valid image of the calling subclass.
+       /// @param dataSize Size of initData in bytes.
+      JpegBase(ImageType type, BasicIo::UniquePtr io, bool create,
+               const byte initData[], long dataSize);
+      //@}
 
-        //! @name Accessors
-        //@{
-        /*!
-          @brief Determine if the content of the BasicIo instance is of the
-              type supported by this class.
+      //! @name Accessors
+      //@{
+      /// @brief Determine if the content of the BasicIo instance is of the type supported by this class.
+      ///
+      /// The advance flag determines if the read position in the stream is moved (see below). This applies only if the
+      /// type matches and the function returns true. If the type does not match, the stream position is not changed.
+      /// However, if reading from the stream fails, the stream position is undefined. Consult the stream state to
+      /// obtain more information in this case.
+      ///
+      /// @param iIo BasicIo instance to read from.
+      /// @param advance Flag indicating whether the position of the io should be advanced by the number of characters
+      /// read to analyse the data (true) or left at its original position (false). This applies only if the type
+      /// matches.
+      /// @return true if the data matches the type of this class;<BR> false if the data does not match
+      virtual bool isThisType(BasicIo &iIo, bool advance) const = 0;
+      //@}
 
-          The advance flag determines if the read position in the stream is
-          moved (see below). This applies only if the type matches and the
-          function returns true. If the type does not match, the stream
-          position is not changed. However, if reading from the stream fails,
-          the stream position is undefined. Consult the stream state to obtain
-          more information in this case.
+      //! @name Manipulators
+      //@{
+      /// @brief Writes the image header (aka signature) to the BasicIo instance.
+      /// @param oIo BasicIo instance that the header is written to.
+      /// @return 0 if successful;<BR> 4 if the output file can not be written to
+      virtual int writeHeader(BasicIo &oIo) const = 0;
+      //@}
 
-          @param iIo BasicIo instance to read from.
-          @param advance Flag indicating whether the position of the io
-              should be advanced by the number of characters read to
-              analyse the data (true) or left at its original
-              position (false). This applies only if the type matches.
-          @return  true  if the data matches the type of this class;<BR>
-                   false if the data does not match
-         */
-        virtual bool isThisType(BasicIo& iIo, bool advance) const =0;
-        //@}
+      // Constant Data
+      static const byte dht_;      //!< JPEG DHT marker
+      static const byte dqt_;      //!< JPEG DQT marker
+      static const byte dri_;      //!< JPEG DRI marker
+      static const byte sos_;      //!< JPEG SOS marker
+      static const byte eoi_;      //!< JPEG EOI marker
+      static const byte app0_;     //!< JPEG APP0 marker
+      static const byte app1_;     //!< JPEG APP1 marker
+      static const byte app2_;     //!< JPEG APP2 marker
+      static const byte app13_;    //!< JPEG APP13 marker
+      static const byte com_;      //!< JPEG Comment marker
+      static const byte sof0_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof1_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof2_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof3_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof5_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof6_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof7_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof9_;     //!< JPEG Start-Of-Frame marker
+      static const byte sof10_;    //!< JPEG Start-Of-Frame marker
+      static const byte sof11_;    //!< JPEG Start-Of-Frame marker
+      static const byte sof13_;    //!< JPEG Start-Of-Frame marker
+      static const byte sof14_;    //!< JPEG Start-Of-Frame marker
+      static const byte sof15_;    //!< JPEG Start-Of-Frame marker
+      static const char exifId_[]; //!< Exif identifier
+      static const char jfifId_[]; //!< JFIF identifier
+      static const char xmpId_[];  //!< XMP packet identifier
+      static const char iccId_[];  //!< ICC profile identifier
 
-        //! @name Manipulators
-        //@{
-        /*!
-          @brief Writes the image header (aka signature) to the BasicIo instance.
-          @param oIo BasicIo instance that the header is written to.
-          @return 0 if successful;<BR>
-                  4 if the output file can not be written to
-         */
-        virtual int writeHeader(BasicIo& oIo) const =0;
-        //@}
-
-        // Constant Data
-        static const byte dht_;                 //!< JPEG DHT marker
-        static const byte dqt_;                 //!< JPEG DQT marker
-        static const byte dri_;                 //!< JPEG DRI marker
-        static const byte sos_;                 //!< JPEG SOS marker
-        static const byte eoi_;                 //!< JPEG EOI marker
-        static const byte app0_;                //!< JPEG APP0 marker
-        static const byte app1_;                //!< JPEG APP1 marker
-        static const byte app2_;                //!< JPEG APP2 marker
-        static const byte app13_;               //!< JPEG APP13 marker
-        static const byte com_;                 //!< JPEG Comment marker
-        static const byte sof0_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof1_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof2_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof3_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof5_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof6_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof7_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof9_;                //!< JPEG Start-Of-Frame marker
-        static const byte sof10_;               //!< JPEG Start-Of-Frame marker
-        static const byte sof11_;               //!< JPEG Start-Of-Frame marker
-        static const byte sof13_;               //!< JPEG Start-Of-Frame marker
-        static const byte sof14_;               //!< JPEG Start-Of-Frame marker
-        static const byte sof15_;               //!< JPEG Start-Of-Frame marker
-        static const char exifId_[];            //!< Exif identifier
-        static const char jfifId_[];            //!< JFIF identifier
-        static const char xmpId_[];             //!< XMP packet identifier
-        static const char iccId_[];             //!< ICC profile identifier
-
-        JpegBase() = delete;
-        JpegBase& operator=(const JpegBase& rhs) = delete;
-        JpegBase& operator=(const JpegBase&& rhs) = delete;
-        JpegBase(const JpegBase& rhs) = delete;
-        JpegBase(const JpegBase&& rhs) = delete;
+      JpegBase() = delete;
+      JpegBase &operator=(const JpegBase &rhs) = delete;
+      JpegBase &operator=(const JpegBase &&rhs) = delete;
+      JpegBase(const JpegBase &rhs) = delete;
+      JpegBase(const JpegBase &&rhs) = delete;
 
     private:
         //! @name Manipulators
         //@{
-        /*!
-          @brief Initialize the image with the provided data.
-          @param initData Data to be written to the associated BasicIo
-          @param dataSize Size in bytes of data to be written
-          @return 0 if successful;<BR>
-                  4 if the image can not be written to.
-         */
+        /// @brief Initialize the image with the provided data.
+        /// @param initData Data to be written to the associated BasicIo
+        /// @param dataSize Size in bytes of data to be written
+        /// @return 0 if successful;<BR> 4 if the image can not be written to.
         int initImage(const byte initData[], long dataSize);
-        /*!
-          @brief Provides the main implementation of writeMetadata() by
-                writing all buffered metadata to the provided BasicIo.
-          @param oIo BasicIo instance to write to (a temporary location).
 
-          @return 4 if opening or writing to the associated BasicIo fails
-         */
+        /// @brief Provides the main implementation of writeMetadata() by writing all buffered metadata to the provided
+        /// BasicIo.
+        /// @param oIo BasicIo instance to write to (a temporary location).
+        /// @return 4 if opening or writing to the associated BasicIo fails
         void doWriteMetadata(BasicIo& oIo);
         //@}
 
         //! @name Accessors
         //@{
-        /*!
-          @brief Advances associated io instance to one byte past the next
-              Jpeg marker and returns the marker. This method should be called
-              when the BasicIo instance is positioned one byte past the end of a
-              Jpeg segment.
-          @return the next Jpeg segment marker if successful;<BR>
-                 -1 if a maker was not found before EOF
-         */
+        /// @brief Advances associated io instance to one byte past the next Jpeg marker and returns the marker.
+        /// This method should be called when the BasicIo instance is positioned one byte past the end of a Jpeg segment.
+        /// @return the next Jpeg segment marker if successful;<BR> -1 if a maker was not found before EOF
         int advanceToMarker() const;
         //@}
 
     }; // class JpegBase
 
-    /*!
-      @brief Class to access JPEG images
-     */
+    /// @brief Class to access JPEG images
     class EXIV2API JpegImage : public JpegBase {
         friend EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
     public:
         //! @name Creators
         //@{
-        /*!
-          @brief Constructor that can either open an existing Jpeg image or create
-              a new image from scratch. If a new image is to be created, any
-              existing data is overwritten. Since the constructor can not return
-              a result, callers should check the good() method after object
-              construction to determine success or failure.
-          @param io An auto-pointer that owns a BasicIo instance used for
-              reading and writing image metadata. \b Important: The constructor
-              takes ownership of the passed in BasicIo instance through the
-              auto-pointer. Callers should not continue to use the BasicIo
-              instance after it is passed to this method.  Use the Image::io()
-              method to get a temporary reference.
-          @param create Specifies if an existing image should be read (false)
-              or if a new file should be created (true).
-         */
+        /// @brief Constructor that can either open an existing Jpeg image or create a new image from scratch.
+        ///
+        /// If a new image is to be created, any existing data is overwritten. Since the constructor can not return a
+        /// result, callers should check the good() method after object construction to determine success or failure.
+        /// @param io An auto-pointer that owns a BasicIo instance used for reading and writing image metadata.
+        /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
+        /// Callers should not continue to use the BasicIo instance after it is passed to this method. Use the
+        /// Image::io() method to get a temporary reference.
+        /// @param create Specifies if an existing image should be read (false) or if a new file should be created (true).
         JpegImage(BasicIo::UniquePtr io, bool create);
+
         //@}
         //! @name Accessors
         //@{
@@ -321,14 +254,12 @@ namespace Exiv2 {
         //@}
         //! @name Manipulators
         //@{
-        /*!
-          @brief Writes a Jpeg header (aka signature) to the BasicIo instance.
-          @param oIo BasicIo instance that the header is written to.
-          @return 0 if successful;<BR>
-                 2 if the input image is invalid or can not be read;<BR>
-                 4 if the temporary image can not be written to;<BR>
-                -3 other temporary errors
-         */
+        /// @brief Writes a Jpeg header (aka signature) to the BasicIo instance.
+        /// @param oIo BasicIo instance that the header is written to.
+        /// @return 0 if successful;<BR>
+        ///  2 if the input image is invalid or can not be read;<BR>
+        ///  4 if the temporary image can not be written to;<BR>
+        ///  -3 other temporary errors
         int writeHeader(BasicIo& oIo) const override;
         //@}
 
@@ -351,21 +282,15 @@ namespace Exiv2 {
     public:
         //! @name Creators
         //@{
-        /*!
-          @brief Constructor that can either open an existing EXV image or create
-              a new image from scratch. If a new image is to be created, any
-              existing data is overwritten. Since the constructor can not return
-              a result, callers should check the good() method after object
-              construction to determine success or failure.
-          @param io An auto-pointer that owns a BasicIo instance used for
-              reading and writing image metadata. \b Important: The constructor
-              takes ownership of the passed in BasicIo instance through the
-              auto-pointer. Callers should not continue to use the BasicIo
-              instance after it is passed to this method.  Use the Image::io()
-              method to get a temporary reference.
-          @param create Specifies if an existing image should be read (false)
-                 or if a new file should be created (true).
-         */
+        /// @brief Constructor that can either open an existing EXV image or create a new image from scratch.
+        ///
+        /// If a new image is to be created, any existing data is overwritten. Since the constructor can not return a
+        /// result, callers should check the good() method after object construction to determine success or failure.
+        /// @param io An auto-pointer that owns a BasicIo instance used for reading and writing image metadata.
+        /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
+        /// Callers should not continue to use the BasicIo instance after it is passed to this method.  Use the
+        /// Image::io() method to get a temporary reference.
+        /// @param create Specifies if an existing image should be read (false) or a new file should be created (true).
         ExvImage(BasicIo::UniquePtr io, bool create);
         //@}
         //! @name Accessors
@@ -399,23 +324,15 @@ namespace Exiv2 {
 // *****************************************************************************
 // template, inline and free functions
 
-    // These could be static private functions on Image subclasses but then
-    // ImageFactory needs to be made a friend.
-    /*!
-      @brief Create a new JpegImage instance and return an auto-pointer to it.
-             Caller owns the returned object and the auto-pointer ensures that
-             it will be deleted.
-     */
+    // These could be static private functions on Image subclasses but then ImageFactory needs to be made a friend.
+
+    /// @brief Create a new JpegImage instance and return an auto-pointer to it.
     EXIV2API Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create);
-    //! Check if the file iIo is a JPEG image.
+    /// @brief Check if the file iIo is a JPEG image.
     EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
-    /*!
-      @brief Create a new ExvImage instance and return an auto-pointer to it.
-             Caller owns the returned object and the auto-pointer ensures that
-             it will be deleted.
-     */
+    /// @brief Create a new ExvImage instance and return an auto-pointer to it.
     EXIV2API Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create);
-    //! Check if the file iIo is an EXV file
+    /// @brief Check if the file iIo is an EXV file
     EXIV2API bool isExvType(BasicIo& iIo, bool advance);
 
 }                                       // namespace Exiv2

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -40,19 +40,20 @@
 
 // *****************************************************************************
 // namespace extensions
-namespace Exiv2 {
-
-// *****************************************************************************
-// class definitions
+namespace Exiv2
+{
+    // *****************************************************************************
+    // class definitions
 
     /// @brief Helper class, has methods to deal with %Photoshop "Information Resource Blocks" (IRBs).
-    struct EXIV2API Photoshop {
+    struct EXIV2API Photoshop
+    {
         // Todo: Public for now
-        static const char     ps3Id_[]; //!< %Photoshop marker
-        static const char*    irbId_[]; //!< %Photoshop IRB markers
-        static const char     bimId_[]; //!< %Photoshop IRB marker (deprecated)
-        static const uint16_t iptc_;    //!< %Photoshop IPTC marker
-        static const uint16_t preview_; //!< %Photoshop preview marker
+        static const char ps3Id_[];      //!< %Photoshop marker
+        static const char* irbId_[];     //!< %Photoshop IRB markers
+        static const char bimId_[];      //!< %Photoshop IRB marker (deprecated)
+        static const uint16_t iptc_;     //!< %Photoshop IPTC marker
+        static const uint16_t preview_;  //!< %Photoshop preview marker
 
         /// @brief Checks an IRB
         /// @param pPsData        Existing IRB buffer
@@ -64,7 +65,7 @@ namespace Exiv2 {
         /// @param pPsData        Existing IRB buffer
         /// @param sizePsData     Size of the IRB buffer, may be 0
         /// @return true  if all IRBs are valid;<BR> false otherwise
-        static bool valid(const byte *pPsData, long sizePsData);
+        static bool valid(const byte* pPsData, long sizePsData);
 
         /// @brief Locates the data for a %Photoshop tag in a %Photoshop formated memory buffer. Operates on raw data
         /// to simplify reuse.
@@ -80,26 +81,16 @@ namespace Exiv2 {
         /// @return 0 if successful;<BR>
         ///  3 if no data for psTag was found in pPsData;<BR>
         ///  -2 if the pPsData buffer does not contain valid data.
-        static int locateIrb(const byte *pPsData,
-                             long sizePsData,
-                             uint16_t psTag,
-                             const byte **record,
-                             uint32_t *const sizeHdr,
-                             uint32_t *const sizeData);
+        static int locateIrb(const byte* pPsData, long sizePsData, uint16_t psTag, const byte** record,
+                             uint32_t* const sizeHdr, uint32_t* const sizeData);
 
         /// @brief Forwards to locateIrb() with \em psTag = \em iptc_
-        static int locateIptcIrb(const byte *pPsData,
-                                 long sizePsData,
-                                 const byte **record,
-                                 uint32_t *const sizeHdr,
-                                 uint32_t *const sizeData);
+        static int locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* const sizeHdr,
+                                 uint32_t* const sizeData);
 
         /// @brief Forwards to locatePreviewIrb() with \em psTag = \em preview_
-        static int locatePreviewIrb(const byte *pPsData,
-                                    long sizePsData,
-                                    const byte **record,
-                                    uint32_t *const sizeHdr,
-                                    uint32_t *const sizeData);
+        static int locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* const sizeHdr,
+                                    uint32_t* const sizeData);
 
         /// @brief Set the new IPTC IRB, keeps existing IRBs but removes the IPTC block if there is no new IPTC data
         /// to write.
@@ -108,95 +99,95 @@ namespace Exiv2 {
         /// @param sizePsData Size of the IRB buffer, may be 0
         /// @param iptcData   Iptc data to embed, may be empty
         /// @return A data buffer containing the new IRB buffer, may have 0 size
-        static DataBuf setIptcIrb(const byte *pPsData, long sizePsData, const IptcData &iptcData);
+        static DataBuf setIptcIrb(const byte* pPsData, long sizePsData, const IptcData& iptcData);
 
-    }; // class Photoshop
+    };  // class Photoshop
 
     /// @brief Abstract helper base class to access JPEG images.
-    class EXIV2API JpegBase : public Image {
+    class EXIV2API JpegBase : public Image
+    {
     public:
         void readMetadata() override;
         void writeMetadata() override;
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth) override;
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
 
     protected:
-       //! @name Creators
-       //@{
-       /// @brief Constructor that can either open an existing image or create a new image from scratch. If a new
-       /// image is to be created, any existing data is overwritten.
-       /// @param type Image type.
-       /// @param io An auto-pointer that owns a BasicIo instance used for reading and writing image metadata.
-       /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
-       /// Callers should not continue to use the BasicIo instance after it is passed to this method.  Use the
-       /// Image::io() method to get a temporary reference.
-       /// @param create Specifies if an existing image should be read (false) or if a new image should be created
-       /// (true).
-       /// @param initData Data to initialize newly created images. Only used when \em create is true. Should contain
-       /// data for the smallest valid image of the calling subclass.
-       /// @param dataSize Size of initData in bytes.
-      JpegBase(ImageType type, BasicIo::UniquePtr io, bool create,
-               const byte initData[], long dataSize);
-      //@}
+        //! @name Creators
+        //@{
+        /// @brief Constructor that can either open an existing image or create a new image from scratch. If a new
+        /// image is to be created, any existing data is overwritten.
+        /// @param type Image type.
+        /// @param io An auto-pointer that owns a BasicIo instance used for reading and writing image metadata.
+        /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
+        /// Callers should not continue to use the BasicIo instance after it is passed to this method.  Use the
+        /// Image::io() method to get a temporary reference.
+        /// @param create Specifies if an existing image should be read (false) or if a new image should be created
+        /// (true).
+        /// @param initData Data to initialize newly created images. Only used when \em create is true. Should contain
+        /// data for the smallest valid image of the calling subclass.
+        /// @param dataSize Size of initData in bytes.
+        JpegBase(ImageType type, BasicIo::UniquePtr io, bool create, const byte initData[], long dataSize);
+        //@}
 
-      //! @name Accessors
-      //@{
-      /// @brief Determine if the content of the BasicIo instance is of the type supported by this class.
-      ///
-      /// The advance flag determines if the read position in the stream is moved (see below). This applies only if the
-      /// type matches and the function returns true. If the type does not match, the stream position is not changed.
-      /// However, if reading from the stream fails, the stream position is undefined. Consult the stream state to
-      /// obtain more information in this case.
-      ///
-      /// @param iIo BasicIo instance to read from.
-      /// @param advance Flag indicating whether the position of the io should be advanced by the number of characters
-      /// read to analyse the data (true) or left at its original position (false). This applies only if the type
-      /// matches.
-      /// @return true if the data matches the type of this class;<BR> false if the data does not match
-      virtual bool isThisType(BasicIo &iIo, bool advance) const = 0;
-      //@}
+        //! @name Accessors
+        //@{
+        /// @brief Determine if the content of the BasicIo instance is of the type supported by this class.
+        ///
+        /// The advance flag determines if the read position in the stream is moved (see below). This applies only if
+        /// the type matches and the function returns true. If the type does not match, the stream position is not
+        /// changed. However, if reading from the stream fails, the stream position is undefined. Consult the stream
+        /// state to obtain more information in this case.
+        ///
+        /// @param iIo BasicIo instance to read from.
+        /// @param advance Flag indicating whether the position of the io should be advanced by the number of characters
+        /// read to analyse the data (true) or left at its original position (false). This applies only if the type
+        /// matches.
+        /// @return true if the data matches the type of this class;<BR> false if the data does not match
+        virtual bool isThisType(BasicIo& iIo, bool advance) const = 0;
+        //@}
 
-      //! @name Manipulators
-      //@{
-      /// @brief Writes the image header (aka signature) to the BasicIo instance.
-      /// @param oIo BasicIo instance that the header is written to.
-      /// @return 0 if successful;<BR> 4 if the output file can not be written to
-      virtual int writeHeader(BasicIo &oIo) const = 0;
-      //@}
+        //! @name Manipulators
+        //@{
+        /// @brief Writes the image header (aka signature) to the BasicIo instance.
+        /// @param oIo BasicIo instance that the header is written to.
+        /// @return 0 if successful;<BR> 4 if the output file can not be written to
+        virtual int writeHeader(BasicIo& oIo) const = 0;
+        //@}
 
-      // Constant Data
-      static const byte dht_;      //!< JPEG DHT marker
-      static const byte dqt_;      //!< JPEG DQT marker
-      static const byte dri_;      //!< JPEG DRI marker
-      static const byte sos_;      //!< JPEG SOS marker
-      static const byte eoi_;      //!< JPEG EOI marker
-      static const byte app0_;     //!< JPEG APP0 marker
-      static const byte app1_;     //!< JPEG APP1 marker
-      static const byte app2_;     //!< JPEG APP2 marker
-      static const byte app13_;    //!< JPEG APP13 marker
-      static const byte com_;      //!< JPEG Comment marker
-      static const byte sof0_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof1_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof2_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof3_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof5_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof6_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof7_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof9_;     //!< JPEG Start-Of-Frame marker
-      static const byte sof10_;    //!< JPEG Start-Of-Frame marker
-      static const byte sof11_;    //!< JPEG Start-Of-Frame marker
-      static const byte sof13_;    //!< JPEG Start-Of-Frame marker
-      static const byte sof14_;    //!< JPEG Start-Of-Frame marker
-      static const byte sof15_;    //!< JPEG Start-Of-Frame marker
-      static const char exifId_[]; //!< Exif identifier
-      static const char jfifId_[]; //!< JFIF identifier
-      static const char xmpId_[];  //!< XMP packet identifier
-      static const char iccId_[];  //!< ICC profile identifier
+        // Constant Data
+        static const byte dht_;       //!< JPEG DHT marker
+        static const byte dqt_;       //!< JPEG DQT marker
+        static const byte dri_;       //!< JPEG DRI marker
+        static const byte sos_;       //!< JPEG SOS marker
+        static const byte eoi_;       //!< JPEG EOI marker
+        static const byte app0_;      //!< JPEG APP0 marker
+        static const byte app1_;      //!< JPEG APP1 marker
+        static const byte app2_;      //!< JPEG APP2 marker
+        static const byte app13_;     //!< JPEG APP13 marker
+        static const byte com_;       //!< JPEG Comment marker
+        static const byte sof0_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof1_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof2_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof3_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof5_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof6_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof7_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof9_;      //!< JPEG Start-Of-Frame marker
+        static const byte sof10_;     //!< JPEG Start-Of-Frame marker
+        static const byte sof11_;     //!< JPEG Start-Of-Frame marker
+        static const byte sof13_;     //!< JPEG Start-Of-Frame marker
+        static const byte sof14_;     //!< JPEG Start-Of-Frame marker
+        static const byte sof15_;     //!< JPEG Start-Of-Frame marker
+        static const char exifId_[];  //!< Exif identifier
+        static const char jfifId_[];  //!< JFIF identifier
+        static const char xmpId_[];   //!< XMP packet identifier
+        static const char iccId_[];   //!< ICC profile identifier
 
-      JpegBase() = delete;
-      JpegBase &operator=(const JpegBase &rhs) = delete;
-      JpegBase &operator=(const JpegBase &&rhs) = delete;
-      JpegBase(const JpegBase &rhs) = delete;
-      JpegBase(const JpegBase &&rhs) = delete;
+        JpegBase() = delete;
+        JpegBase& operator=(const JpegBase& rhs) = delete;
+        JpegBase& operator=(const JpegBase&& rhs) = delete;
+        JpegBase(const JpegBase& rhs) = delete;
+        JpegBase(const JpegBase&& rhs) = delete;
 
     private:
         //! @name Manipulators
@@ -217,16 +208,19 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         /// @brief Advances associated io instance to one byte past the next Jpeg marker and returns the marker.
-        /// This method should be called when the BasicIo instance is positioned one byte past the end of a Jpeg segment.
+        /// This method should be called when the BasicIo instance is positioned one byte past the end of a Jpeg
+        /// segment.
         /// @return the next Jpeg segment marker if successful;<BR> -1 if a maker was not found before EOF
         int advanceToMarker() const;
         //@}
 
-    }; // class JpegBase
+    };  // class JpegBase
 
     /// @brief Class to access JPEG images
-    class EXIV2API JpegImage : public JpegBase {
+    class EXIV2API JpegImage : public JpegBase
+    {
         friend EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
+
     public:
         //! @name Creators
         //@{
@@ -238,7 +232,8 @@ namespace Exiv2 {
         /// \b Important: The constructor takes ownership of the passed in BasicIo instance through the auto-pointer.
         /// Callers should not continue to use the BasicIo instance after it is passed to this method. Use the
         /// Image::io() method to get a temporary reference.
-        /// @param create Specifies if an existing image should be read (false) or if a new file should be created (true).
+        /// @param create Specifies if an existing image should be read (false) or if a new file should be created
+        /// (true).
         JpegImage(BasicIo::UniquePtr io, bool create);
 
         //@}
@@ -265,8 +260,8 @@ namespace Exiv2 {
 
     private:
         // Constant data
-        static const byte soi_;          // SOI marker
-        static const byte blank_[];      // Minimal Jpeg image
+        static const byte soi_;      // SOI marker
+        static const byte blank_[];  // Minimal Jpeg image
 
     public:
         JpegImage() = delete;
@@ -274,11 +269,13 @@ namespace Exiv2 {
         JpegImage& operator=(const JpegImage&& rhs) = delete;
         JpegImage(const JpegImage& rhs) = delete;
         JpegImage(const JpegImage&& rhs) = delete;
-    }; // class JpegImage
+    };  // class JpegImage
 
     //! Helper class to access %Exiv2 files
-    class EXIV2API ExvImage : public JpegBase {
+    class EXIV2API ExvImage : public JpegBase
+    {
         friend EXIV2API bool isExvType(BasicIo& iIo, bool advance);
+
     public:
         //! @name Creators
         //@{
@@ -310,8 +307,8 @@ namespace Exiv2 {
 
     private:
         // Constant data
-        static const char exiv2Id_[];    // EXV identifier
-        static const byte blank_[];      // Minimal exiv2 file
+        static const char exiv2Id_[];  // EXV identifier
+        static const byte blank_[];    // Minimal exiv2 file
 
     public:
         ExvImage() = delete;
@@ -321,8 +318,8 @@ namespace Exiv2 {
         ExvImage(const ExvImage&& rhs) = delete;
     };  // class ExvImage
 
-// *****************************************************************************
-// template, inline and free functions
+    // *****************************************************************************
+    // template, inline and free functions
 
     // These could be static private functions on Image subclasses but then ImageFactory needs to be made a friend.
 
@@ -335,4 +332,4 @@ namespace Exiv2 {
     /// @brief Check if the file iIo is an EXV file
     EXIV2API bool isExvType(BasicIo& iIo, bool advance);
 
-}                                       // namespace Exiv2
+}  // namespace Exiv2

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -832,8 +832,12 @@ namespace Exiv2 {
 #endif
         return wm;
 
-    } // ExifParser::encode
-
+    }
+    
+    void ExifParser::encode(Blob &blob, ByteOrder byteOrder, const ExifData &exifData) {
+        encode(blob, 0, 0, byteOrder, exifData);
+    }
+    
 }                                       // namespace Exiv2
 
 // *****************************************************************************

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -580,6 +580,10 @@ namespace Exiv2 {
                             FindExifdatumByKey(key.key()));
     }
 
+    bool ExifData::empty() const { return count() == 0; }
+
+    long ExifData::count() const { return static_cast<long>(exifMetadata_.size()); }
+    
     ExifData::iterator ExifData::findKey(const ExifKey& key)
     {
         return std::find_if(exifMetadata_.begin(), exifMetadata_.end(),

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -258,6 +258,7 @@ namespace Exiv2 {
 
         return result;
     } // fileProtocol
+    /// \todo Remove code duplication
 #ifdef EXV_UNICODE_PATH
     Protocol fileProtocol(const std::wstring& wpath) {
         Protocol result = pFile ;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -536,32 +536,6 @@ namespace Exiv2 {
         clearIccProfile();
     }
 
-    ExifData& Image::exifData()
-    {
-        return exifData_;
-    }
-
-    IptcData& Image::iptcData()
-    {
-        return iptcData_;
-    }
-
-    XmpData& Image::xmpData()
-    {
-        return xmpData_;
-    }
-
-    std::string& Image::xmpPacket()
-    {
-        // Serialize the current XMP
-        if (xmpData_.count() > 0 && !writeXmpFromPacket()) {
-            XmpParser::encode(xmpPacket_, xmpData_,
-                              XmpParser::useCompactFormat |
-                              XmpParser::omitAllFormatting);
-        }
-        return xmpPacket_;
-    }
-
     void Image::setMetadata(const Image& image)
     {
         if (checkMode(mdExif) & amWrite) {
@@ -685,14 +659,29 @@ namespace Exiv2 {
         return pixelHeight_;
     }
 
+    ExifData& Image::exifData()
+    {
+        return exifData_;
+    }
+
     const ExifData& Image::exifData() const
     {
         return exifData_;
     }
 
+    IptcData& Image::iptcData()
+    {
+        return iptcData_;
+    }
+
     const IptcData& Image::iptcData() const
     {
         return iptcData_;
+    }
+
+    XmpData& Image::xmpData()
+    {
+        return xmpData_;
     }
 
     const XmpData& Image::xmpData() const
@@ -703,6 +692,15 @@ namespace Exiv2 {
     std::string Image::comment() const
     {
         return comment_;
+    }
+
+    std::string& Image::xmpPacket()
+    {
+        // Serialize the current XMP
+        if (xmpData_.count() > 0 && !writeXmpFromPacket()) {
+            XmpParser::encode(xmpPacket_, xmpData_, XmpParser::useCompactFormat | XmpParser::omitAllFormatting);
+        }
+        return xmpPacket_;
     }
 
     const std::string& Image::xmpPacket() const
@@ -885,7 +883,8 @@ namespace Exiv2 {
     Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
     {
         Image::UniquePtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
-        if (image.get() == 0) throw Error(kerFileContainsUnknownImageType, path);
+        if (image.get() == 0)
+            throw Error(kerFileContainsUnknownImageType, path);
         return image;
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -663,6 +663,8 @@ namespace Exiv2 {
         iccProfile_.free();
     }
 
+    bool Image::iccProfileDefined() const { return iccProfile_.size_?true:false;}
+
     void Image::setByteOrder(ByteOrder byteOrder)
     {
         byteOrder_ = byteOrder;

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_image_int.cpp
     test_ImageFactory.cpp
     test_PngChunks.cpp
+    test_ImageJpeg.cpp
     $<TARGET_OBJECTS:exiv2lib_int>
 )
 

--- a/unitTests/mainTestRunner.cpp
+++ b/unitTests/mainTestRunner.cpp
@@ -1,14 +1,23 @@
 #include <gtest/gtest.h>
 
+#include <exiv2/properties.hpp>
+
 #include <iostream>
 
-int main(int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
+class Environment : public ::testing::Environment {
+public:
+  void SetUp() override {}
 
-    int ret = RUN_ALL_TESTS();
+  void TearDown() override { Exiv2::XmpProperties::unregisterNs(); }
+};
 
-    std::cout << "Tests finished with return value: " << ret << std::endl;
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new Environment);
 
-    return ret;
+  int ret = RUN_ALL_TESTS();
+
+  std::cout << "Tests finished with return value: " << ret << std::endl;
+
+  return ret;
 }

--- a/unitTests/test_ImageJpeg.cpp
+++ b/unitTests/test_ImageJpeg.cpp
@@ -1,0 +1,58 @@
+#include <image.hpp> // Unit under test
+
+#include <gtest/gtest.h>
+
+using namespace Exiv2;
+
+namespace
+{
+    const std::string testData(TESTDATA_PATH); /// \todo use filesystem library with C++17
+}
+
+TEST(AJpegImage, canReadMetadata)
+{
+    auto image = ImageFactory::open(testData + "/DSC_3079.jpg", false);
+    ASSERT_NO_THROW(image->readMetadata());
+
+    ASSERT_EQ(bigEndian, image->byteOrder());
+    ASSERT_TRUE(image->good());
+    ASSERT_EQ(720, image->pixelWidth());
+    ASSERT_EQ(1280, image->pixelHeight());
+
+    ASSERT_TRUE(image->comment().empty());
+    ASSERT_FALSE(image->xmpPacket().empty());
+    ASSERT_FALSE(image->iccProfileDefined());
+
+    ASSERT_FALSE(image->supportsMetadata(mdNone));
+    ASSERT_TRUE(image->supportsMetadata(mdExif));
+    ASSERT_TRUE(image->supportsMetadata(mdIptc));
+    ASSERT_TRUE(image->supportsMetadata(mdComment));
+    ASSERT_TRUE(image->supportsMetadata(mdXmp));
+    ASSERT_FALSE(image->supportsMetadata(mdIccProfile));
+
+    ASSERT_TRUE(image->nativePreviews().empty());
+
+    ASSERT_EQ(ImageType::jpeg, image->imageType());
+
+    ASSERT_EQ(14, image->exifData().count());
+}
+
+TEST(AJpegImage, hasNoMetadataWhenCreatedFromScratch)
+{
+    const std::string filePath("./here.jpeg");
+    auto image = ImageFactory::create(ImageType::jpeg, filePath);
+    ASSERT_NO_THROW(image->readMetadata());
+
+    ASSERT_EQ(invalidByteOrder, image->byteOrder());
+    ASSERT_TRUE(image->good());
+    ASSERT_EQ(1, image->pixelWidth());
+    ASSERT_EQ(1, image->pixelHeight());
+
+    ASSERT_TRUE(image->comment().empty());
+    ASSERT_TRUE(image->xmpPacket().empty());
+    ASSERT_FALSE(image->iccProfileDefined());
+
+    ASSERT_EQ(0, image->exifData().count());
+
+    ASSERT_EQ(0, std::remove(filePath.c_str()));
+}


### PR DESCRIPTION
I would like to continue unit testing the core stuff from Exiv2 and before doing that I would like the doxygen style as I have commented few times. Here I have focused in updating the doxygen style in the files `image.hpp`, `exif.hpp` and `jpgimage.hpp`. I also took the opportunity to review the documentation in those files and make it shorter when possible (without removing any relevant piece of information). 

I also started adding few basic unit tests covering the basic functionality provided by the **Image** abstract class. In future PRs I will continue testing that part of the code in more depth. Something interesting revealed by adding these tests is that we were leaking ... When reading the JPEG metadata, there is an internal call to `XmpProperties::registerNs()` and I needed to add a global fixture in the unit tests runner to call `XmpProperties::unregisterNs()` to avoid the leak.

I also removed the `virtual` specifier for those methods which are not reimplemented by any image type. It seems that all the image types can rely in the implementation from the Abstract **Image** class. 

Recommendation: Review commit by commit. 