### PR TITLE
Remove CentOS from Gitlab

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -44,23 +44,6 @@ case "$distro_id" in
         debian_build_gtest
         ;;
 
-    'centos'|'rhel')
-        yum -y install epel-release
-        # enable copr for gtest
-        curl https://copr.fedorainfracloud.org/coprs/defolos/devel/repo/epel-7/defolos-devel-epel-7.repo > /etc/yum.repos.d/_copr_defolos-devel.repo
-        yum clean all
-        yum -y install gcc-c++ clang cmake3 make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which python36 dos2unix
-        # symlink up to date versions of python & cmake to 'default' names
-        if [ ! -e /usr/bin/python3 ]; then
-            ln -s /usr/bin/python36 /usr/bin/python3
-        elif [ -L /usr/bin/python3 ]; then
-            rm /usr/bin/python3
-            ln -s /usr/bin/python36 /usr/bin/python3
-        fi
-        mv /bin/cmake /bin/.cmake.old
-        ln -s /bin/cmake3 /bin/cmake
-        ;;
-
     'opensuse'|'opensuse-tumbleweed')
         zypper --non-interactive refresh
         zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel libcurl-devel gtest which dos2unix libxml2-tools

--- a/contrib/vms/README.md
+++ b/contrib/vms/README.md
@@ -7,11 +7,12 @@ of exiv2 (the provisioning is shared with the GitLab CI).
 
 The following Linux distributions are provided (the name in the brackets is the
 name of the Vagrant VM):
-- Fedora 28 ("Fedora")
+- Fedora 29 ("Fedora")
 - Debian 9 aka Stretch ("Debian")
 - Archlinux ("Archlinux")
-- Ubuntu 16.04 aka Bionic Beaver ("Ubuntu")
+- Ubuntu 18.04 aka Bionic Beaver ("Ubuntu")
 - OpenSUSE Tumbleweed ("OpenSUSE")
+- Alpine v3.8 ("Alpine")
 
 The Fedora, Archlinux and OpenSUSE boxes are the 'vanilla' distribution with
 some additional packages installed.

--- a/contrib/vms/README.md
+++ b/contrib/vms/README.md
@@ -11,7 +11,6 @@ name of the Vagrant VM):
 - Debian 9 aka Stretch ("Debian")
 - Archlinux ("Archlinux")
 - Ubuntu 16.04 aka Bionic Beaver ("Ubuntu")
-- CentOS 7 ("CentOS")
 - OpenSUSE Tumbleweed ("OpenSUSE")
 
 The Fedora, Archlinux and OpenSUSE boxes are the 'vanilla' distribution with
@@ -19,11 +18,6 @@ some additional packages installed.
 
 For Debian and Ubuntu, we build gtest manually from source and install the
 resulting library to /usr/lib/.
-
-On CentOS, we have to install a `cmake3` and `python36` (the default cmake is
-too old and a default python3 does not exist) which we symlink to
-`/usr/bin/cmake` & `/usr/bin/python3` to retain a similar workflow to the other
-distributions.
 
 For further details, consult the shell scripts `setup.sh` and
 `ci/install_dependencies.sh`.

--- a/contrib/vms/Vagrantfile
+++ b/contrib/vms/Vagrantfile
@@ -22,11 +22,6 @@ Vagrant.configure("2") do |config|
     ubuntu.vm.hostname = "ubuntu-exiv2"
   end
 
-  config.vm.define "CentOS" do |centos|
-    centos.vm.box = "centos/7"
-    centos.vm.hostname = "centos-exiv2"
-  end
-
   config.vm.define "OpenSUSE" do |opensuse|
     opensuse.vm.box = "opensuse/openSUSE-Tumbleweed-x86_64"
     opensuse.vm.hostname = "opensuse-exiv2"

--- a/contrib/vms/setup.sh
+++ b/contrib/vms/setup.sh
@@ -17,12 +17,6 @@ case "$distro_id" in
         pacman --noconfirm -S python-pip git
         ;;
 
-    'centos' | 'rhel')
-        yum -y install centos-release-scl-rh
-        yum clean all
-        yum -y install rh-python36-python-pip git
-        ;;
-
     'opensuse' | 'opensuse-tumbleweed')
         zypper --non-interactive install python3-pip git
         ;;

--- a/contrib/vms/setup_user.sh
+++ b/contrib/vms/setup_user.sh
@@ -21,10 +21,6 @@ case "$distro_id" in
         PIP=pip
         ;;
 
-    'centos' | 'rhel')
-        PIP=/opt/rh/rh-python36/root/usr/bin/pip3
-        ;;
-
     *)
         echo "Sorry, no predefined dependencies for your distribution exist yet"
         exit 1


### PR DESCRIPTION
As explained in #800 , some tests in the CentOS build started to fail after merging #796 . 

@nehaljwani has been trying to to upgrade the gcc version for that CI image in #804 but it seems it is being a bit complex and it implies the upgrade of the default gcc version in that distribution. 

IMHO, the point of having different linux distributions in the Gitlab pipelines is to test Exiv2 in those systems without updating compilers or libraries, just relying in the default packages provided by the distributions. Therefore, I propose to drop the CentOS image until they release a newer version of the distribution bringing a c++11 fully compliant compiler. 