### PR TITLE
Fix #814 on 'master'

### DIFF
--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -281,12 +281,12 @@ CMake provides Generators for different editions of Visual Studio.  The 64 and 3
 
 #### Static Builds
 
-The default builds of Exiv2 and sample applications build use DLLs.
+The default builds of Exiv2 and sample applications build and use DLLs.
 
-To build static libraries, use the cmake option -DBUILD\_SHARED\_LIBS=Off.
+To build static libraries, use the cmake option `-DBUILD_SHARED_LIBS=Off`.  You will probably also want to use the static run-time.  The default is to use the dynamic run-time library.
 
 ```bash
-$ cmake -DBUILD_SHARED_LIBS=Off ..
+$ cmake -DBUILD_SHARED_LIBS=Off -DEXIV2_ENABLE_DYNAMIC_RUNTIME=Off
 ```
 
 If you wish to use the static C run-time library, use the following option in the conan profile.
@@ -294,6 +294,9 @@ If you wish to use the static C run-time library, use the following option in th
 |                      | Static Release      | Static Debug |
 |:---                  |:---------           |:-------------------|
 | **profile setting**  | compiler.runtime=MT | compiler.runtime=MTd |
+
+If you receive a linker warning concerning `LIBCMT`, it is because you are attempting to link libraries which have been built with different run-time libraries.
+You should link everything with the dynamic or static run-time. You can link a static library with the dynamic run-time if you wish.
 
 ### Changing profile settings with the conan command
 


### PR DESCRIPTION
Issue is discussed in #814.  Fix is a documentation change which was submitted to '0.27-maintenance'  and #816.  This PR is the same change being submitted to 'master'.

Regrettably both README.md and README-CONAN.md are diverging between '0.27-maintenance' and 'master'.  I intend to maintain '0.27-maintenance` for every dot release and only perform important changes (such as this one) to `master`.  I'll overhaul these files on 'master' for v0.28 RC1.