### PR TITLE
Throw an exception if the data location is invalid.

### DIFF
--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -734,12 +734,11 @@ namespace Exiv2 {
 
     DataLocId CiffComponent::dataLocation(uint16_t tag)
     {
-        DataLocId di = invalidDataLocId;
         switch (tag & 0xc000) {
-        case 0x0000: di = valueData; break;
-        case 0x4000: di = directoryData; break;
+        case 0x0000: return valueData;
+        case 0x4000: return directoryData;
+        default: throw Error(33);
         }
-        return di;
     } // CiffComponent::dataLocation
 
     /*!

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -78,7 +78,6 @@ namespace Exiv2 {
 
     //! Type to identify where the data is stored in a directory
     enum DataLocId {
-        invalidDataLocId,
         valueData,
         directoryData,
         lastDataLocId


### PR DESCRIPTION
Fixes #841 on the 0.25 branch.