### PR TITLE
Reduce system calls in FileIo::eof()

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -222,10 +222,9 @@ constexpr size_t operator"" _z(unsigned long long n)
     protected:
         //! @name Creators
         //@{
-        //! Default Constructor
-        BasicIo() : bigBlock_(nullptr) {};
+        BasicIo();
         //@}
-    }; // class BasicIo
+    };
 
     /*!
       @brief Utility class that closes a BasicIo instance upon destruction.
@@ -276,7 +275,7 @@ constexpr size_t operator"" _z(unsigned long long n)
         FileIo(const std::wstring& wpath);
 #endif
         //! Destructor. Flushes and closes an open file.
-        virtual ~FileIo();
+        virtual ~FileIo() override;
         //@}
 
         //! @name Manipulators
@@ -409,7 +408,7 @@ constexpr size_t operator"" _z(unsigned long long n)
          */
         MemIo(const byte* data, size_t size);
         //! Destructor. Releases all managed memory
-        virtual ~MemIo();
+        virtual ~MemIo() override;
         //@}
 
         //! @name Manipulators
@@ -636,7 +635,7 @@ constexpr size_t operator"" _z(unsigned long long n)
         explicit XPathIo(const std::wstring& wOrgPathpath);
 #endif
         //! Destructor. Releases all managed memory and removes the temp file.
-        virtual ~XPathIo();
+        virtual ~XPathIo() override;
         //@}
 
         //! @name Manipulators
@@ -684,7 +683,7 @@ constexpr size_t operator"" _z(unsigned long long n)
     class EXIV2API RemoteIo : public BasicIo {
     public:
         //! Destructor. Releases all managed memory.
-        virtual ~RemoteIo();
+        virtual ~RemoteIo() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -143,7 +143,7 @@ constexpr size_t operator"" _z(unsigned long long n)
               DataBuf::size_ member to find the number of bytes read.
               DataBuf::size_ will be 0 on failure.
          */
-        virtual DataBuf read(long rcount) = 0;
+        virtual DataBuf read(size_t rcount) = 0;
         /*!
           @brief Read data from the IO source. Reading starts at the current
               IO position and the position is advanced by the number of bytes
@@ -395,7 +395,7 @@ constexpr size_t operator"" _z(unsigned long long n)
                 DataBuf::size_ member to find the number of bytes read.
                 DataBuf::size_ will be 0 on failure.
          */
-        DataBuf read(long rcount) override;
+        DataBuf read(size_t rcount) override;
         /*!
           @brief Read data from the file. Reading starts at the current
               file position and the position is advanced by the number of
@@ -609,7 +609,7 @@ constexpr size_t operator"" _z(unsigned long long n)
                 DataBuf::size_ member to find the number of bytes read.
                 DataBuf::size_ will be 0 on failure.
          */
-        DataBuf read(long rcount) override;
+        DataBuf read(size_t rcount) override;
         /*!
           @brief Read data from the memory block. Reading starts at the current
               IO position and the position is advanced by the number of
@@ -887,7 +887,7 @@ constexpr size_t operator"" _z(unsigned long long n)
                DataBuf::size_ member to find the number of bytes read.
                DataBuf::size_ will be 0 on failure.
         */
-       DataBuf read(long rcount) override;
+       DataBuf read(size_t rcount) override;
        /*!
          @brief Read data from the the memory blocks. Reading starts at the current
              IO position and the position is advanced by the number of

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -55,13 +55,10 @@ constexpr size_t operator"" _z(unsigned long long n)
 // *****************************************************************************
 // class definitions
 
-    /*!
-      @brief An interface for simple binary IO.
-
-      Designed to have semantics and names similar to those of C style FILE*
-      operations. Subclasses should all behave the same so that they can be
-      interchanged.
-     */
+    /// @brief An interface for simple binary IO.
+    ///
+    /// Designed to have semantics and names similar to those of C style FILE* operations. Subclasses should all
+    /// behave the same so that they can be interchanged.
     class EXIV2API BasicIo {
     public:
         //! BasicIo auto_ptr type
@@ -83,80 +80,55 @@ constexpr size_t operator"" _z(unsigned long long n)
 
         //! @name Manipulators
         //@{
-        /*!
-          @brief Open the IO source using the default access mode. The
-              default mode should allow for reading and writing.
-
-          This method can also be used to "reopen" an IO source which will
-          flush any unwritten data and reset the IO position to the start.
-          Subclasses may provide custom methods to allow for
-          opening IO sources differently.
-
-          @return 0 if successful;<BR>
-              Nonzero if failure.
-         */
+        /// @brief Open the IO source using the default access mode. The default mode should allow for reading and
+        /// writing.
+        ///
+        /// This method can also be used to "reopen" an IO source which will flush any unwritten data and reset the
+        /// IO position to the start. Subclasses may provide custom methods to allow for opening IO sources differently.
+        /// @return 0 if successful;<BR> Nonzero if failure.
         virtual int open() = 0;
 
-        /*!
-          @brief Close the IO source. After closing a BasicIo instance can not
-              be read or written. Closing flushes any unwritten data. It is
-              safe to call close on a closed instance.
-          @return 0 if successful;<BR>
-              Nonzero if failure.
-         */
+        /// @brief Close the IO source. After closing a BasicIo instance can not be read or written.
+        ///
+        /// Closing flushes any unwritten data. It is safe to call close on a closed instance.
+        /// @return 0 if successful;<BR> Nonzero if failure.
         virtual int close() = 0;
-        /*!
-          @brief Write data to the IO source. Current IO position is advanced
-              by the number of bytes written.
-          @param data Pointer to data. Data must be at least \em wcount
-              bytes long
-          @param wcount Number of bytes to be written.
-          @return Number of bytes written to IO source successfully;<BR>
-              0 if failure;
-         */
+
+        /// @brief Write data to the IO source. Current IO position is advanced by the number of bytes written.
+        /// @param data Pointer to data. Data must be at least \em wcount bytes long
+        /// @param wcount Number of bytes to be written.
+        /// @return Number of bytes written to IO source successfully;<BR> 0 if failure;
         virtual size_t write(const byte* data, size_t wcount) = 0;
-        /*!
-          @brief Write data that is read from another BasicIo instance to
-              the IO source. Current IO position is advanced by the number
-              of bytes written.
-          @param src Reference to another BasicIo instance. Reading start
-              at the source's current IO position
-          @return Number of bytes written to IO source successfully;<BR>
-              0 if failure;
-         */
+
+        /// @brief Write data that is read from another BasicIo instance to the IO source.
+        ///
+        /// Current IO position is advanced by the number of bytes written.
+        /// @param src Reference to another BasicIo instance. Reading start at the source's current IO position
+        /// @return Number of bytes written to IO source successfully;<BR> 0 if failure;
         virtual size_t write(BasicIo& src) = 0;
-        /*!
-          @brief Write one byte to the IO source. Current IO position is
-              advanced by one byte.
-          @param data The single byte to be written.
-          @return The value of the byte written if successful;<BR>
-              EOF if failure;
-         */
+
+        /// @brief Write one byte to the IO source. Current IO position is advanced by one byte.
+        /// @param data The single byte to be written.
+        /// @return The value of the byte written if successful;<BR> EOF if failure;
         virtual int putb(byte data) = 0;
-        /*!
-          @brief Read data from the IO source. Reading starts at the current
-              IO position and the position is advanced by the number of bytes
-              read.
-          @param rcount Maximum number of bytes to read. Fewer bytes may be
-              read if \em rcount bytes are not available.
-          @return DataBuf instance containing the bytes read. Use the
-              DataBuf::size_ member to find the number of bytes read.
-              DataBuf::size_ will be 0 on failure.
-         */
+
+        /// @brief Read data from the IO source.
+        ///
+        /// Reading starts at the current IO position and the position is advanced by the number of bytes read.
+        /// @param rcount Maximum number of bytes to read. Fewer bytes may be read if \em rcount bytes are not available.
+        /// @return DataBuf instance containing the bytes read. Use the DataBuf::size_ member to find the number of
+        /// bytes read. DataBuf::size_ will be 0 on failure.
         virtual DataBuf read(size_t rcount) = 0;
-        /*!
-          @brief Read data from the IO source. Reading starts at the current
-              IO position and the position is advanced by the number of bytes
-              read.
-          @param buf Pointer to a block of memory into which the read data
-              is stored. The memory block must be at least \em rcount bytes
-              long.
-          @param rcount Maximum number of bytes to read. Fewer bytes may be
-              read if \em rcount bytes are not available.
-          @return Number of bytes read from IO source successfully;<BR>
-              0 if failure;
-         */
+
+        /// @brief Read data from the IO source.
+        ///
+        /// Reading starts at the current IO position and the position is advanced by the number of bytes read.
+        /// @param buf Pointer to a block of memory into which the read data is stored. The memory block must be at
+        /// least \em rcount bytes long.
+        /// @param rcount Maximum number of bytes to read. Fewer bytes may be read if \em rcount bytes are not available.
+        /// @return Number of bytes read from IO source successfully;<BR> 0 if failure;
         virtual size_t read(byte* buf, size_t rcount) = 0;
+
         /*!
           @brief Read data from the IO source. Reading starts at the current
               IO position and the position is advanced by the number of bytes
@@ -168,26 +140,19 @@ constexpr size_t operator"" _z(unsigned long long n)
           @param rcount Number of bytes to read.
          */
         void readOrThrow(byte* buf, size_t rcount);
-        /*!
-          @brief Read one byte from the IO source. Current IO position is
-              advanced by one byte.
-          @return The byte read from the IO source if successful;<BR>
-              EOF if failure;
-         */
+
+        /// @brief Read one byte from the IO source. Current IO position is advanced by one byte.
+        /// @return The byte read from the IO source if successful;<BR> EOF if failure;
         virtual int getb() = 0;
-        /*!
-          @brief Remove all data from this object's IO source and then transfer
-              data from the \em src BasicIo object into this object.
 
-          The source object is invalidated by this operation and should not be
-          used after this method returns. This method exists primarily to
-          be used with the BasicIo::temporary() method.
-
-          @param src Reference to another BasicIo instance. The entire contents
-              of src are transferred to this object. The \em src object is
-              invalidated by the method.
-          @throw Error In case of failure
-         */
+        /// @brief Remove all data from this object's IO source and then transfer data from the \em src BasicIo object
+        /// into this object.
+        ///
+        /// The source object is invalidated by this operation and should not be used after this method returns. This
+        /// method exists primarily to be used with the BasicIo::temporary() method.
+        /// @param src Reference to another BasicIo instance. The entire contents of src are transferred to this object.
+        /// The \em src object is invalidated by the method.
+        /// @throw Error In case of failure
         virtual void transfer(BasicIo& src) = 0;
 
         /// @brief Move the current file position.
@@ -196,72 +161,60 @@ constexpr size_t operator"" _z(unsigned long long n)
         /// @return 0 if successful;<BR> Nonzero if failure;
         virtual int seek(int64 offset, Position pos) = 0;
 
-        /*!
-          @brief Direct access to the IO data. For files, this is done by
-                 mapping the file into the process's address space; for memory
-                 blocks, this allows direct access to the memory block.
-          @param isWriteable Set to true if the mapped area should be writeable
-                 (default is false).
-          @return A pointer to the mapped area.
-          @throw Error In case of failure.
-         */
+        /// @brief Direct access to the IO data.
+        ///
+        /// For files, this is done by mapping the file into the process's address space; for memory blocks, this
+        /// allows direct access to the memory block.
+        /// @param isWriteable Set to true if the mapped area should be writeable (default is false).
+        /// @return A pointer to the mapped area.
+        /// @throw Error In case of failure.
         virtual byte* mmap(bool isWriteable =false) =0;
-        /*!
-          @brief Remove a mapping established with mmap(). If the mapped area
-                 is writeable, this ensures that changes are written back.
-          @return 0 if successful;<BR>
-                  Nonzero if failure;
-         */
+
+        /// @brief Remove a mapping established with mmap().
+        ///
+        /// If the mapped area is writeable, this ensures that changes are written back.
+        /// @return 0 if successful;<BR> Nonzero if failure;
         virtual int munmap() =0;
 
         //@}
 
         //! @name Accessors
         //@{
-        /*!
-          @brief Get the current IO position.
-          @return Offset from the start of IO if successful;<BR>
-                 -1 if failure;
-         */
+        /// @brief Get the current IO position.
+        /// @return Offset from the start of IO if successful;<BR> -1 if failure;
         virtual int64 tell() const = 0;
-        /*!
-          @brief Get the current size of the IO source in bytes.
-          @return Size of the IO source in bytes;<BR>
-                 -1 if failure;
-         */
+
+        /// @brief Get the current size of the IO source in bytes.
+        /// @return Size of the IO source in bytes;<BR> -1 if failure;
         virtual size_t size() const = 0;
-        //!Returns true if the IO source is open, otherwise false.
+
+        /// @brief Returns true if the IO source is open, otherwise false.
         virtual bool isopen() const = 0;
-        //!Returns 0 if the IO source is in a valid state, otherwise nonzero.
+
+        /// @brief Returns 0 if the IO source is in a valid state, otherwise nonzero.
         virtual int error() const = 0;
-        //!Returns true if the IO position has reached the end, otherwise false.
+
+        /// @brief Returns true if the IO position has reached the end, otherwise false.
         virtual bool eof() const = 0;
-        /*!
-          @brief Return the path to the IO resource. Often used to form
-              comprehensive error messages where only a BasicIo instance is
-              available.
-         */
+
+        /// @brief Return the path to the IO resource.
+        ///
+        /// Often used to form comprehensive error messages where only a BasicIo instance is available.
         virtual std::string path() const =0;
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like path() but returns a unicode path in an std::wstring.
-          @note This function is only available on Windows.
-         */
+        /// @brief Like path() but returns a unicode path in an std::wstring.
+        /// @note This function is only available on Windows.
         virtual std::wstring wpath() const =0;
 #endif
 
-        /*!
-          @brief Mark all the bNone blocks to bKnow. This avoids allocating memory
-            for parts of the file that contain image-date (non-metadata/pixel data)
-
-          @note This method should be only called after the concerned data (metadata)
-                are all downloaded from the remote file to memory.
-         */
+        /// @brief Mark all the bNone blocks to bKnow.
+        ///
+        /// This avoids allocating memory for parts of the file that contain image-date (non-metadata/pixel data).
+        /// @note This method should be only called after the concerned data (metadata) are all downloaded from the
+        /// remote file to memory.
         virtual void populateFakeData() {}
 
-        /*!
-          @brief this is allocated and populated by mmap()
-         */
+        /// @brief this is allocated and populated by mmap()
         byte* bigBlock_;
 
         //@}
@@ -328,186 +281,91 @@ constexpr size_t operator"" _z(unsigned long long n)
 
         //! @name Manipulators
         //@{
-        /*!
-          @brief Open the file using using the specified mode.
-
-          This method can also be used to "reopen" a file which will flush any
-          unwritten data and reset the IO position to the start. Although
-          files can be opened in binary or text mode, this class has
-          only been tested carefully in binary mode.
-
-          @param mode Specified that type of access allowed on the file.
-              Valid values match those of the C fopen command exactly.
-          @return 0 if successful;<BR>
-              Nonzero if failure.
-         */
+        /// @brief Open the file using using the specified mode.
+        ///
+        /// This method can also be used to "reopen" a file which will flush any unwritten data and reset the IO
+        /// position to the start. Although files can be opened in binary or text mode, this class has only been
+        /// tested carefully in binary mode.
+        /// @param mode Specified that type of access allowed on the file. (values from the C fopen command).
+        /// @return 0 if successful;<BR> Nonzero if failure.
         int open(const std::string& mode);
 
         /// @brief Open the file using using the default access mode of "rb".
-        ///
-        /// This method can also be used to "reopen" a file which will flush any unwritten data and reset the IO
-        /// position to the start.
-        /// @return 0 if successful; Nonzero if failure.
+        /// @note Go to BasicIo::open() for detailed explanation.
         int open() override;
 
-        /*!
-          @brief Flush and unwritten data and close the file . It is
-              safe to call close on an already closed instance.
-          @return 0 if successful;<BR>
-                 Nonzero if failure;
-         */
+        /// @brief Flush and unwritten data and close the file . It is safe to call close on an already closed instance.
+        /// @return 0 if successful;<BR> Nonzero if failure;
         int close() override;
-        /*!
-          @brief Write data to the file. The file position is advanced
-              by the number of bytes written.
-          @param data Pointer to data. Data must be at least \em wcount
-              bytes long
-          @param wcount Number of bytes to be written.
-          @return Number of bytes written to the file successfully;<BR>
-                 0 if failure;
-         */
+
         size_t write(const byte* data, size_t wcount) override;
-        /*!
-          @brief Write data that is read from another BasicIo instance to
-              the file. The file position is advanced by the number
-              of bytes written.
-          @param src Reference to another BasicIo instance. Reading start
-              at the source's current IO position
-          @return Number of bytes written to the file successfully;<BR>
-                 0 if failure;
-         */
+
         size_t write(BasicIo& src) override;
-        /*!
-          @brief Write one byte to the file. The file position is
-              advanced by one byte.
-          @param data The single byte to be written.
-          @return The value of the byte written if successful;<BR>
-                 EOF if failure;
-         */
+
         int putb(byte data) override;
-        /*!
-          @brief Read data from the file. Reading starts at the current
-              file position and the position is advanced by the number of
-              bytes read.
-          @param rcount Maximum number of bytes to read. Fewer bytes may be
-              read if \em rcount bytes are not available.
-          @return DataBuf instance containing the bytes read. Use the
-                DataBuf::size_ member to find the number of bytes read.
-                DataBuf::size_ will be 0 on failure.
-         */
+
         DataBuf read(size_t rcount) override;
-        /*!
-          @brief Read data from the file. Reading starts at the current
-              file position and the position is advanced by the number of
-              bytes read.
-          @param buf Pointer to a block of memory into which the read data
-              is stored. The memory block must be at least \em rcount bytes
-              long.
-          @param rcount Maximum number of bytes to read. Fewer bytes may be
-              read if \em rcount bytes are not available.
-          @return Number of bytes read from the file successfully;<BR>
-                 0 if failure;
-         */
+
         size_t read(byte* buf, size_t rcount) override;
-        /*!
-          @brief Read one byte from the file. The file position is
-              advanced by one byte.
-          @return The byte read from the file if successful;<BR>
-                 EOF if failure;
-         */
+
         int getb() override;
-        /*!
-          @brief Remove the contents of the file and then transfer data from
-              the \em src BasicIo object into the empty file.
 
-          This method is optimized to simply rename the source file if the
-          source object is another FileIo instance. The source BasicIo object
-          is invalidated by this operation and should not be used after this
-          method returns. This method exists primarily to be used with
-          the BasicIo::temporary() method.
-
-          @note If the caller doesn't have permissions to write to the file,
-              an exception is raised and \em src is deleted.
-
-          @param src Reference to another BasicIo instance. The entire contents
-              of src are transferred to this object. The \em src object is
-              invalidated by the method.
-          @throw Error In case of failure
-         */
+        /// @brief Remove the contents of the file and then transfer data from the \em src BasicIo object into the
+        /// empty file.
+        ///
+        /// This method is optimized to simply rename the source file if the source object is another FileIo instance.
+        /// The source BasicIo object is invalidated by this operation and should not be used after this method returns.
+        /// This method exists primarily to be used with the BasicIo::temporary() method.
+        ///
+        /// @note If the caller doesn't have permissions to write to the file, an exception is raised and \em src is
+        /// deleted.
+        /// @param src Reference to another BasicIo instance. The entire contents of src are transferred to this object.
+        /// The \em src object is invalidated by the method.
+        /// @throw Error In case of failure
         void transfer(BasicIo& src) override;
 
         int seek(int64 offset, Position pos) override;
 
-        /*!
-          @brief Map the file into the process's address space. The file must be
-                 open before mmap() is called. If the mapped area is writeable,
-                 changes may not be written back to the underlying file until
-                 munmap() is called. The pointer is valid only as long as the
-                 FileIo object exists.
-          @param isWriteable Set to true if the mapped area should be writeable
-                 (default is false).
-          @return A pointer to the mapped area.
-          @throw Error In case of failure.
-         */
+        /// @brief Map the file into the process's address space.
+        ///
+        /// The file must be open before mmap() is called. If the mapped area is writeable, changes may not be written
+        /// back to the underlying file until munmap() is called. The pointer is valid only as long as the FileIo
+        /// object exists.
+        /// @param isWriteable Set to true if the mapped area should be writeable (default is false).
+        /// @return A pointer to the mapped area.
+        /// @throw Error In case of failure.
         byte* mmap(bool isWriteable =false) override;
-        /*!
-          @brief Remove a mapping established with mmap(). If the mapped area is
-                 writeable, this ensures that changes are written back to the
-                 underlying file.
-          @return 0 if successful;<BR>
-                  Nonzero if failure;
-         */
+
         int munmap() override;
-        /*!
-          @brief close the file source and set a new path.
-         */
+
+        /// @brief close the file source and set a new path.
         virtual void setPath(const std::string& path);
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like setPath(const std::string& path) but accepts a
-              unicode path in an std::wstring.
-          @note This method is only available on Windows.
-         */
+        /// @brief Like setPath(const std::string& path) but accepts a unicode path in an std::wstring.
+        /// @note This method is only available on Windows.
         virtual void setPath(const std::wstring& wpath);
 #endif
         //@}
         //! @name Accessors
         //@{
-        /// @brief Get the current file position.
-        /// @return Offset from the start of the file if successful;<BR> -1 if failure;
         int64 tell() const override;
 
         /// @brief Flush any buffered writes and get the current file size in bytes.
         /// @return Size of the file in bytes;<BR> -1 if failure;
         size_t size() const override;
 
-        //! Returns true if the file is open, otherwise false.
         bool isopen() const override;
 
-        //! Returns 0 if the file is in a valid state, otherwise nonzero.
         int error() const override;
 
-        //! Returns true if the file position has reached the end, otherwise false.
         bool eof() const override;
 
-        //! Returns the path of the file
         std::string path() const override;
 
 #ifdef EXV_UNICODE_PATH
-        /*
-          @brief Like path() but returns the unicode path of the file in an std::wstring.
-          @note This function is only available on Windows.
-         */
         std::wstring wpath() const override;
 #endif
 
-        /*!
-          @brief Mark all the bNone blocks to bKnow. This avoids allocating memory
-            for parts of the file that contain image-date (non-metadata/pixel data)
-
-          @note This method should be only called after the concerned data (metadata)
-                are all downloaded from the remote file to memory.
-         */
         void populateFakeData() override;
         //@}
 
@@ -521,8 +379,7 @@ constexpr size_t operator"" _z(unsigned long long n)
         // Pimpl idiom
         class Impl;
         std::unique_ptr<Impl> p_;
-
-    }; // class FileIo
+    };
 
     /*!
       @brief Provides binary IO on blocks of memory by implementing the BasicIo

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -68,7 +68,12 @@ constexpr size_t operator"" _z(unsigned long long n)
         typedef std::unique_ptr<BasicIo> UniquePtr;
 
         //! Seek starting positions
-        enum Position { beg, cur, end };
+        enum Position
+        {
+            beg,
+            cur,
+            end
+        };
 
         //! @name Creators
         //@{
@@ -184,14 +189,11 @@ constexpr size_t operator"" _z(unsigned long long n)
           @throw Error In case of failure
          */
         virtual void transfer(BasicIo& src) = 0;
-        /*!
-          @brief Move the current IO position.
-          @param offset Number of bytes to move the position relative
-              to the starting position specified by \em pos
-          @param pos Position from which the seek should start
-          @return 0 if successful;<BR>
-              Nonzero if failure;
-         */
+
+        /// @brief Move the current file position.
+        /// @param offset Number of bytes to move the file position relative to the starting position specified by pos
+        /// @param pos Position from which the seek should start
+        /// @return 0 if successful;<BR> Nonzero if failure;
         virtual int seek(int64 offset, Position pos) = 0;
 
         /*!
@@ -306,27 +308,18 @@ constexpr size_t operator"" _z(unsigned long long n)
         IoCloser& operator=(const IoCloser&);
     }; // class IoCloser
 
-    /*!
-      @brief Provides binary file IO by implementing the BasicIo
-          interface.
-     */
+    /// @brief Provides binary file IO by implementing the BasicIo interface.
     class EXIV2API FileIo : public BasicIo {
     public:
         //! @name Creators
         //@{
-        /*!
-          @brief Constructor that accepts the file path on which IO will be
-              performed. The constructor does not open the file, and
-              therefore never failes.
-          @param path The full path of a file
-         */
+        /// @brief Constructor that accepts the file path on which IO will be performed.
+        ///
+        /// The constructor does not open the file, and therefore never failes.
         explicit FileIo(const std::string& path);
 #ifdef EXV_UNICODE_PATH
-        /*!
-          @brief Like FileIo(const std::string& path) but accepts a
-              unicode path in an std::wstring.
-          @note This constructor is only available on Windows.
-         */
+        /// @brief Like FileIo(const std::string& path) but accepts a unicode path in an std::wstring.
+        /// @note This constructor is only available on Windows.
         FileIo(const std::wstring& wpath);
 #endif
         //! Destructor. Flushes and closes an open file.
@@ -349,14 +342,14 @@ constexpr size_t operator"" _z(unsigned long long n)
               Nonzero if failure.
          */
         int open(const std::string& mode);
-        /*!
-          @brief Open the file using using the default access mode of "rb".
-              This method can also be used to "reopen" a file which will flush
-              any unwritten data and reset the IO position to the start.
-          @return 0 if successful;<BR>
-              Nonzero if failure.
-         */
+
+        /// @brief Open the file using using the default access mode of "rb".
+        ///
+        /// This method can also be used to "reopen" a file which will flush any unwritten data and reset the IO
+        /// position to the start.
+        /// @return 0 if successful; Nonzero if failure.
         int open() override;
+
         /*!
           @brief Flush and unwritten data and close the file . It is
               safe to call close on an already closed instance.
@@ -442,14 +435,7 @@ constexpr size_t operator"" _z(unsigned long long n)
           @throw Error In case of failure
          */
         void transfer(BasicIo& src) override;
-        /*!
-          @brief Move the current file position.
-          @param offset Number of bytes to move the file position
-              relative to the starting position specified by \em pos
-          @param pos Position from which the seek should start
-          @return 0 if successful;<BR>
-                 Nonzero if failure;
-         */
+
         int seek(int64 offset, Position pos) override;
 
         /*!
@@ -487,27 +473,26 @@ constexpr size_t operator"" _z(unsigned long long n)
         //@}
         //! @name Accessors
         //@{
-        /*!
-          @brief Get the current file position.
-          @return Offset from the start of the file if successful;<BR>
-                 -1 if failure;
-         */
+        /// @brief Get the current file position.
+        /// @return Offset from the start of the file if successful;<BR> -1 if failure;
         int64 tell() const override;
-        /*!
-          @brief Flush any buffered writes and get the current file size
-              in bytes.
-          @return Size of the file in bytes;<BR>
-                 -1 if failure;
-         */
+
+        /// @brief Flush any buffered writes and get the current file size in bytes.
+        /// @return Size of the file in bytes;<BR> -1 if failure;
         size_t size() const override;
+
         //! Returns true if the file is open, otherwise false.
         bool isopen() const override;
+
         //! Returns 0 if the file is in a valid state, otherwise nonzero.
         int error() const override;
+
         //! Returns true if the file position has reached the end, otherwise false.
         bool eof() const override;
+
         //! Returns the path of the file
         std::string path() const override;
+
 #ifdef EXV_UNICODE_PATH
         /*
           @brief Like path() but returns the unicode path of the file in an std::wstring.

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -3,11 +3,10 @@
 
 #include <exiv2/exiv2.hpp>
 
-#include <iostream>
 #include <cassert>
+#include <iostream>
 
-int main(int argc, char* const argv[])
-try {
+int main(int argc, char* const argv[]) try {
     if (argc != 3) {
         std::cout << "Usage: " << argv[0] << " image datafile\n";
         return 1;
@@ -18,9 +17,9 @@ try {
     // Read data file into data buffer
     Exiv2::FileIo io(data);
     if (io.open() != 0) {
-      throw Exiv2::Error(Exiv2::kerDataSourceOpenFailed, io.path(), Exiv2::strError());
+        throw Exiv2::Error(Exiv2::kerDataSourceOpenFailed, io.path(), Exiv2::strError());
     }
-    Exiv2::DataBuf buf((long)io.size());
+    Exiv2::DataBuf buf(io.size());
     std::cout << "Reading " << buf.size_ << " bytes from " << data << "\n";
     size_t readBytes = io.read(buf.pData_, buf.size_);
     if (readBytes != buf.size_ || io.error() || io.eof())
@@ -63,8 +62,7 @@ try {
     image->writeMetadata();
 
     return 0;
-}
-catch (Exiv2::AnyError& e) {
+} catch (Exiv2::AnyError& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
     return -1;
 }

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -22,8 +22,9 @@ try {
     }
     Exiv2::DataBuf buf((long)io.size());
     std::cout << "Reading " << buf.size_ << " bytes from " << data << "\n";
-    io.read(buf.pData_, buf.size_);
-    if (io.error() || !io.eof()) throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
+    size_t readBytes = io.read(buf.pData_, buf.size_);
+    if (readBytes != buf.size_ || io.error() || io.eof())
+        throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
 
     // Read metadata from file
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -90,6 +90,10 @@ namespace Exiv2 {
       enforce(!error(), kerInputDataReadFailed);
     }
 
+    BasicIo::BasicIo() : bigBlock_(nullptr)
+    {
+    }
+
     //! Internal Pimpl structure of class FileIo.
     class FileIo::Impl {
     public:

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -979,10 +979,11 @@ namespace Exiv2 {
         return rc;
     }
 
-    DataBuf FileIo::read(long rcount)
+    DataBuf FileIo::read(size_t rcount)
     {
         assert(p_->fp_ != 0);
-        if ( (size_t) rcount > size() ) throw Error(kerInvalidMalloc);
+        if (rcount > size())
+            throw Error(kerInvalidMalloc);
         DataBuf buf(rcount);
         size_t readCount = read(buf.pData_, buf.size_);
         buf.size_ = readCount;
@@ -995,7 +996,7 @@ namespace Exiv2 {
         if (p_->switchMode(Impl::opRead) != 0) {
             return 0;
         }
-        return (long)std::fread(buf, 1, rcount, p_->fp_);
+        return std::fread(buf, 1, rcount, p_->fp_);
     }
 
     int FileIo::getb()
@@ -1337,7 +1338,7 @@ namespace Exiv2 {
         return 0;
     }
 
-    DataBuf MemIo::read(long rcount)
+    DataBuf MemIo::read(size_t rcount)
     {
         DataBuf buf(rcount);
         size_t readCount = read(buf.pData_, buf.size_);
@@ -1804,7 +1805,7 @@ namespace Exiv2 {
         return 0;
     }
 
-    DataBuf RemoteIo::read(long rcount)
+    DataBuf RemoteIo::read(size_t rcount)
     {
         DataBuf buf(rcount);
         size_t readCount = read(buf.pData_, buf.size_);

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -896,6 +896,7 @@ namespace Exiv2 {
 
     int FileIo::seek(int64 offset, Position pos )
     {
+        /// \todo check if isopen() and throw if not?
         assert(p_->fp_ != 0);
 
         int fileSeek = 0;
@@ -933,7 +934,8 @@ namespace Exiv2 {
         Impl::StructStat buf;
         int ret = p_->stat(buf);
 
-        if (ret != 0) return -1;
+        if (ret != 0)
+            return -1;
         return buf.st_size;
     }
 
@@ -998,8 +1000,8 @@ namespace Exiv2 {
 
     int FileIo::getb()
     {
-        assert(p_->fp_ != 0);
-        if (p_->switchMode(Impl::opRead) != 0) return EOF;
+        if (p_->switchMode(Impl::opRead) != 0)
+            return EOF;
         return getc(p_->fp_);
     }
 

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1010,8 +1010,7 @@ namespace Exiv2 {
 
     bool FileIo::eof() const
     {
-        assert(p_->fp_ != 0);
-        return feof(p_->fp_) != 0 || tell() >= (long) size() ;
+        return std::feof(p_->fp_) != 0;
     }
 
     std::string FileIo::path() const

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -1358,12 +1358,14 @@ namespace Exiv2 {
         bool result = true;
         byte tmpBuf[2];
         iIo.read(tmpBuf, 2);
-        if (iIo.error() || iIo.eof()) return false;
+        if (iIo.error() || iIo.eof())
+            return false;
 
         if (0xff != tmpBuf[0] || JpegImage::soi_ != tmpBuf[1]) {
             result = false;
         }
-        if (!advance || !result ) iIo.seek(-2, BasicIo::cur);
+        if (!advance || !result)
+            iIo.seek(-2, BasicIo::cur);
         return result;
     }
 

--- a/tests/bugfixes/github/test_issue_428.py
+++ b/tests/bugfixes/github/test_issue_428.py
@@ -13,11 +13,11 @@ class PngReadRawProfile(metaclass=system_tests.CaseMeta):
 
     filenames = [
         system_tests.path("$data_path/issue_428_poc1.png"),
-        system_tests.path("$data_path/issue_428_poc2.png"),
         system_tests.path("$data_path/issue_428_poc3.png"),
         system_tests.path("$data_path/issue_428_poc4.png"),
         system_tests.path("$data_path/issue_428_poc8.png"),
 
+        system_tests.path("$data_path/issue_428_poc2.png"),
         system_tests.path("$data_path/issue_428_poc5.png"),
         system_tests.path("$data_path/issue_428_poc6.png"),
         system_tests.path("$data_path/issue_428_poc7.png"),
@@ -25,7 +25,10 @@ class PngReadRawProfile(metaclass=system_tests.CaseMeta):
 
     commands = ["$exiv2 " + fname for fname in filenames]
     stdout = [""] * len(filenames)
-    stderr = [ stderr_exception(fname) for fname in filenames[0:5] ]
+    stderr = [ stderr_exception(fname) for fname in filenames[0:4] ]
+    stderr.append("""$exiv2_exception_message """ + filenames[4] + """:
+$kerInputDataReadFailed
+""")
     stderr.append("""$exiv2_exception_message """ + filenames[5] + """:
 $kerCorruptedMetadata
 """)

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -20,6 +20,7 @@ easyaccess_test: ${ENV:exiv2_path}/easyaccess-test${ENV:binary_extension}
 
 [variables]
 kerFailedToReadImageData: Failed to read image data
+kerInputDataReadFailed: Failed to read input data
 kerCorruptedMetadata: corrupted image metadata
 kerInvalidMalloc: invalid memory allocation request
 kerInvalidTypeValue: invalid type value detected in Image::printIFDStructure

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -1,22 +1,22 @@
 find_package(GTest REQUIRED)
 
 add_executable(unit_tests mainTestRunner.cpp
-    test_types.cpp
-    test_tiffheader.cpp
-    test_futils.cpp
-    test_enforce.cpp
-    test_safe_op.cpp
-    test_XmpKey.cpp
-    test_DateValue.cpp
-    test_TimeValue.cpp
     test_cr2header_int.cpp
+    test_DateValue.cpp
+    test_enforce.cpp
     test_FileIO.cpp
+    test_futils.cpp
     test_helper_functions.cpp
-    test_slice.cpp
-    test_image_int.cpp
     test_ImageFactory.cpp
-    test_PngChunks.cpp
+    test_image_int.cpp
     test_ImageJpeg.cpp
+    test_PngChunks.cpp
+    test_safe_op.cpp
+    test_slice.cpp
+    test_tiffheader.cpp
+    test_TimeValue.cpp
+    test_types.cpp
+    test_XmpKey.cpp
     $<TARGET_OBJECTS:exiv2lib_int>
 )
 

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_DateValue.cpp
     test_TimeValue.cpp
     test_cr2header_int.cpp
+    test_FileIO.cpp
     test_helper_functions.cpp
     test_slice.cpp
     test_image_int.cpp

--- a/unitTests/test_FileIO.cpp
+++ b/unitTests/test_FileIO.cpp
@@ -1,0 +1,74 @@
+#include "basicio.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace Exiv2;
+
+namespace
+{
+    const std::string testData(TESTDATA_PATH);
+    const std::string imagePath(testData + "/DSC_3079.jpg");
+}  // namespace
+
+TEST(AFileIO, canBeInstantiatedWithFilePath)
+{
+    ASSERT_NO_THROW(FileIo file(imagePath));
+}
+
+TEST(AFileIO, canBeOpenInReadBinaryMode)
+{
+    FileIo file(imagePath);
+    ASSERT_EQ(0, file.open());
+}
+
+TEST(AFileIO, isOpenDoItsJob)
+{
+    FileIo file(imagePath);
+    ASSERT_FALSE(file.isopen());
+    file.open();
+    ASSERT_TRUE(file.isopen());
+}
+
+TEST(AFileIO, returnsFileSizeIfItsOpened)
+{
+    FileIo file(imagePath);
+    file.open();
+    ASSERT_EQ(118685, file.size());
+}
+
+TEST(AFileIO, returnsFileSizeEvenWhenFileItIsNotOpened)
+{
+    FileIo file(imagePath);
+    ASSERT_EQ(118685, file.size());
+}
+
+TEST(AFileIO, isOpenedAtPosition0)
+{
+    FileIo file(imagePath);
+    file.open();
+    ASSERT_EQ(0, file.tell());
+}
+
+TEST(AFileIO, canSeekToExistingPositions)
+{
+    FileIo file(imagePath);
+    file.open();
+
+    ASSERT_EQ(0, file.seek(100, BasicIo::beg));
+    ASSERT_EQ(0, file.seek(-50, BasicIo::cur));
+    ASSERT_EQ(0, file.seek(-50, BasicIo::end));
+
+    ASSERT_FALSE(file.error());
+    ASSERT_FALSE(file.eof());
+}
+
+TEST(AFileIO, canSeekBeyondEOF)
+{
+    FileIo file(imagePath);
+    file.open();
+
+    // POSIX allows seeking beyond the existing end of file.
+    ASSERT_EQ(0, file.seek(200000, BasicIo::beg));
+    ASSERT_FALSE(file.error());
+    ASSERT_FALSE(file.eof());
+}


### PR DESCRIPTION
This PR fixes #530 .

In #515 there was a long discussion about the performance implications of having so many system calls when parsing many files. After reading all these comments, I decided to give it a try and I my first thought  was: "Why the hell we need to call `tell() and size()` within `FileIo::eof()` when `feof()` is already doing its job"? Maybe I am missing something there ... but the changes I did keep the complete test suite working.

Basically I replaced:

```cpp
// old version
bool FileIo::eof() const
{
    return feof(p_->fp_) != 0 || tell() >= (long) size();
}

// new version
bool FileIo::eof() const
{
    return feof(p_->fp_) != 0;
}
```
Only 2 tests got affected by this, and I only had to do the following:
- Update the expectation in one of them (now we are raising a different exception for the crafted POC).
- Fix a bug in the `largeiptc-test` application. 

Now there are many less calls to `stat` when parsing a large PNG file:

```
// Previous version
luis@luis-W740SU:~/programming/builds/exiv2_master_release$ strace -e stat bin/exiv2 /media/data/Images/Stonehenge.png 2>&1|grep stat|wc -l
1850

// New version
luis@luis-W740SU:~/programming/builds/exiv2_master_release$ strace -e stat bin/exiv2 /media/data/Images/Stonehenge.png 2>&1|grep stat|wc -l
11
```

Apart from that change I did some improvements here and there over that are of the code base. So I recommend to review the PR commit by commit. 