### PR TITLE
Add CTest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(exiv2
 )
 
 include(cmake/mainSetup.cmake  REQUIRED)
+include(CTest)
 
 # options and their default values
 option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"                    ON  )

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ For new bug reports and feature requests, please open an issue in Github.
 
 ## 4 Running the test suite
 
-The test suite is a mix of bash and python scripts.  The python scripts are new to v0.27 and the bash scripts are being replaced as time permits.
+The test suite is a mix of bash and python scripts (in addition to the unit tests written in C++).  The python scripts are new to v0.27 and the bash scripts are being replaced as time permits.
 
 <div id="4-1">
 
@@ -638,16 +638,19 @@ $ ./icc-test.sh
 
 The code for the unit tests is in `<exiv2dir>/unitTests`
 
-To build the unit tests, use the *cmake* option `-DEXIV2_BUILD_UNIT_TESTS=ON`.
+To build the unit tests, use the *cmake* option `-DEXIV2_BUILD_UNIT_TESTS=ON`. Note that we depends on GTest and GMock for being able to compile and run those tests.
 
 To execute the unit tests:
 
 ```bash
 $ cd <exiv2dir>/build
 $ bin/unit_tests
-```
 
-There is a discussion on the web about installing GTest: [https://github.com/Exiv2/exiv2/issues/575](https://github.com/Exiv2/exiv2/issues/575)
+# Alternatively you can run them with CTest
+$ cd <exiv2dir>/build
+$ ctest
+
+```
 
 [TOC](#TOC)
 <div id="5">

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(GTest REQUIRED)
+enable_testing()
 
 add_executable(unit_tests mainTestRunner.cpp
     test_types.cpp
@@ -48,3 +49,5 @@ if (MSVC)
     # Fix linking issue about missing 3rd party PDB
     set_target_properties(unit_tests PROPERTIES LINK_FLAGS "/ignore:4099")	
 endif()
+
+add_test(NAME unit_tests COMMAND unit_tests)

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -44,10 +44,7 @@ set_target_properties(unit_tests PROPERTIES
     COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
 )
 
-if (USING_CONAN)
-    target_compile_definitions(unit_tests PRIVATE ${CONAN_COMPILE_DEFINITIONS_GTEST})
-endif()
-
-if (MSVC)
-    set_target_properties(unit_tests PROPERTIES LINK_FLAGS "/ignore:4099")
+if (MSVC)	
+    # Fix linking issue about missing 3rd party PDB
+    set_target_properties(unit_tests PROPERTIES LINK_FLAGS "/ignore:4099")	
 endif()


### PR DESCRIPTION
This PR fixes #467 by adding support for **CTest**.

I also could cleanup a bit the CMake code regarding the **unitTest** folder. Those things where only needed on 0.27 where we were using an older version of gtest. 