### PR TITLE
fix880_NikonEndian

### DIFF
--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -206,7 +206,7 @@ namespace Exiv2 {
     //! Nikon Auto Focus binary array - configuration
     extern const ArrayCfg nikonAfCfg = {
         nikonAfId,        // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -224,7 +224,7 @@ namespace Exiv2 {
     //! Nikon Auto Focus 2 binary array - configuration
     extern const ArrayCfg nikonAf2Cfg = {
         nikonAf2Id,       // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -252,7 +252,7 @@ namespace Exiv2 {
     //! Nikon AF Fine Tune binary array - configuration
     extern const ArrayCfg nikonAFTCfg = {
         nikonAFTId,       // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -270,7 +270,7 @@ namespace Exiv2 {
     //! Nikon File Info binary array - configuration
     extern const ArrayCfg nikonFiCfg = {
         nikonFiId,        // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -288,7 +288,7 @@ namespace Exiv2 {
     //! Nikon Multi Exposure binary array - configuration
     extern const ArrayCfg nikonMeCfg = {
         nikonMeId,        // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -307,7 +307,7 @@ namespace Exiv2 {
     //! Nikon Flash Info binary array - configuration 1
     extern const ArrayCfg nikonFl1Cfg = {
         nikonFl1Id,       // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -331,7 +331,7 @@ namespace Exiv2 {
     //! Nikon Flash Info binary array - configuration 2
     extern const ArrayCfg nikonFl2Cfg = {
         nikonFl2Id,       // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element
@@ -353,7 +353,7 @@ namespace Exiv2 {
     //! Nikon Flash Info binary array - configuration 3
     extern const ArrayCfg nikonFl3Cfg = {
         nikonFl3Id,       // Group for the elements
-        littleEndian,     // Byte order
+        invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
         notEncrypted,     // Not encrypted
         false,            // No size element

--- a/test/data/exifdata-test.out
+++ b/test/data/exifdata-test.out
@@ -745,7 +745,7 @@ Exif.Nikon3.Lens                              0x0084 Makernote    Rational    4 
 Exif.Nikon3.FlashMode                         0x0087 Makernote    Byte        1 0
 Exif.NikonAf.AFAreaMode                       0x0000 Makernote    Byte        1 0
 Exif.NikonAf.AFPoint                          0x0001 Makernote    Byte        1 0
-Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 256
+Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 1
 Exif.Nikon3.ShootingMode                      0x0089 Makernote    Short       1 0
 Exif.Nikon3.AutoBracketRelease                0x008a Makernote    Short       1 0
 Exif.Nikon3.LensFStops                        0x008b Makernote    Undefined   4 64 1 12 0
@@ -916,7 +916,7 @@ Exif.Nikon3.Lens                              0x0084 Makernote    Rational    4 
 Exif.Nikon3.FlashMode                         0x0087 Makernote    Byte        1 0
 Exif.NikonAf.AFAreaMode                       0x0000 Makernote    Byte        1 0
 Exif.NikonAf.AFPoint                          0x0001 Makernote    Byte        1 0
-Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 256
+Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 1
 Exif.Nikon3.ShootingMode                      0x0089 Makernote    Short       1 0
 Exif.Nikon3.AutoBracketRelease                0x008a Makernote    Short       1 0
 Exif.Nikon3.LensFStops                        0x008b Makernote    Undefined   4 64 1 12 0
@@ -1088,7 +1088,7 @@ Exif.Nikon3.Lens                              0x0084 Makernote    Rational    4 
 Exif.Nikon3.FlashMode                         0x0087 Makernote    Byte        1 0
 Exif.NikonAf.AFAreaMode                       0x0000 Makernote    Byte        1 0
 Exif.NikonAf.AFPoint                          0x0001 Makernote    Byte        1 0
-Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 256
+Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 1
 Exif.Nikon3.ShootingMode                      0x0089 Makernote    Short       1 0
 Exif.Nikon3.AutoBracketRelease                0x008a Makernote    Short       1 0
 Exif.Nikon3.LensFStops                        0x008b Makernote    Undefined   4 64 1 12 0
@@ -1260,7 +1260,7 @@ Exif.Nikon3.Lens                              0x0084 Makernote    Rational    4 
 Exif.Nikon3.FlashMode                         0x0087 Makernote    Byte        1 0
 Exif.NikonAf.AFAreaMode                       0x0000 Makernote    Byte        1 0
 Exif.NikonAf.AFPoint                          0x0001 Makernote    Byte        1 0
-Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 256
+Exif.NikonAf.AFPointsInFocus                  0x0002 Makernote    Short       1 1
 Exif.Nikon3.ShootingMode                      0x0089 Makernote    Short       1 0
 Exif.Nikon3.AutoBracketRelease                0x008a Makernote    Short       1 0
 Exif.Nikon3.LensFStops                        0x008b Makernote    Undefined   4 64 1 12 0

--- a/test/data/exiv2-test.out
+++ b/test/data/exiv2-test.out
@@ -860,7 +860,7 @@ File  4/15: 20040329_224245.jpg
 20040329_224245.jpg   Exif.Nikon3.FlashMode                        Byte        1  Did not fire
 20040329_224245.jpg   Exif.NikonAf.AFAreaMode                      Byte        1  Single Area
 20040329_224245.jpg   Exif.NikonAf.AFPoint                         Byte        1  Center
-20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Center
+20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Lower-right
 20040329_224245.jpg   Exif.Nikon3.ShootingMode                     Short       1  Single-frame
 20040329_224245.jpg   Exif.Nikon3.AutoBracketRelease               Short       1  None
 20040329_224245.jpg   Exif.Nikon3.LensFStops                       Undefined   4  5.33333
@@ -2473,7 +2473,7 @@ Compare image data and extracted data ------------------------------------
 < 20040329_224245.jpg   Exif.Nikon3.FlashMode                        Byte        1  Did not fire
 < 20040329_224245.jpg   Exif.NikonAf.AFAreaMode                      Byte        1  Single Area
 < 20040329_224245.jpg   Exif.NikonAf.AFPoint                         Byte        1  Center
-< 20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Center
+< 20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Lower-right
 < 20040329_224245.jpg   Exif.Nikon3.ShootingMode                     Short       1  Single-frame
 < 20040329_224245.jpg   Exif.Nikon3.AutoBracketRelease               Short       1  None
 < 20040329_224245.jpg   Exif.Nikon3.LensFStops                       Undefined   4  5.33333
@@ -4014,7 +4014,7 @@ Compare image data and extracted data ------------------------------------
 > 20040329_224245.exv   Exif.Nikon3.FlashMode                        Byte        1  Did not fire
 > 20040329_224245.exv   Exif.NikonAf.AFAreaMode                      Byte        1  Single Area
 > 20040329_224245.exv   Exif.NikonAf.AFPoint                         Byte        1  Center
-> 20040329_224245.exv   Exif.NikonAf.AFPointsInFocus                 Short       1  Center
+> 20040329_224245.exv   Exif.NikonAf.AFPointsInFocus                 Short       1  Lower-right
 > 20040329_224245.exv   Exif.Nikon3.ShootingMode                     Short       1  Single-frame
 > 20040329_224245.exv   Exif.Nikon3.AutoBracketRelease               Short       1  None
 > 20040329_224245.exv   Exif.Nikon3.LensFStops                       Undefined   4  5.33333
@@ -5775,7 +5775,7 @@ Compare original and inserted image data ---------------------------------
 < 20040329_224245.jpg   Exif.Nikon3.FlashMode                        Byte        1  Did not fire
 < 20040329_224245.jpg   Exif.NikonAf.AFAreaMode                      Byte        1  Single Area
 < 20040329_224245.jpg   Exif.NikonAf.AFPoint                         Byte        1  Center
-< 20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Center
+< 20040329_224245.jpg   Exif.NikonAf.AFPointsInFocus                 Short       1  Lower-right
 < 20040329_224245.jpg   Exif.Nikon3.ShootingMode                     Short       1  Single-frame
 < 20040329_224245.jpg   Exif.Nikon3.AutoBracketRelease               Short       1  None
 < 20040329_224245.jpg   Exif.Nikon3.LensFStops                       Undefined   4  5.33333
@@ -7316,7 +7316,7 @@ Compare original and inserted image data ---------------------------------
 > 20040329_224245.exv   Exif.Nikon3.FlashMode                        Byte        1  Did not fire
 > 20040329_224245.exv   Exif.NikonAf.AFAreaMode                      Byte        1  Single Area
 > 20040329_224245.exv   Exif.NikonAf.AFPoint                         Byte        1  Center
-> 20040329_224245.exv   Exif.NikonAf.AFPointsInFocus                 Short       1  Center
+> 20040329_224245.exv   Exif.NikonAf.AFPointsInFocus                 Short       1  Lower-right
 > 20040329_224245.exv   Exif.Nikon3.ShootingMode                     Short       1  Single-frame
 > 20040329_224245.exv   Exif.Nikon3.AutoBracketRelease               Short       1  None
 > 20040329_224245.exv   Exif.Nikon3.LensFStops                       Undefined   4  5.33333


### PR DESCRIPTION
In src/tiffimage_int.cpp, I changed `littleEndian` in `ArrayCfg` instances for Nikon Cameras to `invalidByteOrder`.  This caused test failures to be detected by exiv2-test.sh and exifdata-test.sh.  I have investigated and documented this in #880.  So this PR contains the modified code and updated reference test output.

I see there are instances of `bigEndian` in `ArrayCfg` in src/tiffimage_int.cpp  When I changed them to `invalidByteOrder`, I got new test failures.  The test `bugfixes/redmine/test_issue_666.py` writes a new Nikon MakerNote into an empty JPEG.  Changing the default endian setting results in different byte order in the MakerNote.  This is a non-trivial matter to investigate and determine if the current behaviour is incorrect.  So, I will not touch the instances of `bigEndian` as no bug has been reported about writing Nikon MakerNotes. 

I know nothing about 666: https://dev.exiv2.org/issues/666.  

Fix #880