### PR TITLE
DLL information depends now on proper definition

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -224,7 +224,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     int debug=1;
 #endif
 
-#if defined(DLL_EXPORT)
+#ifdef exiv2lib_EXPORTS
     int dll=1;
 #else
     int dll=0;


### PR DESCRIPTION
This PR fix #903 

With this change the behaviour is (On Windows):

```
Build: -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON

$ bin/exiv2 -vVg debug
exiv2 0.27.2.99
debug=0

$ bin/exiv2 -vVg dll
exiv2 0.27.2.99
dll=1

Build: -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF

$ bin/exiv2 -vVg debug
exiv2 0.27.2.99
debug=0

$ bin/exiv2 -vVg dll
exiv2 0.27.2.99
dll=0

Build: -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON

$ bin/exiv2 -vVg debug
exiv2 0.27.2.99
debug=1

$ bin/exiv2 -vVg dll
exiv2 0.27.2.99
dll=1

Build: -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF

$ bin/exiv2 -vVg debug
exiv2 0.27.2.99
debug=1

$ bin/exiv2 -vVg dll
exiv2 0.27.2.99
dll=0
```