### PR TITLE
DLL information depends now on proper definition

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -98,7 +98,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     constexpr int debug = 1;
 #endif
 
-#if defined(DLL_EXPORT)
+#ifdef exiv2lib_EXPORTS
     constexpr int dll = 1;
 #else
     constexpr int dll = 0;


### PR DESCRIPTION
Same than #909 for `master`.