### PR TITLE
Add libFuzzer integration + report bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required( VERSION 3.5.0 )
 
+# Specify search path for CMake modules to be loaded by include()
+# and find_package()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Add defaults for cmake
+# Those need to be set before the project() call.
+include(DefineCompilerFlags REQUIRED)
+
 project(exiv2
     VERSION 0.27.99.0   # Fake version number to indicate that the next version will be 28.0
     LANGUAGES CXX C
@@ -25,12 +33,12 @@ option( EXIV2_BUILD_SAMPLES           "Build sample applications"               
 option( EXIV2_BUILD_PO                "Build translations files"                              OFF )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )
 option( EXIV2_BUILD_UNIT_TESTS        "Build unit tests"                                      OFF )
+option( EXIV2_BUILD_FUZZ_TESTS        "Build fuzz tests (libFuzzer)"                          OFF )
 option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentation"            OFF )
 
 # Only intended to be used by Exiv2 developers/contributors
 option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
 option( EXIV2_TEAM_WARNINGS_AS_ERRORS "Treat warnings as errors"                              OFF )
-option( EXIV2_TEAM_USE_SANITIZERS     "Enable ASAN and UBSAN when available"                  OFF )
 option( EXIV2_TEAM_PACKAGING          "Additional stuff for generating packages"              OFF )
 set(EXTRA_COMPILE_FLAGS " ")
 
@@ -80,6 +88,14 @@ add_subdirectory( src )
 
 if( EXIV2_BUILD_UNIT_TESTS )
     add_subdirectory ( unitTests )
+endif()
+
+if( EXIV2_BUILD_FUZZ_TESTS)
+    if ((NOT COMPILER_IS_CLANG) OR (NOT CMAKE_BUILD_TYPE STREQUAL "AddressSanitizer"))
+        message(FATAL_ERROR "You need to build with Clang and sanitizers for the fuzzers to work. "
+                "Use Clang and -DCMAKE_BUILD_TYPE=AddressSanitizer")
+    endif()
+    add_subdirectory ( fuzz )
 endif()
 
 if( EXIV2_BUILD_SAMPLES )

--- a/README.md
+++ b/README.md
@@ -663,6 +663,27 @@ $ ctest
 
 ```
 
+### 4.3 Fuzz tests
+
+The code for the fuzzers is in `exiv2dir/fuzz`
+
+To build the fuzzers, use the *cmake* option `-DEXIV2_BUILD_FUZZ_TESTS=ON` and `-DCMAKE_BUILD_TYPE=AddressSanitizer`.
+Note that it only works with clang compiler as libFuzzer is integrate with clang > 6.0
+
+To build the fuzzers:
+
+```bash
+cmake .. -G "Unix Makefiles" "-DEXIV2_BUILD_FUZZ_TESTS=ON"  "-DCMAKE_BUILD_TYPE=AddressSanitizer"
+make -j4
+```
+
+To execute the fuzzers:
+
+```bash
+cd <exiv2dir>/build
+bin/<fuzzer_name> # for example ./bin/read-metadata.cpp
+```
+
 [TOC](#TOC)
 <div id="5">
 

--- a/cmake/DefineCompilerFlags.cmake
+++ b/cmake/DefineCompilerFlags.cmake
@@ -1,0 +1,13 @@
+if (UNIX AND NOT WIN32)
+    # Activate with: -DCMAKE_BUILD_TYPE=AddressSanitizer
+    set(CMAKE_C_FLAGS_ADDRESSSANITIZER "-g -O1 -fsanitize=address -fno-omit-frame-pointer"
+            CACHE STRING "Flags used by the C compiler during ADDRESSSANITIZER builds.")
+    set(CMAKE_CXX_FLAGS_ADDRESSSANITIZER "-g -O1 -fsanitize=address -fno-omit-frame-pointer"
+            CACHE STRING "Flags used by the CXX compiler during ADDRESSSANITIZER builds.")
+    set(CMAKE_SHARED_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during the creation of shared libraries during ADDRESSSANITIZER builds.")
+    set(CMAKE_MODULE_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during the creation of shared libraries during ADDRESSSANITIZER builds.")
+    set(CMAKE_EXEC_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during ADDRESSSANITIZER builds.")
+endif()

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -32,38 +32,6 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W")
 
-        if ( EXIV2_TEAM_USE_SANITIZERS )
-            # ASAN is available in gcc from 4.8 and UBSAN from 4.9
-            # ASAN is available in clang from 3.1 and UBSAN from 3.3
-            # UBSAN is not fatal by default, instead it only prints runtime errors to stderr
-            # => make it fatal with -fno-sanitize-recover (gcc) or -fno-sanitize-recover=all (clang)
-            # add -fno-omit-frame-pointer for better stack traces
-            if ( COMPILER_IS_GCC )
-                if ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 )
-                    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover")
-                elseif( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8 )
-                    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address")
-                endif()
-            elseif( COMPILER_IS_CLANG )
-                if ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 )
-                    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all")
-                elseif ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.4 )
-                    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address,undefined")
-                elseif( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.1 )
-                    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address")
-                endif()
-            endif()
-
-            # sorry, ASAN does not work on Windows
-            if ( NOT CYGWIN AND NOT MINGW AND NOT MSYS )
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
-                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
-                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZER_FLAGS}")
-                set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${SANITIZER_FLAGS}")
-            endif()
-
-        endif()
-
         if ( EXIV2_TEAM_EXTRA_WARNINGS )
             # Note that this is intended to be used only by Exiv2 developers/contributors.
 

--- a/cmake/printSummary.cmake
+++ b/cmake/printSummary.cmake
@@ -59,6 +59,7 @@ OptionOutput( "Building exiv2 command:             " EXIV2_BUILD_EXIV2_COMMAND  
 OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES             )
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
+OptionOutput( "Building fuzz tests:                " EXIV2_BUILD_FUZZ_TESTS          )
 OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC                 )
 OptionOutput( "Building with coverage flags:       " BUILD_WITH_COVERAGE             )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,15 @@
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,fuzzer")
+
+macro(fuzzer name)
+    add_executable(${name} ${name}.cpp)
+    set_target_properties(${name}
+            PROPERTIES
+                COMPILE_FLAGS "-fsanitize=fuzzer"
+                LINK_FLAGS "-fsanitize=fuzzer")
+    target_link_libraries(${name}
+            PRIVATE
+            exiv2lib
+            )
+endmacro()
+
+fuzzer(read-metadata)

--- a/fuzz/read-metadata.cpp
+++ b/fuzz/read-metadata.cpp
@@ -1,0 +1,65 @@
+// ***************************************************************** -*- C++ -*-
+// exifprint.cpp
+// Sample program to print the Exif metadata of an image
+
+#include <exiv2/exiv2.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cassert>
+
+// https://github.com/Exiv2/exiv2/issues/468
+#if defined(EXV_UNICODE_PATH) && defined(__MINGW__)
+#undef  EXV_UNICODE_PATH
+#endif
+
+#ifdef  EXV_UNICODE_PATH
+#define _tchar      wchar_t
+#define _tstrcmp    wcscmp
+#define _t(s)       L##s
+#define _tcout      wcout
+#define _tmain      wmain
+#else
+#define _tchar      char
+#define _tstrcmp    strcmp
+#define _t(s)       s
+#define _tcout      cout
+#define _tmain      main
+#endif
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
+try {
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(Data, Size);
+    assert(image.get() != 0);
+    image->readMetadata();
+
+    Exiv2::ExifData &exifData = image->exifData();
+    if (exifData.empty()) {
+        std::string error("No Exif data found in file");
+        throw Exiv2::Error(Exiv2::kerErrorMessage, error);
+    }
+
+    Exiv2::ExifData::const_iterator end = exifData.end();
+    for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != end; ++i) {
+        const char* tn = i->typeName();
+        std::cout << std::setw(44) << std::setfill(' ') << std::left
+                  << i->key() << " "
+                  << "0x" << std::setw(4) << std::setfill('0') << std::right
+                  << std::hex << i->tag() << " "
+                  << std::setw(9) << std::setfill(' ') << std::left
+                  << (tn ? tn : "Unknown") << " "
+                  << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right
+                  << i->count() << "  "
+                  << std::dec << i->value()
+                  << "\n";
+    }
+
+    return 0;
+}
+//catch (std::exception& e) {
+//catch (Exiv2::AnyError& e) {
+catch (Exiv2::Error& e) {
+    std::cout << "Caught Exiv2 exception '" << e.what() << "'\n";
+    return -1;
+}


### PR DESCRIPTION
This commit places the basics for libFuzzer integration with one
fuzzer which fuzzes the readMetadata function. The fuzzer is
located at fuzz/read-metadata.

To add more fuzzers please add them to ./fuzz directory as
described in the README.

Also a memory corruption bug is found using this fuzzer which
might lead to additional bugs after fix is pushed.