### PR TITLE
Add bounds check to MemIo::seek().

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1294,7 +1294,12 @@ namespace Exiv2 {
         if (newIdx < 0)
             return 1;
 
-        p_->idx_ = static_cast<long>(newIdx);   //not very sure about this. need more test!!    - note by Shawn  fly2xj@gmail.com //TODO
+        if (static_cast<size_t>(newIdx) > p_->size_) {
+            p_->eof_ = true;
+            return 1;
+        }
+
+        p_->idx_ = static_cast<size_t>(newIdx);
         p_->eof_ = false;
         return 0;
     }

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(GTest REQUIRED)
 enable_testing()
 
 add_executable(unit_tests mainTestRunner.cpp
+    test_basicio.cpp
     test_types.cpp
     test_tiffheader.cpp
     test_futils.cpp

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -19,6 +19,42 @@ TEST(MemIo, seek_out_of_bounds)
     // The problem is that MemIo::seek() does not check that the new offset is
     // in bounds.
     byte tmp[16];
-    io.seek(0x10000000, BasicIo::beg);
+    ASSERT_EQ(io.seek(0x10000000, BasicIo::beg), 1);
+    ASSERT_TRUE(io.eof());
+
+    // The seek was invalid, so the offset didn't change and this read still works.
+    ASSERT_EQ(io.read(tmp, sizeof(tmp)), sizeof(tmp));
+
+    // Reset the file.
+    ASSERT_EQ(io.seek(0, BasicIo::beg), 0);
+    ASSERT_FALSE(io.eof());
+
+    // Seek to the end of the file.
+    ASSERT_EQ(io.seek(0, BasicIo::end), 0);
     ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
+
+    // Try to seek past the end of the file.
+    ASSERT_EQ(io.seek(0x10000000, BasicIo::end), 1);
+    ASSERT_TRUE(io.eof());
+    ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
+
+    // Reset the file.
+    ASSERT_EQ(io.seek(100, BasicIo::beg), 0);
+    ASSERT_FALSE(io.eof());
+
+    // Try to seek past the end of the file.
+    ASSERT_EQ(io.seek(0x10000000, BasicIo::cur), 1);
+    ASSERT_TRUE(io.eof());
+    // The seek was invalid, so the offset didn't change and this read still works.
+    ASSERT_EQ(io.read(tmp, sizeof(tmp)), sizeof(tmp));
+
+    // Reset the file.
+    ASSERT_EQ(io.seek(100, BasicIo::beg), 0);
+    ASSERT_FALSE(io.eof());
+
+    // Try to seek past the beginning of the file.
+    ASSERT_EQ(io.seek(-0x10000000, BasicIo::cur), 1);
+    ASSERT_FALSE(io.eof());
+    // The seek was invalid, so the offset didn't change and this read still works.
+    ASSERT_EQ(io.read(tmp, sizeof(tmp)), sizeof(tmp));
 }

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -7,7 +7,7 @@
 
 using namespace Exiv2;
 
-TEST(MemIo, seek_out_of_bounds)
+TEST(MemIo, seek_out_of_bounds_00)
 {
     byte buf[1024];
     memset(buf, 0, sizeof(buf));
@@ -24,10 +24,17 @@ TEST(MemIo, seek_out_of_bounds)
 
     // The seek was invalid, so the offset didn't change and this read still works.
     ASSERT_EQ(io.read(tmp, sizeof(tmp)), sizeof(tmp));
+}
 
-    // Reset the file.
-    ASSERT_EQ(io.seek(0, BasicIo::beg), 0);
+TEST(MemIo, seek_out_of_bounds_01)
+{
+    byte buf[1024];
+    memset(buf, 0, sizeof(buf));
+
+    MemIo io(buf, sizeof(buf));
     ASSERT_FALSE(io.eof());
+
+    byte tmp[16];
 
     // Seek to the end of the file.
     ASSERT_EQ(io.seek(0, BasicIo::end), 0);
@@ -37,20 +44,34 @@ TEST(MemIo, seek_out_of_bounds)
     ASSERT_EQ(io.seek(0x10000000, BasicIo::end), 1);
     ASSERT_TRUE(io.eof());
     ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
+}
 
-    // Reset the file.
-    ASSERT_EQ(io.seek(100, BasicIo::beg), 0);
+TEST(MemIo, seek_out_of_bounds_02)
+{
+    byte buf[1024];
+    memset(buf, 0, sizeof(buf));
+
+    MemIo io(buf, sizeof(buf));
     ASSERT_FALSE(io.eof());
+
+    byte tmp[16];
 
     // Try to seek past the end of the file.
     ASSERT_EQ(io.seek(0x10000000, BasicIo::cur), 1);
     ASSERT_TRUE(io.eof());
     // The seek was invalid, so the offset didn't change and this read still works.
     ASSERT_EQ(io.read(tmp, sizeof(tmp)), sizeof(tmp));
+}
 
-    // Reset the file.
-    ASSERT_EQ(io.seek(100, BasicIo::beg), 0);
+TEST(MemIo, seek_out_of_bounds_03)
+{
+    byte buf[1024];
+    memset(buf, 0, sizeof(buf));
+
+    MemIo io(buf, sizeof(buf));
     ASSERT_FALSE(io.eof());
+
+    byte tmp[16];
 
     // Try to seek past the beginning of the file.
     ASSERT_EQ(io.seek(-0x10000000, BasicIo::cur), 1);

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -1,0 +1,24 @@
+#include <exiv2/basicio.hpp>
+
+#include <cmath>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+using namespace Exiv2;
+
+TEST(MemIo, seek_out_of_bounds)
+{
+    byte buf[1024];
+    memset(buf, 0, sizeof(buf));
+
+    MemIo io(buf, sizeof(buf));
+    ASSERT_FALSE(io.eof());
+
+    // Regression test for bug reported in https://github.com/Exiv2/exiv2/pull/945
+    // The problem is that MemIo::seek() does not check that the new offset is
+    // in bounds.
+    byte tmp[16];
+    io.seek(0x10000000, BasicIo::beg);
+    ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
+}

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -1,8 +1,4 @@
 #include <exiv2/basicio.hpp>
-
-#include <cmath>
-#include <limits>
-
 #include <gtest/gtest.h>
 
 using namespace Exiv2;


### PR DESCRIPTION
Quick fix for bug reported in #943.