### PR TITLE
Add libFuzzer integration + report bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option( EXIV2_BUILD_SAMPLES           "Build sample applications"               
 option( EXIV2_BUILD_PO                "Build translations files"                              OFF )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )
 option( EXIV2_BUILD_UNIT_TESTS        "Build unit tests"                                      OFF )
+option( EXIV2_BUILD_FUZZ_TESTS        "Build fuzz tests (libFuzzer)"                          OFF )
 option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentation"            OFF )
 
 # Only intended to be used by Exiv2 developers/contributors
@@ -80,6 +81,14 @@ add_subdirectory( src )
 
 if( EXIV2_BUILD_UNIT_TESTS )
     add_subdirectory ( unitTests )
+endif()
+
+if( EXIV2_BUILD_FUZZ_TESTS)
+    if ((NOT COMPILER_IS_CLANG) OR (NOT EXIV2_TEAM_USE_SANITIZERS))
+        message(FATAL_ERROR "You need to build with Clang and sanitizers for the fuzzers to work. "
+                "Use Clang and -DEXIV2_TEAM_USE_SANITIZERS=ON")
+    endif()
+    add_subdirectory ( fuzz )
 endif()
 
 if( EXIV2_BUILD_SAMPLES )

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     1. [Running tests on a UNIX-like system](#4-1)
     2. [Running tests on Visual Studio builds](#4-2)
     3. [Unit tests](#4-3)
+    4. [Fuzzing](#4-4)
 5. [Platform Notes](#5)
     1. [Linux](#5-1)
     2. [MacOS-X](#5-2)
@@ -661,6 +662,29 @@ $ bin/unit_tests
 $ cd <exiv2dir>/build
 $ ctest
 
+```
+
+### 4.4 Fuzzing
+
+The code for the fuzzers is in `exiv2dir/fuzz`
+
+To build the fuzzers, use the *cmake* option `-DEXIV2_BUILD_FUZZ_TESTS=ON` and `-DEXIV2_TEAM_USE_SANITIZERS=ON`.
+Note that it only works with clang compiler as libFuzzer is integrate with clang > 6.0
+
+To build the fuzzers:
+
+```bash
+export CXX=clang++
+export CC=clang
+cmake .. -G "Unix Makefiles" "-DEXIV2_BUILD_FUZZ_TESTS=ON"  "-DEXIV2_TEAM_USE_SANITIZERS=ON"
+make -j4
+```
+
+To execute the fuzzers:
+
+```bash
+cd <exiv2dir>/build
+bin/<fuzzer_name> # for example ./bin/read-metadata.cpp
 ```
 
 [TOC](#TOC)

--- a/cmake/printSummary.cmake
+++ b/cmake/printSummary.cmake
@@ -59,6 +59,7 @@ OptionOutput( "Building exiv2 command:             " EXIV2_BUILD_EXIV2_COMMAND  
 OptionOutput( "Building samples:                   " EXIV2_BUILD_SAMPLES             )
 OptionOutput( "Building PO files:                  " EXIV2_BUILD_PO                  )
 OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS          )
+OptionOutput( "Building fuzz tests:                " EXIV2_BUILD_FUZZ_TESTS          )
 OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC                 )
 OptionOutput( "Building with coverage flags:       " BUILD_WITH_COVERAGE             )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+macro(fuzzer name)
+    add_executable(${name} ${name}.cpp)
+    set_target_properties(${name}
+            PROPERTIES
+                COMPILE_FLAGS "-fsanitize=fuzzer"
+                LINK_FLAGS "-fsanitize=fuzzer")
+    target_link_libraries(${name}
+            PRIVATE
+            exiv2lib
+            )
+endmacro()
+
+fuzzer(read-metadata)

--- a/fuzz/read-metadata.cpp
+++ b/fuzz/read-metadata.cpp
@@ -1,0 +1,24 @@
+#include <exiv2/exiv2.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cassert>
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t * Data, size_t Size)
+try {
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(Data, Size);
+    assert(image.get() != 0);
+    image->readMetadata();
+
+    Exiv2::ExifData &exifData = image->exifData();
+    if (exifData.empty()) {
+        return -1;
+    }
+
+
+    return 0;
+}
+catch (Exiv2::Error& e) {
+    return -1;
+}


### PR DESCRIPTION
This is a fix as discussed in this comment: [https://github.com/Exiv2/exiv2/pull/943#issuecomment-508491876](https://github.com/Exiv2/exiv2/pull/943#issuecomment-508491876)
This commit places the basics for libFuzzer integration with one
fuzzer which fuzzes the readMetadata function. The fuzzer is
located at fuzz/read-metadata.

To add more fuzzers please add them to ./fuzz directory as
described in the README.

Also a memory corruption bug is found using this fuzzer which
might lead to additional bugs after fix is pushed.