### PR TITLE
Conan update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ before_build:
     - cmd: cd envs
     - cmd: python -m virtualenv conan
     - cmd: conan/Scripts/activate
-    - cmd: python -m pip install conan==1.11.2
+    - cmd: python -m pip install conan==1.11.2 # TODO: Update to latest version (needs python 3)
     - cmd: cd ..
     - cmd: conan --version
     - cmd: conan remote add conan-bincrafters https://api.bintray.com/conan/bincrafters/public-conan

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -22,7 +22,7 @@ else
 fi
 
 python --version
-pip install conan==1.11.2
+pip install conan==1.17.0
 pip install codecov
 conan --version
 conan config set storage.path=~/conanData

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class Exiv2Conan(ConanFile):
                       )
 
     def configure(self):
-        self.options['libcurl'].shared = True
+        self.options['libcurl'].shared = False
         self.options['libcurl'].with_openssl = True
         self.options['gtest'].shared = True
 
@@ -34,7 +34,7 @@ class Exiv2Conan(ConanFile):
                 self.requires('gtest/1.8.1@bincrafters/stable')
 
         if self.options.webready and not os_info.is_macos:
-            self.requires('libcurl/7.61.1@bincrafters/stable')
+            self.requires('libcurl/7.64.1@bincrafters/stable')
 
         if self.options.xmp:
             self.requires('XmpSdk/2016.7@piponazo/stable') # from conan-piponazo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,10 +197,6 @@ if (WIN32)
 endif()
 
 if (NOT MSVC)
-    if ( UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" )
-        target_link_libraries( exiv2lib PRIVATE ${CMAKE_DL_LIBS}) # -ldl = dynamic loader used by src/version.cpp
-    endif()
-
     if ( CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" )
         target_link_libraries( exiv2lib PRIVATE -lprocstat)
     endif()


### PR DESCRIPTION
After a recent change in the **libcurl** conan binaries, our build started to fail. The issues have been reported to the maintainers of that conan package:

https://github.com/bincrafters/community/issues/872

To solve the issue in our CI I just decided to switch to the static version of the libraries to avoid the linking issues with shared libraries. I did not want to spend too much time trying to solve the issue since anyways, each distribution provide different versions of the libraries and those things are already covered by the Gitlab scripts. I just tried to do the minimal amount of work to fix the situation in our travis CI builds. 

After changing to the static version of the library, one of the builders fail with linking errors about the **dl** library:
https://travis-ci.org/Exiv2/exiv2/builds/557689271

That's why I added the second commit. 