### PR TITLE
fix_966_macosx_libintl_mono_framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"      
 option( EXIV2_ENABLE_XMP              "Build with XMP metadata support"                       ON  )
 option( EXIV2_ENABLE_EXTERNAL_XMP     "Use external version of XMP"                           OFF )
 option( EXIV2_ENABLE_PNG              "Build with png support (requires libz)"                ON  )
-cmake_dependent_option(EXIV2_ENABLE_NLS "Build native language support (requires gettext)" ON "UNIX" OFF)
+option( EXIV2_ENABLE_NLS              "Build native language support (requires gettext)"      OFF )
 option( EXIV2_ENABLE_PRINTUCS2        "Build with Printucs2"                                  ON  )
 option( EXIV2_ENABLE_LENSDATA         "Build including lens data"                             ON  )
 option( EXIV2_ENABLE_VIDEO            "Build video support into library"                      OFF )
@@ -23,7 +23,6 @@ option( EXIV2_ENABLE_CURL             "USE Libcurl for HttpIo (WEBREADY)"       
 option( EXIV2_ENABLE_SSH              "USE Libssh for SshIo (WEBREADY)"                       OFF )
 
 option( EXIV2_BUILD_SAMPLES           "Build sample applications"                             ON  )
-option( EXIV2_BUILD_PO                "Build translations files"                              OFF )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )
 option( EXIV2_BUILD_UNIT_TESTS        "Build unit tests"                                      OFF )
 option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentation"            OFF )
@@ -95,7 +94,7 @@ if( EXIV2_BUILD_SAMPLES )
     add_dependencies(tests exiv2lib exiv2 ${SAMPLES})
 endif()
 
-if( EXIV2_BUILD_PO )
+if( EXIV2_ENABLE_NLS )
     add_subdirectory( po )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -135,20 +135,22 @@ $ cmake -DBUILD_SHARED_LIBS=On -DEXIV2_ENABLE_NLS=OFF
 
 ### 2.4 Dependencies
 
-The following Exiv2 features are enabled by default and require external libraries. You can disable the dependency with CMake options:
+The following Exiv2 features require external libraries:
 
-| Feature                     | Package   |  cmake option to disable     | Availability |
-|:--------------------------  |:--------  |:---------------------------- |:----------- |
-| PNG image support           | zlib      | -DEXIV2\_ENABLE\_PNG=Off     | [http://zlib.net/](http://zlib.net/) |
-| Native language support     | gettext   | -DEXIV2\_ENABLE\_NLS=Off     | [http://www.gnu.org/software/gettext/](http://www.gnu.org/software/gettext/) |
-| XMP support                 | expat     | -DEXIV2\_ENABLE\_XMP=Off     | [http://expat.sourceforge.net](http://expat.sourceforge.net)/<br/>Use _**Expat 2.2.6**_ and later |
+| Feature                     | Package   |  Default | To change default             | Availability |
+|:--------------------------  |:--------  |:--------:| :---------------------------- |:-----------  |
+| PNG image support           | zlib      | ON       | -DEXIV2\_ENABLE\_PNG=Off      | [http://zlib.net/](http://zlib.net/) |
+| XMP support                 | expat     | ON       | -DEXIV2\_ENABLE\_XMP=Off      | [http://expat.sourceforge.net](http://expat.sourceforge.net)/<br/>Use _**Expat 2.2.6**_ and later |
+| Natural language system     | gettext   | OFF      | -DEXIV2\_ENABLE\_NLS=On       | [http://www.gnu.org/software/gettext/](http://www.gnu.org/software/gettext/) |
 
 On UNIX systems, you may install the dependencies using the distribution's package management system. Install the
 development package of a dependency to install the header files and libraries required to build Exiv2. In the file
 `ci/install_dependencies.sh` you can check to the list of packages we install on different Linux distributions. This
 file is used to setup some CI images in which we try out the Exiv2 compilation.
 
-Notes about different platforms are included in this document: [Platform Notes](#5)
+Natural language system is discussed in more detail here: [Localisation](#2-8)
+
+Notes about different platforms are included here: [Platform Notes](#5)
 
 You may choose to install dependences with conan.  This is supported on all platforms and is especially useful for users of Visual Studio.
 See [README-CONAN](README-CONAN.md) for more information.
@@ -215,7 +217,6 @@ $
 
 This [repository](https://github.com/piponazo/exiv2Consumer) shows an example of how to consume Exiv2 with CMake.
 
-
 [TOC](#TOC)
 <div id="2-7">
 
@@ -248,7 +249,9 @@ g++ -std=c++98 myprogram.cpp -o myprogram $(pkg-config exiv2 --libs --cflags)
 
 Localisation is supported on a UNIX-like platform:  Linux, MacOS-X, Cygwin and MinGW/msys2.  Localisation is not supported for Visual Studio builds.
 
-To build localisation support, use the CMake option `-DEXIV2_BUILD_PO=ON`. There are no additional build steps as the normal build commands will compile the library, samples and localisation support.  You must install the build to ensure the localisation messages files can be found at run-time.
+To build localisation support, use the CMake option `-DEXIV2_ENABLE_NLS=ON`.  You must install the `gettext` package with your package manager or from source.  The `gettext` package is available from [http://www.gnu.org/software/gettext/](http://www.gnu.org/software/gettext/) and includes the library `libintl` and utilities to build localisation files.  If CMake produces error messages which mention libintl or gettext, you should verify that the package `gettext` has been correctly built and installed.
+
+You must install the build to test localisation.  This ensures that the localisation message files can be found at run-time.  You cannot test localisation in the directory `build\bin`.
 
 1) Running exiv2 in another language
 
@@ -892,4 +895,4 @@ Work in progress:  [https://github.com/Exiv2/exiv2/issues/902](https://github.co
 
 Robin Mills
 
-Revised: 2019-07-19
+Revised: 2019-07-29

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,3 @@ build_script:
     - cmd: cd ../../tests/
     - cmd: set EXIV2_EXT=.exe
     - cmd: if %INTEGRATION_TESTS% == 1 c:\Python36\python.exe runner.py -v
-
-cache:
-    - c:\Users\appveyor\conanCache  # Conan cache

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -1,6 +1,11 @@
 # set include path for FindXXX.cmake files
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+# don't use Frameworks on the Mac (#966)
+if (APPLE)
+     set(CMAKE_FIND_FRAMEWORK NEVER)
+endif()
+
 # Check if the conan file exist to find the dependencies
 if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     set(USING_CONAN ON)
@@ -36,7 +41,11 @@ endif()
 
 
 if (EXIV2_ENABLE_NLS)
-    find_package(Intl REQUIRED)
+    find_package(Intl)
+    if ( NOT ${Intl_FOUND} )
+       message(WARNING "*** EXIV2_ENABLE_NLS has been disabled because libintl is not available ***")
+       set(EXIV2_ENABLE_NLS Off)
+    endif()
 endif( )
 
 find_package(Iconv)

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -39,13 +39,8 @@ else()
     endif ()
 endif()
 
-
 if (EXIV2_ENABLE_NLS)
-    find_package(Intl)
-    if ( NOT ${Intl_FOUND} )
-       message(WARNING "*** EXIV2_ENABLE_NLS has been disabled because libintl is not available ***")
-       set(EXIV2_ENABLE_NLS Off)
-    endif()
+    find_package(Intl REQUIRED)
 endif( )
 
 find_package(Iconv)


### PR DESCRIPTION
See #966  This has been caused by installing Visual Studio for Mac.  As I believe this was released in April 2019, this issue is recent and new.

While I don't like to see code changes between exiv2 v0.27.2-RC3 and v0.27.2, I think this is a rather important low risk change.  I'll leave the reviewers to agree or disagree.  If you decide to defer for v0.27.3, please update the target.  I've changed the Jenkins script to build release bundles to EXIV2_ENABLE_NLS=Off to avoid another instance of this issue if this change doesn't get into v0.27.2

The other change here is to enable EXIV2_ENABLE_NLS to set itself Off when libintl is not found.  I believe we had code for that in the good old days.