### PR TITLE
appveyor: use ninja + give priority to more recent compilers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,22 @@ environment:
   PYTHON: "C:\\Python37"
     
   matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      CMAKE_GENERATOR: Ninja
+      INTEGRATION_TESTS: 1
+      VS_COMPILER_VERSION: 14
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      ARCHITECTURE: x86_64
+      UNIT_TESTS: 1
+      WARNINGS_AS_ERRORS: ON
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: Ninja
+      INTEGRATION_TESTS: 1
+      VS_COMPILER_VERSION: 15
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+      ARCHITECTURE: x86_64
+      UNIT_TESTS: 1
+      WARNINGS_AS_ERRORS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Visual Studio 10 2010
       INTEGRATION_TESTS: 0
@@ -11,7 +27,7 @@ environment:
       UNIT_TESTS: 0
       WARNINGS_AS_ERRORS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 11 2012 Win64
+      CMAKE_GENERATOR: Ninja
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 11
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat
@@ -19,26 +35,10 @@ environment:
       UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 12 2013 Win64
+      CMAKE_GENERATOR: Ninja
       INTEGRATION_TESTS: 0
       VS_COMPILER_VERSION: 12
       VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86_64
-      UNIT_TESTS: 1
-      WARNINGS_AS_ERRORS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      CMAKE_GENERATOR: Visual Studio 14 2015 Win64
-      INTEGRATION_TESTS: 1
-      VS_COMPILER_VERSION: 14
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86_64
-      UNIT_TESTS: 1
-      WARNINGS_AS_ERRORS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      CMAKE_GENERATOR: Visual Studio 15 2017 Win64
-      INTEGRATION_TESTS: 1
-      VS_COMPILER_VERSION: 15
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
       ARCHITECTURE: x86_64
       UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
@@ -71,7 +71,6 @@ build_script:
     - cmd: cd build
     - cmd: call "%VCVARS%" x86_amd64
     - cmd: conan --version
-    - cmd: conan remote list
     - cmd: conan install .. -o webready=True --build missing
     - cmd: echo %CMAKE_GENERATOR%
     - cmd: cmake -G "%CMAKE_GENERATOR%" -DEXIV2_TEAM_WARNINGS_AS_ERRORS=%WARNINGS_AS_ERRORS% -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=%UNIT_TESTS% -DCMAKE_INSTALL_PREFIX=install ..


### PR DESCRIPTION
With the drop of the caching system in Appveyor I dediced to backport from master the introduction of the Ninja Build System in Appveyor. Thanks to the usage of **ninja** the compilation of exiv2 on the CI builders is almost twice faster (although when the builders need to compile some of the 3rd party dependencies with conan, the default visual studio generators are used).

Note that for Visual Studio 2010, when using the ninja generator, CMake was finding clang instead of the visual studio compiler. That's why I had to use the `CMAKE_GENERATOR` variable to control which generator to use. 