### PR TITLE
Add XMP Initialisation/Cleanup code to every main()

### DIFF
--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -114,6 +114,9 @@ void sftpcon(const std::string& url) {
 
 int main(int argc,const char** argv)
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc < 2) {
         std::cout << "Usage: " << argv[0] << " url {-http1_0}" << std::endl;
         return 1;

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -10,6 +10,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -43,6 +43,9 @@ static const EasyAccess easyAccess[] = {
 
 int main(int argc, char **argv)
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -19,6 +19,8 @@
 // Main
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
 
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -24,6 +24,9 @@ void print(const std::string& file);
 int main(int argc, char* const argv[])
 {
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -152,6 +152,9 @@ std::string formatXML(Exiv2::ExifData& exifData)
 ///////////////////////////////////////////////////////////////////////
 int main(int argc,const char* argv[])
 {
+	Exiv2::XmpParser::initialize();
+	::atexit(Exiv2::XmpParser::terminate);
+
 	format_t formats;
 	formats["wolf"] = wolf;
 	formats["csv" ] = csv ;

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -29,6 +29,9 @@
 
 int _tmain(int argc, _tchar* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     const _tchar* prog = argv[0];
     const _tchar* file = argv[1];
 

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -11,6 +11,9 @@
 
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 3) {
         std::cerr << "Usage: " << argv[0] << " file key\n";
         return 1;

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -268,6 +268,9 @@ void fileSystemPush(const char* path,Jzon::Node& nfs)
 
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     try {
         if (argc < 2 || argc > 3) {
             std::cout << "Usage: " << argv[0] << " [-option] file"       << std::endl;

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -764,6 +764,9 @@ bool mySort(const std::string& a, const std::string& b)
 
 int main(int argc,const char* argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     int result=0;
     const char* program = argv[0];
 

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -83,6 +83,9 @@ public:
 
 int main(int argc, char** const argv)
 {
+	Exiv2::XmpParser::initialize();
+	::atexit(Exiv2::XmpParser::terminate);
+
 	int n;
 
 #ifdef EXV_HAVE_UNISTD_H

--- a/samples/httptest.cpp
+++ b/samples/httptest.cpp
@@ -20,6 +20,9 @@ static int testSyntax(const char* arg)
 
 int main(int argc,const char** argv)
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if ( argc < 2 ) {
         std::cout << "usage  : " << argv[0] << " [key value]+" << std::endl;
         std::cout << "example: " << argv[0] << " [[-url] url | -server clanmills.com -page /LargsPanorama.jpg] -header \"Range: bytes=0-200\"" << std::endl;

--- a/samples/ini-test.cpp
+++ b/samples/ini-test.cpp
@@ -9,14 +9,15 @@ Config loaded from : 'initest.ini' version=6, name=Bob Smith, email=bob@smith.co
 
 // Example that shows simple usage of the INIReader class
 
-#include <iostream>
+#include <exiv2/exiv2.hpp>
 
-// #include <exiv2/exiv2.h>
-#include "config.h"
-#include "ini.hpp"
+#include <iostream>
 
 int main()
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     int              result = 0 ;
     const char*      ini    = "ini-test.ini";
     Exiv2::INIReader reader(ini);

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -46,7 +46,10 @@ int WriteReadSeek(BasicIo &io);
 // Main
 int main(int argc, char* const argv[])
 {
-try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
+    try {
     if (argc != 4) {
         std::cout << "Usage: " << argv[0] << " filein fileout1 fileout2\n";
         std::cout << "fileouts are overwritten and should match filein exactly\n";

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -10,6 +10,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -11,6 +11,9 @@
 int main(int argc, char* const argv[])
 try {
 
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -26,6 +26,9 @@ void processModify(const std::string& line, int num, IptcData &iptcData);
 // Main
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     try {
 
         if (argc != 2) {

--- a/samples/key-test.cpp
+++ b/samples/key-test.cpp
@@ -19,6 +19,9 @@ using namespace Exiv2;
 
 int main()
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     int tc = 0;
     int rc = 0;
 

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -8,6 +8,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 3) {
         std::cout << "Usage: " << argv[0] << " image datafile\n";
         return 1;

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -40,6 +40,9 @@
 int main(int argc, char* const argv[])
 {
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     // Handle command line arguments
     Params params;
     if (params.getopt(argc, argv)) {

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -11,6 +11,9 @@ using namespace Exiv2;
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -11,6 +11,9 @@
 
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     try {
         if (argc != 2) {
             std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/mt-test.cpp
+++ b/samples/mt-test.cpp
@@ -62,6 +62,9 @@ void reportExifMetadataCount(int n,const char* argv[])
 
 int main(int argc,const char* argv[])
 {
+	Exiv2::XmpParser::initialize();
+	::atexit(Exiv2::XmpParser::terminate);
+
 	int result = 0;
 
 	if ( argc < 2 ) {

--- a/samples/path-test.cpp
+++ b/samples/path-test.cpp
@@ -12,6 +12,9 @@
 
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -10,6 +10,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -12,6 +12,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc < 2) {
         std::cout << "Usage: " << argv[0] << " file {--nocurl | --curl}\n\n";
         return 1;

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -40,6 +40,9 @@ const char* testcases[] = {
 
 int main()
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     std::cout << std::setfill(' ');
 
     std::cout << std::setw(12) << std::left << "string";

--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -18,6 +18,9 @@ using namespace Exiv2;
 
 int main(int argc, char* argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     int rc = EXIT_SUCCESS;
     std::ostringstream out;
     try {

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -19,6 +19,9 @@ void mini9(const char* path);
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/tiffaddpath-test.cpp
+++ b/samples/tiffaddpath-test.cpp
@@ -64,6 +64,9 @@ std::string tiffTagName(uint32_t tag)
 // Main program
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 3) {
         std::cout << "Usage: " << argv[0] << " tag group\n"
                   << "Print the TIFF path for a tag and group (decimal numbers)\n";

--- a/samples/toexv.cpp
+++ b/samples/toexv.cpp
@@ -45,7 +45,10 @@ static size_t exifMetadataCount(Exiv2::Image::AutoPtr& image)
 // Main
 int main(int argc, char* const argv[])
 {
-	try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
+    try {
 		// Handle command line arguments
 		Params params(":iecCahsx");
 		if (params.getopt(argc, argv)) return params.usage();

--- a/samples/werror-test.cpp
+++ b/samples/werror-test.cpp
@@ -8,6 +8,9 @@
 
 int main()
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     try {
         throw Exiv2::Error(Exiv2::kerGeneralError, "ARG1", "ARG2", "ARG3");
     }

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -39,7 +39,10 @@ void exifPrint(const ExifData& exifData);
 // Main
 int main(int argc, char* const argv[])
 {
-try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
+    try {
 
     if (argc != 3) {
         std::cout << "Usage: write-test file case\n\n"

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -23,7 +23,10 @@ void print(const std::string& file);
 // Main
 int main(int argc, char* const argv[])
 {
-try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
+    try {
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -11,6 +11,9 @@
 
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     try {
         if (argc != 2) {
             std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -10,6 +10,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -10,6 +10,9 @@
 
 int main(int argc, char* const argv[])
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " file\n";
         return 1;

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -16,7 +16,10 @@
 
 int main(int argc, char** argv)
 {
-try 
+  Exiv2::XmpParser::initialize();
+  ::atexit(Exiv2::XmpParser::terminate);
+
+  try
   {
     if (argc != 2) 
       {

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -19,6 +19,9 @@ bool isEqual(float a, float b)
 
 int main()
 try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
     // The XMP property container
     Exiv2::XmpData xmpData;
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -127,6 +127,9 @@ namespace {
 // Main
 int main(int argc, char* const argv[])
 {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
+
 #ifdef EXV_ENABLE_NLS
     setlocale(LC_ALL, "");
     const std::string localeDir = Exiv2::getProcessPath() + EXV_LOCALEDIR;


### PR DESCRIPTION
XMPsdk is leaking when not terminated.  XMPsdk is "automagically" initialised by the function readMetadata(), however it's not terminated.  I've made this explicit in the exiv2 command-line application and all our sample programs.

I've also added sections to README.md concerning thread-safety and library initialisation/cleanup.