### PR TITLE
Bump ci containers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,12 +33,12 @@ stages:
   - deploy
 
 Fedora:
-  image: fedora:29
+  image: fedora:latest
   <<: *default_config
   <<: *distro_build
 
 Fedora_MinGW:
-  image: fedora:29
+  image: fedora:latest
   before_script:
     - dnf -y upgrade
     - dnf -y install mingw64-gcc-c++ mingw64-filesystem mingw64-expat mingw64-zlib cmake make
@@ -71,12 +71,12 @@ OpenSUSE:
   <<: *distro_build
 
 Alpine:
-  image: alpine:3.9
+  image: alpine:latest
   <<: *default_config
   <<: *distro_build
 
 Install:
-  image: fedora:29
+  image: fedora:latest
   stage: deploy
   <<: *default_config
   script:
@@ -88,7 +88,7 @@ Install:
     - EXIV2_BINDIR=/usr/bin/ make tests
 
 pages:
-  image: fedora:29
+  image: fedora:latest
   stage: deploy
   <<: *default_config
   script:

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -50,7 +50,7 @@ case "$distro_id" in
         curl https://copr.fedorainfracloud.org/coprs/defolos/devel/repo/epel-7/defolos-devel-epel-7.repo > /etc/yum.repos.d/_copr_defolos-devel.repo
         yum clean all
         yum -y install devtoolset-3-gcc-c++ devtoolset-3-gcc-c++ devtoolset-3-binutils clang cmake3 make ccache \
-            expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which python36 dos2unix
+            expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which python3 dos2unix
         echo source /opt/rh/devtoolset-3/enable >> ~/.bash_profile
         echo export CCACHE_PATH=$HOME/bin:$PATH >> ~/.bash_profile
         mkdir ~/bin
@@ -63,13 +63,7 @@ EOF
 /usr/bin/clang --gcc-toolchain=/opt/rh/devtoolset-3/root/ \$@
 EOF
         chmod +x ~/bin/clang*
-        # symlink up to date versions of python & cmake to 'default' names
-        if [ ! -e /usr/bin/python3 ]; then
-            ln -s /usr/bin/python36 /usr/bin/python3
-        elif [ -L /usr/bin/python3 ]; then
-            rm /usr/bin/python3
-            ln -s /usr/bin/python36 /usr/bin/python3
-        fi
+        # symlink up to date version of cmake to the 'default' name
         mv /bin/cmake /bin/.cmake.old
         ln -s /bin/cmake3 /bin/cmake
         ;;

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -24,7 +24,7 @@ distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
 
 case "$distro_id" in
     'fedora')
-        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which dos2unix
+        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which dos2unix glibc-langpack-en
         ;;
 
     'debian')

--- a/contrib/vms/Vagrantfile
+++ b/contrib/vms/Vagrantfile
@@ -3,12 +3,12 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.define "Fedora" do |fedora|
-    fedora.vm.box = "fedora/29-cloud-base"
+    fedora.vm.box = "fedora/30-cloud-base"
     fedora.vm.hostname = "fedora-exiv2"
   end
 
   config.vm.define "Debian" do |debian|
-    debian.vm.box = "generic/debian9"
+    debian.vm.box = "generic/debian10"
     debian.vm.hostname = "debian-exiv2"
   end
 
@@ -27,8 +27,8 @@ Vagrant.configure("2") do |config|
     centos.vm.hostname = "centos-exiv2"
   end
 
-  config.vm.define "OpenSUSE" do |opensuse|
-    opensuse.vm.box = "opensuse/openSUSE-Tumbleweed-x86_64"
+  config.vm.define "openSUSE" do |opensuse|
+    opensuse.vm.box = "opensuse/openSUSE-Tumbleweed-Vagrant.x86_64"
     opensuse.vm.hostname = "opensuse-exiv2"
   end
 


### PR DESCRIPTION
This should fix the build failures on CentOS that appeared today. Also, I bumped the version of the GitLab CI containers to use the `latest` tag where applicable.