### PR TITLE
Fix a memory leak in CiffHeader::read()

### DIFF
--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -212,7 +212,7 @@ namespace Exiv2 {
             throw Error(kerNotACrwImage);
         }
 
-        delete pPadding_;
+        delete[] pPadding_;
         pPadding_ = new byte[offset_ - 14];
         padded_ = offset_ - 14;
         std::memcpy(pPadding_, pData + 14, padded_);


### PR DESCRIPTION
Memory for `pPadding_` was allocated with `new[]` .