### PR TITLE
[ci] Install diffutils in the Fedora container

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -24,7 +24,7 @@ distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
 
 case "$distro_id" in
     'fedora')
-        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which dos2unix glibc-langpack-en
+        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel gmock-devel which dos2unix glibc-langpack-en diffutils
         ;;
 
     'debian')


### PR DESCRIPTION
diff got removed from the base image but it required for the tests to run