### PR TITLE
Add missing library link on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,12 +182,12 @@ if (NOT MSVC)
     endif()
 
     if (CYGWIN OR MINGW OR MSYS)
-        target_link_libraries( exiv2lib PRIVATE psapi ws2_32 )
+        target_link_libraries( exiv2lib PRIVATE psapi ws2_32 shell32 )
     endif()
 
     target_link_libraries( exiv2lib PRIVATE Threads::Threads)
 else()
-    target_link_libraries( exiv2lib PRIVATE psapi ws2_32 )
+    target_link_libraries( exiv2lib PRIVATE psapi ws2_32 shell32 )
 endif()
 
 if( EXIV2_ENABLE_PNG )


### PR DESCRIPTION
https://github.com/Exiv2/exiv2/blob/a37293d35093563591dd0a5d8c5f539ebfcdfde6/src/makernote_int.cpp#L100
https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpatha