### PR TITLE
Test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ project(exiv2
 include(cmake/mainSetup.cmake  REQUIRED)
 include(CTest)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-include (gcovr)
+include(cmake/gcovr.cmake REQUIRED)
 
 # options and their default values
 option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"                    ON  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(exiv2
 include(cmake/mainSetup.cmake  REQUIRED)
 include(CTest)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include (gcovr)
+
 # options and their default values
 option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"                    ON  )
 option( EXIV2_ENABLE_XMP              "Build with XMP metadata support"                       ON  )

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -1,0 +1,16 @@
+if(USE_GCOV)
+ 
+    SET(GCOVR gcovr)
+ 
+    SET(GCC_COVERAGE_COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
+    SET(GCC_COVERAGE_LINK_FLAGS "-lgcov")
+    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
+    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}" )               
+ 
+    add_custom_command(OUTPUT _run_gcovr_parser
+    POST_BUILD
+    COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o output.html
+    #COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --branches --exclude-unreachable-branches -e test_*
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    add_custom_target (coverage DEPENDS _run_gcovr_parser)
+endif(USE_GCOV)

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -1,15 +1,15 @@
 if(BUILD_WITH_COVERAGE)
 
     find_program (GCOVR gcovr)
-    if(NOT GCOVR)
-        message(FATAL_ERROR "gcovr not found")
+
+    if(GCOVR)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_output )
+        add_custom_command(OUTPUT _run_gcovr_parser
+            POST_BUILD
+            COMMAND ${GCOVR} --root ${CMAKE_SOURCE_DIR} --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+        add_custom_target (coverage DEPENDS _run_gcovr_parser)
     endif()
              
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_output )
-    add_custom_command(OUTPUT _run_gcovr_parser
-        POST_BUILD
-        COMMAND ${GCOVR} --root ${CMAKE_SOURCE_DIR} --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-    add_custom_target (coverage DEPENDS _run_gcovr_parser)
 endif(BUILD_WITH_COVERAGE)

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -1,16 +1,12 @@
-if(USE_GCOV)
- 
-    SET(GCOVR gcovr)
- 
-    SET(GCC_COVERAGE_COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
-    SET(GCC_COVERAGE_LINK_FLAGS "-lgcov")
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
-    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}" )
+if(BUILD_WITH_COVERAGE)
+
+    find_program (GCOVR gcovr)
              
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_output )
     add_custom_command(OUTPUT _run_gcovr_parser
-    POST_BUILD
-    COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+        POST_BUILD
+        COMMAND ${GCOVR} --root ${CMAKE_SOURCE_DIR} --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
     add_custom_target (coverage DEPENDS _run_gcovr_parser)
-endif(USE_GCOV)
+endif(BUILD_WITH_COVERAGE)

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -1,6 +1,9 @@
 if(BUILD_WITH_COVERAGE)
 
     find_program (GCOVR gcovr)
+    if(NOT GCOVR)
+        message(FATAL_ERROR "gcovr not found")
+    endif()
              
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_output )
     add_custom_command(OUTPUT _run_gcovr_parser

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -5,12 +5,12 @@ if(USE_GCOV)
     SET(GCC_COVERAGE_COMPILE_FLAGS "-fprofile-arcs -ftest-coverage")
     SET(GCC_COVERAGE_LINK_FLAGS "-lgcov")
     SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
-    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}" )               
- 
+    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}" )
+             
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/coverage_output )
     add_custom_command(OUTPUT _run_gcovr_parser
     POST_BUILD
-    COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o output.html
-    #COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --branches --exclude-unreachable-branches -e test_*
+    COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR}/src --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     add_custom_target (coverage DEPENDS _run_gcovr_parser)
 endif(USE_GCOV)


### PR DESCRIPTION
Implements creation of local coverage reports using gcovr as stated in #1068 

Example usage:

```
cmake -DBUILD_WITH_COVERAGE=yes ../
make all
make tests
make coverage
```

It will create a directory called coverage_output inside the CMAKE_BINARY_DIR directory, storing the html output from gcovr.