### PR TITLE
A couple fixes for EXIV2_DEBUG_MESSAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Those blocks of code are not compiled unless you define `EXIV2_DEBUG_MESSAGES` b
 ```ShellSession
 $ cd <exiv2dir>
 $ touch src/webpimage.cpp
-$ make CXXFLAGS=-DEXIV2_DEBUG_MESSAGESDEBUG
+$ make CXXFLAGS=-DEXIV2_DEBUG_MESSAGES
 $ bin/exiv2 ...
 -- or --
 $ sudo make install

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -450,7 +450,7 @@ int timeZoneAdjust()
     struct tm local = *localtime(&now) ;
     offset          = local.tm_gmtoff ;
 
-#if EXIV2_DEBUG_MESSAGES
+#ifdef EXIV2_DEBUG_MESSAGES
     struct tm utc = *gmtime(&now);
     printf("utc  :  offset = %6d dst = %d time = %s", 0     ,utc  .tm_isdst, asctime(&utc  ));
     printf("local:  offset = %6d dst = %d time = %s", offset,local.tm_isdst, asctime(&local));

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -351,7 +351,7 @@ namespace Exiv2
 
                         if (bExif || bIptc) {
                             DataBuf parsedBuf = PngChunk::readRawProfile(dataBuf, tEXt);
-#if EXIV2_DEBUG_MESSAGES
+#ifdef EXIV2_DEBUG_MESSAGES
                             std::cerr << Exiv2::Internal::binaryToString(parsedBuf.pData_,
                                                                          parsedBuf.size_ > 50 ? 50 : parsedBuf.size_, 0)
                                       << std::endl;


### PR DESCRIPTION
Hi,

This PR offers a couple small fixes regarding `EXIV2_DEBUG_MESSAGES` (see 1de8e73488371d152a7d1a3cc1c1f810c8e2af54):

* A typo in the readme is corrected.
* Two instances of `#if EXIV2_DEBUG_MESSAGES` in the code are changed to `#ifdef EXIV2_DEBUG_MESSAGES` to match what is done everywhere else.