### PR TITLE
Update Mac operating system name to "macOS"

### DIFF
--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -633,7 +633,7 @@ You must tell CMake to link Adobe's library:
 ```bash
 $ cmake .. -DEXIV2_ENABLE_EXTERNAL_XMP=On # -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Release
 ```
-**MacOS-X** users should use the cmake _**Xcode**_ Generator
+**macOS** users should use the cmake _**Xcode**_ Generator
 
 ```bash
 $ cmake .. -DEXIV2_ENABLE_EXTERNAL_XMP=On -G Xcode

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
     4. [Fuzzing](#4-4)
 5. [Platform Notes](#5)
     1. [Linux](#5-1)
-    2. [MacOS-X](#5-2)
+    2. [macOS](#5-2)
     3. [MinGW](#5-3)
     4. [Cygwin](#5-4)
     5. [Microsoft Visual C++](#5-5)
@@ -105,7 +105,7 @@ $ export PATH="/usr/local/bin:$PATH"
 
 ```ShellSession
 $ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"      # Linux, Cygwin, MinGW/msys2
-$ export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"  # MacOS-X
+$ export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"  # macOS
 ```
 
 
@@ -114,7 +114,7 @@ $ export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"  # MacOS-X
 
 ### 2.2 Build and Install Exiv2 with Visual Studio
 
-We recommend that you use conan to download the Exiv2 external dependencies on Windows (On Linux/OSX you can use or install system packages).
+We recommend that you use conan to download the Exiv2 external dependencies on Windows (On Linux/macOS you can use or install system packages).
 Apart from handling the dependencies, to configure and compile the project is pretty similar to the UNIX like systems.
 See [README-CONAN](README-CONAN.md) for more information
 
@@ -264,7 +264,7 @@ g++ -std=c++11 myprogram.cpp -o myprogram $(pkg-config exiv2 --libs --cflags)
 
 ### 2.8 Localisation
 
-Localisation is supported on a UNIX-like platform:  Linux, MacOS-X, Cygwin and MinGW/msys2.  Localisation is not supported for Visual Studio builds.
+Localisation is supported on a UNIX-like platform:  Linux, macOS, Cygwin and MinGW/msys2.  Localisation is not supported for Visual Studio builds.
 
 To build localisation support, use the CMake option `-DEXIV2_ENABLE_NLS=ON`.  You must install the `gettext` package with your package manager or from source.  The `gettext` package is available from [http://www.gnu.org/software/gettext/](http://www.gnu.org/software/gettext/) and includes the library `libintl` and utilities to build localisation files.  If CMake produces error messages which mention libintl or gettext, you should verify that the package `gettext` has been correctly built and installed.
 
@@ -531,7 +531,7 @@ $ cmake ..
 $ cmake --build .
 ```
 
-2) On MacOS-X
+2) On macOS
 
 Apple provide clang with Xcode.  GCC has not been supported by Apple since 2013.  The _"normal unix build"_ uses Clang.
 
@@ -783,7 +783,7 @@ To build exiv2 on CentOS, please install the following additional packages:
 [TOC](#TOC)
 <div id="5-2">
 
-### 5.2 MacOS-X
+### 5.2 macOS
 
 You will need to install Xcode and the Xcode command-line tools to build on the Mac.
 

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -9,7 +9,7 @@ set(CPACK_SOURCE_IGNORE_FILES $(CPACK_SOURCE_IGNORE_FILES) "/.git/" "/build/" "\
 if ( MSVC )
     set(CPACK_GENERATOR ZIP)  # use .zip - less likely to damage bin/exiv2.dll permissions
 else()
-    set(CPACK_GENERATOR TGZ)  # MinGW/Cygwin/Linux/MacOS-X etc use .tar.gz
+    set(CPACK_GENERATOR TGZ)  # MinGW/Cygwin/Linux/macOS etc. use .tar.gz
 endif()
 
 set (BS "") # Bit Size

--- a/git_guidelines.md
+++ b/git_guidelines.md
@@ -26,7 +26,7 @@
 
 A good commit message would look like this:
 ```
-[travis] Fix mac osx jobs
+[travis] Fix macOS jobs
 
 - Specify concrete ubuntu and mac versions
 - Use latest conan version

--- a/man/man1/exiv2.1
+++ b/man/man1/exiv2.1
@@ -195,7 +195,7 @@ Show the program version and exit.
 When \fB\-V\fP is combined with \fB\-v\fP (Verbose version), build information
 is printed to standard output along with a list of shared libraries which
 have been loaded into memory. Verbose version is supported on Windows
-(MSVC, Cygwin and MinGW builds), MacOSX and Linux and is provided
+(MSVC, Cygwin and MinGW builds), macOS and Linux and is provided
 for test and debugging.
 .TP
 .B \-v

--- a/releasenotes/Darwin/ReadMe.txt
+++ b/releasenotes/Darwin/ReadMe.txt
@@ -1,5 +1,5 @@
-MacOS-X (Darwin) Exiv2 v0.27 Release Bundle
--------------------------------------------
+macOS (Darwin) Exiv2 v0.27 Release Bundle
+-----------------------------------------
 
 Structure of the bundle
 -----------------------

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1863,7 +1863,7 @@ namespace
 #if defined(_MSC_VER) || defined(__MINGW__)
     static CRITICAL_SECTION cs;
 #else
-/* Unix/Linux/Cygwin/MacOSX */
+/* Unix/Linux/Cygwin/macOS */
 #include <pthread.h>
 /* This is the critical section object (statically allocated). */
 #if defined(__APPLE__)

--- a/test/build-test.py
+++ b/test/build-test.py
@@ -81,7 +81,7 @@ def apple(dict):
              # , 'libstdc++.6.dylib' # I suspect this is only with GCC (Xcode4 and earlier)
              ] ;
 
-    # which version of MacOS-X ?
+    # which version of macOS?
     os_major=int(os.uname()[2].split('.')[0])
     os_minor=int(os.uname()[2].split('.')[1])
     NC=13;ML=12;LION=11;SL=10;LEO=9;

--- a/test/functions.source
+++ b/test/functions.source
@@ -420,7 +420,7 @@ copyVideoFiles ()
 checkSum()
 {
     # cygwin checksum: http://esrg.sourceforge.net/utils_win_up/md5sum/
-    # macosx - built/installed coreutils 8.25 http://ftp.gnu.org/gnu/coreutils/
+    # macOS - built/installed coreutils 8.25 http://ftp.gnu.org/gnu/coreutils/
     platform=$(uname)
     if [ "$platform" == 'NetBSD' -o "$platform" == 'FreeBSD' ]; then
       md5 -q $1


### PR DESCRIPTION
The operating system formerly known as "Mac OS X" and subsequently known as "OS X" is now (since 2016) known as "macOS".

I haven't touched the ChangeLog, since that's historical information, but I think this fixes the OS name in all the other files.