### PR TITLE
Fix compilation errors when EXIV2_DEBUG_MESSAGES is defined

### DIFF
--- a/src/RemoteIo.cpp
+++ b/src/RemoteIo.cpp
@@ -29,6 +29,7 @@
 
 #include <cstring>  // std::memcpy
 #include <cassert>      /// \todo check usages of assert and try to cover the negative case with unit tests.
+#include <iostream>
 
 namespace Exiv2
 {

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -352,9 +352,8 @@ namespace Exiv2
                         if (bExif || bIptc) {
                             DataBuf parsedBuf = PngChunk::readRawProfile(dataBuf, tEXt);
 #ifdef EXIV2_DEBUG_MESSAGES
-                            std::cerr << Exiv2::Internal::binaryToString(parsedBuf.pData_,
-                                                                         parsedBuf.size_ > 50 ? 50 : parsedBuf.size_, 0)
-                                      << std::endl;
+                            auto slice = makeSlice(parsedBuf.pData_, 0, parsedBuf.size_ > 50 ? 50 : parsedBuf.size_);
+                            std::cerr << Exiv2::Internal::binaryToString(slice) << std::endl;
 #endif
                             if (parsedBuf.size_) {
                                 if (bExif) {


### PR DESCRIPTION
This PR fixes #1082. 