### PR TITLE
GitHub actions workflow

### DIFF
--- a/.github/workflows/build-test-workflow.yml
+++ b/.github/workflows/build-test-workflow.yml
@@ -1,0 +1,48 @@
+name: Build and Test
+on: [push]
+
+jobs:
+  build:
+    name: Linux build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        id: Build
+      - name: Install dependencies
+        run: sudo ./ci/install_dependencies.sh
+      - name: Build
+        run: python3 ci/test_build.py
+
+  windows:
+    name: Windows build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Conan
+        run: pip.exe install conan
+      - name: Conan
+        run: |
+          md build
+          cd build
+          conan profile list
+          conan install .. --build missing
+      - name: Build
+        run: |
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DEXIV2_ENABLE_NLS=OFF -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_ENABLE_WIN_UNICODE=ON -DCMAKE_INSTALL_PREFIX=install ..
+          cmake --build . --config Release
+      - name: Test
+        env:
+          EXIV2_EXT: .exe
+        run: |
+          cd build
+          cd bin
+          dir
+          ./unit_tests.exe
+          cd ../../tests/
+          python.exe runner.py -v

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -40,7 +40,7 @@ case "$distro_id" in
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libgmock-dev libxml2-utils locales locales-all
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libxml2-utils locales locales-all
         debian_build_gtest
         ;;
 


### PR DESCRIPTION
This GitHub Actions workflow builds and tests on two platforms: ubuntu-18.04 and windows-latest.
I had to modify `install_dependencies.sh` to get it to work on ubuntu-18.04. It seems that `libgmock-dev` wasn't added until ubuntu-18.10, but GitHub Actions doesn't offer 18.10 as a platform. Does anybody know what `libgmock-dev` is used for? The standard build works fine without it, but this PR will help me to find out if it is important for some of the other CI/CD scripts.