### PR TITLE
Fix integer overflow by checking size against header_size

### DIFF
--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -795,8 +795,9 @@ namespace Exiv2 {
         }
     }
 
-    long WebPImage::getHeaderOffset(byte *data, long data_size,
-                                    byte *header, long header_size) {
+    long WebPImage::getHeaderOffset(byte* data, long data_size, byte* header, long header_size)
+    {
+        if (data_size < header_size) { return -1; }
         long pos = -1;
         for (long i=0; i < data_size - header_size; i++) {
             if (memcmp(header, &data[i], header_size) == 0) {


### PR DESCRIPTION
Note that the problem occurs when data_size is less than header_size
what causes a buffer overflow in &data[i]

Fixes CVE-2019-14982

Co-Authored-By: D4N <dan.cermak@cgc-instruments.com>
(cherry picked from commit e925bc5addd881543fa503470c8a859e112cca62)