### PR TITLE
Makernote update

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -384,7 +384,15 @@ namespace Exiv2 {
         { (long int)0x80000401, "EOS 5DS R" },
         { (long int)0x80000404, "EOS Rebel T6 / 1300D / Kiss X80" },
         { (long int)0x80000405, "EOS Rebel T7i / 800D / Kiss X9i" },
-        { (long int)0x80000408, "EOS 77D / 9000D" }
+        { (long int)0x80000406, "EOS 6D Mark II" },
+        { (long int)0x80000408, "EOS 77D / 9000D" },
+        { (long int)0x80000417, "EOS Rebel SL2 / 200D / Kiss X9" },
+        { (long int)0x80000422, "EOS Rebel T100 / 4000D / 3000D" },
+        { (long int)0x80000424, "EOS R" },
+        { (long int)0x80000432, "EOS Rebel T7 / 2000D / 1500D / Kiss X90" },
+        { (long int)0x80000433, "EOS RP" },
+        { (long int)0x80000436, "EOS SL3 / 250D / Kiss X10" },
+        { (long int)0x80000437, "EOS 90D" },
     };
 
     //! SerialNumberFormat, tag 0x0015
@@ -1104,6 +1112,18 @@ namespace Exiv2 {
         { 4160,"Canon EF-S 35mm f/2.8 Macro IS STM"                         },
         {36910,"Canon EF 70-300mm f/4-5.6 IS II USM"                        },
         {36912,"Canon EF-S 18-135mm f/3.5-5.6 IS USM"                       },
+        {61491,"Canon CN-E 14mm T3.1 L F"                                   },
+        {61492,"Canon CN-E 24mm T1.5 L F"                                   },
+        {61494,"Canon CN-E 85mm T1.3 L F"                                   },
+        {61495,"Canon CN-E 135mm T2.2 L F"                                  },
+        {61496,"Canon CN-E 35mm T1.5 L FR"                                  },
+        {61182,"Canon RF 35mm F1.8 Macro IS STM or other Canon RF Lens"     },
+        {61182,"Canon RF 50mm F1.2 L USM"                                   },
+        {61182,"Canon RF 24-105mm F4 L IS USM"                              },
+        {61182,"Canon RF 28-70mm F2 L USM"                                  },
+        {61182,"Canon RF 85mm F1.2L USM"                                    },
+        {61182,"Canon RF 24-240mm F4-6.3 IS USM"                            },
+        {61182,"Canon RF 24-70mm F2.8 L IS USM"                             },
         {65535,"n/a"                                                        }
     };
 
@@ -1166,6 +1186,7 @@ namespace Exiv2 {
         { 747, printCsLensByFocalLength }, // not tested
         { 4143,printCsLensByFocalLength }, // not tested
         { 4154,printCsLensByFocalLength }, // not tested
+        {61182,printCsLensByFocalLength },
        {0xffff,printCsLensFFFF          }
     };
 
@@ -1361,24 +1382,49 @@ namespace Exiv2 {
         { 0x0040, "2 EV"     }
     };
 
+    extern const TagDetails cameraType[] = {
+        {   0, "n/a"           },
+        { 248, "EOS High-end"  },
+        { 250, "Compact"       },
+        { 252, "EOS Mid-range" },
+        { 255, "DV Camera"     },
+    };
+
+    extern const TagDetails autoExposureBracketing[] = {
+        { 65535, "On"          },
+        { 0,     "Off"         },
+        { 1,     "On (shot 1)" },
+        { 2,     "On (shot 2)" },
+        { 3,     "On (shot 3)" },
+    };
+
+	extern const TagDetails slowShutter[] = {
+        { 65535, "n/a"         },
+        { 0,     "Off"         },
+        { 1,     "Night Scene" },
+        { 2,     "On"          },
+        { 3,     "None"        },
+    };
+
+
     // Canon Shot Info Tag
     const TagInfo CanonMakerNote::tagInfoSi_[] = {
-        TagInfo(0x0001, "0x0001", "0x0001", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x0001, "AutoISO", N_("AutoISO"), N_("AutoISO"), canonSiId, makerTags, unsignedShort, 1, printSi0x0001),
         TagInfo(0x0002, "ISOSpeed", N_("ISO Speed Used"), N_("ISO speed used"), canonSiId, makerTags, unsignedShort, 1, printSi0x0002),
         TagInfo(0x0003, "MeasuredEV", N_("Measured EV"), N_("Measured EV"), canonSiId, makerTags, unsignedShort, 1, printSi0x0003),
         TagInfo(0x0004, "TargetAperture", N_("Target Aperture"), N_("Target Aperture"), canonSiId, makerTags, unsignedShort, 1, printSi0x0015),
         TagInfo(0x0005, "TargetShutterSpeed", N_("Target Shutter Speed"), N_("Target shutter speed"), canonSiId, makerTags, unsignedShort, 1, printSi0x0016),
         TagInfo(0x0006, "0x0006", "0x0006", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
         TagInfo(0x0007, "WhiteBalance", N_("White Balance"), N_("White balance setting"), canonSiId, makerTags, unsignedShort, 1, EXV_PRINT_TAG(canonSiWhiteBalance)),
-        TagInfo(0x0008, "0x0008", "0x0008", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x0008, "SlowShutter", N_("Slow Shutter"), N_("Slow shutter"), canonSiId, makerTags, unsignedShort, 1, EXV_PRINT_TAG(slowShutter)),
         TagInfo(0x0009, "Sequence", N_("Sequence"), N_("Sequence number (if in a continuous burst)"), canonSiId, makerTags, unsignedShort, 1, printSi0x0009),
         TagInfo(0x000a, "0x000a", "0x000a", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
         TagInfo(0x000b, "0x000b", "0x000b", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
-        TagInfo(0x000c, "0x000c", "0x000c", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
-        TagInfo(0x000d, "0x000d", "0x000d", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x000c, "CameraTemperature", N_("Camera Temperature"), N_("Camera temperature"), canonSiId, makerTags, signedShort, 1, printSi0x000c),
+        TagInfo(0x000d, "FlashGuideNumber", N_("Flash Guide Number"), N_("Flash guide number"), canonSiId, makerTags, unsignedShort, 1, printSi0x000d),
         TagInfo(0x000e, "AFPointUsed", N_("AF Point Used"), N_("AF point used"), canonSiId, makerTags, unsignedShort, 1, printSi0x000e),
         TagInfo(0x000f, "FlashBias", N_("Flash Bias"), N_("Flash bias"), canonSiId, makerTags, unsignedShort, 1, EXV_PRINT_TAG(canonSiFlashBias)),
-        TagInfo(0x0010, "0x0010", "0x0010", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x0010, "AutoExposureBracketing", N_("Auto Exposure Bracketing"), N_("Auto exposure bracketing"), canonSiId, makerTags, unsignedShort, 1, EXV_PRINT_TAG(autoExposureBracketing)),
         TagInfo(0x0011, "0x0011", "0x0011", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
         TagInfo(0x0012, "0x0012", "0x0012", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
         TagInfo(0x0013, "SubjectDistance", N_("Subject Distance"), N_("Subject distance"), canonSiId, makerTags, unsignedShort, 1, printSi0x0013),
@@ -1386,9 +1432,10 @@ namespace Exiv2 {
         TagInfo(0x0015, "ApertureValue", N_("Aperture Value"), N_("Aperture"), canonSiId, makerTags, unsignedShort, 1, printSi0x0015),
         TagInfo(0x0016, "ShutterSpeedValue", N_("Shutter Speed Value"), N_("Shutter speed"), canonSiId, makerTags, unsignedShort, 1, printSi0x0016),
         TagInfo(0x0017, "MeasuredEV2", N_("Measured EV 2"), N_("Measured EV 2"), canonSiId, makerTags, unsignedShort, 1, printSi0x0017),
-        TagInfo(0x0018, "0x0018", "0x0018", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x0018, "BulbDuration", N_("Bulb Duration"), N_("Bulb duration"), canonSiId, makerTags, unsignedShort, 1, printSi0x0018),
         TagInfo(0x0019, "0x0019", "0x0019", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
-        TagInfo(0x001a, "0x001a", "0x001a", N_("Unknown"), canonSiId, makerTags, unsignedShort, 1, printValue),
+        TagInfo(0x001a, "CameraType", N_("Camera Type"), N_("Camera type"), canonSiId, makerTags, unsignedShort, 1, EXV_PRINT_TAG(cameraType)),
+        TagInfo(0x001b, "AutoRotate", N_("Auto Rotate"), N_("Auto rotate"), canonSiId, makerTags, signedShort, 1, printValue),
         // End of list marker
         TagInfo(0xffff, "(UnknownCanonCsTag)", "(UnknownCanonCsTag)", N_("Unknown Canon Camera Settings 1 tag"), canonCsId, makerTags, unsignedShort, 1, printValue)
     };
@@ -2022,6 +2069,19 @@ namespace Exiv2 {
         return os;
     }
 
+    std::ostream& CanonMakerNote::printSi0x0001(std::ostream& os,
+                                                const Value& value,
+                                                const ExifData*)
+    {
+        std::ios::fmtflags f( os.flags() );
+        if (   value.typeId() == unsignedShort
+            && value.count() > 0) {
+            os << exp(canonEv(value.toLong()) / 32 * log(2.0)) * 100.0;
+        }
+        os.flags(f);
+        return os;
+    }
+
     std::ostream& CanonMakerNote::printSi0x0002(std::ostream& os,
                                                 const Value& value,
                                                 const ExifData*)
@@ -2066,6 +2126,24 @@ namespace Exiv2 {
         os << l << "";
         // Todo: determine unit
         return os;
+    }
+
+    std::ostream& CanonMakerNote::printSi0x000c(std::ostream& os,
+                                                const Value& value,
+                                                const ExifData*)
+    {
+        if (value.toLong() == 0) return os << "--";
+
+        return os << value.toLong() - 128 << " °C";
+    }
+
+    std::ostream& CanonMakerNote::printSi0x000d(std::ostream& os,
+                                                const Value& value,
+                                                const ExifData*)
+    {
+        if (value.toLong() == 65535) return os << "--";
+
+        return os << value.toLong() / 32;
     }
 
     std::ostream& CanonMakerNote::printSi0x000e(std::ostream& os,
@@ -2157,6 +2235,13 @@ namespace Exiv2 {
         return os;
     }
 
+    std::ostream& CanonMakerNote::printSi0x0018(std::ostream& os,
+                                                const Value& value,
+                                                const ExifData*)
+    {
+        return os << value.toLong() / 10;
+    }
+
     std::ostream& CanonMakerNote::printFiFocusDistance(std::ostream& os,
                                                        const Value& value,
                                                        const ExifData*)
@@ -2170,7 +2255,7 @@ namespace Exiv2 {
       os << std::fixed << std::setprecision(2);
 
       long l = value.toLong();
-      if (l == 0xffff) {
+      if (l == -1) {
         os << "Infinite";
       }
       else {

--- a/src/canonmn_int.hpp
+++ b/src/canonmn_int.hpp
@@ -89,12 +89,18 @@ namespace Exiv2 {
         static std::ostream& printCsLensType(std::ostream& os, const Value& value, const ExifData* metadata);
         //! Camera lens information
         static std::ostream& printCsLens(std::ostream& os, const Value& value, const ExifData*);
+        //! AutoISO speed used
+        static std::ostream& printSi0x0001(std::ostream& os, const Value& value, const ExifData*);
         //! ISO speed used
         static std::ostream& printSi0x0002(std::ostream& os, const Value& value, const ExifData*);
         //! MeasuredEV
         static std::ostream& printSi0x0003(std::ostream& os, const Value& value, const ExifData*);
         //! Sequence number
         static std::ostream& printSi0x0009(std::ostream& os, const Value& value, const ExifData*);
+        //! Ambient Temperature
+        static std::ostream& printSi0x000c(std::ostream& os, const Value& value, const ExifData*);
+        //! Flash Guide Number
+        static std::ostream& printSi0x000d(std::ostream& os, const Value& value, const ExifData*);
         //! AF point used
         static std::ostream& printSi0x000e(std::ostream& os, const Value& value, const ExifData* pExifData);
         //! Subject distance
@@ -105,6 +111,8 @@ namespace Exiv2 {
         static std::ostream& printSi0x0016(std::ostream& os, const Value& value, const ExifData*);
         //! MeasuredEV2
         static std::ostream& printSi0x0017(std::ostream& os, const Value& value, const ExifData*);
+        //! Bulb Duration
+        static std::ostream& printSi0x0018(std::ostream& os, const Value& value, const ExifData*);
         //! Focus Distance
         static std::ostream& printFiFocusDistance(std::ostream& os, const Value& value, const ExifData*);
         //@}

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -885,7 +885,8 @@ namespace Exiv2 {
         { 3, N_("On (39-point)")      },
         { 4, N_("On (73-point)")      },
         { 5, N_("On (73-point, new)") },
-        { 6, N_("On (105-point)")     }
+        { 6, N_("On (105-point)")     },
+        { 7, N_("On (153-point)")     },
     };
 
     // Nikon3 Auto Focus Tag Info

--- a/src/panasonicmn_int.cpp
+++ b/src/panasonicmn_int.cpp
@@ -556,6 +556,8 @@ namespace Exiv2 {
         if      (l0 ==   0 && l1 ==  1) os << _("Spot mode on or 9 area");
         else if (l0 ==   0 && l1 == 16) os << _("Spot mode off or 3-area (high speed)");
         else if (l0 ==   0 && l1 == 23) os << _("23-area");
+        else if (l0 ==   0 && l1 == 49) os << _("49-area");
+        else if (l0 ==   0 && l1 ==225) os << _("225-area");
         else if (l0 ==   1 && l1 ==  0) os << _("Spot focussing");
         else if (l0 ==   1 && l1 ==  1) os << _("5-area");
         else if (l0 ==  16 && l1 ==  0) os << _("1-area");
@@ -566,6 +568,7 @@ namespace Exiv2 {
         else if (l0 ==  32 && l1 ==  3) os << _("3-area (right)");
         else if (l0 ==  64 && l1 ==  0) os << _("Face Detect");
         else if (l0 == 128 && l1 ==  0) os << _("Spot Focusing 2");
+        else if (l0 == 240 && l1 ==  0) os << _("Tracking");
         else os << value;
         return os;
     } // PanasonicMakerNote::print0x000f

--- a/test/data/exifdata-test.out
+++ b/test/data/exifdata-test.out
@@ -233,22 +233,22 @@ Exif.CanonCs.SpotMeteringMode                 0x0027 Makernote    Short       1 
 Exif.Canon.FocalLength                        0x0002 Makernote    Short       4 2 682 286 215
 Exif.Canon.0x0003                             0x0003 Makernote    Short       4 0 0 0 0
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 54
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 160
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 276
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 149
 Exif.CanonSi.TargetShutterSpeed               0x0005 Makernote    Short       1 287
 Exif.CanonSi.0x0006                           0x0006 Makernote    Short       1 0
 Exif.CanonSi.WhiteBalance                     0x0007 Makernote    Short       1 0
-Exif.CanonSi.0x0008                           0x0008 Makernote    Short       1 0
+Exif.CanonSi.SlowShutter                      0x0008 Makernote    Short       1 0
 Exif.CanonSi.Sequence                         0x0009 Makernote    Short       1 0
 Exif.CanonSi.0x000a                           0x000a Makernote    Short       1 6
 Exif.CanonSi.0x000b                           0x000b Makernote    Short       1 0
-Exif.CanonSi.0x000c                           0x000c Makernote    Short       1 0
-Exif.CanonSi.0x000d                           0x000d Makernote    Short       1 0
+Exif.CanonSi.CameraTemperature                0x000c Makernote    Short       1 0
+Exif.CanonSi.FlashGuideNumber                 0x000d Makernote    Short       1 0
 Exif.CanonSi.AFPointUsed                      0x000e Makernote    Short       1 12290
 Exif.CanonSi.FlashBias                        0x000f Makernote    Short       1 0
-Exif.CanonSi.0x0010                           0x0010 Makernote    Short       1 0
+Exif.CanonSi.AutoExposureBracketing           0x0010 Makernote    Short       1 0
 Exif.CanonSi.0x0011                           0x0011 Makernote    Short       1 0
 Exif.CanonSi.0x0012                           0x0012 Makernote    Short       1 1
 Exif.CanonSi.SubjectDistance                  0x0013 Makernote    Short       1 782
@@ -256,9 +256,9 @@ Exif.CanonSi.0x0014                           0x0014 Makernote    Short       1 
 Exif.CanonSi.ApertureValue                    0x0015 Makernote    Short       1 149
 Exif.CanonSi.ShutterSpeedValue                0x0016 Makernote    Short       1 289
 Exif.CanonSi.MeasuredEV2                      0x0017 Makernote    Short       1 0
-Exif.CanonSi.0x0018                           0x0018 Makernote    Short       1 0
+Exif.CanonSi.BulbDuration                     0x0018 Makernote    Short       1 0
 Exif.CanonSi.0x0019                           0x0019 Makernote    Short       1 0
-Exif.CanonSi.0x001a                           0x001a Makernote    Short       1 250
+Exif.CanonSi.CameraType                       0x001a Makernote    Short       1 250
 Exif.Canon.0x0000                             0x0000 Makernote    Short       6 0 0 0 0 0 0
 Exif.Canon.0x0000                             0x0000 Makernote    Short       4 0 0 0 0
 Exif.Canon.ImageType                          0x0006 Makernote    Ascii      32 IMG:PowerShot S40 JPEG
@@ -362,22 +362,22 @@ Exif.CanonCs.SpotMeteringMode                 0x0027 Makernote    Short       1 
 Exif.Canon.FocalLength                        0x0002 Makernote    Short       4 2 682 286 215
 Exif.Canon.0x0003                             0x0003 Makernote    Short       4 0 0 0 0
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 54
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 160
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 276
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 149
 Exif.CanonSi.TargetShutterSpeed               0x0005 Makernote    Short       1 287
 Exif.CanonSi.0x0006                           0x0006 Makernote    Short       1 0
 Exif.CanonSi.WhiteBalance                     0x0007 Makernote    Short       1 0
-Exif.CanonSi.0x0008                           0x0008 Makernote    Short       1 0
+Exif.CanonSi.SlowShutter                      0x0008 Makernote    Short       1 0
 Exif.CanonSi.Sequence                         0x0009 Makernote    Short       1 0
 Exif.CanonSi.0x000a                           0x000a Makernote    Short       1 6
 Exif.CanonSi.0x000b                           0x000b Makernote    Short       1 0
-Exif.CanonSi.0x000c                           0x000c Makernote    Short       1 0
-Exif.CanonSi.0x000d                           0x000d Makernote    Short       1 0
+Exif.CanonSi.CameraTemperature                0x000c Makernote    Short       1 0
+Exif.CanonSi.FlashGuideNumber                 0x000d Makernote    Short       1 0
 Exif.CanonSi.AFPointUsed                      0x000e Makernote    Short       1 12290
 Exif.CanonSi.FlashBias                        0x000f Makernote    Short       1 0
-Exif.CanonSi.0x0010                           0x0010 Makernote    Short       1 0
+Exif.CanonSi.AutoExposureBracketing           0x0010 Makernote    Short       1 0
 Exif.CanonSi.0x0011                           0x0011 Makernote    Short       1 0
 Exif.CanonSi.0x0012                           0x0012 Makernote    Short       1 1
 Exif.CanonSi.SubjectDistance                  0x0013 Makernote    Short       1 782
@@ -385,9 +385,9 @@ Exif.CanonSi.0x0014                           0x0014 Makernote    Short       1 
 Exif.CanonSi.ApertureValue                    0x0015 Makernote    Short       1 149
 Exif.CanonSi.ShutterSpeedValue                0x0016 Makernote    Short       1 289
 Exif.CanonSi.MeasuredEV2                      0x0017 Makernote    Short       1 0
-Exif.CanonSi.0x0018                           0x0018 Makernote    Short       1 0
+Exif.CanonSi.BulbDuration                     0x0018 Makernote    Short       1 0
 Exif.CanonSi.0x0019                           0x0019 Makernote    Short       1 0
-Exif.CanonSi.0x001a                           0x001a Makernote    Short       1 250
+Exif.CanonSi.CameraType                       0x001a Makernote    Short       1 250
 Exif.Canon.0x0000                             0x0000 Makernote    Short       6 0 0 0 0 0 0
 Exif.Canon.0x0000                             0x0000 Makernote    Short       4 0 0 0 0
 Exif.Canon.ImageType                          0x0006 Makernote    Ascii      32 IMG:PowerShot S40 JPEG
@@ -492,22 +492,22 @@ Exif.CanonCs.SpotMeteringMode                 0x0027 Makernote    Short       1 
 Exif.Canon.FocalLength                        0x0002 Makernote    Short       4 2 682 286 215
 Exif.Canon.0x0003                             0x0003 Makernote    Short       4 0 0 0 0
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 54
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 160
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 276
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 149
 Exif.CanonSi.TargetShutterSpeed               0x0005 Makernote    Short       1 287
 Exif.CanonSi.0x0006                           0x0006 Makernote    Short       1 0
 Exif.CanonSi.WhiteBalance                     0x0007 Makernote    Short       1 0
-Exif.CanonSi.0x0008                           0x0008 Makernote    Short       1 0
+Exif.CanonSi.SlowShutter                      0x0008 Makernote    Short       1 0
 Exif.CanonSi.Sequence                         0x0009 Makernote    Short       1 0
 Exif.CanonSi.0x000a                           0x000a Makernote    Short       1 6
 Exif.CanonSi.0x000b                           0x000b Makernote    Short       1 0
-Exif.CanonSi.0x000c                           0x000c Makernote    Short       1 0
-Exif.CanonSi.0x000d                           0x000d Makernote    Short       1 0
+Exif.CanonSi.CameraTemperature                0x000c Makernote    Short       1 0
+Exif.CanonSi.FlashGuideNumber                 0x000d Makernote    Short       1 0
 Exif.CanonSi.AFPointUsed                      0x000e Makernote    Short       1 12290
 Exif.CanonSi.FlashBias                        0x000f Makernote    Short       1 0
-Exif.CanonSi.0x0010                           0x0010 Makernote    Short       1 0
+Exif.CanonSi.AutoExposureBracketing           0x0010 Makernote    Short       1 0
 Exif.CanonSi.0x0011                           0x0011 Makernote    Short       1 0
 Exif.CanonSi.0x0012                           0x0012 Makernote    Short       1 1
 Exif.CanonSi.SubjectDistance                  0x0013 Makernote    Short       1 782
@@ -515,9 +515,9 @@ Exif.CanonSi.0x0014                           0x0014 Makernote    Short       1 
 Exif.CanonSi.ApertureValue                    0x0015 Makernote    Short       1 149
 Exif.CanonSi.ShutterSpeedValue                0x0016 Makernote    Short       1 289
 Exif.CanonSi.MeasuredEV2                      0x0017 Makernote    Short       1 0
-Exif.CanonSi.0x0018                           0x0018 Makernote    Short       1 0
+Exif.CanonSi.BulbDuration                     0x0018 Makernote    Short       1 0
 Exif.CanonSi.0x0019                           0x0019 Makernote    Short       1 0
-Exif.CanonSi.0x001a                           0x001a Makernote    Short       1 250
+Exif.CanonSi.CameraType                       0x001a Makernote    Short       1 250
 Exif.Canon.0x0000                             0x0000 Makernote    Short       6 0 0 0 0 0 0
 Exif.Canon.0x0000                             0x0000 Makernote    Short       4 0 0 0 0
 Exif.Canon.ImageType                          0x0006 Makernote    Ascii      32 IMG:PowerShot S40 JPEG
@@ -622,22 +622,22 @@ Exif.CanonCs.SpotMeteringMode                 0x0027 Makernote    Short       1 
 Exif.Canon.FocalLength                        0x0002 Makernote    Short       4 2 682 286 215
 Exif.Canon.0x0003                             0x0003 Makernote    Short       4 0 0 0 0
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 54
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 160
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 276
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 149
 Exif.CanonSi.TargetShutterSpeed               0x0005 Makernote    Short       1 287
 Exif.CanonSi.0x0006                           0x0006 Makernote    Short       1 0
 Exif.CanonSi.WhiteBalance                     0x0007 Makernote    Short       1 0
-Exif.CanonSi.0x0008                           0x0008 Makernote    Short       1 0
+Exif.CanonSi.SlowShutter                      0x0008 Makernote    Short       1 0
 Exif.CanonSi.Sequence                         0x0009 Makernote    Short       1 0
 Exif.CanonSi.0x000a                           0x000a Makernote    Short       1 6
 Exif.CanonSi.0x000b                           0x000b Makernote    Short       1 0
-Exif.CanonSi.0x000c                           0x000c Makernote    Short       1 0
-Exif.CanonSi.0x000d                           0x000d Makernote    Short       1 0
+Exif.CanonSi.CameraTemperature                0x000c Makernote    Short       1 0
+Exif.CanonSi.FlashGuideNumber                 0x000d Makernote    Short       1 0
 Exif.CanonSi.AFPointUsed                      0x000e Makernote    Short       1 12290
 Exif.CanonSi.FlashBias                        0x000f Makernote    Short       1 0
-Exif.CanonSi.0x0010                           0x0010 Makernote    Short       1 0
+Exif.CanonSi.AutoExposureBracketing           0x0010 Makernote    Short       1 0
 Exif.CanonSi.0x0011                           0x0011 Makernote    Short       1 0
 Exif.CanonSi.0x0012                           0x0012 Makernote    Short       1 1
 Exif.CanonSi.SubjectDistance                  0x0013 Makernote    Short       1 782
@@ -645,9 +645,9 @@ Exif.CanonSi.0x0014                           0x0014 Makernote    Short       1 
 Exif.CanonSi.ApertureValue                    0x0015 Makernote    Short       1 149
 Exif.CanonSi.ShutterSpeedValue                0x0016 Makernote    Short       1 289
 Exif.CanonSi.MeasuredEV2                      0x0017 Makernote    Short       1 0
-Exif.CanonSi.0x0018                           0x0018 Makernote    Short       1 0
+Exif.CanonSi.BulbDuration                     0x0018 Makernote    Short       1 0
 Exif.CanonSi.0x0019                           0x0019 Makernote    Short       1 0
-Exif.CanonSi.0x001a                           0x001a Makernote    Short       1 250
+Exif.CanonSi.CameraType                       0x001a Makernote    Short       1 250
 Exif.Canon.0x0000                             0x0000 Makernote    Short       6 0 0 0 0 0 0
 Exif.Canon.0x0000                             0x0000 Makernote    Short       4 0 0 0 0
 Exif.Canon.ImageType                          0x0006 Makernote    Ascii      32 IMG:PowerShot S40 JPEG

--- a/test/data/exiv2-test.out
+++ b/test/data/exiv2-test.out
@@ -676,22 +676,22 @@ File  2/15: 20031214_000043.jpg
 20031214_000043.jpg   Exif.Canon.FocalLength                       Short       4  21.3 mm
 20031214_000043.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 20031214_000043.jpg   Exif.CanonSi.0x0000                          Short       1  54
-20031214_000043.jpg   Exif.CanonSi.0x0001                          Short       1  0
+20031214_000043.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 20031214_000043.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 20031214_000043.jpg   Exif.CanonSi.MeasuredEV                      Short       1  13.63
 20031214_000043.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5
 20031214_000043.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 20031214_000043.jpg   Exif.CanonSi.0x0006                          Short       1  0
 20031214_000043.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-20031214_000043.jpg   Exif.CanonSi.0x0008                          Short       1  0
+20031214_000043.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 20031214_000043.jpg   Exif.CanonSi.Sequence                        Short       1  0
 20031214_000043.jpg   Exif.CanonSi.0x000a                          Short       1  6
 20031214_000043.jpg   Exif.CanonSi.0x000b                          Short       1  0
-20031214_000043.jpg   Exif.CanonSi.0x000c                          Short       1  0
-20031214_000043.jpg   Exif.CanonSi.0x000d                          Short       1  0
+20031214_000043.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+20031214_000043.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 20031214_000043.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 20031214_000043.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-20031214_000043.jpg   Exif.CanonSi.0x0010                          Short       1  0
+20031214_000043.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 20031214_000043.jpg   Exif.CanonSi.0x0011                          Short       1  0
 20031214_000043.jpg   Exif.CanonSi.0x0012                          Short       1  1
 20031214_000043.jpg   Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -699,9 +699,9 @@ File  2/15: 20031214_000043.jpg
 20031214_000043.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5
 20031214_000043.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 20031214_000043.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-20031214_000043.jpg   Exif.CanonSi.0x0018                          Short       1  0
+20031214_000043.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 20031214_000043.jpg   Exif.CanonSi.0x0019                          Short       1  0
-20031214_000043.jpg   Exif.CanonSi.0x001a                          Short       1  250
+20031214_000043.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
 20031214_000043.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 20031214_000043.jpg   Exif.Canon.0x0000                            Short       4  0 0 0 0
 20031214_000043.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
@@ -1100,22 +1100,22 @@ File  6/15: 20030925_201850.jpg
 20030925_201850.jpg   Exif.Canon.FocalLength                       Short       4  18.0 mm
 20030925_201850.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 20030925_201850.jpg   Exif.CanonSi.0x0000                          Short       1  66
-20030925_201850.jpg   Exif.CanonSi.0x0001                          Short       1  0
+20030925_201850.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 20030925_201850.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 20030925_201850.jpg   Exif.CanonSi.MeasuredEV                      Short       1  11.25
 20030925_201850.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 20030925_201850.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/79 s
 20030925_201850.jpg   Exif.CanonSi.0x0006                          Short       1  0
 20030925_201850.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-20030925_201850.jpg   Exif.CanonSi.0x0008                          Short       1  3
+20030925_201850.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 20030925_201850.jpg   Exif.CanonSi.Sequence                        Short       1  0
 20030925_201850.jpg   Exif.CanonSi.0x000a                          Short       1  8
 20030925_201850.jpg   Exif.CanonSi.0x000b                          Short       1  8
-20030925_201850.jpg   Exif.CanonSi.0x000c                          Short       1  0
-20030925_201850.jpg   Exif.CanonSi.0x000d                          Short       1  0
+20030925_201850.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+20030925_201850.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 20030925_201850.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 20030925_201850.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-20030925_201850.jpg   Exif.CanonSi.0x0010                          Short       1  0
+20030925_201850.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 20030925_201850.jpg   Exif.CanonSi.0x0011                          Short       1  0
 20030925_201850.jpg   Exif.CanonSi.0x0012                          Short       1  1
 20030925_201850.jpg   Exif.CanonSi.SubjectDistance                 Short       1  Infinite
@@ -1123,10 +1123,10 @@ File  6/15: 20030925_201850.jpg
 20030925_201850.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 20030925_201850.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/81 s
 20030925_201850.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  11.50
-20030925_201850.jpg   Exif.CanonSi.0x0018                          Short       1  0
+20030925_201850.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 20030925_201850.jpg   Exif.CanonSi.0x0019                          Short       1  0
-20030925_201850.jpg   Exif.CanonSi.0x001a                          Short       1  252
-20030925_201850.jpg   Exif.CanonSi.0x001b                          Short       1  1
+20030925_201850.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+20030925_201850.jpg   Exif.CanonSi.AutoRotate                      Short       1  1
 20030925_201850.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 20030925_201850.jpg   Exif.CanonSi.0x001d                          Short       1  0
 20030925_201850.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -1693,22 +1693,22 @@ Warning: Directory Canon has an unexpected next pointer; ignored.
 20060802_095200.jpg   Exif.Canon.FocalLength                       Short       4  95.0 mm
 20060802_095200.jpg   Exif.Canon.0x0003                            Short       4  0 100 0 0
 20060802_095200.jpg   Exif.CanonSi.0x0000                          Short       1  68
-20060802_095200.jpg   Exif.CanonSi.0x0001                          Short       1  0
+20060802_095200.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 20060802_095200.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 20060802_095200.jpg   Exif.CanonSi.MeasuredEV                      Short       1  5.25
 20060802_095200.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 20060802_095200.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/60 s
 20060802_095200.jpg   Exif.CanonSi.0x0006                          Short       1  0
 20060802_095200.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Custom
-20060802_095200.jpg   Exif.CanonSi.0x0008                          Short       1  3
+20060802_095200.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 20060802_095200.jpg   Exif.CanonSi.Sequence                        Short       1  0
 20060802_095200.jpg   Exif.CanonSi.0x000a                          Short       1  8
 20060802_095200.jpg   Exif.CanonSi.0x000b                          Short       1  8
-20060802_095200.jpg   Exif.CanonSi.0x000c                          Short       1  0
-20060802_095200.jpg   Exif.CanonSi.0x000d                          Short       1  65535
+20060802_095200.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+20060802_095200.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  --
 20060802_095200.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 20060802_095200.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-20060802_095200.jpg   Exif.CanonSi.0x0010                          Short       1  0
+20060802_095200.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 20060802_095200.jpg   Exif.CanonSi.0x0011                          Short       1  0
 20060802_095200.jpg   Exif.CanonSi.0x0012                          Short       1  1
 20060802_095200.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -1716,10 +1716,10 @@ Warning: Directory Canon has an unexpected next pointer; ignored.
 20060802_095200.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 20060802_095200.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/2048 s
 20060802_095200.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  4.88
-20060802_095200.jpg   Exif.CanonSi.0x0018                          Short       1  0
+20060802_095200.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 20060802_095200.jpg   Exif.CanonSi.0x0019                          Short       1  0
-20060802_095200.jpg   Exif.CanonSi.0x001a                          Short       1  252
-20060802_095200.jpg   Exif.CanonSi.0x001b                          Short       1  0
+20060802_095200.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+20060802_095200.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 20060802_095200.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 20060802_095200.jpg   Exif.CanonSi.0x001d                          Short       1  0
 20060802_095200.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -1901,22 +1901,22 @@ File 14/15: 20001004_015404.jpg
 20001004_015404.jpg   Exif.Canon.FocalLength                       Short       4  70.0 mm
 20001004_015404.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 20001004_015404.jpg   Exif.CanonSi.0x0000                          Short       1  50
-20001004_015404.jpg   Exif.CanonSi.0x0001                          Short       1  0
+20001004_015404.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 20001004_015404.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 20001004_015404.jpg   Exif.CanonSi.MeasuredEV                      Short       1  12.75
 20001004_015404.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 20001004_015404.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/347 s
 20001004_015404.jpg   Exif.CanonSi.0x0006                          Short       1  0
 20001004_015404.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Daylight
-20001004_015404.jpg   Exif.CanonSi.0x0008                          Short       1  3
+20001004_015404.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 20001004_015404.jpg   Exif.CanonSi.Sequence                        Short       1  1
 20001004_015404.jpg   Exif.CanonSi.0x000a                          Short       1  8
 20001004_015404.jpg   Exif.CanonSi.0x000b                          Short       1  8
-20001004_015404.jpg   Exif.CanonSi.0x000c                          Short       1  0
-20001004_015404.jpg   Exif.CanonSi.0x000d                          Short       1  0
+20001004_015404.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+20001004_015404.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 20001004_015404.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; none used
 20001004_015404.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-20001004_015404.jpg   Exif.CanonSi.0x0010                          Short       1  0
+20001004_015404.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 20001004_015404.jpg   Exif.CanonSi.0x0011                          Short       1  0
 20001004_015404.jpg   Exif.CanonSi.0x0012                          Short       1  1
 20001004_015404.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -1924,7 +1924,7 @@ File 14/15: 20001004_015404.jpg
 20001004_015404.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 20001004_015404.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/431 s
 20001004_015404.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  13.25
-20001004_015404.jpg   Exif.CanonSi.0x0018                          Short       1  0
+20001004_015404.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 20001004_015404.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 20001004_015404.jpg   Exif.Canon.0x000a                            Short      59  118 8 8 0 0 12 7970 63771 12886 5201 28427 28912 13362 52780 584 8689 41493 288 8099 2844 12933 6065 60947 404 13298 55853 12878 9473 56351 4511 8115 1819 29306 6194 4629 25042 13378 59693 16980 9329 56351 33193 8003 5147 17037 6098 7445 41427 13426 60717 53852 9473 58656 45479 4 126 127 126 127
 20001004_015404.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:EOS D30 JPEG
@@ -2044,22 +2044,22 @@ File 15/15: 20060127_225027.jpg
 20060127_225027.jpg   Exif.Canon.FocalLength                       Short       4  5.8 mm
 20060127_225027.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 20060127_225027.jpg   Exif.CanonSi.0x0000                          Short       1  68
-20060127_225027.jpg   Exif.CanonSi.0x0001                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 20060127_225027.jpg   Exif.CanonSi.ISOSpeed                        Short       1  50
 20060127_225027.jpg   Exif.CanonSi.MeasuredEV                      Short       1  15.00
 20060127_225027.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 20060127_225027.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/1002 s
 20060127_225027.jpg   Exif.CanonSi.0x0006                          Short       1  0
 20060127_225027.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-20060127_225027.jpg   Exif.CanonSi.0x0008                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 20060127_225027.jpg   Exif.CanonSi.Sequence                        Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x000a                          Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x000b                          Short       1  0
-20060127_225027.jpg   Exif.CanonSi.0x000c                          Short       1  0
-20060127_225027.jpg   Exif.CanonSi.0x000d                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+20060127_225027.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 20060127_225027.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 20060127_225027.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-20060127_225027.jpg   Exif.CanonSi.0x0010                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 20060127_225027.jpg   Exif.CanonSi.0x0011                          Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x0012                          Short       1  1
 20060127_225027.jpg   Exif.CanonSi.SubjectDistance                 Short       1  65.53 m
@@ -2067,10 +2067,10 @@ File 15/15: 20060127_225027.jpg
 20060127_225027.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 20060127_225027.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/1024 s
 20060127_225027.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-20060127_225027.jpg   Exif.CanonSi.0x0018                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x0019                          Short       1  0
-20060127_225027.jpg   Exif.CanonSi.0x001a                          Short       1  250
-20060127_225027.jpg   Exif.CanonSi.0x001b                          Short       1  0
+20060127_225027.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
+20060127_225027.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x001c                          Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x001d                          Short       1  0
 20060127_225027.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -2289,22 +2289,22 @@ Compare image data and extracted data ------------------------------------
 < 20031214_000043.jpg   Exif.Canon.FocalLength                       Short       4  21.3 mm
 < 20031214_000043.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 < 20031214_000043.jpg   Exif.CanonSi.0x0000                          Short       1  54
-< 20031214_000043.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20031214_000043.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20031214_000043.jpg   Exif.CanonSi.MeasuredEV                      Short       1  13.63
 < 20031214_000043.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5
 < 20031214_000043.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 < 20031214_000043.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20031214_000043.jpg   Exif.CanonSi.0x0008                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 < 20031214_000043.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x000a                          Short       1  6
 < 20031214_000043.jpg   Exif.CanonSi.0x000b                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20031214_000043.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 < 20031214_000043.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20031214_000043.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20031214_000043.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20031214_000043.jpg   Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -2312,9 +2312,9 @@ Compare image data and extracted data ------------------------------------
 < 20031214_000043.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5
 < 20031214_000043.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 < 20031214_000043.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-< 20031214_000043.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x001a                          Short       1  250
+< 20031214_000043.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
 < 20031214_000043.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 < 20031214_000043.jpg   Exif.Canon.0x0000                            Short       4  0 0 0 0
 < 20031214_000043.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
@@ -2713,22 +2713,22 @@ Compare image data and extracted data ------------------------------------
 < 20030925_201850.jpg   Exif.Canon.FocalLength                       Short       4  18.0 mm
 < 20030925_201850.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 < 20030925_201850.jpg   Exif.CanonSi.0x0000                          Short       1  66
-< 20030925_201850.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20030925_201850.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20030925_201850.jpg   Exif.CanonSi.MeasuredEV                      Short       1  11.25
 < 20030925_201850.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 < 20030925_201850.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/79 s
 < 20030925_201850.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20030925_201850.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20030925_201850.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20030925_201850.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20030925_201850.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20030925_201850.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20030925_201850.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20030925_201850.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20030925_201850.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20030925_201850.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20030925_201850.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20030925_201850.jpg   Exif.CanonSi.SubjectDistance                 Short       1  Infinite
@@ -2736,10 +2736,10 @@ Compare image data and extracted data ------------------------------------
 < 20030925_201850.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 < 20030925_201850.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/81 s
 < 20030925_201850.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  11.50
-< 20030925_201850.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20030925_201850.jpg   Exif.CanonSi.0x001a                          Short       1  252
-< 20030925_201850.jpg   Exif.CanonSi.0x001b                          Short       1  1
+< 20030925_201850.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+< 20030925_201850.jpg   Exif.CanonSi.AutoRotate                      Short       1  1
 < 20030925_201850.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 < 20030925_201850.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -3305,22 +3305,22 @@ Compare image data and extracted data ------------------------------------
 < 20060802_095200.jpg   Exif.Canon.FocalLength                       Short       4  95.0 mm
 < 20060802_095200.jpg   Exif.Canon.0x0003                            Short       4  0 100 0 0
 < 20060802_095200.jpg   Exif.CanonSi.0x0000                          Short       1  68
-< 20060802_095200.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20060802_095200.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20060802_095200.jpg   Exif.CanonSi.MeasuredEV                      Short       1  5.25
 < 20060802_095200.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 < 20060802_095200.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/60 s
 < 20060802_095200.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Custom
-< 20060802_095200.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20060802_095200.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20060802_095200.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20060802_095200.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20060802_095200.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20060802_095200.jpg   Exif.CanonSi.0x000d                          Short       1  65535
+< 20060802_095200.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20060802_095200.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  --
 < 20060802_095200.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20060802_095200.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20060802_095200.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20060802_095200.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20060802_095200.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -3328,10 +3328,10 @@ Compare image data and extracted data ------------------------------------
 < 20060802_095200.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 < 20060802_095200.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/2048 s
 < 20060802_095200.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  4.88
-< 20060802_095200.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20060802_095200.jpg   Exif.CanonSi.0x001a                          Short       1  252
-< 20060802_095200.jpg   Exif.CanonSi.0x001b                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+< 20060802_095200.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 < 20060802_095200.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -3513,22 +3513,22 @@ Compare image data and extracted data ------------------------------------
 < 20001004_015404.jpg   Exif.Canon.FocalLength                       Short       4  70.0 mm
 < 20001004_015404.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 < 20001004_015404.jpg   Exif.CanonSi.0x0000                          Short       1  50
-< 20001004_015404.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20001004_015404.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20001004_015404.jpg   Exif.CanonSi.MeasuredEV                      Short       1  12.75
 < 20001004_015404.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 < 20001004_015404.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/347 s
 < 20001004_015404.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Daylight
-< 20001004_015404.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20001004_015404.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20001004_015404.jpg   Exif.CanonSi.Sequence                        Short       1  1
 < 20001004_015404.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20001004_015404.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20001004_015404.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20001004_015404.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20001004_015404.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; none used
 < 20001004_015404.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20001004_015404.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20001004_015404.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20001004_015404.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -3536,7 +3536,7 @@ Compare image data and extracted data ------------------------------------
 < 20001004_015404.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 < 20001004_015404.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/431 s
 < 20001004_015404.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  13.25
-< 20001004_015404.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20001004_015404.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 < 20001004_015404.jpg   Exif.Canon.0x000a                            Short      59  118 8 8 0 0 12 7970 63771 12886 5201 28427 28912 13362 52780 584 8689 41493 288 8099 2844 12933 6065 60947 404 13298 55853 12878 9473 56351 4511 8115 1819 29306 6194 4629 25042 13378 59693 16980 9329 56351 33193 8003 5147 17037 6098 7445 41427 13426 60717 53852 9473 58656 45479 4 126 127 126 127
 < 20001004_015404.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:EOS D30 JPEG
@@ -3656,22 +3656,22 @@ Compare image data and extracted data ------------------------------------
 < 20060127_225027.jpg   Exif.Canon.FocalLength                       Short       4  5.8 mm
 < 20060127_225027.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 < 20060127_225027.jpg   Exif.CanonSi.0x0000                          Short       1  68
-< 20060127_225027.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20060127_225027.jpg   Exif.CanonSi.ISOSpeed                        Short       1  50
 < 20060127_225027.jpg   Exif.CanonSi.MeasuredEV                      Short       1  15.00
 < 20060127_225027.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 < 20060127_225027.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/1002 s
 < 20060127_225027.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20060127_225027.jpg   Exif.CanonSi.0x0008                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 < 20060127_225027.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x000a                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x000b                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20060127_225027.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20060127_225027.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20060127_225027.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20060127_225027.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20060127_225027.jpg   Exif.CanonSi.SubjectDistance                 Short       1  65.53 m
@@ -3679,10 +3679,10 @@ Compare image data and extracted data ------------------------------------
 < 20060127_225027.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 < 20060127_225027.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/1024 s
 < 20060127_225027.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-< 20060127_225027.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x001a                          Short       1  250
-< 20060127_225027.jpg   Exif.CanonSi.0x001b                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
+< 20060127_225027.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001c                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -3830,22 +3830,22 @@ Compare image data and extracted data ------------------------------------
 > 20031214_000043.exv   Exif.Canon.FocalLength                       Short       4  21.3 mm
 > 20031214_000043.exv   Exif.Canon.0x0003                            Short       4  0 0 0 0
 > 20031214_000043.exv   Exif.CanonSi.0x0000                          Short       1  54
-> 20031214_000043.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20031214_000043.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20031214_000043.exv   Exif.CanonSi.MeasuredEV                      Short       1  13.63
 > 20031214_000043.exv   Exif.CanonSi.TargetAperture                  Short       1  F5
 > 20031214_000043.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 > 20031214_000043.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20031214_000043.exv   Exif.CanonSi.0x0008                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.SlowShutter                     Short       1  Off
 > 20031214_000043.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x000a                          Short       1  6
 > 20031214_000043.exv   Exif.CanonSi.0x000b                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20031214_000043.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 > 20031214_000043.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20031214_000043.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20031214_000043.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20031214_000043.exv   Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -3853,9 +3853,9 @@ Compare image data and extracted data ------------------------------------
 > 20031214_000043.exv   Exif.CanonSi.ApertureValue                   Short       1  F5
 > 20031214_000043.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 > 20031214_000043.exv   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-> 20031214_000043.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x001a                          Short       1  250
+> 20031214_000043.exv   Exif.CanonSi.CameraType                      Short       1  Compact
 > 20031214_000043.exv   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 > 20031214_000043.exv   Exif.Canon.0x0000                            Short       4  0 0 0 0
 > 20031214_000043.exv   Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
@@ -4254,22 +4254,22 @@ Compare image data and extracted data ------------------------------------
 > 20030925_201850.exv   Exif.Canon.FocalLength                       Short       4  18.0 mm
 > 20030925_201850.exv   Exif.Canon.0x0003                            Short       4  100 0 0 0
 > 20030925_201850.exv   Exif.CanonSi.0x0000                          Short       1  66
-> 20030925_201850.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20030925_201850.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20030925_201850.exv   Exif.CanonSi.MeasuredEV                      Short       1  11.25
 > 20030925_201850.exv   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 > 20030925_201850.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/79 s
 > 20030925_201850.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20030925_201850.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20030925_201850.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20030925_201850.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20030925_201850.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20030925_201850.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20030925_201850.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20030925_201850.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20030925_201850.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20030925_201850.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20030925_201850.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20030925_201850.exv   Exif.CanonSi.SubjectDistance                 Short       1  Infinite
@@ -4277,10 +4277,10 @@ Compare image data and extracted data ------------------------------------
 > 20030925_201850.exv   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 > 20030925_201850.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/81 s
 > 20030925_201850.exv   Exif.CanonSi.MeasuredEV2                     Short       1  11.50
-> 20030925_201850.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20030925_201850.exv   Exif.CanonSi.0x001a                          Short       1  252
-> 20030925_201850.exv   Exif.CanonSi.0x001b                          Short       1  1
+> 20030925_201850.exv   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+> 20030925_201850.exv   Exif.CanonSi.AutoRotate                      Short       1  1
 > 20030925_201850.exv   Exif.CanonSi.0x001c                          Short       1  65535
 > 20030925_201850.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x001e                          Short       1  0
@@ -4846,22 +4846,22 @@ Compare image data and extracted data ------------------------------------
 > 20060802_095200.exv   Exif.Canon.FocalLength                       Short       4  95.0 mm
 > 20060802_095200.exv   Exif.Canon.0x0003                            Short       4  0 100 0 0
 > 20060802_095200.exv   Exif.CanonSi.0x0000                          Short       1  68
-> 20060802_095200.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20060802_095200.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20060802_095200.exv   Exif.CanonSi.MeasuredEV                      Short       1  5.25
 > 20060802_095200.exv   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 > 20060802_095200.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/60 s
 > 20060802_095200.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.WhiteBalance                    Short       1  Custom
-> 20060802_095200.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20060802_095200.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20060802_095200.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20060802_095200.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20060802_095200.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20060802_095200.exv   Exif.CanonSi.0x000d                          Short       1  65535
+> 20060802_095200.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20060802_095200.exv   Exif.CanonSi.FlashGuideNumber                Short       1  --
 > 20060802_095200.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20060802_095200.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20060802_095200.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20060802_095200.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20060802_095200.exv   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -4869,10 +4869,10 @@ Compare image data and extracted data ------------------------------------
 > 20060802_095200.exv   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 > 20060802_095200.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/2048 s
 > 20060802_095200.exv   Exif.CanonSi.MeasuredEV2                     Short       1  4.88
-> 20060802_095200.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20060802_095200.exv   Exif.CanonSi.0x001a                          Short       1  252
-> 20060802_095200.exv   Exif.CanonSi.0x001b                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+> 20060802_095200.exv   Exif.CanonSi.AutoRotate                      Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x001c                          Short       1  65535
 > 20060802_095200.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x001e                          Short       1  0
@@ -5054,22 +5054,22 @@ Compare image data and extracted data ------------------------------------
 > 20001004_015404.exv   Exif.Canon.FocalLength                       Short       4  70.0 mm
 > 20001004_015404.exv   Exif.Canon.0x0003                            Short       4  100 0 0 0
 > 20001004_015404.exv   Exif.CanonSi.0x0000                          Short       1  50
-> 20001004_015404.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20001004_015404.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20001004_015404.exv   Exif.CanonSi.MeasuredEV                      Short       1  12.75
 > 20001004_015404.exv   Exif.CanonSi.TargetAperture                  Short       1  F4
 > 20001004_015404.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/347 s
 > 20001004_015404.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.WhiteBalance                    Short       1  Daylight
-> 20001004_015404.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20001004_015404.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20001004_015404.exv   Exif.CanonSi.Sequence                        Short       1  1
 > 20001004_015404.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20001004_015404.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20001004_015404.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20001004_015404.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20001004_015404.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; none used
 > 20001004_015404.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20001004_015404.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20001004_015404.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20001004_015404.exv   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -5077,7 +5077,7 @@ Compare image data and extracted data ------------------------------------
 > 20001004_015404.exv   Exif.CanonSi.ApertureValue                   Short       1  F4
 > 20001004_015404.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/431 s
 > 20001004_015404.exv   Exif.CanonSi.MeasuredEV2                     Short       1  13.25
-> 20001004_015404.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20001004_015404.exv   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 > 20001004_015404.exv   Exif.Canon.0x000a                            Short      59  118 8 8 0 0 12 7970 63771 12886 5201 28427 28912 13362 52780 584 8689 41493 288 8099 2844 12933 6065 60947 404 13298 55853 12878 9473 56351 4511 8115 1819 29306 6194 4629 25042 13378 59693 16980 9329 56351 33193 8003 5147 17037 6098 7445 41427 13426 60717 53852 9473 58656 45479 4 126 127 126 127
 > 20001004_015404.exv   Exif.Canon.ImageType                         Ascii      32  IMG:EOS D30 JPEG
@@ -5197,22 +5197,22 @@ Compare image data and extracted data ------------------------------------
 > 20060127_225027.exv   Exif.Canon.FocalLength                       Short       4  5.8 mm
 > 20060127_225027.exv   Exif.Canon.0x0003                            Short       4  0 0 0 0
 > 20060127_225027.exv   Exif.CanonSi.0x0000                          Short       1  68
-> 20060127_225027.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20060127_225027.exv   Exif.CanonSi.ISOSpeed                        Short       1  50
 > 20060127_225027.exv   Exif.CanonSi.MeasuredEV                      Short       1  15.00
 > 20060127_225027.exv   Exif.CanonSi.TargetAperture                  Short       1  F4
 > 20060127_225027.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/1002 s
 > 20060127_225027.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20060127_225027.exv   Exif.CanonSi.0x0008                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.SlowShutter                     Short       1  Off
 > 20060127_225027.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x000a                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x000b                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20060127_225027.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20060127_225027.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20060127_225027.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20060127_225027.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20060127_225027.exv   Exif.CanonSi.SubjectDistance                 Short       1  65.53 m
@@ -5220,10 +5220,10 @@ Compare image data and extracted data ------------------------------------
 > 20060127_225027.exv   Exif.CanonSi.ApertureValue                   Short       1  F4
 > 20060127_225027.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/1024 s
 > 20060127_225027.exv   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-> 20060127_225027.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x001a                          Short       1  250
-> 20060127_225027.exv   Exif.CanonSi.0x001b                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.CameraType                      Short       1  Compact
+> 20060127_225027.exv   Exif.CanonSi.AutoRotate                      Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001c                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001e                          Short       1  0
@@ -5591,22 +5591,22 @@ Compare original and inserted image data ---------------------------------
 < 20031214_000043.jpg   Exif.Canon.FocalLength                       Short       4  21.3 mm
 < 20031214_000043.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 < 20031214_000043.jpg   Exif.CanonSi.0x0000                          Short       1  54
-< 20031214_000043.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20031214_000043.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20031214_000043.jpg   Exif.CanonSi.MeasuredEV                      Short       1  13.63
 < 20031214_000043.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5
 < 20031214_000043.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 < 20031214_000043.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20031214_000043.jpg   Exif.CanonSi.0x0008                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 < 20031214_000043.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x000a                          Short       1  6
 < 20031214_000043.jpg   Exif.CanonSi.0x000b                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20031214_000043.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 < 20031214_000043.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20031214_000043.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20031214_000043.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20031214_000043.jpg   Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -5614,9 +5614,9 @@ Compare original and inserted image data ---------------------------------
 < 20031214_000043.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5
 < 20031214_000043.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 < 20031214_000043.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-< 20031214_000043.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20031214_000043.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20031214_000043.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20031214_000043.jpg   Exif.CanonSi.0x001a                          Short       1  250
+< 20031214_000043.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
 < 20031214_000043.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 < 20031214_000043.jpg   Exif.Canon.0x0000                            Short       4  0 0 0 0
 < 20031214_000043.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
@@ -6015,22 +6015,22 @@ Compare original and inserted image data ---------------------------------
 < 20030925_201850.jpg   Exif.Canon.FocalLength                       Short       4  18.0 mm
 < 20030925_201850.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 < 20030925_201850.jpg   Exif.CanonSi.0x0000                          Short       1  66
-< 20030925_201850.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20030925_201850.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20030925_201850.jpg   Exif.CanonSi.MeasuredEV                      Short       1  11.25
 < 20030925_201850.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 < 20030925_201850.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/79 s
 < 20030925_201850.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20030925_201850.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20030925_201850.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20030925_201850.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20030925_201850.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20030925_201850.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20030925_201850.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20030925_201850.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20030925_201850.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20030925_201850.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20030925_201850.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20030925_201850.jpg   Exif.CanonSi.SubjectDistance                 Short       1  Infinite
@@ -6038,10 +6038,10 @@ Compare original and inserted image data ---------------------------------
 < 20030925_201850.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 < 20030925_201850.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/81 s
 < 20030925_201850.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  11.50
-< 20030925_201850.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20030925_201850.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20030925_201850.jpg   Exif.CanonSi.0x001a                          Short       1  252
-< 20030925_201850.jpg   Exif.CanonSi.0x001b                          Short       1  1
+< 20030925_201850.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+< 20030925_201850.jpg   Exif.CanonSi.AutoRotate                      Short       1  1
 < 20030925_201850.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 < 20030925_201850.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20030925_201850.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -6607,22 +6607,22 @@ Compare original and inserted image data ---------------------------------
 < 20060802_095200.jpg   Exif.Canon.FocalLength                       Short       4  95.0 mm
 < 20060802_095200.jpg   Exif.Canon.0x0003                            Short       4  0 100 0 0
 < 20060802_095200.jpg   Exif.CanonSi.0x0000                          Short       1  68
-< 20060802_095200.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20060802_095200.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20060802_095200.jpg   Exif.CanonSi.MeasuredEV                      Short       1  5.25
 < 20060802_095200.jpg   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 < 20060802_095200.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/60 s
 < 20060802_095200.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Custom
-< 20060802_095200.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20060802_095200.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20060802_095200.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20060802_095200.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20060802_095200.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20060802_095200.jpg   Exif.CanonSi.0x000d                          Short       1  65535
+< 20060802_095200.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20060802_095200.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  --
 < 20060802_095200.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20060802_095200.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20060802_095200.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20060802_095200.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20060802_095200.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -6630,10 +6630,10 @@ Compare original and inserted image data ---------------------------------
 < 20060802_095200.jpg   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 < 20060802_095200.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/2048 s
 < 20060802_095200.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  4.88
-< 20060802_095200.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20060802_095200.jpg   Exif.CanonSi.0x001a                          Short       1  252
-< 20060802_095200.jpg   Exif.CanonSi.0x001b                          Short       1  0
+< 20060802_095200.jpg   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+< 20060802_095200.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x001c                          Short       1  65535
 < 20060802_095200.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20060802_095200.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -6815,22 +6815,22 @@ Compare original and inserted image data ---------------------------------
 < 20001004_015404.jpg   Exif.Canon.FocalLength                       Short       4  70.0 mm
 < 20001004_015404.jpg   Exif.Canon.0x0003                            Short       4  100 0 0 0
 < 20001004_015404.jpg   Exif.CanonSi.0x0000                          Short       1  50
-< 20001004_015404.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20001004_015404.jpg   Exif.CanonSi.ISOSpeed                        Short       1  100
 < 20001004_015404.jpg   Exif.CanonSi.MeasuredEV                      Short       1  12.75
 < 20001004_015404.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 < 20001004_015404.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/347 s
 < 20001004_015404.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Daylight
-< 20001004_015404.jpg   Exif.CanonSi.0x0008                          Short       1  3
+< 20001004_015404.jpg   Exif.CanonSi.SlowShutter                     Short       1  None
 < 20001004_015404.jpg   Exif.CanonSi.Sequence                        Short       1  1
 < 20001004_015404.jpg   Exif.CanonSi.0x000a                          Short       1  8
 < 20001004_015404.jpg   Exif.CanonSi.0x000b                          Short       1  8
-< 20001004_015404.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20001004_015404.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20001004_015404.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; none used
 < 20001004_015404.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20001004_015404.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20001004_015404.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20001004_015404.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20001004_015404.jpg   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -6838,7 +6838,7 @@ Compare original and inserted image data ---------------------------------
 < 20001004_015404.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 < 20001004_015404.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/431 s
 < 20001004_015404.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  13.25
-< 20001004_015404.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20001004_015404.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20001004_015404.jpg   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 < 20001004_015404.jpg   Exif.Canon.0x000a                            Short      59  118 8 8 0 0 12 7970 63771 12886 5201 28427 28912 13362 52780 584 8689 41493 288 8099 2844 12933 6065 60947 404 13298 55853 12878 9473 56351 4511 8115 1819 29306 6194 4629 25042 13378 59693 16980 9329 56351 33193 8003 5147 17037 6098 7445 41427 13426 60717 53852 9473 58656 45479 4 126 127 126 127
 < 20001004_015404.jpg   Exif.Canon.ImageType                         Ascii      32  IMG:EOS D30 JPEG
@@ -6958,22 +6958,22 @@ Compare original and inserted image data ---------------------------------
 < 20060127_225027.jpg   Exif.Canon.FocalLength                       Short       4  5.8 mm
 < 20060127_225027.jpg   Exif.Canon.0x0003                            Short       4  0 0 0 0
 < 20060127_225027.jpg   Exif.CanonSi.0x0000                          Short       1  68
-< 20060127_225027.jpg   Exif.CanonSi.0x0001                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.AutoISO                         Short       1  100
 < 20060127_225027.jpg   Exif.CanonSi.ISOSpeed                        Short       1  50
 < 20060127_225027.jpg   Exif.CanonSi.MeasuredEV                      Short       1  15.00
 < 20060127_225027.jpg   Exif.CanonSi.TargetAperture                  Short       1  F4
 < 20060127_225027.jpg   Exif.CanonSi.TargetShutterSpeed              Short       1  1/1002 s
 < 20060127_225027.jpg   Exif.CanonSi.0x0006                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-< 20060127_225027.jpg   Exif.CanonSi.0x0008                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.SlowShutter                     Short       1  Off
 < 20060127_225027.jpg   Exif.CanonSi.Sequence                        Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x000a                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x000b                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x000c                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x000d                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.CameraTemperature               Short       1  --
+< 20060127_225027.jpg   Exif.CanonSi.FlashGuideNumber                Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 < 20060127_225027.jpg   Exif.CanonSi.FlashBias                       Short       1  0 EV
-< 20060127_225027.jpg   Exif.CanonSi.0x0010                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 < 20060127_225027.jpg   Exif.CanonSi.0x0011                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x0012                          Short       1  1
 < 20060127_225027.jpg   Exif.CanonSi.SubjectDistance                 Short       1  65.53 m
@@ -6981,10 +6981,10 @@ Compare original and inserted image data ---------------------------------
 < 20060127_225027.jpg   Exif.CanonSi.ApertureValue                   Short       1  F4
 < 20060127_225027.jpg   Exif.CanonSi.ShutterSpeedValue               Short       1  1/1024 s
 < 20060127_225027.jpg   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-< 20060127_225027.jpg   Exif.CanonSi.0x0018                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.BulbDuration                    Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x0019                          Short       1  0
-< 20060127_225027.jpg   Exif.CanonSi.0x001a                          Short       1  250
-< 20060127_225027.jpg   Exif.CanonSi.0x001b                          Short       1  0
+< 20060127_225027.jpg   Exif.CanonSi.CameraType                      Short       1  Compact
+< 20060127_225027.jpg   Exif.CanonSi.AutoRotate                      Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001c                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001d                          Short       1  0
 < 20060127_225027.jpg   Exif.CanonSi.0x001e                          Short       1  0
@@ -7132,22 +7132,22 @@ Compare original and inserted image data ---------------------------------
 > 20031214_000043.exv   Exif.Canon.FocalLength                       Short       4  21.3 mm
 > 20031214_000043.exv   Exif.Canon.0x0003                            Short       4  0 0 0 0
 > 20031214_000043.exv   Exif.CanonSi.0x0000                          Short       1  54
-> 20031214_000043.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20031214_000043.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20031214_000043.exv   Exif.CanonSi.MeasuredEV                      Short       1  13.63
 > 20031214_000043.exv   Exif.CanonSi.TargetAperture                  Short       1  F5
 > 20031214_000043.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 > 20031214_000043.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20031214_000043.exv   Exif.CanonSi.0x0008                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.SlowShutter                     Short       1  Off
 > 20031214_000043.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x000a                          Short       1  6
 > 20031214_000043.exv   Exif.CanonSi.0x000b                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20031214_000043.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 > 20031214_000043.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20031214_000043.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20031214_000043.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20031214_000043.exv   Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -7155,9 +7155,9 @@ Compare original and inserted image data ---------------------------------
 > 20031214_000043.exv   Exif.CanonSi.ApertureValue                   Short       1  F5
 > 20031214_000043.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 > 20031214_000043.exv   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-> 20031214_000043.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20031214_000043.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20031214_000043.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20031214_000043.exv   Exif.CanonSi.0x001a                          Short       1  250
+> 20031214_000043.exv   Exif.CanonSi.CameraType                      Short       1  Compact
 > 20031214_000043.exv   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 > 20031214_000043.exv   Exif.Canon.0x0000                            Short       4  0 0 0 0
 > 20031214_000043.exv   Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
@@ -7556,22 +7556,22 @@ Compare original and inserted image data ---------------------------------
 > 20030925_201850.exv   Exif.Canon.FocalLength                       Short       4  18.0 mm
 > 20030925_201850.exv   Exif.Canon.0x0003                            Short       4  100 0 0 0
 > 20030925_201850.exv   Exif.CanonSi.0x0000                          Short       1  66
-> 20030925_201850.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20030925_201850.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20030925_201850.exv   Exif.CanonSi.MeasuredEV                      Short       1  11.25
 > 20030925_201850.exv   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 > 20030925_201850.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/79 s
 > 20030925_201850.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20030925_201850.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20030925_201850.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20030925_201850.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20030925_201850.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20030925_201850.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20030925_201850.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20030925_201850.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20030925_201850.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20030925_201850.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20030925_201850.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20030925_201850.exv   Exif.CanonSi.SubjectDistance                 Short       1  Infinite
@@ -7579,10 +7579,10 @@ Compare original and inserted image data ---------------------------------
 > 20030925_201850.exv   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 > 20030925_201850.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/81 s
 > 20030925_201850.exv   Exif.CanonSi.MeasuredEV2                     Short       1  11.50
-> 20030925_201850.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20030925_201850.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20030925_201850.exv   Exif.CanonSi.0x001a                          Short       1  252
-> 20030925_201850.exv   Exif.CanonSi.0x001b                          Short       1  1
+> 20030925_201850.exv   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+> 20030925_201850.exv   Exif.CanonSi.AutoRotate                      Short       1  1
 > 20030925_201850.exv   Exif.CanonSi.0x001c                          Short       1  65535
 > 20030925_201850.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20030925_201850.exv   Exif.CanonSi.0x001e                          Short       1  0
@@ -8148,22 +8148,22 @@ Compare original and inserted image data ---------------------------------
 > 20060802_095200.exv   Exif.Canon.FocalLength                       Short       4  95.0 mm
 > 20060802_095200.exv   Exif.Canon.0x0003                            Short       4  0 100 0 0
 > 20060802_095200.exv   Exif.CanonSi.0x0000                          Short       1  68
-> 20060802_095200.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20060802_095200.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20060802_095200.exv   Exif.CanonSi.MeasuredEV                      Short       1  5.25
 > 20060802_095200.exv   Exif.CanonSi.TargetAperture                  Short       1  F5.6
 > 20060802_095200.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/60 s
 > 20060802_095200.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.WhiteBalance                    Short       1  Custom
-> 20060802_095200.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20060802_095200.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20060802_095200.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20060802_095200.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20060802_095200.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20060802_095200.exv   Exif.CanonSi.0x000d                          Short       1  65535
+> 20060802_095200.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20060802_095200.exv   Exif.CanonSi.FlashGuideNumber                Short       1  --
 > 20060802_095200.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20060802_095200.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20060802_095200.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20060802_095200.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20060802_095200.exv   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -8171,10 +8171,10 @@ Compare original and inserted image data ---------------------------------
 > 20060802_095200.exv   Exif.CanonSi.ApertureValue                   Short       1  F5.4
 > 20060802_095200.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/2048 s
 > 20060802_095200.exv   Exif.CanonSi.MeasuredEV2                     Short       1  4.88
-> 20060802_095200.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20060802_095200.exv   Exif.CanonSi.0x001a                          Short       1  252
-> 20060802_095200.exv   Exif.CanonSi.0x001b                          Short       1  0
+> 20060802_095200.exv   Exif.CanonSi.CameraType                      Short       1  EOS Mid-range
+> 20060802_095200.exv   Exif.CanonSi.AutoRotate                      Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x001c                          Short       1  65535
 > 20060802_095200.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20060802_095200.exv   Exif.CanonSi.0x001e                          Short       1  0
@@ -8356,22 +8356,22 @@ Compare original and inserted image data ---------------------------------
 > 20001004_015404.exv   Exif.Canon.FocalLength                       Short       4  70.0 mm
 > 20001004_015404.exv   Exif.Canon.0x0003                            Short       4  100 0 0 0
 > 20001004_015404.exv   Exif.CanonSi.0x0000                          Short       1  50
-> 20001004_015404.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20001004_015404.exv   Exif.CanonSi.ISOSpeed                        Short       1  100
 > 20001004_015404.exv   Exif.CanonSi.MeasuredEV                      Short       1  12.75
 > 20001004_015404.exv   Exif.CanonSi.TargetAperture                  Short       1  F4
 > 20001004_015404.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/347 s
 > 20001004_015404.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.WhiteBalance                    Short       1  Daylight
-> 20001004_015404.exv   Exif.CanonSi.0x0008                          Short       1  3
+> 20001004_015404.exv   Exif.CanonSi.SlowShutter                     Short       1  None
 > 20001004_015404.exv   Exif.CanonSi.Sequence                        Short       1  1
 > 20001004_015404.exv   Exif.CanonSi.0x000a                          Short       1  8
 > 20001004_015404.exv   Exif.CanonSi.0x000b                          Short       1  8
-> 20001004_015404.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20001004_015404.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20001004_015404.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; none used
 > 20001004_015404.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20001004_015404.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20001004_015404.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20001004_015404.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20001004_015404.exv   Exif.CanonSi.SubjectDistance                 Short       1  0 m
@@ -8379,7 +8379,7 @@ Compare original and inserted image data ---------------------------------
 > 20001004_015404.exv   Exif.CanonSi.ApertureValue                   Short       1  F4
 > 20001004_015404.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/431 s
 > 20001004_015404.exv   Exif.CanonSi.MeasuredEV2                     Short       1  13.25
-> 20001004_015404.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20001004_015404.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20001004_015404.exv   Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 > 20001004_015404.exv   Exif.Canon.0x000a                            Short      59  118 8 8 0 0 12 7970 63771 12886 5201 28427 28912 13362 52780 584 8689 41493 288 8099 2844 12933 6065 60947 404 13298 55853 12878 9473 56351 4511 8115 1819 29306 6194 4629 25042 13378 59693 16980 9329 56351 33193 8003 5147 17037 6098 7445 41427 13426 60717 53852 9473 58656 45479 4 126 127 126 127
 > 20001004_015404.exv   Exif.Canon.ImageType                         Ascii      32  IMG:EOS D30 JPEG
@@ -8499,22 +8499,22 @@ Compare original and inserted image data ---------------------------------
 > 20060127_225027.exv   Exif.Canon.FocalLength                       Short       4  5.8 mm
 > 20060127_225027.exv   Exif.Canon.0x0003                            Short       4  0 0 0 0
 > 20060127_225027.exv   Exif.CanonSi.0x0000                          Short       1  68
-> 20060127_225027.exv   Exif.CanonSi.0x0001                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.AutoISO                         Short       1  100
 > 20060127_225027.exv   Exif.CanonSi.ISOSpeed                        Short       1  50
 > 20060127_225027.exv   Exif.CanonSi.MeasuredEV                      Short       1  15.00
 > 20060127_225027.exv   Exif.CanonSi.TargetAperture                  Short       1  F4
 > 20060127_225027.exv   Exif.CanonSi.TargetShutterSpeed              Short       1  1/1002 s
 > 20060127_225027.exv   Exif.CanonSi.0x0006                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.WhiteBalance                    Short       1  Auto
-> 20060127_225027.exv   Exif.CanonSi.0x0008                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.SlowShutter                     Short       1  Off
 > 20060127_225027.exv   Exif.CanonSi.Sequence                        Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x000a                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x000b                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x000c                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x000d                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.CameraTemperature               Short       1  --
+> 20060127_225027.exv   Exif.CanonSi.FlashGuideNumber                Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.AFPointUsed                     Short       1  0 focus points; none used
 > 20060127_225027.exv   Exif.CanonSi.FlashBias                       Short       1  0 EV
-> 20060127_225027.exv   Exif.CanonSi.0x0010                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 > 20060127_225027.exv   Exif.CanonSi.0x0011                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x0012                          Short       1  1
 > 20060127_225027.exv   Exif.CanonSi.SubjectDistance                 Short       1  65.53 m
@@ -8522,10 +8522,10 @@ Compare original and inserted image data ---------------------------------
 > 20060127_225027.exv   Exif.CanonSi.ApertureValue                   Short       1  F4
 > 20060127_225027.exv   Exif.CanonSi.ShutterSpeedValue               Short       1  1/1024 s
 > 20060127_225027.exv   Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-> 20060127_225027.exv   Exif.CanonSi.0x0018                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.BulbDuration                    Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x0019                          Short       1  0
-> 20060127_225027.exv   Exif.CanonSi.0x001a                          Short       1  250
-> 20060127_225027.exv   Exif.CanonSi.0x001b                          Short       1  0
+> 20060127_225027.exv   Exif.CanonSi.CameraType                      Short       1  Compact
+> 20060127_225027.exv   Exif.CanonSi.AutoRotate                      Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001c                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001d                          Short       1  0
 > 20060127_225027.exv   Exif.CanonSi.0x001e                          Short       1  0

--- a/test/data/write2-test.out
+++ b/test/data/write2-test.out
@@ -21,7 +21,7 @@ Exif.CanonCs.0x0000                           0x0000 Makernote    Short       1 
 Exif.CanonCs.Macro                            0x0001 Makernote    Short       1 0
 Exif.CanonCs.Selftimer                        0x0002 Makernote    Short       1 41
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 12
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 0
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 0
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 0
@@ -45,7 +45,7 @@ Exif.CanonCs.0x0000                           0x0000 Makernote    Short       1 
 Exif.CanonCs.Macro                            0x0001 Makernote    Short       1 88
 Exif.CanonCs.Selftimer                        0x0002 Makernote    Short       1 41
 Exif.CanonSi.0x0000                           0x0000 Makernote    Short       1 12
-Exif.CanonSi.0x0001                           0x0001 Makernote    Short       1 0
+Exif.CanonSi.AutoISO                          0x0001 Makernote    Short       1 0
 Exif.CanonSi.ISOSpeed                         0x0002 Makernote    Short       1 0
 Exif.CanonSi.MeasuredEV                       0x0003 Makernote    Short       1 0
 Exif.CanonSi.TargetAperture                   0x0004 Makernote    Short       1 99

--- a/tests/bugfixes/github/test_issue_247.py
+++ b/tests/bugfixes/github/test_issue_247.py
@@ -68,18 +68,25 @@ Exif.CanonCs.ZoomSourceWidth                 Short       1  2272
 Exif.CanonCs.ZoomTargetWidth                 Short       1  2272
 Exif.CanonCs.SpotMeteringMode                Short       1  AF Point
 Exif.Canon.FocalLength                       Short       4  21.3 mm
+Exif.CanonSi.AutoISO                         Short       1  100
 Exif.CanonSi.ISOSpeed                        Short       1  100
 Exif.CanonSi.MeasuredEV                      Short       1  13.63
 Exif.CanonSi.TargetAperture                  Short       1  F5
 Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 Exif.CanonSi.WhiteBalance                    Short       1  Auto
+Exif.CanonSi.SlowShutter                     Short       1  Off
 Exif.CanonSi.Sequence                        Short       1  0
+Exif.CanonSi.CameraTemperature               Short       1  --
+Exif.CanonSi.FlashGuideNumber                Short       1  0
 Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 Exif.CanonSi.FlashBias                       Short       1  0 EV
+Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
 Exif.CanonSi.ApertureValue                   Short       1  F5
 Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
+Exif.CanonSi.BulbDuration                    Short       1  0
+Exif.CanonSi.CameraType                      Short       1  Compact
 Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG
 Exif.Canon.FirmwareVersion                   Ascii      24  Firmware Version 1.10
 Exif.Canon.FileNumber                        Long        1  117-1771

--- a/tests/bugfixes/redmine/test_issue_445.py
+++ b/tests/bugfixes/redmine/test_issue_445.py
@@ -90,22 +90,22 @@ Exif.CanonCs.SpotMeteringMode                Short       1  AF Point
 Exif.Canon.FocalLength                       Short       4  21.3 mm
 Exif.Canon.0x0003                            Short       4  0 0 0 0
 Exif.CanonSi.0x0000                          Short       1  54
-Exif.CanonSi.0x0001                          Short       1  0
+Exif.CanonSi.AutoISO                         Short       1  100
 Exif.CanonSi.ISOSpeed                        Short       1  100
 Exif.CanonSi.MeasuredEV                      Short       1  13.63
 Exif.CanonSi.TargetAperture                  Short       1  F5
 Exif.CanonSi.TargetShutterSpeed              Short       1  1/501 s
 Exif.CanonSi.0x0006                          Short       1  0
 Exif.CanonSi.WhiteBalance                    Short       1  Auto
-Exif.CanonSi.0x0008                          Short       1  0
+Exif.CanonSi.SlowShutter                     Short       1  Off
 Exif.CanonSi.Sequence                        Short       1  0
 Exif.CanonSi.0x000a                          Short       1  6
 Exif.CanonSi.0x000b                          Short       1  0
-Exif.CanonSi.0x000c                          Short       1  0
-Exif.CanonSi.0x000d                          Short       1  0
+Exif.CanonSi.CameraTemperature               Short       1  --
+Exif.CanonSi.FlashGuideNumber                Short       1  0
 Exif.CanonSi.AFPointUsed                     Short       1  3 focus points; center used
 Exif.CanonSi.FlashBias                       Short       1  0 EV
-Exif.CanonSi.0x0010                          Short       1  0
+Exif.CanonSi.AutoExposureBracketing          Short       1  Off
 Exif.CanonSi.0x0011                          Short       1  0
 Exif.CanonSi.0x0012                          Short       1  1
 Exif.CanonSi.SubjectDistance                 Short       1  7.82 m
@@ -113,9 +113,9 @@ Exif.CanonSi.0x0014                          Short       1  0
 Exif.CanonSi.ApertureValue                   Short       1  F5
 Exif.CanonSi.ShutterSpeedValue               Short       1  1/523 s
 Exif.CanonSi.MeasuredEV2                     Short       1  -6.00
-Exif.CanonSi.0x0018                          Short       1  0
+Exif.CanonSi.BulbDuration                    Short       1  0
 Exif.CanonSi.0x0019                          Short       1  0
-Exif.CanonSi.0x001a                          Short       1  250
+Exif.CanonSi.CameraType                      Short       1  Compact
 Exif.Canon.0x0000                            Short       6  0 0 0 0 0 0
 Exif.Canon.0x0000                            Short       4  0 0 0 0
 Exif.Canon.ImageType                         Ascii      32  IMG:PowerShot S40 JPEG


### PR DESCRIPTION
Hi all, i run by some maker note attributes of canon, panasonic and nikon images that are decoded by exiftool but not yet by exiv2. I added them to exiv2 with this pull request. Could you include them in the next release if possible?

Thanks
Daniel