### PR TITLE
fix_packaging_0.27

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -89,6 +89,18 @@ if ( MSVC )
     endif()
 endif()
 
+# Set RC = Release Candidate
+if ( PROJECT_VERSION_TWEAK STREQUAL "9" )
+    set (RC "Not for release")
+elseif ( (PROJECT_VERSION_TWEAK STREQUAL "0") OR (PROJECT_VERSION_TWEAK STREQUAL "")  )
+    set(RC "GM Release")
+else()
+     set ( RC "Release Candidate ${PROJECT_VERSION_TWEAK}" )
+endif()
+
+# Set RV = Release Version
+set(RV "Exiv2 v${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+
 set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${VS}${BUNDLE_NAME}${BS}${CC}${LT}${BT}${VI}${WR})
 
 # https://stackoverflow.com/questions/17495906/copying-files-and-including-them-in-a-cpack-archive
@@ -117,7 +129,9 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/build/logs/test.txt)
 endif()
 
 # Copy releasenotes.txt and appropriate ReadMe.txt (eg releasenotes/${PACKDIR}/ReadMe.txt)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/${PACKDIR}/ReadMe.txt DESTINATION .)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/releasenotes.txt      DESTINATION .)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/${PACKDIR}/ReadMe.txt ReadMe.txt       @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/releasenotes.txt      releasenotes.txt @ONLY)
+install       (FILES  ${CMAKE_CURRENT_BINARY_DIR}/ReadMe.txt ${CMAKE_CURRENT_BINARY_DIR}/releasenotes.txt DESTINATION .)
+# file        (REMOVE ${CMAKE_CURRENT_BINARY_DIR}/releasenotes.txt ${CMAKE_CURRENT_BINARY_DIR}/ReadMe.txt)
 
 include (CPack)

--- a/releasenotes/CYGWIN/ReadMe.txt
+++ b/releasenotes/CYGWIN/ReadMe.txt
@@ -1,5 +1,4 @@
-CYGWIN Exiv2 v0.27.2 Bundle
--------------------------------
+@RV@ Cygwin/Windows Bundle @RC@
 
 Structure of the bundle:
 ------------------------

--- a/releasenotes/Darwin/ReadMe.txt
+++ b/releasenotes/Darwin/ReadMe.txt
@@ -1,5 +1,4 @@
-macOS (Darwin) Exiv2 v0.27.2 Bundle
------------------------------------
+@RV@ macOS (Darwin) Bundle @RC@
 
 Structure of the bundle
 -----------------------

--- a/releasenotes/Linux/ReadMe.txt
+++ b/releasenotes/Linux/ReadMe.txt
@@ -1,5 +1,4 @@
-Linux Exiv2 v0.27.2-RC3 Bundle
-------------------------------
+@RV@ Linux Bundle @RC@
 
 Structure of the bundle:
 ------------------------

--- a/releasenotes/MinGW/ReadMe.txt
+++ b/releasenotes/MinGW/ReadMe.txt
@@ -1,5 +1,4 @@
-MinGW/msys2 Exiv2 v0.27.2 Bundle
-------------------------------------
+@RV@ MinGW/Windows Bundle @RC@
 
 Structure of the bundle:
 ------------------------

--- a/releasenotes/Unix/ReadMe.txt
+++ b/releasenotes/Unix/ReadMe.txt
@@ -1,5 +1,4 @@
-Unix Exiv2 v0.27.2 Bundle (FreeBSD and NetBSD)
---------------------------------------------------
+@RV@ @CMAKE_SYSTEM_NAME@ Bundle @RC@
 
 Structure of the bundle:
 ------------------------

--- a/releasenotes/msvc/ReadMe.txt
+++ b/releasenotes/msvc/ReadMe.txt
@@ -1,5 +1,4 @@
-Visual Studio 2017 Release DLL v0.27.2 Bundle
--------------------------------------------------
+@RV@ Visual Studio Bundle @RC@
 
 Structure of the bundle:
 ------------------------

--- a/releasenotes/releasenotes.txt
+++ b/releasenotes/releasenotes.txt
@@ -1,13 +1,9 @@
-Exiv2 v0.27.2
--------------
+@RV@ @RC@
 
-Exiv2 v0.27 Second Dot Release
+Headline Features of Exiv2 v0.27.3
+----------------------------------
+To be written
 
-Thank You to Kevin for security contributions to this release.
-Thank You to Ting-Wei for Unix contributions to this release.
-Thank You to Dan and Luis for their solid efforts on Exiv2.
-Thank You to Andreas S for representing Team Exiv2 at LGM 2019.
-Contributors: Jens, Nehal, Phil, Toni, Paul
 
 Headline Features of Exiv2 v0.27.2
 ----------------------------------


### PR DESCRIPTION
The packaging has been update to "stamp" version information into releasenotes.txt and ReadMe.txt  This avoids the chore of updating this manually for every release.