### PR TITLE
Update conan version in appveyor & use python-x64 version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
+init:
+  - echo %PYTHON%
+
 environment:
-  PYTHON: "C:\\Python37"
+  PYTHON: "C:/Python37-x64"
     
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -18,14 +21,6 @@ environment:
       ARCHITECTURE: x86_64
       UNIT_TESTS: 1
       WARNINGS_AS_ERRORS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      CMAKE_GENERATOR: Visual Studio 10 2010
-      INTEGRATION_TESTS: 0
-      VS_COMPILER_VERSION: 10
-      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat
-      ARCHITECTURE: x86
-      UNIT_TESTS: 0
-      WARNINGS_AS_ERRORS: OFF
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       CMAKE_GENERATOR: Ninja
       INTEGRATION_TESTS: 0
@@ -54,7 +49,7 @@ install:
     - 7z x ninja.zip -oC:\projects\deps\ninja > nul
     - set PATH=C:\projects\deps\ninja;%PATH%
     - ninja --version
-    - pip.exe install conan==1.17.2
+    - pip.exe install conan==1.24.0
     - cd %APPVEYOR_BUILD_FOLDER%
 
 before_build:
@@ -80,4 +75,4 @@ build_script:
     - cmd: if %UNIT_TESTS% == 1 unit_tests.exe
     - cmd: cd ../../tests/
     - cmd: set EXIV2_EXT=.exe
-    - cmd: if %INTEGRATION_TESTS% == 1 c:\Python36\python.exe runner.py -v
+    - cmd: if %INTEGRATION_TESTS% == 1 %PYTHON%/python.exe runner.py -v

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,7 +39,7 @@ class Exiv2Conan(ConanFile):
             # could use any of the versions.Also note that the issue was not with libcurl but with
             # libopenssl (a transitive dependency)
             if os_info.is_windows:
-                self.requires('libcurl/7.61.1@bincrafters/stable')
+                self.requires('libcurl/7.69.1')
             else:
                 self.requires('libcurl/7.64.1@bincrafters/stable')
 


### PR DESCRIPTION
I have to create this PR to check if the changes run correctly in AppVeyor. In contrast to travis-ci, Appveyor does not create jobs without a PR. I configured Appveyor like that in the past because the building times are much bigger in comparison to travis-ci. 