### PR TITLE
fix 1158 pathtest.exe (0.27->master)

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -132,6 +132,5 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/${PACKDIR}/ReadMe.txt ReadMe.txt       @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/releasenotes/releasenotes.txt      releasenotes.txt @ONLY)
 install       (FILES  ${CMAKE_CURRENT_BINARY_DIR}/ReadMe.txt ${CMAKE_CURRENT_BINARY_DIR}/releasenotes.txt DESTINATION .)
-# file        (REMOVE ${CMAKE_CURRENT_BINARY_DIR}/releasenotes.txt ${CMAKE_CURRENT_BINARY_DIR}/ReadMe.txt)
 
 include (CPack)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -42,7 +42,9 @@ foreach(entry ${SAMPLES})
     list(APPEND APPLICATIONS ${target})
     add_test( ${target}_test ${target} )
     target_include_directories(${target} PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find unused.h
-    install( TARGETS ${target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    if ( NOT ${target} MATCHES ".*test.*")                                # don't install tests
+        install( TARGETS ${target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
 endforeach()
 
 ###################################
@@ -59,15 +61,15 @@ add_executable( metacopy metacopy.cpp ../src/utils.cpp ../src/getopt.cpp)
 list(APPEND APPLICATIONS metacopy)
 target_include_directories(metacopy PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find utils.hpp
 
-add_executable(          pathtest  path-test.cpp ../src/utils.cpp ../src/getopt.cpp)
-list(APPEND APPLICATIONS pathtest)
-set_target_properties(   pathtest  PROPERTIES OUTPUT_NAME path-test )
-target_include_directories(pathtest PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find utils.hpp
+add_executable(          path-test  path-test.cpp ../src/utils.cpp ../src/getopt.cpp)
+list(APPEND APPLICATIONS path-test)
+set_target_properties(   path-test  PROPERTIES OUTPUT_NAME path-test )
+target_include_directories(path-test PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find utils.hpp
 
 add_executable(          exiv2json exiv2json.cpp Jzon.cpp Jzon.h)
 list(APPEND APPLICATIONS exiv2json)
 
-install( TARGETS metacopy pathtest exiv2json RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install( TARGETS metacopy exiv2json RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if( EXPAT_FOUND )
     add_executable(        geotag    geotag.cpp)


### PR DESCRIPTION
#1158  As well as fixing path-test, I have:

1) Modified samples/CMakeLists.txt to ignore `test` targets such as `iotest, iptctest, ...` which should not be installed in `/usr/local/bin`
2) Removed a redundant commented off line in cmake/packaging.cmake

Amazingly, CPack correctly does not put `iotest, iptctest, ...` in the binary package.