### PR TITLE
Enhanced test2 v0.27 (0.27->master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,23 +103,23 @@ if( EXIV2_BUILD_SAMPLES )
 		add_custom_target(tests
 			COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make unit_test
 			COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make ${TEST}
-		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make newtests
+		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make new_tests
 		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make version_test
 			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
 		)
     else()
 		add_custom_target(tests
 			COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make ${TEST}
-		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make newtests
+		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make new_tests
 		    COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make version_test
 			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
 		)
     endif()
-	add_custom_target(newtests
-		COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make newtests
+	add_custom_target(new_tests
+		COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make new_tests
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
 	)
-	add_custom_target(test
+	add_custom_target(bash_tests
 		COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" make ${TEST}
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
 	)

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ $ cd //Mac/Home/gnu/github/exiv2/0.27/maintenance/build_mingw_fedora
 $ export EXIV2_BINDIR=$pwd/bin
 $ export EXIV2_EXT=.exe
 $ cd ../test
-$ make test
+$ make tests
 ```
 
 You will find that 3 tests fail at the end of the test suite.  It is safe to ignore those minor exceptions.
@@ -741,8 +741,8 @@ There are different kinds of tests:
 | Description        | Language | Location | Command<br>_(in build or test directory)_ | CMake Option to Build |
 |:--                 |:--        |:--      |:--                                        |:--   |
 | Run all tests      |           |                      | $ make tests     | |
-| Bash scripts       | bash   | \<exiv2dir\>/test    | $ make test      | -DEXIV2\_BUILD\_SAMPLES=On |
-| Python scripts     | python | \<exiv2dir\>/tests   | $ make newtests  | -DEXIV2\_BUILD\_SAMPLES=On |
+| Bash scripts       | bash   | \<exiv2dir\>/test    | $ make bash_tests   | -DEXIV2\_BUILD\_SAMPLES=On |
+| Python scripts     | python | \<exiv2dir\>/tests   | $ make new_tests  | -DEXIV2\_BUILD\_SAMPLES=On |
 | Unit tests         | C++    | \<exiv2dir\>/unitTests   | $ make unit_test | -DEXIV2\_BUILD\_UNIT\_TESTS_=On | 
 | Version test       | C++    | \<exiv2dir\>/src/version.cpp | $ make version_test | Always in library |
 
@@ -780,7 +780,7 @@ $ env EXIV2_BINDIR=${PWD}/../build/bin ./icc-test.sh
 ICC jpg md5 webp md5 png md5 jpg md5
 all testcases passed.
 
-$ env EXIV2_BINDIR=${PWD}/../build/bin make newtests
+$ env EXIV2_BINDIR=${PWD}/../build/bin make new_tests
 ... lots of output ...
 test_run (tiff_test.test_tiff_test_program.TestTiffTestProg) ... ok
 ----------------------------------------------------------------------
@@ -813,8 +813,8 @@ Once you have modified the PATH and exported EXIV2\_BINDIR and EXIV2\_EXT, you c
 
 ```bash
 $ cd <exiv2dir>/test
-$ make test
-$ make newtests
+$ make tests
+$ make new_tests
 $ ./icc-test.sh
 ```
 
@@ -1073,4 +1073,4 @@ $ sudo pkg install developer/gcc-7
 
 [TOC](#TOC)
 
-Written by Robin Mills<br>robin@clanmills.com<br>Updated: 2020-04-18
+Written by Robin Mills<br>robin@clanmills.com<br>Updated: 2020-04-19

--- a/test/Makefile
+++ b/test/Makefile
@@ -136,7 +136,7 @@ xmpparser-test:
 
 version_test \
 unit_test    \
-test         \
+bash_tests   \
 tests:
 	@./$@.sh
 
@@ -168,7 +168,7 @@ unixtest:
 	    if [ $$rc -ne 0 ]; then              echo '***' $$p result = $$rc >> tmp/test-failed ; fi ; \
 	done
 
-newtests:
+new_tests:
 	( cd ../tests ; python3 runner.py --verbose )
 
 

--- a/test/bash_tests.sh
+++ b/test/bash_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+( source ./functions.source ; cd "$bin/.." ; make bash_tests )
+
+# That's all Folks!
+##

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-( source ./functions.source ; cd "$bin/.." ; make test )
-
-# That's all Folks!
-##


### PR DESCRIPTION
Correction to #1167

Replace make test with make bash_tests because CMake/Linux refuses a target called 'test'