### PR TITLE
enhanced_test3_0.27 (0.27 -> master)

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -138,7 +138,7 @@ version_test \
 unit_test    \
 bash_tests   \
 tests:
-	@./$@.sh
+	-@./$@.sh
 
 alltest:
 	@echo
@@ -169,7 +169,7 @@ unixtest:
 	done
 
 new_tests:
-	( cd ../tests ; python3 runner.py --verbose )
+	-( cd ../tests ; python3 runner.py --verbose )
 
 
 testv:


### PR DESCRIPTION
`$ make tests` ignores errors from bash_tests, new_test, unit_test and version_test