### PR TITLE
fix_1102_msysGCC93_0.27 (0.27->master)

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -38,7 +38,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
         add_compile_options(-Wp,-D_GLIBCXX_ASSERTIONS)
 
-        if (CMAKE_BUILD_TYPE STREQUAL Release AND NOT APPLE)
+        if (CMAKE_BUILD_TYPE STREQUAL Release AND NOT APPLE AND NOT MSYS)
             add_compile_options(-Wp,-D_FORTIFY_SOURCE=2) # Requires to compile with -O2
         endif()
 


### PR DESCRIPTION
See #1102

@D4N You'll see that @gaaned92 asked about adding `-lssp` to the linker settings.   If you think that `-lssp` is a better fix, please update this PR.  I don't want to upgrade the GCC compiler on my build machine l when I'm days away from Exiv2 v0.27.3 RC1, however I'll install it on my laptop/msys2 and test _**if you ask me to do so**_. 

Another possibility is to adding such as `-DEXIV2_ENABLE_STACK_PROTECTOR` and `-DEXIV2_ENABLE_FORTIFY_SOURCE`.  Again, if you prefer that route, please update the PR and I will modify README.md to explain what those options mean.

Thank you @D4N for thinking about this solution to #1102.  BTW, I don't think you are a pain-in-the a***, however I do think you (and Luis) are brilliant.