### PR TITLE
Do not call tell() in File::eof() - Fix tests & performance

### DIFF
--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -887,7 +887,7 @@ namespace Exiv2
     {
         if (p_->fp_ == nullptr)
             return true;
-        return feof(p_->fp_) != 0 || tell() >= static_cast<int64>(size());
+        return std::feof(p_->fp_) != 0;
     }
 
     std::string FileIo::path() const

--- a/tests/bugfixes/github/test_issue_428.py
+++ b/tests/bugfixes/github/test_issue_428.py
@@ -13,11 +13,11 @@ class PngReadRawProfile(metaclass=system_tests.CaseMeta):
 
     filenames = [
         system_tests.path("$data_path/issue_428_poc1.png"),
-        system_tests.path("$data_path/issue_428_poc2.png"),
         system_tests.path("$data_path/issue_428_poc3.png"),
         system_tests.path("$data_path/issue_428_poc4.png"),
         system_tests.path("$data_path/issue_428_poc8.png"),
 
+        system_tests.path("$data_path/issue_428_poc2.png"),
         system_tests.path("$data_path/issue_428_poc5.png"),
         system_tests.path("$data_path/issue_428_poc6.png"),
         system_tests.path("$data_path/issue_428_poc7.png"),
@@ -25,7 +25,10 @@ class PngReadRawProfile(metaclass=system_tests.CaseMeta):
 
     commands = ["$exiv2 " + fname for fname in filenames]
     stdout = [""] * len(filenames)
-    stderr = [ stderr_exception(fname) for fname in filenames[0:5] ]
+    stderr = [ stderr_exception(fname) for fname in filenames[0:4] ]
+    stderr.append("""$exiv2_exception_message """ + filenames[4] + """:
+$kerInputDataReadFailed
+""")
     stderr.append("""$exiv2_exception_message """ + filenames[5] + """:
 $kerCorruptedMetadata
 """)

--- a/tests/bugfixes/redmine/test_issue_480.py
+++ b/tests/bugfixes/redmine/test_issue_480.py
@@ -14,7 +14,11 @@ class LargeIptcTest(metaclass=system_tests.CaseMeta):
     commands = ["$largeiptc_test $bug_file $imagemagick_file"]
 
     stdout = ["""Reading 144766 bytes from $imagemagick_file
-Caught Exiv2 exception '$kerFailedToReadImageData'
+IPTC fields: 0
+IPTC fields: 144775
+IRB buffer : 144788
+Comparing IPTC and IRB size... ok
+Comparing IPTC and IRB data... ok
 """]
     stderr = [""]
-    retval = [1]
+    retval = [0]

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -22,6 +22,7 @@ taglist: ${ENV:exiv2_path}/taglist${ENV:binary_extension}
 [variables]
 kerOffsetOutOfRange: Offset out of range
 kerFailedToReadImageData: Failed to read image data
+kerInputDataReadFailed: Failed to read input data
 kerCorruptedMetadata: corrupted image metadata
 kerInvalidMalloc: invalid memory allocation request
 kerInvalidTypeValue: invalid type in tiff structure


### PR DESCRIPTION
As promised in #1177 & #882 this is the second PR including the change that should avoid some system calls when reading the metadata from some files.