### PR TITLE
GCC 9.3.0 broken on MinGW/msys2 and CYGWIN (0.27->master)

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -23,8 +23,8 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
 
-        # This fails under Fedora - MinGW - Gcc 8.3
-        if (NOT MINGW AND NOT CMAKE_HOST_SOLARIS)
+        # This fails under Fedora, MinGW GCC 8.3.0 and CYGWIN/MSYS 9.3.0
+        if (NOT (MINGW OR CMAKE_HOST_SOLARIS OR CYGWIN OR MSYS) )
             if (COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
                 add_compile_options(-fstack-clash-protection -fcf-protection)
             endif()


### PR DESCRIPTION
The GCC 9.3.0 compiler dies a horrible death on both MinGW/msys2 and CYGWIN as follows:

```
30 MSYS rmills@rmillsmbp-w10:~/gnu/github/exiv2/0.27-maintenance/build $ make
Scanning dependencies of target exiv2-xmp
[  0%] Building CXX object xmpsdk/CMakeFiles/exiv2-xmp.dir/src/ExpatAdapter.cpp.o
[  1%] Building CXX object xmpsdk/CMakeFiles/exiv2-xmp.dir/src/MD5.cpp.o
[  1%] Building CXX object xmpsdk/CMakeFiles/exiv2-xmp.dir/src/ParseRDF.cpp.o
[  2%] Building CXX object xmpsdk/CMakeFiles/exiv2-xmp.dir/src/UnicodeConversions.cpp.o
during RTL pass: final
/home/rmills/gnu/github/exiv2/0.27-maintenance/xmpsdk/src/UnicodeConversions.cpp: In function 'void ToUTF16(const UTF8Unit*, size_t, std::string*, bool)':
/home/rmills/gnu/github/exiv2/0.27-maintenance/xmpsdk/src/UnicodeConversions.cpp:293:1: internal compiler error: in i386_pe_seh_unwind_emit, at config/i386/winnt.c:1258
  293 | } // ToUTF16
      | ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <https://gcc.gnu.org/bugs/> for instructions.
make[2]: *** [xmpsdk/CMakeFiles/exiv2-xmp.dir/build.make:122: xmpsdk/CMakeFiles/exiv2-xmp.dir/src/UnicodeConversions.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:446: xmpsdk/CMakeFiles/exiv2-xmp.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
31 MSYS rmills@rmillsmbp-w10:~/gnu/github/exiv2/0.27-maintenance/build $
```

This issue was recognised and discussed in #1175

The fix is to omit -fstack-clash-protection on those platforms. 