### PR TITLE
taglist_unexpected_arg_0.27 (0.27->master)

### DIFF
--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -83,6 +83,7 @@ int main(int argc, char* argv[])
 
                 try {
                     XmpProperties::printProperties(std::cout, item);
+                    break;
                 } catch (const AnyError&) {
                     rc = 2;
                 }


### PR DESCRIPTION
There's a command-line parsing bug in samples/taglist.cpp that causes it to harmlessly report:
```
689 rmills@rmillsmm-local:~/gnu/github/exiv2/0.27-maintenance/build $ bin/taglist mwg-rs >/dev/null
Unexpected argument mwg-rs
690 rmills@rmillsmm-local:~/gnu/github/exiv2/0.27-maintenance/build $
```
This error message appears when generating the metadata tables for the exiv2.org
```
689 rmills@rmillsmm-local:~/gnu/github/exiv2/0.27-maintenance/doc/templates $ make 
... lots of "Unexpected arguments dc mwg-rs etc ... 
690 rmills@rmillsmm-local:~/gnu/github/exiv2/0.27-maintenance/doc/templates $
```