### PR TITLE
Enforce cxx_std_98 in samples, unit_tests, and exiv2 application

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -22,6 +22,10 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
 
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
+        # On Solaris target_compile_features(${application} PRIVATE cxx_std_98) fails to set this flag
+        if ( CMAKE_HOST_SOLARIS ) 
+            add_compile_options(-std=gnu++98)
+        endif()
 
         # This fails under Fedora, MinGW GCC 8.3.0 and CYGWIN/MSYS 9.3.0
         if (NOT (MINGW OR CMAKE_HOST_SOLARIS OR CYGWIN OR MSYS) )

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -120,6 +120,7 @@ list(APPEND APPLICATIONS remotetest)
 # ******************************************************************************
 foreach(application ${APPLICATIONS})
     target_link_libraries(${application} PRIVATE exiv2lib)
+    target_compile_features(${application} PRIVATE cxx_std_98)
     if( EXIV2_ENABLE_PNG )
         target_link_libraries( ${application} PRIVATE ${ZLIB_LIBRARIES} )
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -256,6 +256,7 @@ if(EXIV2_BUILD_EXIV2_COMMAND)
          getopt.cpp getopt.hpp
          utils.cpp utils.hpp
     )
+    target_compile_features(exiv2 PRIVATE cxx_std_98)
 
     set_target_properties( exiv2 PROPERTIES
         COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -17,8 +17,8 @@ foreach(source IN LISTS exiv2lib_SOURCES exiv2lib_int_SOURCES)
     endif()
 endforeach()
 
-add_executable(unit_tests mainTestRunner.cpp
-    gtestwrapper.h
+add_executable(unit_tests
+    mainTestRunner.cpp
     test_DateValue.cpp
     test_TimeValue.cpp
     test_XmpKey.cpp
@@ -33,6 +33,7 @@ add_executable(unit_tests mainTestRunner.cpp
     test_slice.cpp
     test_tiffheader.cpp
     test_types.cpp
+    gtestwrapper.h
     ${unit_tests_exiv2lib_SOURCES}
 )
 
@@ -41,6 +42,7 @@ target_compile_definitions(unit_tests
     exiv2lib_STATIC
     TESTDATA_PATH="${PROJECT_SOURCE_DIR}/test/data"
 )
+target_compile_features(unit_tests PRIVATE cxx_std_98)
 
 if (exiv2lib_COMPILE_DEFINITIONS)
     target_compile_definitions(unit_tests PRIVATE ${exiv2lib_COMPILE_DEFINITIONS})


### PR DESCRIPTION
Eliminates 2305 GCC unique_ptr warnings.  See issue #1163 and PR #1176