### PR TITLE
set LD_LIBRARY_PATH when running tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -47,7 +47,7 @@ all: test
 top_srcdir = ..
 
 # Initialisations
-SHELL = /bin/sh
+SHELL = /bin/bash
 
 .SUFFIXES:
 
@@ -137,15 +137,7 @@ unit_test    :
 	-@./$@.sh
 
 tests:
-	-@if [ -e $$EXIV2_BINDIR/../Makefile ]; then \
-	    -@./$@.sh ; \
-	else \
-	    make unit_test    ; \
-	    make bash_tests   ; \
-	    make python_tests ; \
-	    make version_test ; \
-	fi
-
+	make unit_test  bash_tests  python_tests version_test
 
 bash_tests:
 	@echo
@@ -167,7 +159,7 @@ python_tests:
 	@echo
 	@echo ---- Running python_tests ----
 	@echo
-	-( cd ../tests ; if [ ! -z $$VERBOSE ]; then verbose=--verbose ;fi ; python3 runner.py $$verbose )
+	-( source functions.source ; cd ../tests ; if [ ! -z $$VERBOSE ]; then verbose=--verbose ;fi ; python3 runner.py $$verbose )
 
 testv:
 	@for t in /video ; do \

--- a/test/functions.source
+++ b/test/functions.source
@@ -478,20 +478,6 @@ prepareTest()
 	export LC_ALL=C
 	export TZ=BST-1
 
-	##
-	# initialize globals
-	this=$(basename $0 .sh)
-	here=$PWD
-	datapath="../data"
-	testdir="$here/tmp"
-	datadir="../data"
-
-	if [ -z "$EXIV2_BINDIR" ] ; then
-        bin="$here/../build/bin/"
-	else
-		bin="$EXIV2_BINDIR/"
-	fi
-
 	os=$(uname)
 	if [ "${os:0:4}" == "CYGW" ]; then
 		export PLATFORM=cygwin
@@ -508,6 +494,29 @@ prepareTest()
 	if [ ! -z $EXIV2_EXT ]; then
 		exe=$EXIV2_EXT
 	fi
+
+	##
+	# initialize globals
+	this=$(basename $0 .sh)
+	here=$PWD
+	datapath="../data"
+	testdir="$here/tmp"
+	datadir="../data"
+
+	if [ -z "$EXIV2_BINDIR" ] ; then
+        bin="$here/../build/bin/"
+	else
+		bin="$EXIV2_BINDIR/"
+	fi
+	
+    # update PATHs to ensure we load the the correct dynamlic library
+    if [ $PLATFORM == 'mingw' -a $PLATFORM == 'cygwin' ]; then
+        export PATH="$bin:$PATH"
+    elif [ 'PLATFORM' == 'Darwin' ]; then
+        export DYLD_LIBRARY_PATH="$bin/../lib:$DYLD_LIBRARY_PATH"
+    else
+        export LD_LIBRARY_PATH="$bin/../lib:$LD_LIBRARY_PATH"
+    fi
 
 	if [ "$PLATFORM" == cygwin ]; then
 		# We need a private version of diff for linux compatibility


### PR DESCRIPTION
LD_LIBRARY_PATH (and DYLD_LIBRARY_PATH on macOS and PATH on Windows) is not set when running tests and consequently, the commands are executing "old" libaries in /usr/local/lib.

In reality, this only impacts Linux (and presumably UNIX) because macOS uses @rpath magic to locate dynamic libraries.  Windows always seaches the process directory for dll before inspecting PATH.