### PR TITLE
Fix cmake install in case of subdirectory use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ if (EXIV2_TEAM_PACKAGING)
 endif()
 
 configure_file(cmake/exiv2.pc.in exiv2.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/exiv2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exiv2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # ******************************************************************************
 # Man page


### PR DESCRIPTION
There's a bug when you use exiv2 with CMake as  `add_subdirectory(/path/to/exiv2)` and then after build you're doing `make install`, you get an error that `exiv2.pc` file is not found. This PR fixes this issue.