### PR TITLE
WIP - Add ARM job to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       compiler: gcc
       env:
         - BUILD_TYPE="Release"
+        - CONAN_WEBREADY_DISABLED=1
+        - COMMON_CMAKE_OPTIONS="-DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_CURL=OFF -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_INSTALL_PREFIX=install"
 
     - name: "Ubuntu 16.04 - gcc-5.4 (Release)"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,15 @@ env:
 
 matrix:
   include:
+    - name: "Ubuntu 16.04 - gcc-5.4 (Release) - ARM"
+      os: linux
+      arch: arm64
+      dist: xenial
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="Release"
+
     - name: "Ubuntu 16.04 - gcc-5.4 (Release)"
       os: linux
       dist: xenial

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -30,6 +30,9 @@ else
   conan install .. -o webready=True  --build missing
 fi
 
+cmake --version
+gcc --version
+
 cmake ${CMAKE_OPTIONS} ..
 make -j2
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -24,7 +24,11 @@ fi
 source conan/bin/activate
 
 mkdir build && cd build
-conan install .. -o webready=True --build missing
+if [ -n "$CONAN_WEBREADY_DISABLED" ]; then
+  conan install .. -o webready=False --build missing
+else
+  conan install .. -o webready=True  --build missing
+fi
 
 cmake ${CMAKE_OPTIONS} ..
 make -j2

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -40,11 +40,14 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
             endif()
         endif()
 
-        add_compile_options(-Wp,-D_GLIBCXX_ASSERTIONS)
+        if (NOT MINGW)
+            add_compile_options(-Wp,-D_GLIBCXX_ASSERTIONS)
 
-        if (CMAKE_BUILD_TYPE STREQUAL Release AND NOT APPLE)
-            add_compile_options(-Wp,-D_FORTIFY_SOURCE=2) # Requires to compile with -O2
+            if (CMAKE_BUILD_TYPE STREQUAL Release AND NOT APPLE)
+                add_compile_options(-Wp,-D_FORTIFY_SOURCE=2) # Requires to compile with -O2
+            endif()
         endif()
+
 
         if(BUILD_WITH_COVERAGE)
             add_compile_options(--coverage)

--- a/cmake/linux-mingw64.cmake
+++ b/cmake/linux-mingw64.cmake
@@ -1,0 +1,23 @@
+set(CMAKE_SYSTEM_NAME Windows)
+#set(CMAKE_SYSTEM_PROCESSOR AMD64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+#set(CMAKE_SYSROOT /usr/x86_64-w64-mingw32/)
+set(CMAKE_SYSROOT /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix)
+
+# cross compilers to use for C and C++
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+#set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+#set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+#set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+#set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+#set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/linux-mingw64.cmake
+++ b/cmake/linux-mingw64.cmake
@@ -1,14 +1,12 @@
 set(CMAKE_SYSTEM_NAME Windows)
-#set(CMAKE_SYSTEM_PROCESSOR AMD64)
 set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
-#set(CMAKE_SYSROOT /usr/x86_64-w64-mingw32/)
-set(CMAKE_SYSROOT /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix)
 
 # cross compilers to use for C and C++
-set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
-set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc-posix)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++-posix)
 set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
 set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+set(CMAKE_CXX_FLAGS "-fno-stack-protector")
 
 # target environment on the build host system
 #   set 1st to dir with the cross compiler's C/C++ headers/libs

--- a/notesOnCrossCompiling.txt
+++ b/notesOnCrossCompiling.txt
@@ -1,0 +1,64 @@
+Conan Profile for linux_to_win64
+
+luis@ryzenLinux:~/.conan/profiles$ cat linux_to_win64 
+        toolchain=/usr/x86_64-w64-mingw32 # Adjust this path
+        target_host=x86_64-w64-mingw32
+        cc_compiler=gcc
+        cxx_compiler=g++
+
+        [env]
+        CONAN_CMAKE_FIND_ROOT_PATH=$toolchain
+        CHOST=$target_host
+        AR=$target_host-ar
+        AS=$target_host-as
+        RANLIB=$target_host-ranlib
+        CC=$target_host-$cc_compiler
+        CXX=$target_host-$cxx_compiler
+        STRIP=$target_host-strip
+        RC=$target_host-windres
+
+        [settings]
+        # We are cross-building to Windows
+        os=Windows
+        arch=x86_64
+        compiler=gcc
+
+        # Adjust to the gcc version of your MinGW package
+        compiler.version=9.3
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+CMake Toolchain file:
+        set(CMAKE_SYSTEM_NAME Windows)
+        set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+        set(CMAKE_SYSROOT /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix)
+
+        set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+        set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+        set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
+        set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+
+
+For configuring and building on mingw
+
+conan install --build missing --profile linux_to_win64 ../
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../cmake/linux-mingw64.cmake ../
+
+Current problem which I am not able to solve:
+
+[ 11%] Building CXX object src/CMakeFiles/exiv2lib_int.dir/cr2header_int.cpp.obj
+cd /media/linuxDev/programming/exiv2/buildMingw/src && /usr/bin/x86_64-w64-mingw32-g++ --sysroot=/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix  -Dexiv2lib_STATIC @CMakeFiles/exiv2lib_int.dir/includes_CXX.rsp -O3 -DNDEBUG -fvisibility=hidden -fno-keep-inline-dllexport   -Wp,-D_GLIBCXX_ASSERTIONS -Wp,-D_FORTIFY_SOURCE=2 -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W -std=c++11 -o CMakeFiles/exiv2lib_int.dir/cr2header_int.cpp.obj -c /media/linuxDev/programming/exiv2/src/cr2header_int.cpp
+In file included from /media/linuxDev/programming/exiv2/include/exiv2/xmp_exiv2.hpp:34,
+                 from /media/linuxDev/programming/exiv2/include/exiv2/image.hpp:31,
+                 from /media/linuxDev/programming/exiv2/src/tiffimage_int.hpp:33,
+                 from /media/linuxDev/programming/exiv2/src/cr2header_int.hpp:31,
+                 from /media/linuxDev/programming/exiv2/src/cr2header_int.cpp:1:
+/media/linuxDev/programming/exiv2/include/exiv2/properties.hpp:215:21: error: ‘mutex’ in namespace ‘std’ does not name a type
+  215 |         static std::mutex mutex_;
+      |                     ^~~~~
+
+
+For some reason is not finding the right headers where to find the new C++11 stuff which are in this
+the folder:
+        set(CMAKE_SYSROOT /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix)

--- a/notesOnCrossCompiling.txt
+++ b/notesOnCrossCompiling.txt
@@ -43,22 +43,14 @@ CMake Toolchain file:
 For configuring and building on mingw
 
 conan install --build missing --profile linux_to_win64 ../
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../cmake/linux-mingw64.cmake ../
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../cmake/linux-mingw64.cmake -DBUILD_SHARED_LIBS=OFF ../
 
-Current problem which I am not able to solve:
+It is possible to build the library and all the applications if the exiv2lib is STATIC
+(-DBUILD_SHARED_LIBS=OFF). However, when building the SHARED library we get this linking error:
 
-[ 11%] Building CXX object src/CMakeFiles/exiv2lib_int.dir/cr2header_int.cpp.obj
-cd /media/linuxDev/programming/exiv2/buildMingw/src && /usr/bin/x86_64-w64-mingw32-g++ --sysroot=/usr/lib/gcc/x86_64-w64-mingw32/9.3-posix  -Dexiv2lib_STATIC @CMakeFiles/exiv2lib_int.dir/includes_CXX.rsp -O3 -DNDEBUG -fvisibility=hidden -fno-keep-inline-dllexport   -Wp,-D_GLIBCXX_ASSERTIONS -Wp,-D_FORTIFY_SOURCE=2 -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W -std=c++11 -o CMakeFiles/exiv2lib_int.dir/cr2header_int.cpp.obj -c /media/linuxDev/programming/exiv2/src/cr2header_int.cpp
-In file included from /media/linuxDev/programming/exiv2/include/exiv2/xmp_exiv2.hpp:34,
-                 from /media/linuxDev/programming/exiv2/include/exiv2/image.hpp:31,
-                 from /media/linuxDev/programming/exiv2/src/tiffimage_int.hpp:33,
-                 from /media/linuxDev/programming/exiv2/src/cr2header_int.hpp:31,
-                 from /media/linuxDev/programming/exiv2/src/cr2header_int.cpp:1:
-/media/linuxDev/programming/exiv2/include/exiv2/properties.hpp:215:21: error: ‘mutex’ in namespace ‘std’ does not name a type
-  215 |         static std::mutex mutex_;
-      |                     ^~~~~
+[ 56%] Linking CXX executable ../bin/exiv2.exe
+/usr/bin/x86_64-w64-mingw32-ld: CMakeFiles/exiv2.dir/objects.a(params.cpp.obj):params.cpp:(.text$_ZN5Exiv210BasicErrorIcEC1INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEENS_9ErrorCodeERKT_[_ZN5Exiv210BasicErrorIcEC1INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEENS_9ErrorCodeERKT_]+0x95): undefined reference to `__imp__ZN5Exiv210BasicErrorIcE6setMsgEv'
+collect2: error: ld returned 1 exit status
 
-
-For some reason is not finding the right headers where to find the new C++11 stuff which are in this
-the folder:
-        set(CMAKE_SYSROOT /usr/lib/gcc/x86_64-w64-mingw32/9.3-posix)
+As discussed in the following link, we have to deal with the BasicError::setMsg monster:
+https://github.com/Exiv2/exiv2/issues/663

--- a/xmpsdk/include/XMP_Environment.h
+++ b/xmpsdk/include/XMP_Environment.h
@@ -44,7 +44,13 @@
 #elif defined macintosh || defined MACOS_CLASSIC || defined MACOS_X_UNIX || defined MACOS_X || defined MACOS || defined(__APPLE__)
 # define MAC_ENV 1
 #else
+
+#ifdef __MINGW32__
+# define WIN_ENV 1
+#else
 # define UNIX_ENV 1
+#endif
+
 #endif
 
 // ! Tempting though it might be to have a standard macro for big or little endian, there seems to


### PR DESCRIPTION
In this PR I am trying to add a new job to travis-ci to check the compilation & test execution on ARM64 architectures.

I had to fight a bit to make the project to compile due to a difference in the CMake version between the ARM64 and AMD64 travis images (issue documented here: https://travis-ci.community/t/about-the-multi-cpu-architecture-category/5336/27?u=piponazo) . 

Now, the job is failing when running the system tests. I will investigate in the next days what's the issue there (@cgilles , I am pinging you just to let you know that there might some parts in Exiv2 that behaves differently depending on the architecture). 