### PR TITLE
Fix build on aarch64

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -26,7 +26,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
         # This fails under Fedora - MinGW - Gcc 8.3
         if (NOT MINGW)
             if (COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
-                if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+                if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
                     add_compile_options(-fstack-clash-protection -fcf-protection)
                 else()
                     add_compile_options(-fstack-clash-protection)


### PR DESCRIPTION
- This is a followup to commit 1ea63cc

This is the patch I used for the flatpak builds of Rawtherapee and Entangle

This does not mean other non-x86_64 builds will work. (it's the only arch with maybe i386 that supports it right now according to the documentation). Ideally this should be checked by checking if the compiler supports it.