### PR TITLE
cmake/compilerFlags.cmake: properly detect availability of flags

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -1,4 +1,5 @@
 # These flags applies to exiv2lib, the applications, and to the xmp code
+include(CheckCCompilerFlag)
 
 if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
@@ -25,16 +26,16 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
         # This fails under Fedora - MinGW - Gcc 8.3
         if (NOT MINGW)
-            if (COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
-                if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
-                    add_compile_options(-fstack-clash-protection -fcf-protection)
-                else()
-                    add_compile_options(-fstack-clash-protection)
-                endif()
+	    check_c_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
+	    check_c_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
+	    check_c_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)
+	    if(HAS_FSTACK_CLASH_PROTECTION)
+                add_compile_options(-fstack-clash-protection)
             endif()
-
-            if (COMPILER_IS_GCC OR (COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 3.7 ))
-                # is not available for clang 3.4.2. it appears to be present in clang 3.7.
+	    if(GCC_HAS_FCF_PROTECTION)
+		add_compile_options(-fcf-protection)
+	    endif()
+	    if(GCC_HAS_FSTACK_PROTECTOR_STRONG)
                 add_compile_options(-fstack-protector-strong)
             endif()
         endif()


### PR DESCRIPTION
Instead of relying on fragile and complex logic to decide if a
compiler flag is available or not, use the check_c_compiler_flag()
macro provided by the CMake standard library.

This for example avoids using -fcf-protection on architectures that
don't support this option.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>