### PR TITLE
fix_1268_GPSProcessingMethod

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -906,7 +906,7 @@ int main(int argc,const char* argv[])
                     image->readMetadata();
                     Exiv2::ExifData& exifData = image->exifData();
                     if ( pPos ) {
-                        exifData["Exif.GPSInfo.GPSProcessingMethod" ] = "65 83 67 73 73 0 0 0 72 89 66 82 73 68 45 70 73 88"; // ASCII HYBRID-FIX
+                        exifData["Exif.GPSInfo.GPSProcessingMethod" ] = "charset=Ascii HYBRID-FIX";
                         exifData["Exif.GPSInfo.GPSVersionID"        ] = "2 2 0 0";
                         exifData["Exif.GPSInfo.GPSMapDatum"         ] = "WGS-84";
 

--- a/test/data/geotag-test.out
+++ b/test/data/geotag-test.out
@@ -23,5 +23,5 @@ Exif.GPSInfo.GPSAltitudeRef                  Byte        1  Below sea level
 Exif.GPSInfo.GPSAltitude                     Rational    1  14.3 m
 Exif.GPSInfo.GPSTimeStamp                    Rational    3  09:54:28
 Exif.GPSInfo.GPSMapDatum                     Ascii       7  WGS-84
-Exif.GPSInfo.GPSProcessingMethod             Undefined  58  65 83 67 73 73 0 0 0 72 89 66 82 73 68 45 70 73 88
+Exif.GPSInfo.GPSProcessingMethod             Undefined  18  charset=Ascii HYBRID-FIX
 Exif.GPSInfo.GPSDateStamp                    Ascii      20  2008:05:08 09:54:28


### PR DESCRIPTION
I discovered this when investigating #1258.  When I dealt with #1046, we fixed the syntax for Exif 'comment' tags and I made changes to the geotag test.  I'm very surprised that I didn't fix this at the time. 