### PR TITLE
clang-tidy: use nullptr where appropriate

### DIFF
--- a/include/exiv2/convert.hpp
+++ b/include/exiv2/convert.hpp
@@ -64,9 +64,9 @@ namespace Exiv2 {
     EXIV2API void syncExifWithXmp(ExifData& exifData, XmpData& xmpData);
 
     //! Convert (copy) IPTC datasets to XMP properties.
-    EXIV2API void copyIptcToXmp(const IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+    EXIV2API void copyIptcToXmp(const IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = nullptr);
     //! Convert (move) IPTC datasets to XMP properties, remove converted IPTC datasets.
-    EXIV2API void moveIptcToXmp(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+    EXIV2API void moveIptcToXmp(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = nullptr);
 
     //! Convert (copy) XMP properties to IPTC datasets.
     EXIV2API void copyXmpToIptc(const XmpData& xmpData, IptcData& iptcData);

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -62,7 +62,7 @@ namespace Exiv2
         /// @param key %ExifKey.
         /// @param pValue Pointer to an %Exifdatum value.
         /// @throw Error if the key cannot be parsed and converted.
-        explicit Exifdatum(const ExifKey& key, const Value* pValue = 0);
+        explicit Exifdatum(const ExifKey& key, const Value* pValue = nullptr);
 
         Exifdatum(const Exifdatum& rhs);
 
@@ -138,7 +138,7 @@ namespace Exiv2
         /// @return Number of characters written.
         long copy(byte* buf, ByteOrder byteOrder) const override;
 
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = nullptr) const override;
         //! Return the type id of the value
         TypeId typeId() const override;
         //! Return the name of the type

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -65,7 +65,7 @@ namespace Exiv2 {
                  to a tag number and record id.
          */
         explicit Iptcdatum(const IptcKey& key,
-                           const Value* pValue =0);
+                           const Value* pValue =nullptr);
         //! Copy constructor
         Iptcdatum(const Iptcdatum& rhs);
         //! Destructor
@@ -106,7 +106,7 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata =nullptr) const override;
         /*!
           @brief Return the key of the Iptcdatum. The key is of the form
                  '<b>Iptc</b>.recordName.datasetName'. Note however that the key

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -157,7 +157,7 @@ namespace Exiv2 {
 
           Implemented in terms of write(), see there.
          */
-        std::string print(const ExifData* pMetadata =0) const;
+        std::string print(const ExifData* pMetadata =nullptr) const;
         /*!
           @brief Write value to a data buffer and return the number
                  of bytes written.
@@ -193,7 +193,7 @@ namespace Exiv2 {
          */
         virtual std::ostream& write(
                   std::ostream& os,
-            const ExifData*     pMetadata =0
+            const ExifData*     pMetadata =nullptr
         ) const =0;
         /*!
           @brief Return the key of the metadatum. The key is of the form

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -242,7 +242,7 @@ namespace Exiv2 {
         void free();
 
         //! Reset value
-        void reset(std::pair<byte*, size_t> =std::make_pair((byte*)(0),size_t(0)));
+        void reset(std::pair<byte*, size_t> =std::make_pair((byte*)nullptr,size_t(0)));
         //@}
 
         /*!

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -606,7 +606,7 @@ namespace Exiv2 {
 
           @return A string containing the comment converted to UTF-8.
          */
-        std::string comment(const char* encoding =0) const;
+        std::string comment(const char* encoding =nullptr) const;
         /*!
           @brief Determine the character encoding that was used to encode the
               UNICODE comment value as an iconv(3) name.
@@ -1504,33 +1504,33 @@ namespace Exiv2 {
 
     template<typename T>
     ValueType<T>::ValueType()
-        : Value(getType<T>()), pDataArea_(0), sizeDataArea_(0)
+        : Value(getType<T>()), pDataArea_(nullptr), sizeDataArea_(0)
     {
     }
 
     template<typename T>
     ValueType<T>::ValueType(TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
     }
 
     template<typename T>
     ValueType<T>::ValueType(const byte* buf, long len, ByteOrder byteOrder, TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
         read(buf, len, byteOrder);
     }
 
     template<typename T>
     ValueType<T>::ValueType(const T& val, TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
         value_.push_back(val);
     }
 
     template<typename T>
     ValueType<T>::ValueType(const ValueType<T>& rhs)
-        : Value(rhs), value_(rhs.value_), pDataArea_(0), sizeDataArea_(0)
+        : Value(rhs), value_(rhs.value_), pDataArea_(nullptr), sizeDataArea_(0)
     {
         if (rhs.sizeDataArea_ > 0) {
             pDataArea_ = new byte[rhs.sizeDataArea_];
@@ -1552,7 +1552,7 @@ namespace Exiv2 {
         Value::operator=(rhs);
         value_ = rhs.value_;
 
-        byte* tmp = 0;
+        byte* tmp = nullptr;
         if (rhs.sizeDataArea_ > 0) {
             tmp = new byte[rhs.sizeDataArea_];
             std::memcpy(tmp, rhs.pDataArea_, rhs.sizeDataArea_);
@@ -1741,7 +1741,7 @@ namespace Exiv2 {
     template<typename T>
     int ValueType<T>::setDataArea(const byte* buf, size_t len)
     {
-        byte* tmp = 0;
+        byte* tmp = nullptr;
         if (len > 0) {
             tmp = new byte[len];
             std::memcpy(tmp, buf, len);

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -65,7 +65,7 @@ namespace Exiv2 {
                  to a known schema namespace prefix and property name.
          */
         explicit Xmpdatum(const XmpKey& key,
-                          const Value* pValue =0);
+                          const Value* pValue =nullptr);
         //! Copy constructor
         Xmpdatum(const Xmpdatum& rhs);
         //! Destructor
@@ -117,7 +117,7 @@ namespace Exiv2 {
         //@{
         //! Not implemented. Calling this method will raise an exception.
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata =nullptr) const override;
         /*!
           @brief Return the key of the Xmpdatum. The key is of the form
                  '<b>Xmp</b>.prefix.property'. Note however that the
@@ -385,7 +385,7 @@ namespace Exiv2 {
 
           @return True if the initialization was successful, else false.
          */
-        static bool initialize(XmpParser::XmpLockFct xmpLockFct =0, void* pLockData =0);
+        static bool initialize(XmpParser::XmpLockFct xmpLockFct =nullptr, void* pLockData =nullptr);
         /*!
           @brief Terminate the XMP Toolkit and unregister custom namespaces.
 

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -74,7 +74,7 @@ try {
     v = pos->getValue();
     // Downcast the Value pointer to its actual type
     Exiv2::URationalValue* prv = dynamic_cast<Exiv2::URationalValue*>(v.release());
-    if (prv == 0) throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
+    if (prv == nullptr) throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
     rv = Exiv2::URationalValue::UniquePtr(prv);
     // Modify the value directly through the interface of URationalValue
     rv->value_[2] = std::make_pair(88,77);
@@ -96,7 +96,7 @@ try {
     // *************************************************************************
     // Finally, write the remaining Exif data to the image file
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
 
     image->setExifData(exifData);
     image->writeMetadata();

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -19,7 +19,7 @@ try {
     }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::XmpData xmpData;

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -52,7 +52,7 @@ try {
     }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
     Exiv2::ExifData& ed = image->exifData();
 

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -28,7 +28,7 @@ try {
     }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
     Exiv2::ExifData &exifData = image->exifData();
 

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -34,7 +34,7 @@ try {
     std::string file(argv[1]);
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::ExifData &ed = image->exifData();
@@ -107,7 +107,7 @@ catch (Exiv2::AnyError& e) {
 void write(const std::string& file, Exiv2::ExifData& ed)
 {
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->setExifData(ed);
     image->writeMetadata();
 }
@@ -115,7 +115,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
 void print(const std::string& file)
 {
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::ExifData &ed = image->exifData();

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -178,7 +178,7 @@ int main(int argc,const char* argv[])
 
 	if ( !result ) try {
 		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-		assert(image.get() != 0);
+		assert(image.get() != nullptr);
 		image->readMetadata();
 		Exiv2::ExifData &exifData = image->exifData();
 

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -71,7 +71,7 @@ try {
     }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::ExifData &exifData = image->exifData();

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* const argv[])
     const char* key  = argv[2];
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
     Exiv2::ExifData &exifData = image->exifData();
 

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -283,7 +283,7 @@ int main(int argc, char* const argv[])
         char        option = opt[0];
 
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
 
         Jzon::Object   root;

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -38,7 +38,7 @@ try {
 
     // Open image file
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
 
     // Set IPTC data and write it to the file
     image->setIptcData(iptcData);

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -20,7 +20,7 @@ try {
     }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::IptcData &iptcData = image->iptcData();

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* const argv[])
         }
 
         Image::UniquePtr image = ImageFactory::open(argv[1]);
-        assert (image.get() != 0);
+        assert (image.get() != nullptr);
         image->readMetadata();
 
         // Process commands

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *const argv[]) {
 
     // Read metadata from file
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     // Set Preview field to the content of the data file
@@ -44,7 +44,7 @@ int main(int argc, char *const argv[]) {
     std::cout << "IPTC fields: " << iptcData.size() << "\n";
 
     // Set IRB, compare with IPTC raw data
-    Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(0, 0, iptcData);
+    Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(nullptr, 0, iptcData);
     std::cout << "IRB buffer : " << irb.size_ << "\n";
     const Exiv2::byte *record;
     uint32_t sizeHdr;

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -60,11 +60,11 @@ try {
     memIo->transfer(*fileIo);
 
     Exiv2::Image::UniquePtr readImg = Exiv2::ImageFactory::open(std::move(memIo));
-    assert(readImg.get() != 0);
+    assert(readImg.get() != nullptr);
     readImg->readMetadata();
 
     Exiv2::Image::UniquePtr writeImg = Exiv2::ImageFactory::open(params.write_);
-    assert(writeImg.get() != 0);
+    assert(writeImg.get() != nullptr);
     if (params.preserve_) writeImg->readMetadata();
     if (params.iptc_) {
         writeImg->setIptcData(readImg->iptcData());

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* const argv[])
         }
 
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
 
         Exiv2::ExifData& exifData = image->exifData();

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -20,7 +20,7 @@ try {
     std::string filename(argv[1]);
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(filename);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::PreviewManager loader(*image);

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -44,14 +44,14 @@ try {
     exifData.add(key, v.get());
 
     Exiv2::Image::UniquePtr writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
-    assert(writeTest.get() != 0);
+    assert(writeTest.get() != nullptr);
     writeTest->setExifData(exifData);
     writeTest->writeMetadata();
 
     // read the result to make sure everything fine
     std::cout << "Print out the new metadata ...\n";
     Exiv2::Image::UniquePtr readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
-    assert(readTest.get() != 0);
+    assert(readTest.get() != nullptr);
     readTest->readMetadata();
     Exiv2::ExifData &exifReadData = readTest->exifData();
     if (exifReadData.empty()) {

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -44,7 +44,7 @@ void mini1(const char* path)
     WriteMethod wm;
 
     // Write nothing to a new structure, without a previous binary image
-    wm = ExifParser::encode(blob, 0, 0, bigEndian, exifData);
+    wm = ExifParser::encode(blob, nullptr, 0, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     assert(blob.size() == 0);
     std::cout << "Test 1: Writing empty Exif data without original binary data: ok.\n";
@@ -58,7 +58,7 @@ void mini1(const char* path)
 
     // Write something to a new structure, without a previous binary image
     exifData["Exif.Photo.DateTimeOriginal"] = "Yesterday at noon";
-    wm = ExifParser::encode(blob, 0, 0, bigEndian, exifData);
+    wm = ExifParser::encode(blob, nullptr, 0, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     std::cout << "Test 3: Wrote non-empty Exif data without original binary data:\n";
     exifData.clear();

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -165,7 +165,7 @@ void testCase(const std::string& file1,
 
     //Open first image
     Image::UniquePtr image1 = ImageFactory::open(file1);
-    assert(image1.get() != 0);
+    assert(image1.get() != nullptr);
 
     // Load existing metadata
     std::cerr << "---> Reading file " << file1 << "\n";
@@ -181,7 +181,7 @@ void testCase(const std::string& file1,
 
     // Open second image
     Image::UniquePtr image2 = ImageFactory::open(file2);
-    assert(image2.get() != 0);
+    assert(image2.get() != nullptr);
 
     image2->setExifData(image1->exifData());
 

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* const argv[])
 
     std::cout <<"\n----- Non-intrusive writing of special Canon MakerNote tags\n";
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::ExifData& rEd = image->exifData();
@@ -209,7 +209,7 @@ catch (Exiv2::AnyError& e) {
 void write(const std::string& file, Exiv2::ExifData& ed)
 {
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
 
     image->setExifData(ed);
     image->writeMetadata();
@@ -218,7 +218,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
 void print(const std::string& file)
 {
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
-    assert(image.get() != 0);
+    assert(image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::ExifData &ed = image->exifData();

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* const argv[])
         }
 
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
 
         const std::string& xmpPacket = image->xmpPacket();

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
       }
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
-    assert (image.get() != 0);
+    assert (image.get() != nullptr);
     image->readMetadata();
 
     Exiv2::XmpData &xmpData = image->xmpData();

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -321,7 +321,7 @@ namespace Exiv2
         if (p_->isWriteable_) {
             prot |= PROT_WRITE;
         }
-        void* rc = ::mmap(0, p_->mappedLength_, prot, MAP_SHARED, fileno(p_->fp_), 0);
+        void* rc = ::mmap(nullptr, p_->mappedLength_, prot, MAP_SHARED, fileno(p_->fp_), 0);
         if (MAP_FAILED == rc) {
 #ifdef EXV_UNICODE_PATH
             if (p_->wpMode_ == Impl::wpUnicode) {

--- a/src/MemIo.cpp
+++ b/src/MemIo.cpp
@@ -152,7 +152,7 @@ namespace Exiv2
             p_->size_ = memIo->p_->size_;
             p_->isMalloced_ = memIo->p_->isMalloced_;
             memIo->p_->idx_ = 0;
-            memIo->p_->data_ = 0;
+            memIo->p_->data_ = nullptr;
             memIo->p_->size_ = 0;
             memIo->p_->isMalloced_ = false;
         } else {

--- a/src/RemoteIo.cpp
+++ b/src/RemoteIo.cpp
@@ -192,7 +192,7 @@ namespace Exiv2
     RemoteIo::Impl::Impl(const std::string& url, size_t blockSize)
         : path_(url)
         , blockSize_(blockSize)
-        , blocksMap_(0)
+        , blocksMap_(nullptr)
         , size_(0)
         , idx_(0)
         , isMalloced_(false)

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -479,7 +479,7 @@ namespace Action
             return -1;
         }
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
         // Set defaults for metadata types and data columns
         if (Params::instance().printTags_ == Exiv2::mdNone) {
@@ -721,7 +721,7 @@ namespace Action
             return -1;
         }
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
         if (Params::instance().verbose_) {
             std::cout << _("JPEG comment") << ": ";
@@ -737,7 +737,7 @@ namespace Action
             return -1;
         }
         Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
-        assert(image.get() != 0);
+        assert(image.get() != nullptr);
         image->readMetadata();
         bool const manyFiles = Params::instance().files_.size() > 1;
         int cnt = 0;
@@ -1406,7 +1406,7 @@ namespace Action
         Exiv2::ExifData& exifData = pImage->exifData();
         Exiv2::IptcData& iptcData = pImage->iptcData();
         Exiv2::XmpData& xmpData = pImage->xmpData();
-        Exiv2::Metadatum* metadatum = 0;
+        Exiv2::Metadatum* metadatum = nullptr;
         if (modifyCmd.metadataId_ == exif) {
             auto pos = exifData.findKey(Exiv2::ExifKey(modifyCmd.key_));
             if (pos != exifData.end()) {
@@ -1432,7 +1432,7 @@ namespace Action
         if (metadatum) {
             value = metadatum->getValue();
         }
-        if (value.get() == 0 || (modifyCmd.explicitType_ && modifyCmd.typeId_ != value->typeId())) {
+        if (value.get() == nullptr || (modifyCmd.explicitType_ && modifyCmd.typeId_ != value->typeId())) {
             value = Exiv2::Value::create(modifyCmd.typeId_);
         }
         int rc = value->read(modifyCmd.value_);
@@ -1808,7 +1808,7 @@ namespace
             return 2;
         if (timeStr[4] != ':' || timeStr[7] != ':' || timeStr[10] != ' ' || timeStr[13] != ':' || timeStr[16] != ':')
             return 3;
-        if (0 == tm)
+        if (nullptr == tm)
             return 4;
         std::memset(tm, 0x0, sizeof(struct tm));
         tm->tm_isdst = -1;
@@ -1848,7 +1848,7 @@ namespace
 
     std::string tm2Str(const struct tm* tm)
     {
-        if (0 == tm)
+        if (nullptr == tm)
             return "";
 
         std::ostringstream os;
@@ -1952,7 +1952,7 @@ namespace
             targetImage->readMetadata();
         } else {
             targetImage = Exiv2::ImageFactory::create(targetType, target);
-            assert(targetImage.get() != 0);
+            assert(targetImage.get() != nullptr);
         }
 
         // Copy each type of metadata

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -119,7 +119,7 @@ namespace Exiv2 {
         //! Constructor for Exif tags and XMP properties.
         Converter(ExifData& exifData, XmpData& xmpData);
         //! Constructor for Iptc tags and XMP properties.
-        Converter(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+        Converter(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = nullptr);
         //@}
 
         //! @name Manipulators
@@ -441,12 +441,12 @@ namespace Exiv2 {
     };
 
     Converter::Converter(ExifData& exifData, XmpData& xmpData)
-        : erase_(false), overwrite_(true), exifData_(&exifData), iptcData_(0), xmpData_(&xmpData), iptcCharset_(0)
+        : erase_(false), overwrite_(true), exifData_(&exifData), iptcData_(nullptr), xmpData_(&xmpData), iptcCharset_(nullptr)
     {
     }
 
     Converter::Converter(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset)
-        : erase_(false), overwrite_(true), exifData_(0), iptcData_(&iptcData), xmpData_(&xmpData), iptcCharset_(iptcCharset)
+        : erase_(false), overwrite_(true), exifData_(nullptr), iptcData_(&iptcData), xmpData_(&xmpData), iptcCharset_(iptcCharset)
     {
     }
 
@@ -528,7 +528,7 @@ namespace Exiv2 {
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         const CommentValue* cv = dynamic_cast<const CommentValue*>(&pos->value());
-        if (cv == 0) {
+        if (cv == nullptr) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to convert " << from << " to " << to << "\n";
 #endif
@@ -651,7 +651,7 @@ namespace Exiv2 {
             }
         }
 
-        const char* subsecTag = 0;
+        const char* subsecTag = nullptr;
         if (std::string(from) == "Exif.Image.DateTime") {
             subsecTag = "Exif.Photo.SubSecTime";
         }
@@ -881,7 +881,7 @@ namespace Exiv2 {
             (*exifData_)[to] = buf;
 
             if (datetime.nanoSecond) {
-                const char* subsecTag = 0;
+                const char* subsecTag = nullptr;
                 if (std::string(to) == "Exif.Image.DateTime") {
                     subsecTag = "Exif.Photo.SubSecTime";
                 }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -116,7 +116,7 @@ namespace Exiv2 {
         std::cerr << "Writing CR2 file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -133,8 +133,8 @@ namespace Exiv2 {
 
         // Write new buffer to file
         MemIo::UniquePtr tempIo(new MemIo);
-        assert(tempIo.get() != 0);
-        tempIo->write((blob.size() > 0 ? &blob[0] : 0), static_cast<long>(blob.size()));
+        assert(tempIo.get() != nullptr);
+        tempIo->write((blob.size() > 0 ? &blob[0] : nullptr), static_cast<long>(blob.size()));
         io_->close();
         io_->transfer(*tempIo); // may throw
 
@@ -142,8 +142,8 @@ namespace Exiv2 {
 
     void CrwParser::decode(CrwImage* pCrwImage, const byte* pData, uint32_t size)
     {
-        assert(pCrwImage != 0);
-        assert(pData != 0);
+        assert(pCrwImage != nullptr);
+        assert(pData != nullptr);
 
         // Parse the image, starting with a CIFF header component
         CiffHeader::UniquePtr head(new CiffHeader);

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -120,7 +120,7 @@ namespace Exiv2 {
         CrwMapping(0x183b, 0x300b,   0, 0x0015, canonId, decodeBasic,  encodeBasic),
         CrwMapping(0x2008, 0x0000,   0, 0,      ifd1Id,  decode0x2008, encode0x2008),
         // End of list marker
-        CrwMapping(0x0000, 0x0000,   0, 0x0000, ifdIdNotSet, 0,            0)
+        CrwMapping(0x0000, 0x0000,   0, 0x0000, ifdIdNotSet, nullptr,            nullptr)
     }; // CrwMap::crwMapping_[]
 
     /*
@@ -606,7 +606,7 @@ namespace Exiv2 {
     CiffComponent* CiffHeader::findComponent(uint16_t crwTagId,
                                              uint16_t crwDir) const
     {
-        if (pRootDir_ == 0) return 0;
+        if (pRootDir_ == nullptr) return nullptr;
         return pRootDir_->findComponent(crwTagId, crwDir);
     } // CiffHeader::findComponent
 
@@ -622,7 +622,7 @@ namespace Exiv2 {
         if (tagId() == crwTagId && dir() == crwDir) {
             return const_cast<CiffComponent*>(this);
         }
-        return 0;
+        return nullptr;
     } // CiffComponent::doFindComponent
 
     CiffComponent* CiffDirectory::doFindComponent(uint16_t crwTagId,
@@ -635,7 +635,7 @@ namespace Exiv2 {
             cc = (*i)->findComponent(crwTagId, crwDir);
             if (cc) return cc;
         }
-        return 0;
+        return nullptr;
     } // CiffDirectory::doFindComponent
 
     void CiffHeader::add(uint16_t crwTagId, uint16_t crwDir, DataBuf buf)
@@ -660,7 +660,7 @@ namespace Exiv2 {
 
     CiffComponent* CiffComponent::doAdd(CrwDirs& /*crwDirs*/, uint16_t /*crwTagId*/)
     {
-        return 0;
+        return nullptr;
     }
 
     CiffComponent* CiffDirectory::doAdd(CrwDirs& crwDirs, uint16_t crwTagId)
@@ -690,7 +690,7 @@ namespace Exiv2 {
                     break;
                 }
             }
-            if (cc_ == 0) {
+            if (cc_ == nullptr) {
                 // Directory doesn't exist yet, add it
                 m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
                 cc_ = m_.get();
@@ -707,7 +707,7 @@ namespace Exiv2 {
                     break;
                 }
             }
-            if (cc_ == 0) {
+            if (cc_ == nullptr) {
                 // Tag doesn't exist yet, add it
                 m_ = UniquePtr(new CiffEntry(crwTagId, tag()));
                 cc_ = m_.get();
@@ -806,7 +806,7 @@ namespace Exiv2 {
                 return &(crwMapping_[i]);
             }
         }
-        return 0;
+        return nullptr;
     } // CrwMap::crwMapping
 
     void CrwMap::decode0x0805(const CiffComponent& ciffComponent,
@@ -908,7 +908,7 @@ namespace Exiv2 {
         if (ciffComponent.size() < 8 || ciffComponent.typeId() != unsignedLong) {
             return decodeBasic(ciffComponent, pCrwMapping, image, byteOrder);
         }
-        assert(pCrwMapping != 0);
+        assert(pCrwMapping != nullptr);
         ULongValue v;
         v.read(ciffComponent.pData(), 8, byteOrder);
         time_t t = v.value_[0];
@@ -970,7 +970,7 @@ namespace Exiv2 {
                                    Image&         image,
                                    ByteOrder      byteOrder)
     {
-        assert(pCrwMapping != 0);
+        assert(pCrwMapping != nullptr);
         // create a key and value pair
         ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
         Value::UniquePtr value;
@@ -1013,7 +1013,7 @@ namespace Exiv2 {
     void CrwMap::encode(CiffHeader* pHead, const Image& image)
     {
         for (const CrwMapping* cmi = crwMapping_; cmi->ifdId_ != ifdIdNotSet; ++cmi) {
-            if (cmi->fromExif_ != 0) {
+            if (cmi->fromExif_ != nullptr) {
                 cmi->fromExif_(image, cmi, pHead);
             }
         }
@@ -1023,8 +1023,8 @@ namespace Exiv2 {
                              const CrwMapping* pCrwMapping,
                                    CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         // Determine the source Exif metadatum
         ExifKey ek(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
@@ -1045,8 +1045,8 @@ namespace Exiv2 {
                               const CrwMapping* pCrwMapping,
                                     CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         std::string comment = image.comment();
 
@@ -1074,8 +1074,8 @@ namespace Exiv2 {
                               const CrwMapping* pCrwMapping,
                                     CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         const ExifKey k1("Exif.Image.Make");
         const ExifKey k2("Exif.Image.Model");
@@ -1101,8 +1101,8 @@ namespace Exiv2 {
                              const CrwMapping* pCrwMapping,
                                    CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         IfdId ifdId = ifdIdNotSet;
         switch (pCrwMapping->tag_) {
@@ -1131,8 +1131,8 @@ namespace Exiv2 {
                               const CrwMapping* pCrwMapping,
                                     CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         time_t t = 0;
         const ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
@@ -1158,8 +1158,8 @@ namespace Exiv2 {
                               const CrwMapping* pCrwMapping,
                                     CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         const ExifKey kX("Exif.Photo.PixelXDimension");
         const ExifKey kY("Exif.Photo.PixelYDimension");
@@ -1201,8 +1201,8 @@ namespace Exiv2 {
                               const CrwMapping* pCrwMapping,
                                     CiffHeader* pHead)
     {
-        assert(pCrwMapping != 0);
-        assert(pHead != 0);
+        assert(pCrwMapping != nullptr);
+        assert(pHead != nullptr);
 
         ExifThumbC exifThumb(image.exifData());
         DataBuf buf = exifThumb.copy();

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -98,11 +98,11 @@ namespace Exiv2 {
         //@{
         //! Default constructor
         CiffComponent()
-            : dir_(0), tag_(0), size_(0), offset_(0), pData_(0),
+            : dir_(0), tag_(0), size_(0), offset_(0), pData_(nullptr),
               isAllocated_(false) {}
         //! Constructor taking a tag and directory
         CiffComponent(uint16_t tag, uint16_t dir)
-            : dir_(dir), tag_(tag), size_(0), offset_(0), pData_(0),
+            : dir_(dir), tag_(tag), size_(0), offset_(0), pData_(nullptr),
               isAllocated_(false) {}
         //! Virtual destructor.
         virtual ~CiffComponent();
@@ -428,10 +428,10 @@ namespace Exiv2 {
         //@{
         //! Default constructor
         CiffHeader()
-            : pRootDir_  (0),
+            : pRootDir_  (nullptr),
               byteOrder_ (littleEndian),
               offset_    (0x0000001a),
-              pPadding_  (0),
+              pPadding_  (nullptr),
               padded_    (0)
             {}
         //! Virtual destructor

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -446,16 +446,16 @@ namespace Exiv2 {
     // Dataset lookup lists.This is an array with pointers to one list per IIM4 Record.
     // The record id is used as the index into the array.
     const DataSet* IptcDataSets::records_[] = {
-        0,
+        nullptr,
         envelopeRecord, application2Record,
-        0
+        nullptr
     };
 
     int IptcDataSets::dataSetIdx(uint16_t number, uint16_t recordId)
     {
         if( recordId != envelope && recordId != application2 ) return -1;
         const DataSet* dataSet = records_[recordId];
-        if (dataSet == 0) return -1;
+        if (dataSet == nullptr) return -1;
         int idx;
         for (idx = 0; dataSet[idx].number_ != number; ++idx) {
             if (dataSet[idx].number_ == 0xffff) return -1;
@@ -467,7 +467,7 @@ namespace Exiv2 {
     {
         if( recordId != envelope && recordId != application2 ) return -1;
         const DataSet* dataSet = records_[recordId];
-        if (dataSet == 0) return -1;
+        if (dataSet == nullptr) return -1;
         int idx;
         for (idx = 0; dataSet[idx].name_ != dataSetName; ++idx) {
             if (dataSet[idx].number_ == 0xffff) return -1;
@@ -577,7 +577,7 @@ namespace Exiv2 {
         const int count = sizeof(records_)/sizeof(records_[0]);
         for (int i=0; i < count; ++i) {
             const DataSet *record = records_[i];
-            for (int j=0; record != 0 && record[j].number_ != 0xffff; ++j) {
+            for (int j=0; record != nullptr && record[j].number_ != 0xffff; ++j) {
                 os << record[j] << "\n";
             }
         }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -207,8 +207,8 @@ namespace Exiv2 {
     Exifdatum::Exifdatum(const Exifdatum& rhs)
         : Metadatum(rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
     }
 
     std::ostream& Exifdatum::write(std::ostream& os, const ExifData* pMetadata) const
@@ -216,13 +216,13 @@ namespace Exiv2 {
         if (value().count() == 0) return os;
         PrintFct fct = printValue;
         const TagInfo* ti = Internal::tagInfo(tag(), static_cast<IfdId>(ifdId()));
-        if (ti != 0) fct = ti->printFct_;
+        if (ti != nullptr) fct = ti->printFct_;
         return fct(os, value(), pMetadata);
     }
 
     const Value& Exifdatum::value() const
     {
-        if (value_.get() == 0) throw Error(kerValueNotSet);
+        if (value_.get() == nullptr) throw Error(kerValueNotSet);
         return *value_;
     }
 
@@ -232,10 +232,10 @@ namespace Exiv2 {
         Metadatum::operator=(rhs);
 
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
 
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
 
         return *this;
     } // Exifdatum::operator=
@@ -290,7 +290,7 @@ namespace Exiv2 {
 
     int Exifdatum::setValue(const std::string& value)
     {
-        if (value_.get() == 0) {
+        if (value_.get() == nullptr) {
             TypeId type = key_->defaultTypeId();
             value_ = Value::create(type);
         }
@@ -299,62 +299,62 @@ namespace Exiv2 {
 
     int Exifdatum::setDataArea(const byte* buf, size_t len)
     {
-        return value_.get() == 0 ? -1 : value_->setDataArea(buf, len);
+        return value_.get() == nullptr ? -1 : value_->setDataArea(buf, len);
     }
 
     std::string Exifdatum::key() const
     {
-        return key_.get() == 0 ? "" : key_->key();
+        return key_.get() == nullptr ? "" : key_->key();
     }
 
     const char* Exifdatum::familyName() const
     {
-        return key_.get() == 0 ? "" : key_->familyName();
+        return key_.get() == nullptr ? "" : key_->familyName();
     }
 
     std::string Exifdatum::groupName() const
     {
-        return key_.get() == 0 ? "" : key_->groupName();
+        return key_.get() == nullptr ? "" : key_->groupName();
     }
 
     std::string Exifdatum::tagName() const
     {
-        return key_.get() == 0 ? "" : key_->tagName();
+        return key_.get() == nullptr ? "" : key_->tagName();
     }
 
     std::string Exifdatum::tagLabel() const
     {
-        return key_.get() == 0 ? "" : key_->tagLabel();
+        return key_.get() == nullptr ? "" : key_->tagLabel();
     }
 
     uint16_t Exifdatum::tag() const
     {
-        return key_.get() == 0 ? 0xffff : key_->tag();
+        return key_.get() == nullptr ? 0xffff : key_->tag();
     }
 
     int Exifdatum::ifdId() const
     {
-        return key_.get() == 0 ? ifdIdNotSet : key_->ifdId();
+        return key_.get() == nullptr ? ifdIdNotSet : key_->ifdId();
     }
 
     const char* Exifdatum::ifdName() const
     {
-        return key_.get() == 0 ? "" : Internal::ifdName(static_cast<Internal::IfdId>(key_->ifdId()));
+        return key_.get() == nullptr ? "" : Internal::ifdName(static_cast<Internal::IfdId>(key_->ifdId()));
     }
 
     int Exifdatum::idx() const
     {
-        return key_.get() == 0 ? 0 : key_->idx();
+        return key_.get() == nullptr ? 0 : key_->idx();
     }
 
     long Exifdatum::copy(byte* buf, ByteOrder byteOrder) const
     {
-        return value_.get() == 0 ? 0 : value_->copy(buf, byteOrder);
+        return value_.get() == nullptr ? 0 : value_->copy(buf, byteOrder);
     }
 
     TypeId Exifdatum::typeId() const
     {
-        return value_.get() == 0 ? invalidTypeId : value_->typeId();
+        return value_.get() == nullptr ? invalidTypeId : value_->typeId();
     }
 
     const char* Exifdatum::typeName() const
@@ -369,52 +369,52 @@ namespace Exiv2 {
 
     size_t Exifdatum::count() const
     {
-        return value_.get() == 0 ? 0 : value_->count();
+        return value_.get() == nullptr ? 0 : value_->count();
     }
 
     size_t Exifdatum::size() const
     {
-        return value_.get() == 0 ? 0 : value_->size();
+        return value_.get() == nullptr ? 0 : value_->size();
     }
 
     std::string Exifdatum::toString() const
     {
-        return value_.get() == 0 ? "" : value_->toString();
+        return value_.get() == nullptr ? "" : value_->toString();
     }
 
     std::string Exifdatum::toString(long n) const
     {
-        return value_.get() == 0 ? "" : value_->toString(n);
+        return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
     long Exifdatum::toLong(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toLong(n);
+        return value_.get() == nullptr ? -1 : value_->toLong(n);
     }
 
     float Exifdatum::toFloat(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toFloat(n);
+        return value_.get() == nullptr ? -1 : value_->toFloat(n);
     }
 
     Rational Exifdatum::toRational(long n) const
     {
-        return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+        return value_.get() == nullptr ? Rational(-1, 1) : value_->toRational(n);
     }
 
     Value::UniquePtr Exifdatum::getValue() const
     {
-        return value_.get() == 0 ? nullptr : value_->clone();
+        return value_.get() == nullptr ? nullptr : value_->clone();
     }
 
     size_t Exifdatum::sizeDataArea() const
     {
-        return value_.get() == 0 ? 0 : value_->sizeDataArea();
+        return value_.get() == nullptr ? 0 : value_->sizeDataArea();
     }
 
     DataBuf Exifdatum::dataArea() const
     {
-        return value_.get() == 0 ? DataBuf(0, 0) : value_->dataArea();
+        return value_.get() == nullptr ? DataBuf(nullptr, 0) : value_->dataArea();
     }
 
     ExifThumbC::ExifThumbC(const ExifData& exifData)
@@ -425,14 +425,14 @@ namespace Exiv2 {
     DataBuf ExifThumbC::copy() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return DataBuf();
+        if (thumbnail.get() == nullptr) return DataBuf();
         return thumbnail->copy(exifData_);
     }
 
     size_t ExifThumbC::writeFile(const std::string& path) const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return 0;
+        if (thumbnail.get() == nullptr) return 0;
         std::string name = path + thumbnail->extension();
         DataBuf buf(thumbnail->copy(exifData_));
         if (buf.size_ == 0) return 0;
@@ -454,14 +454,14 @@ namespace Exiv2 {
     const char* ExifThumbC::mimeType() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return "";
+        if (thumbnail.get() == nullptr) return "";
         return thumbnail->mimeType();
     }
 
     const char* ExifThumbC::extension() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return "";
+        if (thumbnail.get() == nullptr) return "";
         return thumbnail->extension();
     }
 
@@ -718,7 +718,7 @@ namespace Exiv2 {
                                                   Tag::root,
                                                   TiffMapping::findEncoder,
                                                   header.get(),
-                                                  0);
+                                                  nullptr);
         if (mio1.size() <= 65527) {
             append(blob, mio1.mmap(), (uint32_t) mio1.size());
             return wm;
@@ -821,7 +821,7 @@ namespace Exiv2 {
                                       Tag::root,
                                       TiffMapping::findEncoder,
                                       header.get(),
-                                      0);
+                                      nullptr);
         append(blob, mio2.mmap(), (uint32_t) mio2.size());
 #ifdef EXIV2_DEBUG_MESSAGES
         if (wm == wmIntrusive) {
@@ -836,7 +836,7 @@ namespace Exiv2 {
     }
 
     void ExifParser::encode(Blob &blob, ByteOrder byteOrder, const ExifData &exifData) {
-        encode(blob, 0, 0, byteOrder, exifData);
+        encode(blob, nullptr, 0, byteOrder, exifData);
     }
 
 }                                       // namespace Exiv2
@@ -902,7 +902,7 @@ namespace {
         Exiv2::MemIo io;
         Exiv2::IptcData emptyIptc;
         Exiv2::XmpData  emptyXmp;
-        Exiv2::TiffParser::encode(io, 0, 0, Exiv2::littleEndian, thumb, emptyIptc, emptyXmp);
+        Exiv2::TiffParser::encode(io, nullptr, 0, Exiv2::littleEndian, thumb, emptyIptc, emptyXmp);
         return io.read((long) io.size());
     }
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -364,7 +364,7 @@ namespace Exiv2 {
 #ifdef EXV_HAVE_STRERROR_R
         const size_t n = 1024;
 #ifdef EXV_STRERROR_R_CHAR_P
-        char *buf = 0;
+        char *buf = nullptr;
         char buf2[n];
         std::memset(buf2, 0x0, n);
         buf = strerror_r(error, buf2, n);

--- a/src/getopt.cpp
+++ b/src/getopt.cpp
@@ -108,7 +108,7 @@ namespace Util {
             if (c == -1) {
                 break;
             }
-            errcnt_ += option(c, Util::optarg == 0 ? "" : Util::optarg, Util::optopt);
+            errcnt_ += option(c, Util::optarg == nullptr ? "" : Util::optarg, Util::optopt);
             if (c == '?' ) {
                 break;
             }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -128,7 +128,7 @@ namespace {
         { ImageType::bmp,  newBmpInstance,  isBmpType,  amNone,      amNone,      amNone,      amNone      },
         { ImageType::jp2,  newJp2Instance,  isJp2Type,  amReadWrite, amReadWrite, amReadWrite, amNone      },
         // End of list marker
-        { ImageType::none, 0,               0,          amNone,      amNone,      amNone,      amNone      }
+        { ImageType::none, nullptr,               nullptr,          amNone,      amNone,      amNone,      amNone      }
     };
 
 }
@@ -791,7 +791,7 @@ namespace Exiv2 {
     bool ImageFactory::checkType(ImageType type, BasicIo& io, bool advance)
     {
         const Registry* r = find(registry, type);
-        if (0 != r) {
+        if (nullptr != r) {
             return r->isThisType_(io, advance);
         }
         return false;
@@ -876,7 +876,7 @@ namespace Exiv2 {
     Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
     {
         Image::UniquePtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
-        if (image.get() == 0)
+        if (image.get() == nullptr)
             throw Error(kerFileContainsUnknownImageType, path);
         return image;
     }
@@ -894,7 +894,7 @@ namespace Exiv2 {
     {
         BasicIo::UniquePtr io(new MemIo(data, size));
         Image::UniquePtr image = open(std::move(io)); // may throw
-        if (image.get() == 0) throw Error(kerMemoryContainsUnknownImageType);
+        if (image.get() == nullptr) throw Error(kerMemoryContainsUnknownImageType);
         return image;
     }
 
@@ -947,7 +947,7 @@ namespace Exiv2 {
     {
         BasicIo::UniquePtr io(new MemIo);
         Image::UniquePtr image = create(type, std::move(io));
-        if (image.get() == 0) {
+        if (image.get() == nullptr) {
             throw Error(kerUnsupportedImageType, static_cast<int>(type));
         }
         return image;
@@ -971,7 +971,7 @@ namespace Exiv2 {
     void append(Blob& blob, const byte* buf, uint32_t len)
     {
         if (len != 0) {
-            assert(buf != 0);
+            assert(buf != nullptr);
             Blob::size_type size = blob.size();
             if (blob.capacity() - size < len) {
                 blob.reserve(size + 65536);

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -95,8 +95,8 @@ namespace Exiv2 {
     Iptcdatum::Iptcdatum(const Iptcdatum& rhs)
         : Metadatum(rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
     }
 
     Iptcdatum::~Iptcdatum()
@@ -105,7 +105,7 @@ namespace Exiv2 {
 
     long Iptcdatum::copy(byte* buf, ByteOrder byteOrder) const
     {
-        return value_.get() == 0 ? 0 : value_->copy(buf, byteOrder);
+        return value_.get() == nullptr ? 0 : value_->copy(buf, byteOrder);
     }
 
     std::ostream& Iptcdatum::write(std::ostream& os, const ExifData*) const
@@ -115,47 +115,47 @@ namespace Exiv2 {
 
     std::string Iptcdatum::key() const
     {
-        return key_.get() == 0 ? "" : key_->key();
+        return key_.get() == nullptr ? "" : key_->key();
     }
 
     std::string Iptcdatum::recordName() const
     {
-        return key_.get() == 0 ? "" : key_->recordName();
+        return key_.get() == nullptr ? "" : key_->recordName();
     }
 
     uint16_t Iptcdatum::record() const
     {
-        return key_.get() == 0 ? 0 : key_->record();
+        return key_.get() == nullptr ? 0 : key_->record();
     }
 
     const char* Iptcdatum::familyName() const
     {
-        return key_.get() == 0 ? "" : key_->familyName();
+        return key_.get() == nullptr ? "" : key_->familyName();
     }
 
     std::string Iptcdatum::groupName() const
     {
-        return key_.get() == 0 ? "" : key_->groupName();
+        return key_.get() == nullptr ? "" : key_->groupName();
     }
 
     std::string Iptcdatum::tagName() const
     {
-        return key_.get() == 0 ? "" : key_->tagName();
+        return key_.get() == nullptr ? "" : key_->tagName();
     }
 
     std::string Iptcdatum::tagLabel() const
     {
-        return key_.get() == 0 ? "" : key_->tagLabel();
+        return key_.get() == nullptr ? "" : key_->tagLabel();
     }
 
     uint16_t Iptcdatum::tag() const
     {
-        return key_.get() == 0 ? 0 : key_->tag();
+        return key_.get() == nullptr ? 0 : key_->tag();
     }
 
     TypeId Iptcdatum::typeId() const
     {
-        return value_.get() == 0 ? invalidTypeId : value_->typeId();
+        return value_.get() == nullptr ? invalidTypeId : value_->typeId();
     }
 
     const char* Iptcdatum::typeName() const
@@ -170,47 +170,47 @@ namespace Exiv2 {
 
     size_t Iptcdatum::count() const
     {
-        return value_.get() == 0 ? 0 : value_->count();
+        return value_.get() == nullptr ? 0 : value_->count();
     }
 
     size_t Iptcdatum::size() const
     {
-        return value_.get() == 0 ? 0 : value_->size();
+        return value_.get() == nullptr ? 0 : value_->size();
     }
 
     std::string Iptcdatum::toString() const
     {
-        return value_.get() == 0 ? "" : value_->toString();
+        return value_.get() == nullptr ? "" : value_->toString();
     }
 
     std::string Iptcdatum::toString(long n) const
     {
-        return value_.get() == 0 ? "" : value_->toString(n);
+        return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
     long Iptcdatum::toLong(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toLong(n);
+        return value_.get() == nullptr ? -1 : value_->toLong(n);
     }
 
     float Iptcdatum::toFloat(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toFloat(n);
+        return value_.get() == nullptr ? -1 : value_->toFloat(n);
     }
 
     Rational Iptcdatum::toRational(long n) const
     {
-        return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+        return value_.get() == nullptr ? Rational(-1, 1) : value_->toRational(n);
     }
 
     Value::UniquePtr Iptcdatum::getValue() const
     {
-        return value_.get() == 0 ? nullptr : value_->clone();
+        return value_.get() == nullptr ? nullptr : value_->clone();
     }
 
     const Value& Iptcdatum::value() const
     {
-        if (value_.get() == 0) throw Error(kerValueNotSet);
+        if (value_.get() == nullptr) throw Error(kerValueNotSet);
         return *value_;
     }
 
@@ -220,10 +220,10 @@ namespace Exiv2 {
         Metadatum::operator=(rhs);
 
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
 
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
 
         return *this;
     } // Iptcdatum::operator=
@@ -256,7 +256,7 @@ namespace Exiv2 {
 
     int Iptcdatum::setValue(const std::string& value)
     {
-        if (value_.get() == 0) {
+        if (value_.get() == nullptr) {
             TypeId type = IptcDataSets::dataSetType(tag(), record());
             value_ = Value::create(type);
         }

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -622,7 +622,7 @@ static void boxes_check(size_t b,size_t m)
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        assert (tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -122,7 +122,7 @@ namespace Exiv2 {
     bool Photoshop::valid(const byte* pPsData,
                           size_t sizePsData)
     {
-        const byte *record = 0;
+        const byte *record = nullptr;
         uint32_t sizeIptc = 0;
         uint32_t sizeHdr = 0;
         const byte* pCur = pPsData;
@@ -532,7 +532,7 @@ namespace Exiv2 {
         if (psBlob.size() > 0) {
             // Find actual IPTC data within the psBlob
             Blob iptcBlob;
-            const byte *record = 0;
+            const byte *record = nullptr;
             uint32_t sizeIptc = 0;
             uint32_t sizeHdr = 0;
             const byte* pCur = &psBlob[0];
@@ -868,7 +868,7 @@ namespace Exiv2 {
             // binary copy io_ to a temporary file
             BasicIo::UniquePtr tempIo(new MemIo);
 
-            assert(tempIo.get() != 0);
+            assert(tempIo.get() != nullptr);
             for (uint64_t i = 0; i < (count / 2) + 1; i++) {
                 uint64_t start = pos[2 * i] + 2;  // step JPG 2 byte marker
                 if (start == 2)
@@ -900,7 +900,7 @@ namespace Exiv2 {
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        assert (tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -1098,7 +1098,7 @@ namespace Exiv2 {
                     const byte* pExifData = rawExif.pData_;
                     size_t exifSize = rawExif.size_;
                     if (wm == wmIntrusive) {
-                        pExifData = blob.size() > 0 ? &blob[0] : 0;
+                        pExifData = blob.size() > 0 ? &blob[0] : nullptr;
                         exifSize = blob.size();
                     }
                     if (exifSize > 0) {
@@ -1191,7 +1191,7 @@ namespace Exiv2 {
                     // Set the new IPTC IRB, keeps existing IRBs but removes the
                     // IPTC block if there is no new IPTC data to write
                     DataBuf newPsData =
-                        Photoshop::setIptcIrb(psBlob.size() > 0 ? &psBlob[0] : 0, (long)psBlob.size(), iptcData_);
+                        Photoshop::setIptcIrb(psBlob.size() > 0 ? &psBlob[0] : nullptr, (long)psBlob.size(), iptcData_);
                     const long maxChunkSize = 0xffff - 16;
                     const byte* chunkStart = newPsData.pData_;
                     const byte* chunkEnd = chunkStart + newPsData.size_;

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -128,27 +128,27 @@ namespace Exiv2 {
         { "FUJI",           fujiId,      newFujiMn,      newFujiMn2      },
         { "KONICA MINOLTA", minoltaId,   newIfdMn,       newIfdMn2       },
         { "Minolta",        minoltaId,   newIfdMn,       newIfdMn2       },
-        { "NIKON",          ifdIdNotSet, newNikonMn,     0               }, // mnGroup_ is not used
-        { "OLYMPUS",        ifdIdNotSet, newOlympusMn,   0               }, // mnGroup_ is not used
+        { "NIKON",          ifdIdNotSet, newNikonMn,     nullptr               }, // mnGroup_ is not used
+        { "OLYMPUS",        ifdIdNotSet, newOlympusMn,   nullptr               }, // mnGroup_ is not used
         { "Panasonic",      panasonicId, newPanasonicMn, newPanasonicMn2 },
-        { "PENTAX",         ifdIdNotSet, newPentaxMn,    0               }, // mnGroup_ is not used
-        { "RICOH",          ifdIdNotSet, newPentaxMn,    0               }, // mnGroup_ is not used
+        { "PENTAX",         ifdIdNotSet, newPentaxMn,    nullptr               }, // mnGroup_ is not used
+        { "RICOH",          ifdIdNotSet, newPentaxMn,    nullptr               }, // mnGroup_ is not used
         { "SAMSUNG",        samsung2Id,  newSamsungMn,   newSamsungMn2   },
         { "SIGMA",          sigmaId,     newSigmaMn,     newSigmaMn2     },
-        { "SONY",           ifdIdNotSet, newSonyMn,      0               }, // mnGroup_ is not used
-        { "CASIO",          ifdIdNotSet, newCasioMn,     0               }, // mnGroup_ is not used
+        { "SONY",           ifdIdNotSet, newSonyMn,      nullptr               }, // mnGroup_ is not used
+        { "CASIO",          ifdIdNotSet, newCasioMn,     nullptr               }, // mnGroup_ is not used
         // Entries below are only used for lookup by group
-        { "-",              nikon1Id,    0,              newIfdMn2       },
-        { "-",              nikon2Id,    0,              newNikon2Mn2    },
-        { "-",              nikon3Id,    0,              newNikon3Mn2    },
-        { "-",              sony1Id,     0,              newSony1Mn2     },
-        { "-",              sony2Id,     0,              newSony2Mn2     },
-        { "-",              olympusId,   0,              newOlympusMn2   },
-        { "-",              olympus2Id,  0,              newOlympus2Mn2  },
-        { "-",              pentaxId,    0,              newPentaxMn2    },
-        { "-",              pentaxDngId, 0,              newPentaxDngMn2 },
-        { "-",              casioId,     0,              newIfdMn2       },
-        { "-",              casio2Id,    0,              newCasio2Mn2    }
+        { "-",              nikon1Id,    nullptr,              newIfdMn2       },
+        { "-",              nikon2Id,    nullptr,              newNikon2Mn2    },
+        { "-",              nikon3Id,    nullptr,              newNikon3Mn2    },
+        { "-",              sony1Id,     nullptr,              newSony1Mn2     },
+        { "-",              sony2Id,     nullptr,              newSony2Mn2     },
+        { "-",              olympusId,   nullptr,              newOlympusMn2   },
+        { "-",              olympus2Id,  nullptr,              newOlympus2Mn2  },
+        { "-",              pentaxId,    nullptr,              newPentaxMn2    },
+        { "-",              pentaxDngId, nullptr,              newPentaxDngMn2 },
+        { "-",              casioId,     nullptr,              newIfdMn2       },
+        { "-",              casio2Id,    nullptr,              newCasio2Mn2    }
     };
 
     bool TiffMnRegistry::operator==(const std::string& key) const
@@ -170,7 +170,7 @@ namespace Exiv2 {
                                          uint32_t           size,
                                          ByteOrder          byteOrder)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         const TiffMnRegistry* tmr = find(registry_, make);
         if (tmr) {
             assert(tmr->newMnFct_);
@@ -188,11 +188,11 @@ namespace Exiv2 {
                                          IfdId              group,
                                          IfdId              mnGroup)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         const TiffMnRegistry* tmr = find(registry_, mnGroup);
         if (tmr) {
 
-            if (tmr->newMnFct2_ == 0) {
+            if (tmr->newMnFct2_ == nullptr) {
 
                 std::cout << "mnGroup = " << mnGroup << "\n";
 
@@ -657,7 +657,7 @@ namespace Exiv2 {
 
     SamsungMnHeader::SamsungMnHeader()
     {
-        read(0, 0, invalidByteOrder);
+        read(nullptr, 0, invalidByteOrder);
     }
 
     size_t SamsungMnHeader::size() const
@@ -833,7 +833,7 @@ namespace Exiv2 {
                             ByteOrder   /*byteOrder*/)
     {
         // Require at least an IFD with 1 entry, but not necessarily a next pointer
-        if (size < 14) return 0;
+        if (size < 14) return nullptr;
         return newIfdMn2(tag, group, mnGroup);
     }
 
@@ -841,7 +841,7 @@ namespace Exiv2 {
                              IfdId    group,
                              IfdId    mnGroup)
     {
-        return new TiffIfdMakernote(tag, group, mnGroup, 0);
+        return new TiffIfdMakernote(tag, group, mnGroup, nullptr);
     }
 
     TiffComponent* newOlympusMn(uint16_t    tag,
@@ -854,11 +854,11 @@ namespace Exiv2 {
         if (size < 10 ||   std::string(reinterpret_cast<const char*>(pData), 10)
                         != std::string("OLYMPUS\0II", 10)) {
             // Require at least the header and an IFD with 1 entry
-            if (size < OlympusMnHeader::sizeOfSignature() + 18) return 0;
+            if (size < OlympusMnHeader::sizeOfSignature() + 18) return nullptr;
             return newOlympusMn2(tag, group, olympusId);
         }
         // Require at least the header and an IFD with 1 entry
-        if (size < Olympus2MnHeader::sizeOfSignature() + 18) return 0;
+        if (size < Olympus2MnHeader::sizeOfSignature() + 18) return nullptr;
         return newOlympus2Mn2(tag, group, olympus2Id);
     }
 
@@ -884,7 +884,7 @@ namespace Exiv2 {
                              ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry
-        if (size < FujiMnHeader::sizeOfSignature() + 18) return 0;
+        if (size < FujiMnHeader::sizeOfSignature() + 18) return nullptr;
         return newFujiMn2(tag, group, mnGroup);
     }
 
@@ -906,7 +906,7 @@ namespace Exiv2 {
         if (size < 6 ||    std::string(reinterpret_cast<const char*>(pData), 6)
                         != std::string("Nikon\0", 6)) {
             // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
+            if (size < 18) return nullptr;
             return newIfdMn2(tag, group, nikon1Id);
         }
         // If the "Nikon" string is not followed by a TIFF header, we assume
@@ -916,12 +916,12 @@ namespace Exiv2 {
             || !tiffHeader.read(pData + 10, size - 10)
             || tiffHeader.tag() != 0x002a) {
             // Require at least the header and an IFD with 1 entry
-            if (size < Nikon2MnHeader::sizeOfSignature() + 18) return 0;
+            if (size < Nikon2MnHeader::sizeOfSignature() + 18) return nullptr;
             return newNikon2Mn2(tag, group, nikon2Id);
         }
         // Else we have a Nikon3 makernote
         // Require at least the header and an IFD with 1 entry
-        if (size < Nikon3MnHeader::sizeOfSignature() + 18) return 0;
+        if (size < Nikon3MnHeader::sizeOfSignature() + 18) return nullptr;
         return newNikon3Mn2(tag, group, nikon3Id);
     }
 
@@ -947,7 +947,7 @@ namespace Exiv2 {
                                   ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry, but without a next pointer
-        if (size < PanasonicMnHeader::sizeOfSignature() + 14) return 0;
+        if (size < PanasonicMnHeader::sizeOfSignature() + 14) return nullptr;
         return newPanasonicMn2(tag, group, mnGroup);
     }
 
@@ -964,15 +964,15 @@ namespace Exiv2 {
         if (size > 8 && std::string(reinterpret_cast<const char*>(pData), 8) == std::string("PENTAX \0", 8)) {
             // Require at least the header and an IFD with 1 entry
             if (size < PentaxDngMnHeader::sizeOfSignature() + 18)
-                return 0;
+                return nullptr;
             return newPentaxDngMn2(tag, group, (tag == 0xc634 ? pentaxDngId:pentaxId));
         } else if (size > 4 && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
             // Require at least the header and an IFD with 1 entry
             if (size < PentaxMnHeader::sizeOfSignature() + 18)
-                return 0;
+                return nullptr;
             return newPentaxMn2(tag, group, pentaxId);
         } else
-            return 0;
+            return nullptr;
     }
 
     TiffComponent* newPentaxMn2(uint16_t tag,
@@ -1000,13 +1000,13 @@ namespace Exiv2 {
             && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
             // Samsung branded Pentax camera:
             // Require at least the header and an IFD with 1 entry
-            if (size < PentaxMnHeader::sizeOfSignature() + 18) return 0;
+            if (size < PentaxMnHeader::sizeOfSignature() + 18) return nullptr;
             return newPentaxMn2(tag, group, pentaxId);
         }
         else {
             // Genuine Samsung camera:
             // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
+            if (size < 18) return nullptr;
             return newSamsungMn2(tag, group, mnGroup);
         }
     }
@@ -1026,7 +1026,7 @@ namespace Exiv2 {
                               ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry
-        if (size < SigmaMnHeader::sizeOfSignature() + 18) return 0;
+        if (size < SigmaMnHeader::sizeOfSignature() + 18) return nullptr;
         return newSigmaMn2(tag, group, mnGroup);
     }
 
@@ -1048,11 +1048,11 @@ namespace Exiv2 {
         if (size < 12 ||   std::string(reinterpret_cast<const char*>(pData), 12)
                         != std::string("SONY DSC \0\0\0", 12)) {
             // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
+            if (size < 18) return nullptr;
             return newSony2Mn2(tag, group, sony2Id);
         }
         // Require at least the header and an IFD with 1 entry, but without a next pointer
-        if (size < SonyMnHeader::sizeOfSignature() + 14) return 0;
+        if (size < SonyMnHeader::sizeOfSignature() + 14) return nullptr;
         return newSony1Mn2(tag, group, sony1Id);
     }
 
@@ -1067,7 +1067,7 @@ namespace Exiv2 {
                                IfdId    group,
                                IfdId    mnGroup)
     {
-        return new TiffIfdMakernote(tag, group, mnGroup, 0, true);
+        return new TiffIfdMakernote(tag, group, mnGroup, nullptr, true);
     }
 
     TiffComponent* newCasioMn(uint16_t    tag,
@@ -1082,7 +1082,7 @@ namespace Exiv2 {
             return newCasio2Mn2(tag, group, casio2Id);
         };
         // Require at least an IFD with 1 entry, but not necessarily a next pointer
-        if (size < 14) return 0;
+        if (size < 14) return nullptr;
         return newIfdMn2(tag, group, casioId);
     }
 
@@ -1158,7 +1158,7 @@ namespace Exiv2 {
     {
         if (size < 4) return -1;
         const NikonArrayIdx* aix = find(nikonArrayIdx, NikonArrayIdx::Key(tag, reinterpret_cast<const char*>(pData), size));
-        return aix == 0 ? -1 : aix->idx_;
+        return aix == nullptr ? -1 : aix->idx_;
     }
 
     int nikonAf2Selector(uint16_t tag, const byte* /*pData*/, uint32_t size, TiffComponent* const /*pRoot*/)
@@ -1176,7 +1176,7 @@ namespace Exiv2 {
 
         if (size < 4) return buf;
         const NikonArrayIdx* nci = find(nikonArrayIdx, NikonArrayIdx::Key(tag, reinterpret_cast<const char*>(pData), size));
-        if (nci == 0 || nci->start_ == NA || size <= nci->start_) return buf;
+        if (nci == nullptr || nci->start_ == NA || size <= nci->start_) return buf;
 
         // Find Exif.Nikon3.ShutterCount
         TiffFinder finder(0x00a7, nikon3Id);

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1706,7 +1706,7 @@ namespace Exiv2 {
 
         UShortValue v;
         v.value_.push_back(val);
-        return EXV_PRINT_TAG_BITMASK(nikonAfPointsInFocus)(os, v, 0);
+        return EXV_PRINT_TAG_BITMASK(nikonAfPointsInFocus)(os, v, nullptr);
     }
 
     std::ostream& Nikon3MakerNote::print0x0089(std::ostream& os,
@@ -1731,10 +1731,10 @@ namespace Exiv2 {
             }
         }
         if (d70) {
-            EXV_PRINT_TAG_BITMASK(nikonShootingModeD70)(os, value, 0);
+            EXV_PRINT_TAG_BITMASK(nikonShootingModeD70)(os, value, nullptr);
         }
         else {
-            EXV_PRINT_TAG_BITMASK(nikonShootingMode)(os, value, 0);
+            EXV_PRINT_TAG_BITMASK(nikonShootingMode)(os, value, nullptr);
         }
         return os;
     }
@@ -2557,7 +2557,7 @@ fmountlens[] = {
     /* if no meta obj is provided, try to use the value param that *may*
      * be the pre-parsed lensid
      */
-        if (metadata == 0)
+        if (metadata == nullptr)
         {
             const unsigned char  vid = (unsigned)value.toLong(0);
 

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -128,7 +128,7 @@ namespace Exiv2 {
         std::cerr << "Writing ORF file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {
@@ -205,7 +205,7 @@ namespace Exiv2 {
                                         Tag::root,
                                         TiffMapping::findEncoder,
                                         header.get(),
-                                        0);
+                                        nullptr);
     }
 
     // *************************************************************************

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1074,10 +1074,10 @@ namespace
         char* tmp = ::strtok(cts, ":");
         if (tmp)
             hstr = tmp;
-        tmp = ::strtok(0, ":");
+        tmp = ::strtok(nullptr, ":");
         if (tmp)
             mstr = tmp;
-        tmp = ::strtok(0, ":");
+        tmp = ::strtok(nullptr, ":");
         if (tmp)
             sstr = tmp;
         delete[] cts;

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -165,7 +165,7 @@ namespace Exiv2 {
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        assert (tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -303,7 +303,7 @@ namespace Exiv2
                 DataBuf psData = readRawProfile(arr, false);
                 if (psData.size_ > 0) {
                     Blob iptcBlob;
-                    const byte* record = 0;
+                    const byte* record = nullptr;
                     uint32_t sizeIptc = 0;
                     uint32_t sizeHdr = 0;
 

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -512,7 +512,7 @@ namespace Exiv2
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert(tempIo.get() != 0);
+        assert(tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo);  // may throw
         io_->close();
@@ -612,7 +612,7 @@ namespace Exiv2
 
                 if (iptcData_.count() > 0) {
                     // Update IPTC data to a new PNG chunk
-                    DataBuf newPsData = Photoshop::setIptcIrb(0, 0, iptcData_);
+                    DataBuf newPsData = Photoshop::setIptcIrb(nullptr, 0, iptcData_);
                     if (newPsData.size_ > 0) {
                         std::string rawIptc((const char*)newPsData.pData_, newPsData.size_);
                         std::string chunk = PngChunk::makeMetadataChunk(rawIptc, mdIptc);

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -303,51 +303,51 @@ namespace {
 // class member definitions
 
     const Loader::LoaderList Loader::loaderList_[] = {
-        { 0,                       createLoaderNative,       0 },
-        { 0,                       createLoaderNative,       1 },
-        { 0,                       createLoaderNative,       2 },
-        { 0,                       createLoaderNative,       3 },
-        { 0,                       createLoaderExifDataJpeg, 0 },
-        { 0,                       createLoaderExifDataJpeg, 1 },
-        { 0,                       createLoaderExifDataJpeg, 2 },
-        { 0,                       createLoaderExifDataJpeg, 3 },
-        { 0,                       createLoaderExifDataJpeg, 4 },
-        { 0,                       createLoaderExifDataJpeg, 5 },
-        { 0,                       createLoaderExifDataJpeg, 6 },
-        { 0,                       createLoaderExifDataJpeg, 7 },
-        { 0,                       createLoaderExifDataJpeg, 8 },
+        { nullptr,                       createLoaderNative,       0 },
+        { nullptr,                       createLoaderNative,       1 },
+        { nullptr,                       createLoaderNative,       2 },
+        { nullptr,                       createLoaderNative,       3 },
+        { nullptr,                       createLoaderExifDataJpeg, 0 },
+        { nullptr,                       createLoaderExifDataJpeg, 1 },
+        { nullptr,                       createLoaderExifDataJpeg, 2 },
+        { nullptr,                       createLoaderExifDataJpeg, 3 },
+        { nullptr,                       createLoaderExifDataJpeg, 4 },
+        { nullptr,                       createLoaderExifDataJpeg, 5 },
+        { nullptr,                       createLoaderExifDataJpeg, 6 },
+        { nullptr,                       createLoaderExifDataJpeg, 7 },
+        { nullptr,                       createLoaderExifDataJpeg, 8 },
         { "image/x-panasonic-rw2", createLoaderExifDataJpeg, 9 },
-        { 0,                       createLoaderExifDataJpeg,10 },
-        { 0,                       createLoaderExifDataJpeg,11 },
-        { 0,                       createLoaderTiff,         0 },
-        { 0,                       createLoaderTiff,         1 },
-        { 0,                       createLoaderTiff,         2 },
-        { 0,                       createLoaderTiff,         3 },
-        { 0,                       createLoaderTiff,         4 },
-        { 0,                       createLoaderTiff,         5 },
-        { 0,                       createLoaderTiff,         6 },
+        { nullptr,                       createLoaderExifDataJpeg,10 },
+        { nullptr,                       createLoaderExifDataJpeg,11 },
+        { nullptr,                       createLoaderTiff,         0 },
+        { nullptr,                       createLoaderTiff,         1 },
+        { nullptr,                       createLoaderTiff,         2 },
+        { nullptr,                       createLoaderTiff,         3 },
+        { nullptr,                       createLoaderTiff,         4 },
+        { nullptr,                       createLoaderTiff,         5 },
+        { nullptr,                       createLoaderTiff,         6 },
         { "image/x-canon-cr2",     createLoaderTiff,         7 },
-        { 0,                       createLoaderExifJpeg,     0 },
-        { 0,                       createLoaderExifJpeg,     1 },
-        { 0,                       createLoaderExifJpeg,     2 },
-        { 0,                       createLoaderExifJpeg,     3 },
-        { 0,                       createLoaderExifJpeg,     4 },
-        { 0,                       createLoaderExifJpeg,     5 },
-        { 0,                       createLoaderExifJpeg,     6 },
+        { nullptr,                       createLoaderExifJpeg,     0 },
+        { nullptr,                       createLoaderExifJpeg,     1 },
+        { nullptr,                       createLoaderExifJpeg,     2 },
+        { nullptr,                       createLoaderExifJpeg,     3 },
+        { nullptr,                       createLoaderExifJpeg,     4 },
+        { nullptr,                       createLoaderExifJpeg,     5 },
+        { nullptr,                       createLoaderExifJpeg,     6 },
         { "image/x-canon-cr2",     createLoaderExifJpeg,     7 },
-        { 0,                       createLoaderExifJpeg,     8 },
-        { 0,                       createLoaderXmpJpeg,      0 }
+        { nullptr,                       createLoaderExifJpeg,     8 },
+        { nullptr,                       createLoaderXmpJpeg,      0 }
     };
 
     const LoaderExifJpeg::Param LoaderExifJpeg::param_[] = {
-        { "Exif.Image.JPEGInterchangeFormat",     "Exif.Image.JPEGInterchangeFormatLength",     0 }, // 0
-        { "Exif.SubImage1.JPEGInterchangeFormat", "Exif.SubImage1.JPEGInterchangeFormatLength", 0 }, // 1
-        { "Exif.SubImage2.JPEGInterchangeFormat", "Exif.SubImage2.JPEGInterchangeFormatLength", 0 }, // 2
-        { "Exif.SubImage3.JPEGInterchangeFormat", "Exif.SubImage3.JPEGInterchangeFormatLength", 0 }, // 3
-        { "Exif.SubImage4.JPEGInterchangeFormat", "Exif.SubImage4.JPEGInterchangeFormatLength", 0 }, // 4
-        { "Exif.SubThumb1.JPEGInterchangeFormat", "Exif.SubThumb1.JPEGInterchangeFormatLength", 0 }, // 5
-        { "Exif.Image2.JPEGInterchangeFormat",    "Exif.Image2.JPEGInterchangeFormatLength",    0 }, // 6
-        { "Exif.Image.StripOffsets",              "Exif.Image.StripByteCounts",                 0 }, // 7
+        { "Exif.Image.JPEGInterchangeFormat",     "Exif.Image.JPEGInterchangeFormatLength",     nullptr }, // 0
+        { "Exif.SubImage1.JPEGInterchangeFormat", "Exif.SubImage1.JPEGInterchangeFormatLength", nullptr }, // 1
+        { "Exif.SubImage2.JPEGInterchangeFormat", "Exif.SubImage2.JPEGInterchangeFormatLength", nullptr }, // 2
+        { "Exif.SubImage3.JPEGInterchangeFormat", "Exif.SubImage3.JPEGInterchangeFormatLength", nullptr }, // 3
+        { "Exif.SubImage4.JPEGInterchangeFormat", "Exif.SubImage4.JPEGInterchangeFormatLength", nullptr }, // 4
+        { "Exif.SubThumb1.JPEGInterchangeFormat", "Exif.SubThumb1.JPEGInterchangeFormatLength", nullptr }, // 5
+        { "Exif.Image2.JPEGInterchangeFormat",    "Exif.Image2.JPEGInterchangeFormatLength",    nullptr }, // 6
+        { "Exif.Image.StripOffsets",              "Exif.Image.StripByteCounts",                 nullptr }, // 7
         { "Exif.OlympusCs.PreviewImageStart",     "Exif.OlympusCs.PreviewImageLength",          "Exif.MakerNote.Offset"}  // 8
     };
 
@@ -358,12 +358,12 @@ namespace {
         { "Exif.PentaxDng.PreviewOffset",              "Exif.PentaxDng.PreviewLength"                    }, //  3
         { "Exif.Minolta.ThumbnailOffset",              "Exif.Minolta.ThumbnailLength"                    }, //  4
         { "Exif.SonyMinolta.ThumbnailOffset",          "Exif.SonyMinolta.ThumbnailLength"                }, //  5
-        { "Exif.Olympus.ThumbnailImage",               0                                                 }, //  6
-        { "Exif.Olympus2.ThumbnailImage",              0                                                 }, //  7
-        { "Exif.Minolta.Thumbnail",                    0                                                 }, //  8
-        { "Exif.PanasonicRaw.PreviewImage",            0                                                 }, //  9
+        { "Exif.Olympus.ThumbnailImage",               nullptr                                                 }, //  6
+        { "Exif.Olympus2.ThumbnailImage",              nullptr                                                 }, //  7
+        { "Exif.Minolta.Thumbnail",                    nullptr                                                 }, //  8
+        { "Exif.PanasonicRaw.PreviewImage",            nullptr                                                 }, //  9
         { "Exif.SamsungPreview.JPEGInterchangeFormat", "Exif.SamsungPreview.JPEGInterchangeFormatLength" }, // 10
-        { "Exif.Casio2.PreviewImage",                  0                                                 }  // 11
+        { "Exif.Casio2.PreviewImage",                  nullptr                                                 }  // 11
     };
 
     const LoaderTiff::Param LoaderTiff::param_[] = {
@@ -373,8 +373,8 @@ namespace {
         { "SubImage3", "Exif.SubImage3.NewSubfileType", "1" },  // 3
         { "SubImage4", "Exif.SubImage4.NewSubfileType", "1" },  // 4
         { "SubThumb1", "Exif.SubThumb1.NewSubfileType", "1" },  // 5
-        { "Thumbnail", 0,                               0   },  // 6
-        { "Image2",    0,                               0   }   // 7
+        { "Thumbnail", nullptr,                               nullptr   },  // 6
+        { "Image2",    nullptr,                               nullptr   }   // 7
     };
 
     Loader::UniquePtr Loader::create(PreviewId id, const Image &image)
@@ -507,7 +507,7 @@ namespace {
         if (data.size_ == 0) return false;
         try {
             Image::UniquePtr image = ImageFactory::open(data.pData_, data.size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -598,7 +598,7 @@ namespace {
 
         try {
             Image::UniquePtr image = ImageFactory::open(base + offset_, size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -675,7 +675,7 @@ namespace {
 
         try {
             Image::UniquePtr image = ImageFactory::open(buf.pData_, buf.size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -831,7 +831,7 @@ namespace {
         MemIo mio;
         IptcData emptyIptc;
         XmpData  emptyXmp;
-        TiffParser::encode(mio, 0, 0, Exiv2::littleEndian, preview, emptyIptc, emptyXmp);
+        TiffParser::encode(mio, nullptr, 0, Exiv2::littleEndian, preview, emptyIptc, emptyXmp);
         return DataBuf(mio.mmap(), (long) mio.size());
     }
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -143,18 +143,18 @@ namespace Exiv2 {
 
 
         // Structures
-        { "http://ns.adobe.com/xap/1.0/g/",                   "xmpG",    0, N_("Colorant structure")           },
-        { "http://ns.adobe.com/xap/1.0/g/img/",               "xmpGImg", 0, N_("Thumbnail structure")          },
-        { "http://ns.adobe.com/xap/1.0/sType/Dimensions#",    "stDim",   0, N_("Dimensions structure")         },
-        { "http://ns.adobe.com/xap/1.0/sType/Font#",          "stFnt",   0, N_("Font structure")               },
-        { "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#", "stEvt",   0, N_("Resource Event structure")     },
-        { "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",   "stRef",   0, N_("ResourceRef structure")        },
-        { "http://ns.adobe.com/xap/1.0/sType/Version#",       "stVer",   0, N_("Version structure")            },
-        { "http://ns.adobe.com/xap/1.0/sType/Job#",           "stJob",   0, N_("Basic Job/Workflow structure") },
-        { "http://ns.adobe.com/xmp/sType/Area#",              "stArea",  0, N_("Area structure")               },
+        { "http://ns.adobe.com/xap/1.0/g/",                   "xmpG",    nullptr, N_("Colorant structure")           },
+        { "http://ns.adobe.com/xap/1.0/g/img/",               "xmpGImg", nullptr, N_("Thumbnail structure")          },
+        { "http://ns.adobe.com/xap/1.0/sType/Dimensions#",    "stDim",   nullptr, N_("Dimensions structure")         },
+        { "http://ns.adobe.com/xap/1.0/sType/Font#",          "stFnt",   nullptr, N_("Font structure")               },
+        { "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#", "stEvt",   nullptr, N_("Resource Event structure")     },
+        { "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",   "stRef",   nullptr, N_("ResourceRef structure")        },
+        { "http://ns.adobe.com/xap/1.0/sType/Version#",       "stVer",   nullptr, N_("Version structure")            },
+        { "http://ns.adobe.com/xap/1.0/sType/Job#",           "stJob",   nullptr, N_("Basic Job/Workflow structure") },
+        { "http://ns.adobe.com/xmp/sType/Area#",              "stArea",  nullptr, N_("Area structure")               },
 
         // Qualifiers
-        { "http://ns.adobe.com/xmp/Identifier/qual/1.0/", "xmpidq", 0, N_("Qualifier for xmp:Identifier") }
+        { "http://ns.adobe.com/xmp/Identifier/qual/1.0/", "xmpidq", nullptr, N_("Qualifier for xmp:Identifier") }
     };
 
     extern const XmpPropertyInfo xmpDcInfo[] = {
@@ -185,7 +185,7 @@ namespace Exiv2 {
                                                                                                        "a name by which the resource is formally known.")                                      },
         { "type",             N_("Type"),             "bag open Choice", xmpBag,       xmpExternal, N_("A document type; for example, novel, poem, or working paper.")                         },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpDigikamInfo[] = {
@@ -198,7 +198,7 @@ namespace Exiv2 {
         { "PickLabel",              N_("Pick Label"),                "Text",     xmpText, xmpExternal, N_("The pick label assigned to this item. Possible values are \"0\": no label; \"1\": item rejected; \"2\": item in pending validation; \"3\": item accepted.") },
         { "Preview",                N_("JPEG preview"),              "Text",     xmpText, xmpExternal, N_("Reduced size JPEG preview image encoded as base64 for a fast screen rendering.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpKipiInfo[] = {
@@ -208,7 +208,7 @@ namespace Exiv2 {
         { "picasawebGPhotoId",      N_("PicasaWeb Item ID"),         "Text",     xmpText, xmpExternal, N_("Item ID from PicasaWeb web service.") },
         { "yandexGPhotoId",         N_("Yandex Fotki Item ID"),      "Text",     xmpText, xmpExternal, N_("Item ID from Yandex Fotki web service.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpInfo[] = {
@@ -243,7 +243,7 @@ namespace Exiv2 {
         { "Thumbnails",       N_("Thumbnails"),       "alt Thumbnail",            xmpText, xmpInternal, N_("An alternative array of thumbnail images for a file, which can differ in "
                                                                                                              "characteristics such as size or image encoding.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpRightsInfo[] = {
@@ -253,7 +253,7 @@ namespace Exiv2 {
         { "UsageTerms",       N_("Usage Terms"),   "Lang Alt",       langAlt,       xmpExternal, N_("Text instructions on how a resource can be legally used.") },
         { "WebStatement",     N_("Web Statement"), "URL",            xmpText,       xmpExternal, N_("The location of a web page describing the owner and/or rights statement for this resource.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpMMInfo[] = {
@@ -315,7 +315,7 @@ namespace Exiv2 {
                                                                                                         "a rendition.") },
         { "SaveID",           N_("Save ID"),           "Integer",           xmpText,    xmpInternal, N_("Deprecated. Previously used only to support the xmpMM:LastURL property.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpBJInfo[] = {
@@ -324,7 +324,7 @@ namespace Exiv2 {
                                                                                                 "There are multiple values because there can be more than one job using a particular document at any time, and it can "
                                                                                                 "also be useful to keep historical information about what jobs a document was part of previously.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpTPgInfo[] = {
@@ -334,7 +334,7 @@ namespace Exiv2 {
         { "Colorants",        N_("Colorants"),         "seq Colorant", xmpText,    xmpInternal, N_("An ordered array of colorants (swatches) that are used in the document (including any in contained documents).") },
         { "PlateNames",       N_("Plate Names"),       "seq Text",     xmpSeq,     xmpInternal, N_("An ordered array of plate names that are needed to print the document (including any in contained documents).") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpDMInfo[] = {
@@ -424,7 +424,7 @@ namespace Exiv2 {
         { "discNumber",                   N_("Disc Number"),                      "Text",                  xmpText, xmpExternal, N_("If in a multi-disc set, might contain total number of discs. For example: 2/3.") },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftInfo[] = {
@@ -438,14 +438,14 @@ namespace Exiv2 {
         { "LensModel",          N_("Lens Model"),           "Text",     xmpText, xmpExternal, N_("Lens Model.")           },
         { "Rating",             N_("Rating Percent"),       "Text",     xmpText, xmpExternal, N_("Rating Percent.")       },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpLrInfo[] = {
         { "hierarchicalSubject",    N_("Hierarchical Subject"),    "bag Text",  xmpBag,      xmpExternal, N_("Adobe Lightroom hierarchical keywords.")   },
         { "privateRTKInfo",         N_("Private RTK Info"),        "Text",      xmpText,     xmpExternal, N_("Adobe Lightroom private RTK info.")        },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpPdfInfo[] = {
@@ -454,7 +454,7 @@ namespace Exiv2 {
         { "Producer",   N_("Producer"),    "AgentName", xmpText, xmpInternal, N_("The name of the tool that created the PDF document.") },
         { "Trapped",    N_("Trapped"),     "Boolean",   xmpText, xmpExternal, N_("True when the document has been trapped.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpPhotoshopInfo[] = {
@@ -488,7 +488,7 @@ namespace Exiv2 {
         { "SidecarForExtension",    N_("Sidecar F or Extension"),  "Text",       xmpText, xmpExternal, N_("Filename extension of associated image file.") },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP crs:CropUnits
@@ -504,7 +504,7 @@ namespace Exiv2 {
         { "Type",  			N_("Type"),   			"Text",            	xmpText,    xmpExternal, N_("Camera Raw Saved Settings Type.")              },
         { "Parameters", 	N_("Parameters"), 		"Parameters", 		xmpText, 	xmpInternal, N_("*Main structure* Camera Raw Saved Settings Parameters.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpCrsInfo[] = {
@@ -744,7 +744,7 @@ namespace Exiv2 {
         { "Feather",              			N_("Feather"),                  		"Real",                             xmpText, xmpExternal, N_("Not in XMP Specification. Found in sample files.") },
         { "Seed",              				N_("Seed"),                  			"Integer",                          xmpText, xmpExternal, N_("Not in XMP Specification. Found in sample files.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpTiffInfo[] = {
@@ -794,7 +794,7 @@ namespace Exiv2 {
         { "Copyright",                 N_("Copyright"),                  "Lang Alt",                     langAlt, xmpExternal, N_("TIFF tag 33432, 0x8298. Copyright information. "
                                                                                                                                   "Note: This property is stored in XMP as dc:rights.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExifInfo[] = {
@@ -897,7 +897,7 @@ namespace Exiv2 {
         { "GPSAreaInformation",       N_("GPS Area Information"),                "Text",                         xmpText, xmpInternal, N_("GPS tag 28, 0x1C. A character string recording the name of the GPS area.") },
         { "GPSDifferential",          N_("GPS Differential"),                    "Closed Choice of Integer",     xmpText, xmpInternal, N_("GPS tag 30, 0x1E. Indicates whether differential correction is applied to the GPS receiver.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExifEXInfo[] = {
@@ -928,14 +928,14 @@ namespace Exiv2 {
                                                                                                                                  "THM = Indicates a file conforming to DCF thumbnail file stipulated by Design rule for Camera File System. "
                                                                                                                                  "R03 = Indicates a file conforming to DCF Option File stipulated by Design rule for Camera File System.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAuxInfo[] = {
         { "Lens",             N_("Lens"),             "Text",        xmpText,          xmpInternal, N_("A description of the lens used to take the photograph. For example, \"70-200 mm f/2.8-4.0\".") },
         { "SerialNumber",     N_("Serial Number"),     "Text",       xmpText,          xmpInternal, N_("The serial number of the camera or camera body used to take the photograph.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpIptcInfo[] = {
@@ -966,7 +966,7 @@ namespace Exiv2 {
                                                                                                                          "a top-down geographical hierarchy. The code should be taken from ISO 3166 two or three "
                                                                                                                          "letter code. The full name of a country should go to the \"Country\" element.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpIptcExtInfo[] = {
@@ -1001,7 +1001,7 @@ namespace Exiv2 {
         { "AOSourceInvNo",           N_("Artwork or object-Source inventory number"), "Text",             xmpText, xmpExternal, N_("The inventory number issued by the organisation or body holding and registering the artwork or object in the image.") },
         { "AOTitle",                 N_("Artwork or object-Title"),         "Lang Alt",                   langAlt, xmpExternal, N_("A reference for the artwork or object in the image.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP iptcExt:DigitalSourcefileType
@@ -1101,7 +1101,7 @@ namespace Exiv2 {
         { "Custom9", N_("Custom 9"), "bag Lang Alt", xmpBag, xmpExternal, N_("Optional field for use at Licensee's discretion.") },
         { "Custom10", N_("Custom 10"), "bag Lang Alt", xmpBag, xmpExternal, N_("Optional field for use at Licensee's discretion.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP plus:AdultContentWarning
@@ -1239,7 +1239,7 @@ namespace Exiv2 {
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
         { "CatalogSets", N_("Catalog Sets"), "bag Text", xmpBag,  xmpExternal, N_("Descriptive markers of catalog items by content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExpressionMediaInfo[] = {
@@ -1248,20 +1248,20 @@ namespace Exiv2 {
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
         { "CatalogSets", N_("Catalog Sets"), "bag Text", xmpBag,  xmpExternal, N_("Descriptive markers of catalog items by content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoInfo[] = {
         { "RegionInfo", N_("RegionInfo"), "RegionInfo", xmpText, xmpInternal, N_("Microsoft Photo people-tagging metadata root") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfoInfo[] = {
         { "Regions",          N_("Regions"),            "bag Region", xmpBag,  xmpExternal, N_("Contains Regions/person tags") },
         { "DateRegionsValid", N_("Date Regions Valid"), "Date",       xmpText, xmpExternal, N_("Date the last region was created")  },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfo[] = {
@@ -1270,7 +1270,7 @@ namespace Exiv2 {
         { "PersonEmailDigest", N_("Person Email Digest"),   "Text", xmpText, xmpExternal, N_("SHA-1 encrypted message hash of the person's Windows Live e-mail address"), },
         { "PersonLiveIdCID",   N_("Person LiveId CID"),     "Text", xmpText, xmpExternal, N_("Signed decimal representation of the person's Windows Live CID")            },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMWGRegionsInfo[] = {
@@ -1285,7 +1285,7 @@ namespace Exiv2 {
         { "BarCodeValue",        N_("Bar Code Value"),        "Text",             xmpText, xmpExternal,        N_("Decoded BarCode value string")                         },
         { "Extensions",          N_("Extensions"),            "Text",             xmpText, xmpInternal,        N_("Any top level XMP property to describe the region content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMWGKeywordInfo[] = {
@@ -1296,7 +1296,7 @@ namespace Exiv2 {
         { "Children",       N_("Children"),     "bag KeywordStruct",    xmpBag,  xmpExternal,   N_("List of children keyword structures")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpGPanoInfo[] = {
@@ -1324,7 +1324,7 @@ namespace Exiv2 {
         { "InitialCameraDolly",             N_("Initial Camera Dolly"),             "Real",                 xmpText, xmpExternal,   N_("This optional parameter moves the virtual camera position along the line of sight, away from the center of the photo sphere. A rear surface position is represented by the value -1.0, while a front surface position is represented by 1.0. For normal viewing, this parameter should be set to 0.")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpVideoInfo[] = {
@@ -1667,7 +1667,7 @@ namespace Exiv2 {
         { "XResolution",            N_("X Resolution"),                     "Rational",                 xmpText, xmpInternal, N_("Horizontal resolution in pixels per unit.") },
         { "Year",                   N_("Year"),                             "Integer",                  xmpText, xmpExternal, N_("Year in which the video was made.")   },
         { "YResolution",            N_("Y Resolution"),                     "Rational",                 xmpText, xmpInternal, N_("Vertical resolution in pixels per unit.") },
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAudioInfo[] = {
@@ -1718,7 +1718,7 @@ namespace Exiv2 {
         { "URL",                N_("Audio URL"),                    "Text",                  xmpText, xmpExternal, N_("A C string that specifies a URL. There may be additional data after the C string.")   },
         { "URN",                N_("Audio URN"),                    "Text",                  xmpText, xmpExternal, N_("A C string that specifies a URN. There may be additional data after the C string.")   },
         { "VendorID",           N_("Vendor ID"),                    "Text",                  xmpText, xmpExternal, N_("A 32-bit integer that specifies the developer of the compressor that generated the compressed data. Often this field contains 'appl' to indicate Apple Computer, Inc.")   },
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpDctermsInfo[] = {
@@ -1736,7 +1736,7 @@ namespace Exiv2 {
                                     N_("*Main structure* containing Darwin Core location based information."),
         },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
    extern const XmpPropertyInfo xmpDwCInfo[] = {
@@ -2371,7 +2371,7 @@ namespace Exiv2 {
                                                 N_("Comments or notes accompanying the MeasurementOrFact.")
             },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAcdseeInfo[] = {
@@ -2384,7 +2384,7 @@ namespace Exiv2 {
         { "categories",    N_("Categories"),  "Text",                 xmpText, xmpExternal,   N_("Catalog of hierarchical keywords and groups")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPrintInfo xmpPrintInfo[] = {
@@ -2496,7 +2496,7 @@ namespace Exiv2 {
              i != nsRegistry_.end(); ++i) {
             if (i->second == prefix) return &(i->second);
         }
-        return 0;
+        return nullptr;
     }
 
     void XmpProperties::registerNs(const std::string& ns,
@@ -2527,7 +2527,7 @@ namespace Exiv2 {
         c = static_cast<char*>(std::malloc(prefix.size() + 1));
         std::strcpy(c, prefix.c_str());
         xn.prefix_ = c;
-        xn.xmpPropertyInfo_ = 0;
+        xn.xmpPropertyInfo_ = nullptr;
         xn.desc_ = "";
         nsRegistry_[ns2] = xn;
     }
@@ -2580,20 +2580,20 @@ namespace Exiv2 {
     {
         std::lock_guard<std::mutex> scoped_read_lock(mutex_);
         const XmpNsInfo* xn = lookupNsRegistryUnsafe(XmpNsInfo::Prefix(prefix));
-        if (xn != 0) return xn->ns_;
+        if (xn != nullptr) return xn->ns_;
         return nsInfoUnsafe(prefix)->ns_;
     }
 
     const char* XmpProperties::propertyTitle(const XmpKey& key)
     {
         const XmpPropertyInfo* pi = propertyInfo(key);
-        return pi ? pi->title_ : 0;
+        return pi ? pi->title_ : nullptr;
     }
 
     const char* XmpProperties::propertyDesc(const XmpKey& key)
     {
         const XmpPropertyInfo* pi = propertyInfo(key);
-        return pi ? pi->desc_ : 0;
+        return pi ? pi->desc_ : nullptr;
     }
 
     TypeId XmpProperties::propertyType(const XmpKey& key)
@@ -2622,9 +2622,9 @@ namespace Exiv2 {
 #endif
         }
         const XmpPropertyInfo* pl = propertyList(prefix);
-        if (!pl) return 0;
-        const XmpPropertyInfo* pi = 0;
-        for (int j = 0; pl[j].name_ != 0; ++j) {
+        if (!pl) return nullptr;
+        const XmpPropertyInfo* pi = nullptr;
+        for (int j = 0; pl[j].name_ != nullptr; ++j) {
             if (0 == strcmp(pl[j].name_, property.c_str())) {
                 pi = pl + j;
                 break;
@@ -2670,7 +2670,7 @@ namespace Exiv2 {
     {
         const XmpPropertyInfo* pl = propertyList(prefix);
         if (pl) {
-            for (int i = 0; pl[i].name_ != 0; ++i) {
+            for (int i = 0; pl[i].name_ != nullptr; ++i) {
                 os << pl[i];
             }
         }
@@ -2686,7 +2686,7 @@ namespace Exiv2 {
             const XmpPrintInfo* info = find(xmpPrintInfo, key);
             if (info) fct = info->printFct_;
         }
-        return fct(os, value, 0);
+        return fct(os, value, nullptr);
     }
 
     //! @brief Internal Pimpl structure with private members and data of class XmpKey.

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -347,7 +347,7 @@ namespace Exiv2 {
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        assert (tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo);  // may throw
         io_->close();

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -146,7 +146,7 @@ namespace Exiv2 {
         ExifData exifData;
         PreviewImage preview = loader.getPreviewImage(*list.begin());
         Image::UniquePtr image = ImageFactory::open(preview.pData(), preview.size());
-        if (image.get() == 0) {
+        if (image.get() == nullptr) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to open RW2 preview image.\n";
 #endif

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -148,14 +148,14 @@ namespace Exiv2 {
     const char* ExifTags::sectionName(const ExifKey& key)
     {
         const TagInfo* ti = tagInfo(key.tag(), static_cast<Internal::IfdId>(key.ifdId()));
-        if (ti == 0) return sectionInfo[unknownTag.sectionId_].name_;
+        if (ti == nullptr) return sectionInfo[unknownTag.sectionId_].name_;
         return sectionInfo[ti->sectionId_].name_;
     }
 
     uint16_t ExifTags::defaultCount(const ExifKey& key)
     {
         const TagInfo* ti = tagInfo(key.tag(), static_cast<Internal::IfdId>(key.ifdId()));
-        if (ti == 0) return unknownTag.count_;
+        if (ti == nullptr) return unknownTag.count_;
         return ti->count_;
     }
 
@@ -258,13 +258,13 @@ namespace Exiv2 {
     const char* ExifKey::Impl::familyName_ = "Exif";
 
     ExifKey::Impl::Impl()
-        : tagInfo_(0), tag_(0), ifdId_(ifdIdNotSet), idx_(0)
+        : tagInfo_(nullptr), tag_(0), ifdId_(ifdIdNotSet), idx_(0)
     {
     }
 
     std::string ExifKey::Impl::tagName() const
     {
-        if (tagInfo_ != 0 && tagInfo_->tag_ != 0xffff) {
+        if (tagInfo_ != nullptr && tagInfo_->tag_ != 0xffff) {
             return tagInfo_->name_;
         }
         std::ostringstream os;
@@ -300,7 +300,7 @@ namespace Exiv2 {
         uint16_t tag = tagNumber(tn, ifdId);
         // Get tag info
         tagInfo_ = tagInfo(tag, ifdId);
-        if (tagInfo_ == 0) throw Error(kerInvalidKey, key);
+        if (tagInfo_ == nullptr) throw Error(kerInvalidKey, key);
 
         tag_ = tag;
         ifdId_ = ifdId;
@@ -311,7 +311,7 @@ namespace Exiv2 {
 
     void ExifKey::Impl::makeKey(uint16_t tag, IfdId ifdId, const TagInfo* tagInfo)
     {
-        assert(tagInfo != 0);
+        assert(tagInfo != nullptr);
 
         tagInfo_ = tagInfo;
         tag_ = tag;
@@ -328,7 +328,7 @@ namespace Exiv2 {
             throw Error(kerInvalidIfdId, ifdId);
         }
         const TagInfo* ti = tagInfo(tag, ifdId);
-        if (ti == 0) {
+        if (ti == nullptr) {
             throw Error(kerInvalidIfdId, ifdId);
         }
         p_->groupName_ = groupName;
@@ -394,19 +394,19 @@ namespace Exiv2 {
 
     std::string ExifKey::tagLabel() const
     {
-        if (p_->tagInfo_ == 0 || p_->tagInfo_->tag_ == 0xffff) return "";
+        if (p_->tagInfo_ == nullptr || p_->tagInfo_->tag_ == 0xffff) return "";
         return _(p_->tagInfo_->title_);
     }
 
     std::string ExifKey::tagDesc() const
     {
-        if (p_->tagInfo_ == 0 || p_->tagInfo_->tag_ == 0xffff) return "";
+        if (p_->tagInfo_ == nullptr || p_->tagInfo_->tag_ == 0xffff) return "";
         return _(p_->tagInfo_->desc_);
     }
 
     TypeId ExifKey::defaultTypeId() const
     {
-        if (p_->tagInfo_ == 0) return unknownTag.typeId_;
+        if (p_->tagInfo_ == nullptr) return unknownTag.typeId_;
         return p_->tagInfo_->typeId_;
     }
 

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -59,7 +59,7 @@ namespace Exiv2 {
 
     //! List of all known Exif groups. Important: Group name (3rd column) must be unique!
     extern const GroupInfo groupInfo[] = {
-        { ifdIdNotSet,     "Unknown IFD", "Unknown", 0 },
+        { ifdIdNotSet,     "Unknown IFD", "Unknown", nullptr },
         { ifd0Id,          "IFD0",      "Image",        ifdTagList                     },
         { ifd1Id,          "IFD1",      "Thumbnail",    ifdTagList                     },
         { ifd2Id,          "IFD2",      "Image2",       ifdTagList                     },
@@ -166,7 +166,7 @@ namespace Exiv2 {
         { sony2CsId,       "Makernote", "Sony2Cs",      SonyMakerNote::tagListCs       },
         { sony2Cs2Id,      "Makernote", "Sony2Cs2",     SonyMakerNote::tagListCs2      },
         { sony2FpId,       "Makernote", "Sony2Fp",      SonyMakerNote::tagListFp       },
-        { lastId,          "(Last IFD info)", "(Last IFD item)", 0 }
+        { lastId,          "(Last IFD info)", "(Last IFD item)", nullptr }
     };
 
     //! Units for measuring X and Y resolution, tags 0x0128, 0xa210
@@ -2061,7 +2061,7 @@ namespace Exiv2 {
     {
         bool rc = false;
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii != 0 && 0 == strcmp(ii->ifdName_, "Makernote")) {
+        if (ii != nullptr && 0 == strcmp(ii->ifdName_, "Makernote")) {
             rc = true;
         }
         return rc;
@@ -2098,7 +2098,7 @@ namespace Exiv2 {
     void taglist(std::ostream& os, IfdId ifdId)
     {
         const TagInfo* ti = Internal::tagList(ifdId);
-        if (ti != 0) {
+        if (ti != nullptr) {
             for (int k = 0; ti[k].tag_ != 0xffff; ++k) {
                 os << ti[k] << "\n";
             }
@@ -2108,14 +2108,14 @@ namespace Exiv2 {
     const TagInfo* tagList(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0 || ii->tagList_ == 0) return 0;
+        if (ii == nullptr || ii->tagList_ == nullptr) return nullptr;
         return ii->tagList_();
     } // tagList
 
     const TagInfo* tagInfo(uint16_t tag, IfdId ifdId)
     {
         const TagInfo* ti = tagList(ifdId);
-        if (ti == 0) return 0;
+        if (ti == nullptr) return nullptr;
         int idx = 0;
         for (idx = 0; ti[idx].tag_ != 0xffff; ++idx) {
             if (ti[idx].tag_ == tag) break;
@@ -2126,36 +2126,36 @@ namespace Exiv2 {
     const TagInfo* tagInfo(const std::string& tagName, IfdId ifdId)
     {
         const TagInfo* ti = tagList(ifdId);
-        if (ti == 0) return 0;
+        if (ti == nullptr) return nullptr;
         const char* tn = tagName.c_str();
-        if (tn == 0) return 0;
+        if (tn == nullptr) return nullptr;
         for (int idx = 0; ti[idx].tag_ != 0xffff; ++idx) {
             if (0 == strcmp(ti[idx].name_, tn)) {
                 return &ti[idx];
             }
         }
-        return 0;
+        return nullptr;
     } // tagInfo
 
     IfdId groupId(const std::string& groupName)
     {
         IfdId ifdId = ifdIdNotSet;
         const GroupInfo* ii = find(groupInfo, GroupInfo::GroupName(groupName));
-        if (ii != 0) ifdId = static_cast<IfdId>(ii->ifdId_);
+        if (ii != nullptr) ifdId = static_cast<IfdId>(ii->ifdId_);
         return ifdId;
     }
 
     const char* ifdName(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0) return groupInfo[0].ifdName_;
+        if (ii == nullptr) return groupInfo[0].ifdName_;
         return ii->ifdName_;
     }
 
     const char* groupName(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0) return groupInfo[0].groupName_;
+        if (ii == nullptr) return groupInfo[0].groupName_;
         return ii->groupName_;
     }
 
@@ -2211,7 +2211,7 @@ namespace Exiv2 {
     uint16_t tagNumber(const std::string& tagName, IfdId ifdId)
     {
         const TagInfo* ti = tagInfo(tagName, ifdId);
-        if (ti != 0 && ti->tag_ != 0xffff) return ti->tag_;
+        if (ti != nullptr && ti->tag_ != 0xffff) return ti->tag_;
         if (!isHex(tagName, 4, "0x")) throw Error(kerInvalidTag, tagName, ifdId);
         std::istringstream is(tagName);
         uint16_t tag;
@@ -2907,8 +2907,8 @@ namespace Exiv2 {
     const TagInfo* tagList(const std::string& groupName)
     {
         const GroupInfo* ii = find(groupInfo, GroupInfo::GroupName(groupName));
-        if (ii == 0 || ii->tagList_ == 0) {
-            return 0;
+        if (ii == nullptr || ii->tagList_ == nullptr) {
+            return nullptr;
         }
         return ii->tagList_();
     }

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -63,7 +63,7 @@ namespace Exiv2 {
     IoWrapper::IoWrapper(BasicIo& io, const byte* pHeader, long size, OffsetWriter* pow)
         : io_(io), pHeader_(pHeader), size_(size), wroteHeader_(false), pow_(pow)
     {
-        if (pHeader_ == 0 || size_ == 0) wroteHeader_ = true;
+        if (pHeader_ == nullptr || size_ == 0) wroteHeader_ = true;
     }
 
     size_t IoWrapper::write(const byte* pData, size_t wcount)
@@ -90,15 +90,15 @@ namespace Exiv2 {
     }
 
     TiffComponent::TiffComponent(uint16_t tag, IfdId group)
-        : tag_(tag), group_(group), pStart_(0)
+        : tag_(tag), group_(group), pStart_(nullptr)
     {
     }
 
     TiffEntryBase::TiffEntryBase(uint16_t tag, IfdId group, TiffType tiffType)
         : TiffComponent(tag, group),
           tiffType_(tiffType), count_(0), offset_(0),
-          size_(0), pData_(0), isMalloced_(false), idx_(0),
-          pValue_(0)
+          size_(0), pData_(nullptr), isMalloced_(false), idx_(0),
+          pValue_(nullptr)
     {
     }
 
@@ -108,7 +108,7 @@ namespace Exiv2 {
     }
 
     TiffMnEntry::TiffMnEntry(uint16_t tag, IfdId group, IfdId mnGroup)
-        : TiffEntryBase(tag, group, ttUndefined), mnGroup_(mnGroup), mn_(0)
+        : TiffEntryBase(tag, group, ttUndefined), mnGroup_(mnGroup), mn_(nullptr)
     {
     }
 
@@ -131,18 +131,18 @@ namespace Exiv2 {
                                      const ArrayDef* arrayDef,
                                      int defSize)
         : TiffEntryBase(tag, group, arrayCfg->elTiffType_),
-          cfgSelFct_(0),
-          arraySet_(0),
+          cfgSelFct_(nullptr),
+          arraySet_(nullptr),
           arrayCfg_(arrayCfg),
           arrayDef_(arrayDef),
           defSize_(defSize),
           setSize_(0),
-          origData_(0),
+          origData_(nullptr),
           origSize_(0),
-          pRoot_(0),
+          pRoot_(nullptr),
           decoded_(false)
     {
-        assert(arrayCfg != 0);
+        assert(arrayCfg != nullptr);
     }
 
     TiffBinaryArray::TiffBinaryArray(uint16_t tag,
@@ -153,18 +153,18 @@ namespace Exiv2 {
         : TiffEntryBase(tag, group), // Todo: Does it make a difference that there is no type?
           cfgSelFct_(cfgSelFct),
           arraySet_(arraySet),
-          arrayCfg_(0),
-          arrayDef_(0),
+          arrayCfg_(nullptr),
+          arrayDef_(nullptr),
           defSize_(0),
           setSize_(setSize),
-          origData_(0),
+          origData_(nullptr),
           origSize_(0),
-          pRoot_(0),
+          pRoot_(nullptr),
           decoded_(false)
     {
         // We'll figure out the correct cfg later
-        assert(cfgSelFct != 0);
-        assert(arraySet_ != 0);
+        assert(cfgSelFct != nullptr);
+        assert(arraySet_ != nullptr);
     }
 
     TiffBinaryElement::TiffBinaryElement(uint16_t tag, IfdId group)
@@ -253,7 +253,7 @@ namespace Exiv2 {
           pData_(rhs.pData_),
           isMalloced_(rhs.isMalloced_),
           idx_(rhs.idx_),
-          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : 0)
+          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : nullptr)
     {
         if (rhs.isMalloced_) {
             pData_ = new byte[rhs.size_];
@@ -264,7 +264,7 @@ namespace Exiv2 {
     TiffDirectory::TiffDirectory(const TiffDirectory& rhs)
         : TiffComponent(rhs),
           hasNext_(rhs.hasNext_),
-          pNext_(0)
+          pNext_(nullptr)
     {
     }
 
@@ -327,13 +327,13 @@ namespace Exiv2 {
     TiffMnEntry* TiffMnEntry::doClone() const
     {
         assert(false); // Not implemented
-        return 0;
+        return nullptr;
     }
 
     TiffIfdMakernote* TiffIfdMakernote::doClone() const
     {
         assert(false); // Not implemented
-        return 0;
+        return nullptr;
     }
 
     TiffBinaryArray* TiffBinaryArray::doClone() const
@@ -370,12 +370,12 @@ namespace Exiv2 {
         }
         pData_ = pData;
         size_  = size;
-        if (pData_ == 0) size_ = 0;
+        if (pData_ == nullptr) size_ = 0;
     }
 
     void TiffEntryBase::updateValue(Value::UniquePtr value, ByteOrder byteOrder)
     {
-        if (value.get() == 0)
+        if (value.get() == nullptr)
             return;
         uint32_t newSize = value->size();
         if (newSize > size_) {
@@ -391,7 +391,7 @@ namespace Exiv2 {
 
     void TiffEntryBase::setValue(Value::UniquePtr value)
     {
-        if (value.get() == 0) return;
+        if (value.get() == nullptr) return;
         tiffType_ = toTiffType(value->typeId());
         count_ = value->count();
         delete pValue_;
@@ -570,7 +570,7 @@ namespace Exiv2 {
 
     bool TiffBinaryArray::initialize(IfdId group)
     {
-        if (arrayCfg_ != 0) return true; // Not a complex array or already initialized
+        if (arrayCfg_ != nullptr) return true; // Not a complex array or already initialized
 
         for (int idx = 0; idx < setSize_; ++idx) {
             if (arraySet_[idx].cfg_.group_ == group) {
@@ -585,7 +585,7 @@ namespace Exiv2 {
 
     bool TiffBinaryArray::initialize(TiffComponent* const pRoot)
     {
-        if (cfgSelFct_ == 0) return true; // Not a complex array
+        if (cfgSelFct_ == nullptr) return true; // Not a complex array
 
         int idx = cfgSelFct_(tag(), pData(), TiffEntryBase::doSize(), pRoot);
         if (idx > -1) {
@@ -604,7 +604,7 @@ namespace Exiv2 {
 
     bool TiffBinaryArray::updOrigDataBuf(const byte* pData, uint32_t size)
     {
-        assert(pData != 0);
+        assert(pData != nullptr);
 
         if (origSize_ != size) return false;
         if (origData_ == pData) return true;
@@ -654,7 +654,7 @@ namespace Exiv2 {
         tiffPath.pop();
         const TiffPathItem tpi = tiffPath.top();
 
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         // Try to use an existing component if there is still at least one
         // composite tag on the stack or the tag to add is the MakerNote tag.
         // This is used to prevent duplicate entries. Sub-IFDs also, but the > 1
@@ -673,19 +673,19 @@ namespace Exiv2 {
                 }
             }
         }
-        if (tc == 0) {
+        if (tc == nullptr) {
             TiffComponent::UniquePtr atc;
-            if (tiffPath.size() == 1 && object.get() != 0) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
-            assert(atc.get() != 0);
+            assert(atc.get() != nullptr);
 
             // Prevent dangling sub-IFD tags: Do not add a sub-IFD component without children.
             // Todo: How to check before creating the component?
-            if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != 0) return 0;
+            if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != nullptr) return nullptr;
 
             if (tpi.extendedTag() == Tag::next) {
                 tc = this->addNext(std::move(atc));
@@ -712,15 +712,15 @@ namespace Exiv2 {
         }
         const TiffPathItem tpi2 = tiffPath.top();
         tiffPath.push(tpi1);
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         for (Ifds::iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
             if ((*i)->group() == tpi2.group()) {
                 tc = *i;
                 break;
             }
         }
-        if (tc == 0) {
-            if (tiffPath.size() == 1 && object.get() != 0) {
+        if (tc == nullptr) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 tc = addChild(std::move(object));
             }
             else {
@@ -746,7 +746,7 @@ namespace Exiv2 {
         }
         const TiffPathItem tpi2 = tiffPath.top();
         tiffPath.push(tpi1);
-        if (mn_ == 0) {
+        if (mn_ == nullptr) {
             mnGroup_ = tpi2.group();
             mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
             assert(mn_);
@@ -776,7 +776,7 @@ namespace Exiv2 {
         const TiffPathItem tpi = tiffPath.top();
         // Initialize the binary array (if it is a complex array)
         initialize(tpi.group());
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         // Todo: Duplicates are not allowed!
         // To allow duplicate entries, we only check if the new component already
         // exists if there is still at least one composite tag on the stack
@@ -788,15 +788,15 @@ namespace Exiv2 {
                 }
             }
         }
-        if (tc == 0) {
+        if (tc == nullptr) {
             TiffComponent::UniquePtr atc;
-            if (tiffPath.size() == 1 && object.get() != 0) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
-            assert(atc.get() != 0);
+            assert(atc.get() != nullptr);
             assert(tpi.extendedTag() != Tag::next);
             tc = addChild(std::move(atc));
             setCount(static_cast<uint32_t>(elements_.size()));
@@ -811,7 +811,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/)
     {
-        return 0;
+        return nullptr;
     } // TiffComponent::doAddChild
 
     TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent)
@@ -831,7 +831,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc =  mn_->addChild(std::move(tiffComponent));
         }
@@ -858,12 +858,12 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
     {
-        return 0;
+        return nullptr;
     } // TiffComponent::doAddNext
 
     TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (hasNext_) {
             tc = tiffComponent.release();
             pNext_ = tc;
@@ -873,7 +873,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc = mn_->addNext(std::move(tiffComponent));
         }
@@ -937,7 +937,7 @@ namespace Exiv2 {
         if (mn_) mn_->accept(visitor);
         if (!visitor.go(TiffVisitor::geKnownMakernote)) {
             delete mn_;
-            mn_ = 0;
+            mn_ = nullptr;
         }
 
     } // TiffMnEntry::doAccept
@@ -1043,7 +1043,7 @@ namespace Exiv2 {
 
     uint32_t TiffBinaryArray::doCount() const
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doCount();
+        if (cfg() == nullptr || !decoded()) return TiffEntryBase::doCount();
 
         if (elements_.empty()) return 0;
 
@@ -1393,7 +1393,7 @@ namespace Exiv2 {
                                       uint32_t  dataIdx,
                                       uint32_t& imageIdx)
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doWrite(ioWrapper,
+        if (cfg() == nullptr || !decoded()) return TiffEntryBase::doWrite(ioWrapper,
                                                                     byteOrder,
                                                                     offset,
                                                                     valueIdx,
@@ -1404,7 +1404,7 @@ namespace Exiv2 {
         std::sort(elements_.begin(), elements_.end(), cmpTagLt);
         uint32_t idx = 0;
         MemIo mio;
-        IoWrapper mioWrapper(mio, 0, 0, 0);
+        IoWrapper mioWrapper(mio, nullptr, 0, nullptr);
         // Some array entries need to have the size in the first element
         if (cfg()->hasSize_) {
             byte buf[4];
@@ -1562,11 +1562,11 @@ namespace Exiv2 {
                                          ByteOrder byteOrder) const
     {
         uint32_t len = 0;
-        TiffComponent* pSubIfd = 0;
+        TiffComponent* pSubIfd = nullptr;
         for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
             if ((*i)->tag() == 0x014a) {
                 // Hack: delay writing of sub-IFD image data to get the order correct
-                assert(pSubIfd == 0);
+                assert(pSubIfd == nullptr);
                 pSubIfd = *i;
                 continue;
             }
@@ -1710,7 +1710,7 @@ namespace Exiv2 {
 
     uint32_t TiffBinaryArray::doSize() const
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doSize();
+        if (cfg() == nullptr || !decoded()) return TiffEntryBase::doSize();
 
         if (elements_.empty()) return 0;
 
@@ -1872,16 +1872,16 @@ namespace Exiv2 {
 
     bool cmpTagLt(TiffComponent const* lhs, TiffComponent const* rhs)
     {
-        assert(lhs != 0);
-        assert(rhs != 0);
+        assert(lhs != nullptr);
+        assert(rhs != nullptr);
         if (lhs->tag() != rhs->tag()) return lhs->tag() < rhs->tag();
         return lhs->idx() < rhs->idx();
     }
 
     bool cmpGroupLt(TiffComponent const* lhs, TiffComponent const* rhs)
     {
-        assert(lhs != 0);
-        assert(rhs != 0);
+        assert(lhs != nullptr);
+        assert(rhs != nullptr);
         return lhs->group() < rhs->group();
     }
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -647,7 +647,7 @@ namespace Exiv2 {
         //! Constructor
         TiffDataEntry(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup)
             : TiffDataEntryBase(tag, group, szTag, szGroup),
-              pDataArea_(0), sizeDataArea_(0) {}
+              pDataArea_(nullptr), sizeDataArea_(0) {}
         //! Virtual destructor.
         virtual ~TiffDataEntry();
         //@}
@@ -848,7 +848,7 @@ namespace Exiv2 {
         //@{
         //! Default constructor
         TiffDirectory(uint16_t tag, IfdId group, bool hasNext =true)
-            : TiffComponent(tag, group), hasNext_(hasNext), pNext_(0) {}
+            : TiffComponent(tag, group), hasNext_(hasNext), pNext_(nullptr) {}
         //! Virtual destructor
         virtual ~TiffDirectory();
         //@}
@@ -1579,7 +1579,7 @@ namespace Exiv2 {
     TiffComponent::UniquePtr newTiffBinaryArray1(uint16_t tag, IfdId group)
     {
         return TiffComponent::UniquePtr(
-            new TiffBinaryArray(tag, group, arrayCfg, 0, 0));
+            new TiffBinaryArray(tag, group, arrayCfg, nullptr, 0));
     }
 
     //! Function to create and initialize a new complex binary array entry

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -211,7 +211,7 @@ namespace Exiv2 {
         std::cerr << "Writing TIFF file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {
@@ -302,7 +302,7 @@ namespace Exiv2 {
                                         Tag::root,
                                         TiffMapping::findEncoder,
                                         header.get(),
-                                        0);
+                                        nullptr);
     } // TiffParser::encode
 
     // *************************************************************************

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -15,7 +15,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! Constant for non-encrypted binary arrays
-    const CryptFct notEncrypted = 0;
+    const CryptFct notEncrypted = nullptr;
 
     //! Canon Camera Settings binary array - configuration
     extern const ArrayCfg canonCsCfg = {
@@ -1511,11 +1511,11 @@ namespace Exiv2 {
 
     // TIFF mapping table for special decoding and encoding requirements
     const TiffMappingInfo TiffMapping::tiffMappingInfo_[] = {
-        { "*",       Tag::all, ignoreId,  0, 0 }, // Do not decode tags with group == ignoreId
-        { "*",         0x02bc, ifd0Id,    &TiffDecoder::decodeXmp,          0 /*done before the tree is traversed*/ },
-        { "*",         0x83bb, ifd0Id,    &TiffDecoder::decodeIptc,         0 /*done before the tree is traversed*/ },
-        { "*",         0x8649, ifd0Id,    &TiffDecoder::decodeIptc,         0 /*done before the tree is traversed*/ },
-        { "*",         0x0026, canonId,   &TiffDecoder::decodeCanonAFInfo,  0 /* Exiv2.Canon.AFInfo is read-only */ },
+        { "*",       Tag::all, ignoreId,  nullptr, nullptr }, // Do not decode tags with group == ignoreId
+        { "*",         0x02bc, ifd0Id,    &TiffDecoder::decodeXmp,          nullptr /*done before the tree is traversed*/ },
+        { "*",         0x83bb, ifd0Id,    &TiffDecoder::decodeIptc,         nullptr /*done before the tree is traversed*/ },
+        { "*",         0x8649, ifd0Id,    &TiffDecoder::decodeIptc,         nullptr /*done before the tree is traversed*/ },
+        { "*",         0x0026, canonId,   &TiffDecoder::decodeCanonAFInfo,  nullptr /* Exiv2.Canon.AFInfo is read-only */ },
     };
 
     DecoderFct TiffMapping::findDecoder(const std::string& make,
@@ -1538,7 +1538,7 @@ namespace Exiv2 {
               IfdId        group
     )
     {
-        EncoderFct encoderFct = 0;
+        EncoderFct encoderFct = nullptr;
         const TiffMappingInfo* td = find(tiffMappingInfo_,
                                          TiffMappingInfo::Key(make, extendedTag, group));
         if (td) {
@@ -1584,11 +1584,11 @@ namespace Exiv2 {
                               IfdId     group,
                               uint32_t  root)
     {
-        const TiffTreeStruct* ts = 0;
+        const TiffTreeStruct* ts = nullptr;
         do {
             tiffPath.push(TiffPathItem(extendedTag, group));
             ts = find(tiffTreeStruct_, TiffTreeStruct::Key(root, group));
-            assert(ts != 0);
+            assert(ts != nullptr);
             extendedTag = ts->parentExtTag_;
             group = ts->parentGroup_;
         } while (!(ts->root_ == root && ts->group_ == ifdIdNotSet));
@@ -1613,7 +1613,7 @@ namespace Exiv2 {
             pHeader = ph.get();
         }
         TiffComponent::UniquePtr rootDir = parse(pData, size, root, pHeader);
-        if (0 != rootDir.get()) {
+        if (nullptr != rootDir.get()) {
             TiffDecoder decoder(exifData,
                                 iptcData,
                                 xmpData,
@@ -1651,7 +1651,7 @@ namespace Exiv2 {
         TiffComponent::UniquePtr parsedTree = parse(pData, size, root, pHeader);
         PrimaryGroups primaryGroups;
         findPrimaryGroups(primaryGroups, parsedTree.get());
-        if (0 != parsedTree.get()) {
+        if (nullptr != parsedTree.get()) {
             // Attempt to update existing TIFF components based on metadata entries
             TiffEncoder encoder(exifData,
                                 iptcData,
@@ -1666,7 +1666,7 @@ namespace Exiv2 {
         }
         if (writeMethod == wmIntrusive) {
             TiffComponent::UniquePtr createdTree = TiffCreator::create(root, ifdIdNotSet);
-            if (0 != parsedTree.get()) {
+            if (nullptr != parsedTree.get()) {
                 // Copy image tags from the original image to the composite
                 TiffCopier copier(createdTree.get(), root, pHeader, &primaryGroups);
                 parsedTree->accept(copier);
@@ -1676,7 +1676,7 @@ namespace Exiv2 {
                                 iptcData,
                                 xmpData,
                                 createdTree.get(),
-                                parsedTree.get() == 0,
+                                parsedTree.get() == nullptr,
                                 &primaryGroups,
                                 pHeader,
                                 findEncoderFct);
@@ -1684,7 +1684,7 @@ namespace Exiv2 {
             // Write binary representation from the composite tree
             DataBuf header = pHeader->write();
             BasicIo::UniquePtr tempIo(new MemIo);
-            assert(tempIo.get() != 0);
+            assert(tempIo.get() != nullptr);
             IoWrapper ioWrapper(*tempIo, header.pData_, (long)header.size_, pOffsetWriter);
             uint32_t imageIdx(uint32_t(-1));
             createdTree->write(ioWrapper,
@@ -1714,13 +1714,13 @@ namespace Exiv2 {
               TiffHeaderBase*    pHeader
     )
     {
-        if (pData == 0 || size == 0)
+        if (pData == nullptr || size == 0)
             return nullptr;
         if (!pHeader->read(pData, size) || pHeader->offset() >= size) {
             throw Error(kerNotAnImage, "TIFF");
         }
         TiffComponent::UniquePtr rootDir = TiffCreator::create(root, ifdIdNotSet);
-        if (0 != rootDir.get()) {
+        if (nullptr != rootDir.get()) {
             rootDir->setStart(pData + pHeader->offset());
             TiffRwState state(pHeader->byteOrder(), 0);
             TiffReader reader(pData, size, rootDir.get(), state);
@@ -1733,7 +1733,7 @@ namespace Exiv2 {
 
     void TiffParserWorker::findPrimaryGroups(PrimaryGroups& primaryGroups, TiffComponent* pSourceDir)
     {
-        if (0 == pSourceDir)
+        if (nullptr == pSourceDir)
             return;
 
         const IfdId imageGroups[] = {
@@ -1982,7 +1982,7 @@ namespace Exiv2 {
         ExifKey key(tag, groupName(group));
 #endif
         // If there are primary groups and none matches group, we're done
-        if (   pPrimaryGroups != 0
+        if (   pPrimaryGroups != nullptr
             && !pPrimaryGroups->empty()
             && std::find(pPrimaryGroups->begin(), pPrimaryGroups->end(), group)
                == pPrimaryGroups->end()) {
@@ -1993,7 +1993,7 @@ namespace Exiv2 {
         }
         // All tags of marked primary groups other than IFD0 are considered
         // image tags. That should take care of NEFs until we know better.
-        if (   pPrimaryGroups != 0
+        if (   pPrimaryGroups != nullptr
             && !pPrimaryGroups->empty()
             && group != ifd0Id) {
 #ifdef EXIV2_DEBUG_MESSAGES

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -306,7 +306,7 @@ namespace Exiv2 {
                   size_t size,
                   uint32_t           root,
                   FindDecoderFct     findDecoderFct,
-                  TiffHeaderBase*    pHeader =0
+                  TiffHeaderBase*    pHeader =nullptr
         );
         /*!
           @brief Encode TIFF metadata from the metadata containers into a

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -125,7 +125,7 @@ namespace Exiv2 {
     {
         tag_ = tag;
         group_ = group;
-        tiffComponent_ = 0;
+        tiffComponent_ = nullptr;
         setGo(geTraverse, true);
     }
 
@@ -200,9 +200,9 @@ namespace Exiv2 {
           pHeader_(pHeader),
           pPrimaryGroups_(pPrimaryGroups)
     {
-        assert(pRoot_ != 0);
-        assert(pHeader_ != 0);
-        assert(pPrimaryGroups_ != 0);
+        assert(pRoot_ != nullptr);
+        assert(pHeader_ != nullptr);
+        assert(pPrimaryGroups_ != nullptr);
     }
 
     TiffCopier::~TiffCopier()
@@ -211,7 +211,7 @@ namespace Exiv2 {
 
     void TiffCopier::copyObject(TiffComponent* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         if (pHeader_->isImageTag(object->tag(), object->group(), pPrimaryGroups_)) {
             TiffComponent::UniquePtr clone = object->clone();
@@ -290,7 +290,7 @@ namespace Exiv2 {
           findDecoderFct_(findDecoderFct),
           decodedIptc_(false)
     {
-        assert(pRoot != 0);
+        assert(pRoot != nullptr);
 
         exifData_.clear();
         iptcData_.clear();
@@ -347,7 +347,7 @@ namespace Exiv2 {
 
     void TiffDecoder::visitIfdMakernote(TiffIfdMakernote* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         exifData_["Exif.MakerNote.Offset"] = object->mnOffset();
         switch (object->byteOrder()) {
@@ -389,7 +389,7 @@ namespace Exiv2 {
         // add Exif tag anyway
         decodeStdTiffEntry(object);
 
-        byte const* pData = 0;
+        byte const* pData = nullptr;
         long size = 0;
         getObjData(pData, size, 0x02bc, ifd0Id, object);
         if (pData) {
@@ -423,7 +423,7 @@ namespace Exiv2 {
         }
         decodedIptc_ = true;
         // 1st choice: IPTCNAA
-        byte const* pData = 0;
+        byte const* pData = nullptr;
         long size = 0;
         getObjData(pData, size, 0x83bb, ifd0Id, object);
         if (pData) {
@@ -440,11 +440,11 @@ namespace Exiv2 {
 
         // 2nd choice if no IPTCNAA record found or failed to decode it:
         // ImageResources
-        pData = 0;
+        pData = nullptr;
         size = 0;
         getObjData(pData, size, 0x8649, ifd0Id, object);
         if (pData) {
-            byte const* record = 0;
+            byte const* record = nullptr;
             uint32_t sizeHdr = 0;
             uint32_t sizeData = 0;
             if (0 != Photoshop::locateIptcIrb(pData, size,
@@ -466,7 +466,7 @@ namespace Exiv2 {
     static const TagInfo* findTag(const TagInfo* pList,uint16_t tag)
     {
         while ( pList->tag_ != 0xffff && pList->tag_ != tag ) pList++;
-        return  pList->tag_ != 0xffff  ? pList : NULL;
+        return  pList->tag_ != 0xffff  ? pList : nullptr;
     }
 
     void TiffDecoder::decodeCanonAFInfo(const TiffEntryBase* object) {
@@ -537,7 +537,7 @@ namespace Exiv2 {
 
     void TiffDecoder::decodeTiffEntry(const TiffEntryBase* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         // Don't decode the entry if value is not set
         if (!object->pValue()) return;
@@ -553,7 +553,7 @@ namespace Exiv2 {
 
     void TiffDecoder::decodeStdTiffEntry(const TiffEntryBase* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
         ExifKey key(object->tag(), groupName(object->group()));
         key.setIdx(object->idx());
         exifData_.add(key, object->pValue());
@@ -562,7 +562,7 @@ namespace Exiv2 {
 
     void TiffDecoder::visitBinaryArray(TiffBinaryArray* object)
     {
-        if (object->cfg() == 0 || !object->decoded()) {
+        if (object->cfg() == nullptr || !object->decoded()) {
             decodeTiffEntry(object);
         }
     }
@@ -590,14 +590,14 @@ namespace Exiv2 {
           pRoot_(pRoot),
           isNewImage_(isNewImage),
           pPrimaryGroups_(pPrimaryGroups),
-          pSourceTree_(0),
+          pSourceTree_(nullptr),
           findEncoderFct_(findEncoderFct),
           dirty_(false),
           writeMethod_(wmNonIntrusive)
     {
-        assert(pRoot != 0);
-        assert(pPrimaryGroups != 0);
-        assert(pHeader != 0);
+        assert(pRoot != nullptr);
+        assert(pPrimaryGroups != nullptr);
+        assert(pHeader != nullptr);
 
         byteOrder_ = pHeader->byteOrder();
         origByteOrder_ = byteOrder_;
@@ -750,7 +750,7 @@ namespace Exiv2 {
     void TiffEncoder::visitDirectoryNext(TiffDirectory* object)
     {
         // Update type and count in IFD entries, in case they changed
-        assert(object != 0);
+        assert(object != nullptr);
 
         byte* p = object->start() + 2;
         for (TiffDirectory::Components::iterator i = object->components_.begin();
@@ -803,7 +803,7 @@ namespace Exiv2 {
 
     void TiffEncoder::visitIfdMakernote(TiffIfdMakernote* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         ExifData::iterator pos = exifData_.findKey(ExifKey("Exif.MakerNote.ByteOrder"));
         if (pos != exifData_.end()) {
@@ -841,16 +841,16 @@ namespace Exiv2 {
 
     void TiffEncoder::visitBinaryArray(TiffBinaryArray* object)
     {
-        if (object->cfg() == 0 || !object->decoded()) {
+        if (object->cfg() == nullptr || !object->decoded()) {
             encodeTiffComponent(object);
         }
     }
 
     void TiffEncoder::visitBinaryArrayEnd(TiffBinaryArray* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
-        if (object->cfg() == 0 || !object->decoded()) return;
+        if (object->cfg() == nullptr || !object->decoded()) return;
         std::uint32_t size = object->TiffEntryBase::doSize();
         if (size == 0) return;
         if (!object->initialize(pRoot_)) return;
@@ -860,7 +860,7 @@ namespace Exiv2 {
         if ( cryptFct == sonyTagDecipher ) {
              cryptFct  = sonyTagEncipher;
         }
-        if (cryptFct != 0) {
+        if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
             if (buf.size_ > 0) {
@@ -895,11 +895,11 @@ namespace Exiv2 {
         const Exifdatum*     datum
     )
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         ExifData::iterator pos = exifData_.end();
         const Exifdatum* ed = datum;
-        if (ed == 0) {
+        if (ed == nullptr) {
             // Non-intrusive writing: find matching tag
             ExifKey key(object->tag(), groupName(object->group()));
             pos = exifData_.findKey(key);
@@ -1017,7 +1017,7 @@ namespace Exiv2 {
             // Set pseudo strips (without a data pointer) from the size tag
             ExifKey key(object->szTag(), groupName(object->szGroup()));
             ExifData::const_iterator pos = exifData_.findKey(key);
-            const byte* zero = 0;
+            const byte* zero = nullptr;
             if (pos == exifData_.end()) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_ERROR << "Size tag " << key
@@ -1087,8 +1087,8 @@ namespace Exiv2 {
 
     void TiffEncoder::encodeTiffEntryBase(TiffEntryBase* object, const Exifdatum* datum)
     {
-        assert(object != 0);
-        assert(datum != 0);
+        assert(object != nullptr);
+        assert(datum != nullptr);
 
 #ifdef EXIV2_DEBUG_MESSAGES
         bool tooLarge = false;
@@ -1112,8 +1112,8 @@ namespace Exiv2 {
 
     void TiffEncoder::encodeOffsetEntry(TiffEntryBase* object, const Exifdatum* datum)
     {
-        assert(object != 0);
-        assert(datum != 0);
+        assert(object != nullptr);
+        assert(datum != nullptr);
 
         size_t newSize = datum->size();
         if (newSize > object->size_) { // value doesn't fit, encode for intrusive writing
@@ -1142,7 +1142,7 @@ namespace Exiv2 {
         uint32_t       root
     )
     {
-        assert(pRootDir != 0);
+        assert(pRootDir != nullptr);
 
         writeMethod_ = wmIntrusive;
         pSourceTree_ = pSourceDir;
@@ -1181,7 +1181,7 @@ namespace Exiv2 {
                           << std::hex << i->tag() << "\n";
             }
 #endif
-            if (object != 0) {
+            if (object != nullptr) {
                 encodeTiffComponent(object, &(*i));
             }
         }
@@ -1238,7 +1238,7 @@ namespace Exiv2 {
 
     void TiffReader::setMnState(const TiffRwState* state)
     {
-        if (state != 0) {
+        if (state != nullptr) {
             // invalidByteOrder indicates 'no change'
             if (state->byteOrder() == invalidByteOrder) {
                 mnState_ = TiffRwState(origState_.byteOrder(), state->baseOffset());
@@ -1264,7 +1264,7 @@ namespace Exiv2 {
 
     void TiffReader::readDataEntryBase(TiffDataEntryBase* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         readTiffEntry(object);
         TiffFinder finder(object->szTag(), object->szGroup());
@@ -1292,7 +1292,7 @@ namespace Exiv2 {
 
     void TiffReader::visitSizeEntry(TiffSizeEntry* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         readTiffEntry(object);
         TiffFinder finder(object->dtTag(), object->dtGroup());
@@ -1335,7 +1335,7 @@ namespace Exiv2 {
 
     void TiffReader::visitDirectory(TiffDirectory* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         const byte* p = object->start();
         assert(p >= pData_);
@@ -1392,7 +1392,7 @@ namespace Exiv2 {
             if (next) {
                 tc = TiffCreator::create(Tag::next, object->group());
 #ifndef SUPPRESS_WARNINGS
-                if (tc.get() == 0) {
+                if (tc.get() == nullptr) {
                     EXV_WARNING << "Directory " << groupName(object->group())
                                 << " has an unexpected next pointer; ignored.\n";
                 }
@@ -1415,7 +1415,7 @@ namespace Exiv2 {
 
     void TiffReader::visitSubIfd(TiffSubIfd* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         readTiffEntry(object);
         if (   (object->tiffType() == ttUnsignedLong || object->tiffType() == ttSignedLong
@@ -1465,7 +1465,7 @@ namespace Exiv2 {
 
     void TiffReader::visitMnEntry(TiffMnEntry* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         readTiffEntry(object);
         // Find camera make
@@ -1489,7 +1489,7 @@ namespace Exiv2 {
 
     void TiffReader::visitIfdMakernote(TiffIfdMakernote* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         object->setImageByteOrder(byteOrder()); // set the byte order for the image
 
@@ -1527,7 +1527,7 @@ namespace Exiv2 {
 
     void TiffReader::readTiffEntry(TiffEntryBase* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         byte* p = object->start();
         assert(p >= pData_);
@@ -1651,7 +1651,7 @@ namespace Exiv2 {
 
     void TiffReader::visitBinaryArray(TiffBinaryArray* object)
     {
-        assert(object != 0);
+        assert(object != nullptr);
 
         if (!postProc_) {
             // Defer reading children until after all other components are read, but
@@ -1680,10 +1680,10 @@ namespace Exiv2 {
         if (object->TiffEntryBase::doSize() == 0) return;
         if (!object->initialize(pRoot_)) return;
         const ArrayCfg* cfg = object->cfg();
-        if (cfg == 0) return;
+        if (cfg == nullptr) return;
 
         const CryptFct cryptFct = cfg->cryptFct_;
-        if (cryptFct != 0) {
+        if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             int32_t size = object->TiffEntryBase::doSize();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -166,7 +166,7 @@ namespace Exiv2 {
         //@{
         //! Constructor, taking \em tag and \em group of the component to find.
         TiffFinder(uint16_t tag, IfdId group)
-            : tag_(tag), group_(group), tiffComponent_(0) {}
+            : tag_(tag), group_(group), tiffComponent_(nullptr) {}
         //! Virtual destructor
         ~TiffFinder() override;
         //@}
@@ -453,7 +453,7 @@ namespace Exiv2 {
          */
         void encodeTiffComponent(
                   TiffEntryBase* object,
-            const Exifdatum*     datum =0
+            const Exifdatum*     datum =nullptr
         );
 
         //! Callback encoder function for an element of a binary array.
@@ -680,7 +680,7 @@ namespace Exiv2 {
           Uses the \em state passed in, if any, and remembers it for use during
           subsequent calls without any argument.
          */
-        void setMnState(const TiffRwState* state =0);
+        void setMnState(const TiffRwState* state =nullptr);
         //! Set the state to the original state as set in the constructor.
         void setOrigState();
         //! Check IFD directory pointer \em start for circular reference

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -108,7 +108,7 @@ namespace Exiv2 {
     const char* TypeInfo::typeName(TypeId typeId)
     {
         const TypeInfoTable* tit = find(typeInfoTable, typeId);
-        if (!tit) return 0;
+        if (!tit) return nullptr;
         return tit->name_;
     }
 
@@ -138,14 +138,14 @@ namespace Exiv2 {
         delete[] pData_;
     }
 
-    DataBuf::DataBuf() : pData_(0), size_(0)
+    DataBuf::DataBuf() : pData_(nullptr), size_(0)
     {}
 
     DataBuf::DataBuf(size_t size) : pData_(new byte[size]()), size_(size)
     {}
 
     DataBuf::DataBuf(const byte* pData, size_t size)
-        : pData_(0), size_(0)
+        : pData_(nullptr), size_(0)
     {
         if (size > 0) {
             pData_ = new byte[size];
@@ -165,7 +165,7 @@ namespace Exiv2 {
     {
         if (size > size_) {
             delete[] pData_;
-            pData_ = 0;
+            pData_ = nullptr;
             size_ = 0;
             pData_ = new byte[size];
             size_ = size;
@@ -175,7 +175,7 @@ namespace Exiv2 {
     EXV_WARN_UNUSED_RESULT std::pair<byte *, size_t> DataBuf::release()
     {
         std::pair<byte*, size_t> p = std::make_pair(pData_, size_);
-        pData_ = 0;
+        pData_ = nullptr;
         size_ = 0;
         return p;
     }
@@ -183,7 +183,7 @@ namespace Exiv2 {
     void DataBuf::free()
     {
         delete[] pData_;
-        pData_ = 0;
+        pData_ = nullptr;
         size_ = 0;
     }
 
@@ -578,8 +578,8 @@ namespace Exiv2 {
 
     int exifTime(const char* buf, struct tm* tm)
     {
-        assert(buf != 0);
-        assert(tm != 0);
+        assert(buf != nullptr);
+        assert(tm != nullptr);
         int rc = 1;
         int year, mon, mday, hour, min, sec;
         int scanned = std::sscanf(buf, "%4d:%2d:%2d %2d:%2d:%2d",

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -87,7 +87,7 @@ namespace Util {
     bool strtol(const char* nptr, long& n)
     {
         if (!nptr || *nptr == '\0') return false;
-        char* endptr = 0;
+        char* endptr = nullptr;
         long tmp = std::strtol(nptr, &endptr, 10);
         if (*endptr != '\0') return false;
         if (tmp == LONG_MAX || tmp == LONG_MIN) return false;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -192,7 +192,7 @@ namespace Exiv2 {
 
     DataBuf Value::dataArea() const
     {
-        return DataBuf(0, 0);
+        return DataBuf(nullptr, 0);
     }
 
     DataValue::DataValue(TypeId typeId) : Value(typeId)
@@ -335,7 +335,7 @@ namespace Exiv2 {
     {
         if (value_.size() == 0) return 0;
         // byteOrder not needed
-        assert(buf != 0);
+        assert(buf != nullptr);
         return static_cast<long>(
             value_.copy(reinterpret_cast<char*>(buf), value_.size())
             );
@@ -542,7 +542,7 @@ namespace Exiv2 {
         }
         if (c.size() == 0)
             return 0;
-        assert(buf != 0);
+        assert(buf != nullptr);
         return static_cast<long>(c.copy(reinterpret_cast<char*>(buf), c.size()));
     }
 
@@ -563,7 +563,7 @@ namespace Exiv2 {
         }
         c = value_.substr(8);
         if (charsetId() == unicode) {
-            const char* from = encoding == 0 || *encoding == '\0' ? detectCharset(c) : encoding;
+            const char* from = encoding == nullptr || *encoding == '\0' ? detectCharset(c) : encoding;
             convertStringCharset(c, from, "UTF-8");
         }
         return c;

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -119,7 +119,7 @@ namespace Exiv2 {
         }
         IoCloser closer(*io_);
         BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        assert (tempIo.get() != nullptr);
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -141,17 +141,17 @@ namespace Exiv2 {
 
     Xmpdatum::Impl::Impl(const Impl& rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
     }
 
     Xmpdatum::Impl& Xmpdatum::Impl::operator=(const Impl& rhs)
     {
         if (this == &rhs) return *this;
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr) key_ = rhs.key_->clone(); // deep copy
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr) value_ = rhs.value_->clone(); // deep copy
         return *this;
     }
 
@@ -179,37 +179,37 @@ namespace Exiv2 {
 
     std::string Xmpdatum::key() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->key();
+        return p_->key_.get() == nullptr ? "" : p_->key_->key();
     }
 
     const char* Xmpdatum::familyName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->familyName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->familyName();
     }
 
     std::string Xmpdatum::groupName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->groupName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->groupName();
     }
 
     std::string Xmpdatum::tagName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagName();
     }
 
     std::string Xmpdatum::tagLabel() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagLabel();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagLabel();
     }
 
     uint16_t Xmpdatum::tag() const
     {
-        return p_->key_.get() == 0 ? 0 : p_->key_->tag();
+        return p_->key_.get() == nullptr ? 0 : p_->key_->tag();
     }
 
     TypeId Xmpdatum::typeId() const
     {
-        return p_->value_.get() == 0 ? invalidTypeId : p_->value_->typeId();
+        return p_->value_.get() == nullptr ? invalidTypeId : p_->value_->typeId();
     }
 
     const char* Xmpdatum::typeName() const
@@ -224,47 +224,47 @@ namespace Exiv2 {
 
     size_t Xmpdatum::count() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->count();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->count();
     }
 
     size_t Xmpdatum::size() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->size();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->size();
     }
 
     std::string Xmpdatum::toString() const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString();
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString();
     }
 
     std::string Xmpdatum::toString(long n) const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString(n);
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString(n);
     }
 
     long Xmpdatum::toLong(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toLong(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toLong(n);
     }
 
     float Xmpdatum::toFloat(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toFloat(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toFloat(n);
     }
 
     Rational Xmpdatum::toRational(long n) const
     {
-        return p_->value_.get() == 0 ? Rational(-1, 1) : p_->value_->toRational(n);
+        return p_->value_.get() == nullptr ? Rational(-1, 1) : p_->value_->toRational(n);
     }
 
     Value::UniquePtr Xmpdatum::getValue() const
     {
-        return p_->value_.get() == 0 ? nullptr : p_->value_->clone();
+        return p_->value_.get() == nullptr ? nullptr : p_->value_->clone();
     }
 
     const Value& Xmpdatum::value() const
     {
-        if (p_->value_.get() == 0) throw Error(kerValueNotSet);
+        if (p_->value_.get() == nullptr) throw Error(kerValueNotSet);
         return *p_->value_;
     }
 
@@ -299,9 +299,9 @@ namespace Exiv2 {
 
     int Xmpdatum::setValue(const std::string& value)
     {
-        if (p_->value_.get() == 0) {
+        if (p_->value_.get() == nullptr) {
             TypeId type = xmpText;
-            if (0 != p_->key_.get()) {
+            if (nullptr != p_->key_.get()) {
                 type = XmpProperties::propertyType(*p_->key_.get());
             }
             p_->value_ = Value::create(type);
@@ -415,8 +415,8 @@ namespace Exiv2 {
 
 
     bool XmpParser::initialized_ = false;
-    XmpParser::XmpLockFct XmpParser::xmpLockFct_ = 0;
-    void* XmpParser::pLockData_ = 0;
+    XmpParser::XmpLockFct XmpParser::xmpLockFct_ = nullptr;
+    void* XmpParser::pLockData_ = nullptr;
 
 #ifdef EXV_HAVE_XMP_TOOLKIT
     bool XmpParser::initialize(XmpParser::XmpLockFct xmpLockFct, void* pLockData)
@@ -768,7 +768,7 @@ namespace Exiv2 {
 
                 // Encode Lang Alt property
                 const LangAltValue* la = dynamic_cast<const LangAltValue*>(&i->value());
-                if (la == 0) throw Error(kerEncodeLangAltPropertyFailed, i->key());
+                if (la == nullptr) throw Error(kerEncodeLangAltPropertyFailed, i->key());
 
                 int idx = 1;
                 for ( LangAltValue::ValueType::const_iterator k = la->value_.begin()
@@ -787,14 +787,14 @@ namespace Exiv2 {
 
             // Todo: Xmpdatum should have an XmpValue, not a Value
             const XmpValue* val = dynamic_cast<const XmpValue*>(&i->value());
-            if (val == 0) throw Error(kerInvalidKeyXmpValue, i->key(), i->typeName());
+            if (val == nullptr) throw Error(kerInvalidKeyXmpValue, i->key(), i->typeName());
             options =   xmpArrayOptionBits(val->xmpArrayType())
                       | xmpArrayOptionBits(val->xmpStruct());
             if (   i->typeId() == xmpBag
                 || i->typeId() == xmpSeq
                 || i->typeId() == xmpAlt) {
                 printNode(ns, i->tagName(), "", options);
-                meta.SetProperty(ns.c_str(), i->tagName().c_str(), 0, options);
+                meta.SetProperty(ns.c_str(), i->tagName().c_str(), nullptr, options);
                 for (long idx = 0; idx < static_cast<long>(i->count()); ++idx) {
                     const std::string item = i->tagName() + "[" + toString(idx + 1) + "]";
                     printNode(ns, item, i->toString(idx), 0);
@@ -805,7 +805,7 @@ namespace Exiv2 {
             if (i->typeId() == xmpText) {
                 if (i->count() == 0) {
                     printNode(ns, i->tagName(), "", options);
-                    meta.SetProperty(ns.c_str(), i->tagName().c_str(), 0, options);
+                    meta.SetProperty(ns.c_str(), i->tagName().c_str(), nullptr, options);
                 }
                 else {
                     printNode(ns, i->tagName(), i->toString(0), options);

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -184,7 +184,7 @@ namespace Exiv2 {
                 xmpPacket_ = xmlHeader + xmpPacket_ + xmlFooter;
             }
             BasicIo::UniquePtr tempIo(new MemIo);
-            assert(tempIo.get() != 0);
+            assert(tempIo.get() != nullptr);
             // Write XMP packet
             if (tempIo->write(reinterpret_cast<const byte*>(xmpPacket_.data()), xmpPacket_.size()) != xmpPacket_.size())
                 throw Error(kerImageWriteFailed);

--- a/xmpsdk/include/TXMPIterator.hpp
+++ b/xmpsdk/include/TXMPIterator.hpp
@@ -210,7 +210,7 @@ public:
     bool Next ( tStringObj *     schemaNS = 0,
           		tStringObj *     propPath = 0,
            		tStringObj *     propValue = 0,
-           		XMP_OptionBits * options = 0 );
+           		XMP_OptionBits * options = nullptr );
 
     // ---------------------------------------------------------------------------------------------
     /// @brief \c Skip() skips some portion of the remaining iterations.

--- a/xmpsdk/include/TXMPUtils.hpp
+++ b/xmpsdk/include/TXMPUtils.hpp
@@ -842,8 +842,8 @@ public:
     ///   \li \c #kXMPUtil_IncludeAliases - Include aliases if the schema is explicitly specified.
 
     static void RemoveProperties ( TXMPMeta<tStringObj> * xmpObj,
-								   XMP_StringPtr          schemaNS = 0,
-								   XMP_StringPtr          propName = 0,
+								   XMP_StringPtr          schemaNS = nullptr,
+								   XMP_StringPtr          propName = nullptr,
 								   XMP_OptionBits         options = 0 );
 
     // ---------------------------------------------------------------------------------------------
@@ -948,8 +948,8 @@ public:
 								   TXMPMeta<tStringObj> *       dest,
 								   XMP_StringPtr                sourceNS,
 								   XMP_StringPtr                sourceRoot,
-								   XMP_StringPtr                destNS = 0,
-								   XMP_StringPtr                destRoot = 0,
+								   XMP_StringPtr                destNS = nullptr,
+								   XMP_StringPtr                destRoot = nullptr,
 								   XMP_OptionBits               options = 0 );
 
     /// @}

--- a/xmpsdk/include/XMP_Const.h
+++ b/xmpsdk/include/XMP_Const.h
@@ -1006,7 +1006,7 @@ struct XMP_ThumbnailInfo {
 	/// Default constructor.
 	XMP_ThumbnailInfo() : fileFormat(kXMP_UnknownFile), fullWidth(0), fullHeight(0),
 						  tnailWidth(0), tnailHeight(0), fullOrientation(0), tnailOrientation(0),
-						  tnailImage(0), tnailSize(0), tnailFormat(kXMP_UnknownTNail) {};
+						  tnailImage(nullptr), tnailSize(0), tnailFormat(kXMP_UnknownTNail) {};
 
 };
 

--- a/xmpsdk/include/client-glue/TXMPIterator.incl_cpp
+++ b/xmpsdk/include/client-glue/TXMPIterator.incl_cpp
@@ -113,7 +113,7 @@ operator= ( const TXMPIterator<tStringObj> & rhs )
 // -------------------------------------------------------------------------------------------------
 
 XMP_CTorDTorIntro(TXMPIterator)::
-TXMPIterator() : iterRef(0)
+TXMPIterator() : iterRef(nullptr)
 {
 	throw XMP_Error ( kXMPErr_Unavailable, "No default construction for XMP iterators" );
 	#if XMP_TraceCTorDTor
@@ -128,7 +128,7 @@ XMP_CTorDTorIntro(TXMPIterator)::
 TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
 			   XMP_StringPtr  schemaNS,
 			   XMP_StringPtr  propName,
-			   XMP_OptionBits options /* = 0 */ ) : iterRef(0)
+			   XMP_OptionBits options /* = 0 */ ) : iterRef(nullptr)
 {
 	PropIterCTor ( xmpObj.GetInternalRef(), schemaNS, propName, options );
 	#if XMP_TraceCTorDTor
@@ -142,7 +142,7 @@ TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
 XMP_CTorDTorIntro(TXMPIterator)::
 TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
 			   XMP_StringPtr  schemaNS,
-			   XMP_OptionBits options /* = 0 */ ) : iterRef(0)
+			   XMP_OptionBits options /* = 0 */ ) : iterRef(nullptr)
 {
 	PropIterCTor ( xmpObj.GetInternalRef(), schemaNS, "", options );
 	#if XMP_TraceCTorDTor
@@ -155,7 +155,7 @@ TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
 
 XMP_CTorDTorIntro(TXMPIterator)::
 TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
-			   XMP_OptionBits options /* = 0 */ ) : iterRef(0)
+			   XMP_OptionBits options /* = 0 */ ) : iterRef(nullptr)
 {
 	PropIterCTor ( xmpObj.GetInternalRef(), "", "", options );
 	#if XMP_TraceCTorDTor
@@ -169,7 +169,7 @@ TXMPIterator ( const TXMPMeta<tStringObj> & xmpObj,
 XMP_CTorDTorIntro(TXMPIterator)::
 TXMPIterator ( XMP_StringPtr  schemaNS,
 			   XMP_StringPtr  propName,
-			   XMP_OptionBits options ) : iterRef(0)
+			   XMP_OptionBits options ) : iterRef(nullptr)
 {
 	TableIterCTor ( schemaNS, propName, options );
 	#if XMP_TraceCTorDTor
@@ -188,7 +188,7 @@ XMP_CTorDTorIntro(TXMPIterator)::
 		printf ( "Destruct TXMPIterator @ %.8X, ref = %.8X, count = %d\n", this, xiPtr, xiPtr->clientRefs );
 	#endif
 	WXMPIterator_DecrementRefCount_1 ( this->iterRef );
-	this->iterRef = 0;
+	this->iterRef = nullptr;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -199,17 +199,17 @@ Next ( tStringObj *		schemaNS /* = 0 */,
 	   tStringObj *		propValue /* = 0 */,
 	   XMP_OptionBits * options /* = 0 */ )
 {
-	XMP_StringPtr schemaPtr = 0;
+	XMP_StringPtr schemaPtr = nullptr;
 	XMP_StringLen schemaLen = 0;
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
-	XMP_StringPtr valuePtr = 0;
+	XMP_StringPtr valuePtr = nullptr;
 	XMP_StringLen valueLen = 0;
 	WrapCheckBool ( found, zXMPIterator_Next_1 ( &schemaPtr, &schemaLen, &pathPtr, &pathLen, &valuePtr, &valueLen, options ) );
 	if ( found ) {
-		if ( schemaNS != 0 ) schemaNS->assign ( schemaPtr, schemaLen );
-		if ( propPath != 0 ) propPath->assign ( pathPtr, pathLen );
-		if ( propValue != 0 ) propValue->assign ( valuePtr, valueLen );
+		if ( schemaNS != nullptr ) schemaNS->assign ( schemaPtr, schemaLen );
+		if ( propPath != nullptr ) propPath->assign ( pathPtr, pathLen );
+		if ( propValue != nullptr ) propValue->assign ( valuePtr, valueLen );
 		WXMPUtils_UnlockIter_1 ( this->iterRef, 0 );
 	}
 	return found;

--- a/xmpsdk/include/client-glue/TXMPMeta.incl_cpp
+++ b/xmpsdk/include/client-glue/TXMPMeta.incl_cpp
@@ -169,7 +169,7 @@ TXMPMeta ( XMP_StringPtr buffer,
 		this->ParseFromBuffer ( buffer, xmpSize );
 	} catch ( ... ) {
 		WXMPMeta_DecrementRefCount_1 ( this->xmpRef );
-		this->xmpRef = 0;
+		this->xmpRef = nullptr;
 		throw;
 	}
 }
@@ -184,7 +184,7 @@ XMP_CTorDTorIntro(TXMPMeta)::
 		printf ( "Destruct TXMPMeta @ %.8X, ref = %.8X, count = %d\n", this, xmPtr, xmPtr->clientRefs );
 	#endif
 	WXMPMeta_DecrementRefCount_1 ( this->xmpRef );
-	this->xmpRef = 0;
+	this->xmpRef = nullptr;
 
 }	// ~TXMPMeta ()
 
@@ -246,11 +246,11 @@ XMP_MethodIntro(TXMPMeta,bool)::
 GetNamespacePrefix ( XMP_StringPtr namespaceURI,
                      tStringObj *  namespacePrefix )
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetNamespacePrefix_1 ( namespaceURI, &resultPtr, &resultLen ) );
 	if ( found ) {
-		if ( namespacePrefix != 0 ) namespacePrefix->assign ( resultPtr, resultLen );
+		if ( namespacePrefix != nullptr ) namespacePrefix->assign ( resultPtr, resultLen );
 		WXMPMeta_Unlock_1 ( 0 );
 	}
 	return found;
@@ -262,11 +262,11 @@ XMP_MethodIntro(TXMPMeta,bool)::
 GetNamespaceURI ( XMP_StringPtr namespacePrefix,
                   tStringObj *  namespaceURI )
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetNamespaceURI_1 ( namespacePrefix, &resultPtr, &resultLen ) );
 	if ( found ) {
-		if ( namespaceURI != 0 ) namespaceURI->assign ( resultPtr, resultLen );
+		if ( namespaceURI != nullptr ) namespaceURI->assign ( resultPtr, resultLen );
 		WXMPMeta_Unlock_1 ( 0 );
 	}
 	return found;
@@ -301,14 +301,14 @@ ResolveAlias ( XMP_StringPtr    aliasNS,
 			   tStringObj *     actualProp,
 			   XMP_OptionBits * arrayForm )
 {
-	XMP_StringPtr nsPtr = 0;
+	XMP_StringPtr nsPtr = nullptr;
 	XMP_StringLen nsLen = 0;
-	XMP_StringPtr propPtr = 0;
+	XMP_StringPtr propPtr = nullptr;
 	XMP_StringLen propLen = 0;
 	WrapCheckBool ( found, zXMPMeta_ResolveAlias_1 ( aliasNS, aliasProp, &nsPtr, &nsLen, &propPtr, &propLen, arrayForm ) );
 	if ( found ) {
-		if ( actualNS != 0 ) actualNS->assign ( nsPtr, nsLen );
-		if ( actualProp != 0 ) actualProp->assign ( propPtr, propLen );
+		if ( actualNS != nullptr ) actualNS->assign ( nsPtr, nsLen );
+		if ( actualProp != nullptr ) actualProp->assign ( propPtr, propLen );
 		WXMPMeta_Unlock_1 ( 0 );
 	}
 	return found;
@@ -341,11 +341,11 @@ GetProperty ( XMP_StringPtr    schemaNS,
 			  tStringObj *     propValue,
 			  XMP_OptionBits * options ) const
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetProperty_1 ( schemaNS, propName, &resultPtr, &resultLen, options ) );
 	if ( found ) {
-		if ( propValue != 0 ) propValue->assign ( resultPtr, resultLen );
+		if ( propValue != nullptr ) propValue->assign ( resultPtr, resultLen );
 		WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 	}
 	return found;
@@ -360,11 +360,11 @@ GetArrayItem ( XMP_StringPtr    schemaNS,
 			   tStringObj *     itemValue,
 			   XMP_OptionBits * options ) const
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetArrayItem_1 ( schemaNS, arrayName, itemIndex, &resultPtr, &resultLen, options ) );
 	if ( found ) {
-		if ( itemValue != 0 ) itemValue->assign ( resultPtr, resultLen );
+		if ( itemValue != nullptr ) itemValue->assign ( resultPtr, resultLen );
 		WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 	}
 	return found;
@@ -380,11 +380,11 @@ GetStructField ( XMP_StringPtr    schemaNS,
 				 tStringObj *     fieldValue,
 				 XMP_OptionBits * options ) const
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetStructField_1 ( schemaNS, structName, fieldNS, fieldName, &resultPtr, &resultLen, options ) );
 	if ( found ) {
-		if ( fieldValue != 0 ) fieldValue->assign ( resultPtr, resultLen );
+		if ( fieldValue != nullptr ) fieldValue->assign ( resultPtr, resultLen );
 		WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 	}
 	return found;
@@ -400,11 +400,11 @@ GetQualifier ( XMP_StringPtr    schemaNS,
 			   tStringObj *     qualValue,
 			   XMP_OptionBits * options ) const
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetQualifier_1 ( schemaNS, propName, qualNS, qualName, &resultPtr, &resultLen, options ) );
 	if ( found ) {
-		if ( qualValue != 0 ) qualValue->assign ( resultPtr, resultLen );
+		if ( qualValue != nullptr ) qualValue->assign ( resultPtr, resultLen );
 		WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 	}
 	return found;
@@ -631,15 +631,15 @@ GetLocalizedText ( XMP_StringPtr    schemaNS,
 				   tStringObj *     itemValue,
 				   XMP_OptionBits * options ) const
 {
-	XMP_StringPtr langPtr = 0;
+	XMP_StringPtr langPtr = nullptr;
 	XMP_StringLen langLen = 0;
-	XMP_StringPtr itemPtr = 0;
+	XMP_StringPtr itemPtr = nullptr;
 	XMP_StringLen itemLen = 0;
 	WrapCheckBool ( found, zXMPMeta_GetLocalizedText_1 ( schemaNS, altTextName, genericLang, specificLang,
 														 &langPtr, &langLen, &itemPtr, &itemLen, options ) );
 	if ( found ) {
-		if ( actualLang != 0 ) actualLang->assign ( langPtr, langLen );
-		if ( itemValue != 0 ) itemValue->assign ( itemPtr, itemLen );
+		if ( actualLang != nullptr ) actualLang->assign ( langPtr, langLen );
+		if ( itemValue != nullptr ) itemValue->assign ( itemPtr, itemLen );
 		WXMPMeta_UnlockObject_1 ( this->xmpRef, kXMP_NoOptions );
 	}
 	return found;
@@ -681,7 +681,7 @@ GetProperty_Bool ( XMP_StringPtr    schemaNS,
 {
 	XMP_Bool binValue;
 	WrapCheckBool ( found, zXMPMeta_GetProperty_Bool_1 ( schemaNS, propName, &binValue, options ) );
-	if ( found && (propValue != 0) ) *propValue = binValue;
+	if ( found && (propValue != nullptr) ) *propValue = binValue;
 	return found;
 }
 
@@ -695,7 +695,7 @@ GetProperty_Int ( XMP_StringPtr    schemaNS,
 {
 	XMP_Int32 abiValue;
 	WrapCheckBool ( found, zXMPMeta_GetProperty_Int_1 ( schemaNS, propName, &abiValue, options ) );
-	if ( found && (propValue != 0) ) *propValue = abiValue;
+	if ( found && (propValue != nullptr) ) *propValue = abiValue;
 	return found;
 }
 
@@ -709,7 +709,7 @@ GetProperty_Int64 ( XMP_StringPtr    schemaNS,
 {
 	XMP_Int64 abiValue;
 	WrapCheckBool ( found, zXMPMeta_GetProperty_Int64_1 ( schemaNS, propName, &abiValue, options ) );
-	if ( found && (propValue != 0) ) *propValue = abiValue;
+	if ( found && (propValue != nullptr) ) *propValue = abiValue;
 	return found;
 }
 
@@ -807,10 +807,10 @@ GetInternalRef() const
 XMP_MethodIntro(TXMPMeta,void)::
 GetObjectName ( tStringObj * name ) const
 {
-	XMP_StringPtr namePtr = 0;
+	XMP_StringPtr namePtr = nullptr;
 	XMP_StringLen nameLen = 0;
 	WrapCheckVoid ( zXMPMeta_GetObjectName_1 ( &namePtr, &nameLen ) );
-	if ( name != 0 ) name->assign ( namePtr, nameLen );
+	if ( name != nullptr ) name->assign ( namePtr, nameLen );
 	WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 }
 
@@ -913,10 +913,10 @@ SerializeToBuffer ( tStringObj *   pktString,
 					XMP_StringPtr  indent,
 					XMP_Index      baseIndent /* = 0 */ ) const
 {
-	XMP_StringPtr resultPtr = 0;
+	XMP_StringPtr resultPtr = nullptr;
 	XMP_StringLen resultLen = 0;
 	WrapCheckVoid ( zXMPMeta_SerializeToBuffer_1 ( &resultPtr, &resultLen, options, padding, newline, indent, baseIndent ) );
-	if ( pktString != 0 ) pktString->assign ( resultPtr, resultLen );
+	if ( pktString != nullptr ) pktString->assign ( resultPtr, resultLen );
 	WXMPMeta_UnlockObject_1 ( this->xmpRef, 0 );
 }
 

--- a/xmpsdk/include/client-glue/TXMPUtils.incl_cpp
+++ b/xmpsdk/include/client-glue/TXMPUtils.incl_cpp
@@ -29,10 +29,10 @@ ComposeArrayItemPath ( XMP_StringPtr schemaNS,
 					   XMP_Index	 itemIndex,
 					   tStringObj *  fullPath )
 {
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
 	WrapCheckVoid ( zXMPUtils_ComposeArrayItemPath_1 ( schemaNS, arrayName, itemIndex, &pathPtr, &pathLen ) );
-	if ( fullPath != 0 ) fullPath->assign ( pathPtr, pathLen );
+	if ( fullPath != nullptr ) fullPath->assign ( pathPtr, pathLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -45,10 +45,10 @@ ComposeStructFieldPath ( XMP_StringPtr schemaNS,
 						 XMP_StringPtr fieldName,
 						 tStringObj *  fullPath )
 {
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
 	WrapCheckVoid ( zXMPUtils_ComposeStructFieldPath_1 ( schemaNS, structName, fieldNS, fieldName, &pathPtr, &pathLen ) );
-	if ( fullPath != 0 ) fullPath->assign ( pathPtr, pathLen );
+	if ( fullPath != nullptr ) fullPath->assign ( pathPtr, pathLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -61,10 +61,10 @@ ComposeQualifierPath ( XMP_StringPtr schemaNS,
 					   XMP_StringPtr qualName,
 					   tStringObj *	 fullPath )
 {
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
 	WrapCheckVoid ( zXMPUtils_ComposeQualifierPath_1 ( schemaNS, propName, qualNS, qualName, &pathPtr, &pathLen ) );
-	if ( fullPath != 0 ) fullPath->assign ( pathPtr, pathLen );
+	if ( fullPath != nullptr ) fullPath->assign ( pathPtr, pathLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -76,10 +76,10 @@ ComposeLangSelector ( XMP_StringPtr schemaNS,
 					  XMP_StringPtr langName,
 					  tStringObj *	fullPath )
 {
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
 	WrapCheckVoid ( zXMPUtils_ComposeLangSelector_1 ( schemaNS, arrayName, langName, &pathPtr, &pathLen ) );
-	if ( fullPath != 0 ) fullPath->assign ( pathPtr, pathLen );
+	if ( fullPath != nullptr ) fullPath->assign ( pathPtr, pathLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -104,11 +104,11 @@ ComposeFieldSelector ( XMP_StringPtr schemaNS,
 					   XMP_StringPtr fieldValue,
 					   tStringObj *	 fullPath )
 {
-	XMP_StringPtr pathPtr = 0;
+	XMP_StringPtr pathPtr = nullptr;
 	XMP_StringLen pathLen = 0;
 	WrapCheckVoid ( zXMPUtils_ComposeFieldSelector_1 ( schemaNS, arrayName, fieldNS, fieldName, fieldValue,
 													   &pathPtr, &pathLen ) );
-	if ( fullPath != 0 ) fullPath->assign ( pathPtr, pathLen );
+	if ( fullPath != nullptr ) fullPath->assign ( pathPtr, pathLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -132,10 +132,10 @@ XMP_MethodIntro(TXMPUtils,void)::
 ConvertFromBool ( bool		   binValue,
 				  tStringObj * strValue )
 {
-	XMP_StringPtr strPtr = 0;
+	XMP_StringPtr strPtr = nullptr;
 	XMP_StringLen strLen = 0;
 	WrapCheckVoid ( zXMPUtils_ConvertFromBool_1 ( binValue, &strPtr, &strLen ) );
-	if ( strValue != 0 ) strValue->assign ( strPtr, strLen );
+	if ( strValue != nullptr ) strValue->assign ( strPtr, strLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -146,10 +146,10 @@ ConvertFromInt ( long		   binValue,
 				 XMP_StringPtr format,
 				 tStringObj *  strValue )
 {
-	XMP_StringPtr strPtr = 0;
+	XMP_StringPtr strPtr = nullptr;
 	XMP_StringLen strLen = 0;
 	WrapCheckVoid ( zXMPUtils_ConvertFromInt_1 ( binValue, format, &strPtr, &strLen ) );
-	if ( strValue != 0 ) strValue->assign ( strPtr, strLen );
+	if ( strValue != nullptr ) strValue->assign ( strPtr, strLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -160,10 +160,10 @@ ConvertFromInt64 ( long long 	 binValue,
 				   XMP_StringPtr format,
 				   tStringObj *  strValue )
 {
-	XMP_StringPtr strPtr = 0;
+	XMP_StringPtr strPtr = nullptr;
 	XMP_StringLen strLen = 0;
 	WrapCheckVoid ( zXMPUtils_ConvertFromInt64_1 ( binValue, format, &strPtr, &strLen ) );
-	if ( strValue != 0 ) strValue->assign ( strPtr, strLen );
+	if ( strValue != nullptr ) strValue->assign ( strPtr, strLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -174,10 +174,10 @@ ConvertFromFloat ( double		 binValue,
 				   XMP_StringPtr format,
 				   tStringObj *	 strValue )
 {
-	XMP_StringPtr strPtr = 0;
+	XMP_StringPtr strPtr = nullptr;
 	XMP_StringLen strLen = 0;
 	WrapCheckVoid ( zXMPUtils_ConvertFromFloat_1 ( binValue, format, &strPtr, &strLen ) );
-	if ( strValue != 0 ) strValue->assign ( strPtr, strLen );
+	if ( strValue != nullptr ) strValue->assign ( strPtr, strLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -187,10 +187,10 @@ XMP_MethodIntro(TXMPUtils,void)::
 ConvertFromDate ( const XMP_DateTime & binValue,
 				  tStringObj *		   strValue )
 {
-	XMP_StringPtr strPtr = 0;
+	XMP_StringPtr strPtr = nullptr;
 	XMP_StringLen strLen = 0;
 	WrapCheckVoid ( zXMPUtils_ConvertFromDate_1 ( binValue, &strPtr, &strLen ) );
-	if ( strValue != 0 ) strValue->assign ( strPtr, strLen );
+	if ( strValue != nullptr ) strValue->assign ( strPtr, strLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -331,10 +331,10 @@ EncodeToBase64 ( XMP_StringPtr rawStr,
 				 XMP_StringLen rawLen,
 				 tStringObj *  encodedStr )
 {
-	XMP_StringPtr encPtr = 0;
+	XMP_StringPtr encPtr = nullptr;
 	XMP_StringLen encLen = 0;
 	WrapCheckVoid ( zXMPUtils_EncodeToBase64_1 ( rawStr, rawLen, &encPtr, &encLen ) );
-	if ( encodedStr != 0 ) encodedStr->assign ( encPtr, encLen );
+	if ( encodedStr != nullptr ) encodedStr->assign ( encPtr, encLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -354,10 +354,10 @@ DecodeFromBase64 ( XMP_StringPtr encodedStr,
 				   XMP_StringLen encodedLen,
 				   tStringObj *	 rawStr )
 {
-	XMP_StringPtr rawPtr = 0;
+	XMP_StringPtr rawPtr = nullptr;
 	XMP_StringLen rawLen = 0;
 	WrapCheckVoid ( zXMPUtils_DecodeFromBase64_1 ( encodedStr, encodedLen, &rawPtr, &rawLen ) );
-	if ( rawStr != 0 ) rawStr->assign ( rawPtr, rawLen );
+	if ( rawStr != nullptr ) rawStr->assign ( rawPtr, rawLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -381,17 +381,17 @@ PackageForJPEG ( const TXMPMeta<tStringObj> & xmpObj,
                  tStringObj * extendedXMP,
                  tStringObj * extendedDigest )
 {
-	XMP_StringPtr stdStr = 0;
+	XMP_StringPtr stdStr = nullptr;
 	XMP_StringLen stdLen = 0;
-	XMP_StringPtr extStr = 0;
+	XMP_StringPtr extStr = nullptr;
 	XMP_StringLen extLen = 0;
-	XMP_StringPtr digestStr = 0;
+	XMP_StringPtr digestStr = nullptr;
 	XMP_StringLen digestLen = 0;
 	WrapCheckVoid ( zXMPUtils_PackageForJPEG_1 ( xmpObj.GetInternalRef(),
 	                                             &stdStr, &stdLen, &extStr, &extLen, &digestStr, &digestLen ) );
-	if ( standardXMP != 0 ) standardXMP->assign ( stdStr, stdLen );
-	if ( extendedXMP != 0 ) extendedXMP->assign ( extStr, extLen );
-	if ( extendedDigest != 0 ) extendedDigest->assign ( digestStr, digestLen );
+	if ( standardXMP != nullptr ) standardXMP->assign ( stdStr, stdLen );
+	if ( extendedXMP != nullptr ) extendedXMP->assign ( extStr, extLen );
+	if ( extendedDigest != nullptr ) extendedDigest->assign ( digestStr, digestLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -416,11 +416,11 @@ CatenateArrayItems ( const TXMPMeta<tStringObj> & xmpObj,
 					 XMP_OptionBits options,
 					 tStringObj *	catedStr )
 {
-	XMP_StringPtr catedPtr = 0;
+	XMP_StringPtr catedPtr = nullptr;
 	XMP_StringLen catedLen = 0;
 	WrapCheckVoid ( zXMPUtils_CatenateArrayItems_1 ( xmpObj.GetInternalRef(), schemaNS, arrayName, 
 													 separator, quotes, options, &catedPtr, &catedLen ) );
-	if ( catedStr != 0 ) catedStr->assign ( catedPtr, catedLen );
+	if ( catedStr != nullptr ) catedStr->assign ( catedPtr, catedLen );
 	WXMPUtils_Unlock_1 ( 0 );
 }
 
@@ -433,7 +433,7 @@ SeparateArrayItems ( TXMPMeta<tStringObj> * xmpObj,
 					 XMP_OptionBits options,
 					 XMP_StringPtr	catedStr )
 {
-	if ( xmpObj == 0 ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
+	if ( xmpObj == nullptr ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
 	WrapCheckVoid ( zXMPUtils_SeparateArrayItems_1 ( xmpObj->GetInternalRef(), schemaNS, arrayName, options, catedStr ) );
 }
 
@@ -457,7 +457,7 @@ RemoveProperties ( TXMPMeta<tStringObj> * xmpObj,
 				   XMP_StringPtr  propName /* = 0 */,
 				   XMP_OptionBits options /* = 0 */ )
 {
-	if ( xmpObj == 0 ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
+	if ( xmpObj == nullptr ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
 	WrapCheckVoid ( zXMPUtils_RemoveProperties_1 ( xmpObj->GetInternalRef(), schemaNS, propName, options ) );
 }
 
@@ -468,7 +468,7 @@ AppendProperties ( const TXMPMeta<tStringObj> & source,
 				   TXMPMeta<tStringObj> *		dest,
 				   XMP_OptionBits options /* = 0 */ )
 {
-	if ( dest == 0 ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
+	if ( dest == nullptr ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
 	WrapCheckVoid ( zXMPUtils_AppendProperties_1 ( source.GetInternalRef(), dest->GetInternalRef(), options ) );
 }
 
@@ -483,7 +483,7 @@ DuplicateSubtree ( const TXMPMeta<tStringObj> & source,
 				   XMP_StringPtr  destRoot /* = 0 */,
 				   XMP_OptionBits options /* = 0 */ )
 {
-	if ( dest == 0 ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
+	if ( dest == nullptr ) throw XMP_Error ( kXMPErr_BadParam, "Null output SXMPMeta pointer" );
 	WrapCheckVoid ( zXMPUtils_DuplicateSubtree_1 ( source.GetInternalRef(), dest->GetInternalRef(),
 												   sourceNS, sourceRoot, destNS, destRoot, options ) );
 }

--- a/xmpsdk/include/client-glue/WXMP_Common.hpp
+++ b/xmpsdk/include/client-glue/WXMP_Common.hpp
@@ -26,7 +26,7 @@ struct WXMP_Result {
     double        floatResult;
     XMP_Uns64     int64Result;
     XMP_Uns32     int32Result;
-    WXMP_Result() : errMessage(0) {};
+    WXMP_Result() : errMessage(nullptr) {};
 };
 
 #if __cplusplus

--- a/xmpsdk/src/ExpatAdapter.cpp
+++ b/xmpsdk/src/ExpatAdapter.cpp
@@ -71,7 +71,7 @@ extern "C" ExpatAdapter * XMP_NewExpatAdapter()
 
 // =================================================================================================
 
-ExpatAdapter::ExpatAdapter() : parser(0)
+ExpatAdapter::ExpatAdapter() : parser(nullptr)
 {
 
 	#if XMP_DebugBuild
@@ -81,8 +81,8 @@ ExpatAdapter::ExpatAdapter() : parser(0)
 		#endif
 	#endif
 
-	this->parser = XML_ParserCreateNS ( 0, FullNameSeparator );
-	if ( this->parser == 0 ) XMP_Throw ( "Failure creating Expat parser", kXMPErr_ExternalFailure );
+	this->parser = XML_ParserCreateNS ( nullptr, FullNameSeparator );
+	if ( this->parser == nullptr ) XMP_Throw ( "Failure creating Expat parser", kXMPErr_ExternalFailure );
 	
 	XML_SetUserData ( this->parser, this );
 	
@@ -109,8 +109,8 @@ ExpatAdapter::ExpatAdapter() : parser(0)
 ExpatAdapter::~ExpatAdapter()
 {
 
-	if ( this->parser != 0 ) XML_ParserFree ( this->parser );
-	this->parser = 0;
+	if ( this->parser != nullptr ) XML_ParserFree ( this->parser );
+	this->parser = nullptr;
 
 }	// ExpatAdapter::~ExpatAdapter
 
@@ -249,8 +249,8 @@ static void StartNamespaceDeclHandler ( void * userData, XMP_StringPtr prefix, X
 		ExpatAdapter * thiz = (ExpatAdapter*)userData;
 	#endif
 
-	if ( prefix == 0 ) prefix = "_dflt_";	// Have default namespace.
-	if ( uri == 0 ) return;	// Ignore, have xmlns:pre="", no URI to register.
+	if ( prefix == nullptr ) prefix = "_dflt_";	// Have default namespace.
+	if ( uri == nullptr ) return;	// Ignore, have xmlns:pre="", no URI to register.
 	
 	#if XMP_DebugBuild & DumpXMLParseEvents
 		if ( thiz->parseLog != 0 ) {
@@ -274,7 +274,7 @@ static void EndNamespaceDeclHandler ( void * userData, XMP_StringPtr prefix )
 		ExpatAdapter * thiz = (ExpatAdapter*)userData;
 	#endif
 
-	if ( prefix == 0 ) prefix = "_dflt_";	// Have default namespace.
+	if ( prefix == nullptr ) prefix = "_dflt_";	// Have default namespace.
 	
 	#if XMP_DebugBuild & DumpXMLParseEvents
 		if ( thiz->parseLog != 0 ) {
@@ -295,7 +295,7 @@ static void StartElementHandler ( void * userData, XMP_StringPtr name, XMP_Strin
 	ExpatAdapter * thiz = (ExpatAdapter*)userData;
 	
 	size_t attrCount = 0;
-	for ( XMP_StringPtr* a = attrs; *a != 0; ++a ) ++attrCount;
+	for ( XMP_StringPtr* a = attrs; *a != nullptr; ++a ) ++attrCount;
 	if ( (attrCount & 1) != 0 )	XMP_Throw ( "Expat attribute info has odd length", kXMPErr_ExternalFailure );
 	attrCount = attrCount/2;	// They are name/value pairs.
 	
@@ -317,7 +317,7 @@ static void StartElementHandler ( void * userData, XMP_StringPtr name, XMP_Strin
 	
 	SetQualName ( name, elemNode );
 	
-	for ( XMP_StringPtr* attr = attrs; *attr != 0; attr += 2 ) {
+	for ( XMP_StringPtr* attr = attrs; *attr != nullptr; attr += 2 ) {
 
 		XMP_StringPtr attrName = *attr;
 		XMP_StringPtr attrValue = *(attr+1);
@@ -371,7 +371,7 @@ static void CharacterDataHandler ( void * userData, XMP_StringPtr cData, int len
 {
 	ExpatAdapter * thiz = (ExpatAdapter*)userData;
 	
-	if ( (cData == 0) || (len == 0) ) { cData = ""; len = 0; }
+	if ( (cData == nullptr) || (len == 0) ) { cData = ""; len = 0; }
 	
 	#if XMP_DebugBuild & DumpXMLParseEvents
 		if ( thiz->parseLog != 0 ) {
@@ -438,7 +438,7 @@ static void ProcessingInstructionHandler ( void * userData, XMP_StringPtr target
 	ExpatAdapter * thiz = (ExpatAdapter*)userData;
 
 	if ( ! XMP_LitMatch ( target, "xpacket" ) ) return;	// Ignore all PIs except the XMP packet wrapper.
-	if ( data == 0 ) data = "";
+	if ( data == nullptr ) data = "";
 	
 	#if XMP_DebugBuild & DumpXMLParseEvents
 		if ( thiz->parseLog != 0 ) {
@@ -465,7 +465,7 @@ static void CommentHandler ( void * userData, XMP_StringPtr comment )
 		ExpatAdapter * thiz = (ExpatAdapter*)userData;
 	#endif
 
-	if ( comment == 0 ) comment = "";
+	if ( comment == nullptr ) comment = "";
 	
 	#if XMP_DebugBuild & DumpXMLParseEvents
 		if ( thiz->parseLog != 0 ) {

--- a/xmpsdk/src/ParseRDF.cpp
+++ b/xmpsdk/src/ParseRDF.cpp
@@ -395,7 +395,7 @@ AddChildNode ( XMP_Node * xmpParent, const XML_Node & xmlNode, const XMP_StringP
 
 	// Make sure that this is not a duplicate of a named node.
 	if ( ! (isArrayItem | isValueNode) ) {
-		if ( FindChildNode ( xmpParent, childName, kXMP_ExistingOnly ) != 0 ) {
+		if ( FindChildNode ( xmpParent, childName, kXMP_ExistingOnly ) != nullptr ) {
 			XMP_Throw ( "Duplicate property or field node", kXMPErr_BadXMP );
 		}
 		
@@ -442,7 +442,7 @@ AddQualifierNode ( XMP_Node * xmpParent, const XMP_VarString & name, const XMP_V
 	const bool isLang = (name == "xml:lang");
 	const bool isType = (name == "rdf:type");
 
-	XMP_Node * newQual = 0;
+	XMP_Node * newQual = nullptr;
 
 		newQual = new XMP_Node ( xmpParent, name, value, kXMP_PropIsQualifier );
 
@@ -535,7 +535,7 @@ FixupQualifiedNode ( XMP_Node * xmpParent )
 		} else {
 			xmpParent->qualifiers.insert ( xmpParent->qualifiers.begin(), langQual );
 		}
-		valueNode->qualifiers[0] = 0;	// We just moved it to the parent.
+		valueNode->qualifiers[0] = nullptr;	// We just moved it to the parent.
 
 		qualNum = 1;	// Start the remaining copy after the xml:lang qualifier.
 
@@ -544,13 +544,13 @@ FixupQualifiedNode ( XMP_Node * xmpParent )
 	for ( ; qualNum != qualLim; ++qualNum ) {
 
 		XMP_Node * currQual = valueNode->qualifiers[qualNum];
-		if ( FindChildNode ( xmpParent, currQual->name.c_str(), kXMP_ExistingOnly ) != 0 ) {
+		if ( FindChildNode ( xmpParent, currQual->name.c_str(), kXMP_ExistingOnly ) != nullptr ) {
 			XMP_Throw ( "Duplicate qualifier node", kXMPErr_BadXMP );
 		}
 
 		currQual->parent = xmpParent;
 		xmpParent->qualifiers.push_back ( currQual );
-		valueNode->qualifiers[qualNum] = 0;	// We just moved it to the parent.
+		valueNode->qualifiers[qualNum] = nullptr;	// We just moved it to the parent.
 
 	}
 	
@@ -580,7 +580,7 @@ FixupQualifiedNode ( XMP_Node * xmpParent )
 			} else {
 				xmpParent->qualifiers.insert ( xmpParent->qualifiers.begin(), currQual );
 			}
-			xmpParent->children[childNum] = 0;	// We just moved it to the qualifers.
+			xmpParent->children[childNum] = nullptr;	// We just moved it to the qualifers.
 		
 	}
 	
@@ -598,7 +598,7 @@ FixupQualifiedNode ( XMP_Node * xmpParent )
 		xmpParent->_valuePtr = xmpParent->value.c_str();
 	#endif
 
-	xmpParent->children[0] = 0;	// ! Remove the value node itself before the swap.
+	xmpParent->children[0] = nullptr;	// ! Remove the value node itself before the swap.
 	xmpParent->children.swap ( valueNode->children );
 	
 	for ( size_t childNum = 0, childLim = xmpParent->children.size(); childNum != childLim; ++childNum ) {
@@ -866,7 +866,7 @@ RDF_PropertyElement ( XMP_Node * xmpParent, const XML_Node & xmlNode, bool isTop
 
 		XML_cNodePos currAttr = xmlNode.attrs.begin();
 		XML_cNodePos endAttr  = xmlNode.attrs.end();
-		XMP_VarString * attrName = 0;
+		XMP_VarString * attrName = nullptr;
 
 		for ( ; currAttr != endAttr; ++currAttr ) {
 			attrName = &((*currAttr)->name);
@@ -1192,7 +1192,7 @@ RDF_EmptyPropertyElement ( XMP_Node * xmpParent, const XML_Node & xmlNode, bool 
 	bool hasNodeIDAttr    = false;
 	bool hasValueAttr     = false;
 	
-	const XML_Node * valueNode = 0;	// ! Can come from rdf:value or rdf:resource.
+	const XML_Node * valueNode = nullptr;	// ! Can come from rdf:value or rdf:resource.
 	
 	if ( ! xmlNode.content.empty() ) XMP_Throw ( "Nested content not allowed with rdf:resource or property attributes", kXMPErr_BadRDF );
 	

--- a/xmpsdk/src/UnicodeConversions.cpp
+++ b/xmpsdk/src/UnicodeConversions.cpp
@@ -26,36 +26,36 @@ using namespace std;
 
 // *** Look into using asm inlines, e.g. count-leading bits for multi-byte UTF-8.
 
-CodePoint_to_UTF16_Proc CodePoint_to_UTF16BE = 0;
-CodePoint_to_UTF16_Proc CodePoint_to_UTF16LE = 0;
+CodePoint_to_UTF16_Proc CodePoint_to_UTF16BE = nullptr;
+CodePoint_to_UTF16_Proc CodePoint_to_UTF16LE = nullptr;
 
-CodePoint_from_UTF16_Proc CodePoint_from_UTF16BE = 0;
-CodePoint_from_UTF16_Proc CodePoint_from_UTF16LE = 0;
+CodePoint_from_UTF16_Proc CodePoint_from_UTF16BE = nullptr;
+CodePoint_from_UTF16_Proc CodePoint_from_UTF16LE = nullptr;
 
-UTF8_to_UTF16_Proc  UTF8_to_UTF16BE = 0;
-UTF8_to_UTF16_Proc  UTF8_to_UTF16LE = 0;
-UTF8_to_UTF32_Proc  UTF8_to_UTF32BE = 0;
-UTF8_to_UTF32_Proc  UTF8_to_UTF32LE = 0;
+UTF8_to_UTF16_Proc  UTF8_to_UTF16BE = nullptr;
+UTF8_to_UTF16_Proc  UTF8_to_UTF16LE = nullptr;
+UTF8_to_UTF32_Proc  UTF8_to_UTF32BE = nullptr;
+UTF8_to_UTF32_Proc  UTF8_to_UTF32LE = nullptr;
 
-UTF16_to_UTF8_Proc  UTF16BE_to_UTF8 = 0;
-UTF16_to_UTF8_Proc  UTF16LE_to_UTF8 = 0;
-UTF32_to_UTF8_Proc  UTF32BE_to_UTF8 = 0;
-UTF32_to_UTF8_Proc  UTF32LE_to_UTF8 = 0;
+UTF16_to_UTF8_Proc  UTF16BE_to_UTF8 = nullptr;
+UTF16_to_UTF8_Proc  UTF16LE_to_UTF8 = nullptr;
+UTF32_to_UTF8_Proc  UTF32BE_to_UTF8 = nullptr;
+UTF32_to_UTF8_Proc  UTF32LE_to_UTF8 = nullptr;
 
-UTF8_to_UTF16_Proc  UTF8_to_UTF16Native = 0;
-UTF8_to_UTF32_Proc  UTF8_to_UTF32Native = 0;
-UTF16_to_UTF8_Proc  UTF16Native_to_UTF8 = 0;
-UTF32_to_UTF8_Proc  UTF32Native_to_UTF8 = 0;
+UTF8_to_UTF16_Proc  UTF8_to_UTF16Native = nullptr;
+UTF8_to_UTF32_Proc  UTF8_to_UTF32Native = nullptr;
+UTF16_to_UTF8_Proc  UTF16Native_to_UTF8 = nullptr;
+UTF32_to_UTF8_Proc  UTF32Native_to_UTF8 = nullptr;
 
-UTF16_to_UTF32_Proc UTF16BE_to_UTF32BE = 0;
-UTF16_to_UTF32_Proc UTF16BE_to_UTF32LE = 0;
-UTF16_to_UTF32_Proc UTF16LE_to_UTF32BE = 0;
-UTF16_to_UTF32_Proc UTF16LE_to_UTF32LE = 0;
+UTF16_to_UTF32_Proc UTF16BE_to_UTF32BE = nullptr;
+UTF16_to_UTF32_Proc UTF16BE_to_UTF32LE = nullptr;
+UTF16_to_UTF32_Proc UTF16LE_to_UTF32BE = nullptr;
+UTF16_to_UTF32_Proc UTF16LE_to_UTF32LE = nullptr;
 
-UTF32_to_UTF16_Proc UTF32BE_to_UTF16BE = 0;
-UTF32_to_UTF16_Proc UTF32BE_to_UTF16LE = 0;
-UTF32_to_UTF16_Proc UTF32LE_to_UTF16BE = 0;
-UTF32_to_UTF16_Proc UTF32LE_to_UTF16LE = 0;
+UTF32_to_UTF16_Proc UTF32BE_to_UTF16BE = nullptr;
+UTF32_to_UTF16_Proc UTF32BE_to_UTF16LE = nullptr;
+UTF32_to_UTF16_Proc UTF32LE_to_UTF16BE = nullptr;
+UTF32_to_UTF16_Proc UTF32LE_to_UTF16LE = nullptr;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/xmpsdk/src/WXMPIterator.cpp
+++ b/xmpsdk/src/WXMPIterator.cpp
@@ -40,8 +40,8 @@ WXMPIterator_PropCTor_1 ( XMPMetaRef     xmpRef,
 {
     XMP_ENTER_WRAPPER ( "WXMPIterator_PropCTor_1" )
 
-		if ( schemaNS == 0 ) schemaNS = "";
-		if ( propName == 0 ) propName = "";
+		if ( schemaNS == nullptr ) schemaNS = "";
+		if ( propName == nullptr ) propName = "";
 
 		const XMPMeta & xmpObj = WtoXMPMeta_Ref ( xmpRef );
 		XMPIterator *   iter   = new XMPIterator ( xmpObj, schemaNS, propName, options );
@@ -62,8 +62,8 @@ WXMPIterator_TableCTor_1 ( XMP_StringPtr  schemaNS,
 {
     XMP_ENTER_WRAPPER ( "WXMPIterator_TableCTor_1" )
 
-		if ( schemaNS == 0 ) schemaNS = "";
-		if ( propName == 0 ) propName = "";
+		if ( schemaNS == nullptr ) schemaNS = "";
+		if ( propName == nullptr ) propName = "";
 
 		XMPIterator * iter = new XMPIterator ( schemaNS, propName, options );
 		++iter->clientRefs;
@@ -136,13 +136,13 @@ WXMPIterator_Next_1 ( XMPIteratorRef   iterRef,
 {
     XMP_ENTER_WRAPPER ( "WXMPIterator_Next_1" )
 
-		if ( schemaNS == 0 ) schemaNS = &voidStringPtr;
-		if ( nsSize == 0 ) nsSize = &voidStringLen;
-		if ( propPath == 0 ) propPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
-		if ( propValue == 0 ) propValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( propOptions == 0 ) propOptions = &voidOptionBits;
+		if ( schemaNS == nullptr ) schemaNS = &voidStringPtr;
+		if ( nsSize == nullptr ) nsSize = &voidStringLen;
+		if ( propPath == nullptr ) propPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
+		if ( propValue == nullptr ) propValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( propOptions == nullptr ) propOptions = &voidOptionBits;
 
 		XMPIterator * iter = WtoXMPIterator_Ptr ( iterRef );
 		XMP_Bool found = iter->Next ( schemaNS, nsSize, propPath, pathSize, propValue, valueSize, propOptions );

--- a/xmpsdk/src/WXMPMeta.cpp
+++ b/xmpsdk/src/WXMPMeta.cpp
@@ -175,7 +175,7 @@ WXMPMeta_DumpNamespaces_1 ( XMP_TextOutputProc outProc,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DumpNamespaces_1" )
 
-		if ( outProc == 0 ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
+		if ( outProc == nullptr ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
 		
 		XMP_Status status = XMPMeta::DumpNamespaces ( outProc, refCon );
 		wResult->int32Result = status;
@@ -192,7 +192,7 @@ WXMPMeta_DumpAliases_1 ( XMP_TextOutputProc outProc,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DumpAliases_1" )
 
-		if ( outProc == 0 ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
+		if ( outProc == nullptr ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
 		
 		XMP_Status status = XMPMeta::DumpAliases ( outProc, refCon );
 		wResult->int32Result = status;
@@ -222,8 +222,8 @@ WXMPMeta_RegisterNamespace_1 ( XMP_StringPtr   namespaceURI,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_RegisterNamespace_1" )
 
-		if ( (namespaceURI == 0) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
-		if ( (prefix == 0) || (*prefix == 0) ) XMP_Throw ( "Empty prefix", kXMPErr_BadSchema );
+		if ( (namespaceURI == nullptr) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
+		if ( (prefix == nullptr) || (*prefix == 0) ) XMP_Throw ( "Empty prefix", kXMPErr_BadSchema );
 
 		XMPMeta::RegisterNamespace ( namespaceURI, prefix );
 
@@ -240,10 +240,10 @@ WXMPMeta_GetNamespacePrefix_1 ( XMP_StringPtr	namespaceURI,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetNamespacePrefix_1" )
 
-		if ( (namespaceURI == 0) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
+		if ( (namespaceURI == nullptr) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
 
-		if ( namespacePrefix == 0 ) namespacePrefix = &voidStringPtr;
-		if ( prefixSize == 0 ) prefixSize = &voidStringLen;
+		if ( namespacePrefix == nullptr ) namespacePrefix = &voidStringPtr;
+		if ( prefixSize == nullptr ) prefixSize = &voidStringLen;
 
 		bool found = XMPMeta::GetNamespacePrefix ( namespaceURI, namespacePrefix, prefixSize );
 		wResult->int32Result = found;
@@ -261,10 +261,10 @@ WXMPMeta_GetNamespaceURI_1 ( XMP_StringPtr	 namespacePrefix,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetNamespaceURI_1" )
 
-		if ( (namespacePrefix == 0) || (*namespacePrefix == 0) ) XMP_Throw ( "Empty namespace prefix", kXMPErr_BadSchema );
+		if ( (namespacePrefix == nullptr) || (*namespacePrefix == 0) ) XMP_Throw ( "Empty namespace prefix", kXMPErr_BadSchema );
 
-		if ( namespaceURI == 0 ) namespaceURI = &voidStringPtr;
-		if ( uriSize == 0 ) uriSize = &voidStringLen;
+		if ( namespaceURI == nullptr ) namespaceURI = &voidStringPtr;
+		if ( uriSize == nullptr ) uriSize = &voidStringLen;
 	   
 		bool found = XMPMeta::GetNamespaceURI ( namespacePrefix, namespaceURI, uriSize );
 		wResult->int32Result = found;
@@ -280,7 +280,7 @@ WXMPMeta_DeleteNamespace_1 ( XMP_StringPtr namespaceURI,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteNamespace_1" )
 
-		if ( (namespaceURI == 0) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
+		if ( (namespaceURI == nullptr) || (*namespaceURI == 0) ) XMP_Throw ( "Empty namespace URI", kXMPErr_BadSchema );
 
 		XMPMeta::DeleteNamespace ( namespaceURI );
 
@@ -299,10 +299,10 @@ WXMPMeta_RegisterAlias_1 ( XMP_StringPtr  aliasNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_RegisterAlias_1" )
 
-		if ( (aliasNS == 0) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
-		if ( (aliasProp == 0) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
-		if ( (actualNS == 0) || (*actualNS == 0) ) XMP_Throw ( "Empty actual namespace URI", kXMPErr_BadSchema );
-		if ( (actualProp == 0) || (*actualProp == 0) ) XMP_Throw ( "Empty actual property name", kXMPErr_BadXPath );
+		if ( (aliasNS == nullptr) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
+		if ( (aliasProp == nullptr) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
+		if ( (actualNS == nullptr) || (*actualNS == 0) ) XMP_Throw ( "Empty actual namespace URI", kXMPErr_BadSchema );
+		if ( (actualProp == nullptr) || (*actualProp == 0) ) XMP_Throw ( "Empty actual property name", kXMPErr_BadXPath );
 
 		XMPMeta::RegisterAlias ( aliasNS, aliasProp, actualNS, actualProp, arrayForm );
 
@@ -323,14 +323,14 @@ WXMPMeta_ResolveAlias_1 ( XMP_StringPtr	   aliasNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_ResolveAlias_1" )
 	
-		if ( (aliasNS == 0) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
-		if ( (aliasProp == 0) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
+		if ( (aliasNS == nullptr) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
+		if ( (aliasProp == nullptr) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
 	   
-		if ( actualNS == 0 ) actualNS = &voidStringPtr;
-		if ( nsSize == 0 ) nsSize = &voidStringLen;
-		if ( actualProp == 0 ) actualProp = &voidStringPtr;
-		if ( propSize == 0 ) propSize = &voidStringLen;
-		if ( arrayForm == 0 ) arrayForm = &voidOptionBits;
+		if ( actualNS == nullptr ) actualNS = &voidStringPtr;
+		if ( nsSize == nullptr ) nsSize = &voidStringLen;
+		if ( actualProp == nullptr ) actualProp = &voidStringPtr;
+		if ( propSize == nullptr ) propSize = &voidStringLen;
+		if ( arrayForm == nullptr ) arrayForm = &voidOptionBits;
 		
 		bool found = XMPMeta::ResolveAlias ( aliasNS, aliasProp, actualNS, nsSize, actualProp, propSize, arrayForm );
 		wResult->int32Result = found;
@@ -347,8 +347,8 @@ WXMPMeta_DeleteAlias_1 ( XMP_StringPtr aliasNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteAlias_1" )
 
-		if ( (aliasNS == 0) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
-		if ( (aliasProp == 0) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
+		if ( (aliasNS == nullptr) || (*aliasNS == 0) ) XMP_Throw ( "Empty alias namespace URI", kXMPErr_BadSchema );
+		if ( (aliasProp == nullptr) || (*aliasProp == 0) ) XMP_Throw ( "Empty alias property name", kXMPErr_BadXPath );
 
 		XMPMeta::DeleteAlias ( aliasNS, aliasProp );
 
@@ -363,7 +363,7 @@ WXMPMeta_RegisterStandardAliases_1 ( XMP_StringPtr schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_RegisterStandardAliases_1" )
 
-		if ( schemaNS == 0 ) schemaNS = "";
+		if ( schemaNS == nullptr ) schemaNS = "";
 
 		XMPMeta::RegisterStandardAliases ( schemaNS );
 
@@ -406,12 +406,12 @@ WXMPMeta_GetProperty_1 ( XMPMetaRef		  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 		
-		if ( propValue == 0 ) propValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetProperty ( schemaNS, propName, propValue, valueSize, options );
@@ -434,12 +434,12 @@ WXMPMeta_GetArrayItem_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetArrayItem_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 		
-		if ( itemValue == 0 ) itemValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( itemValue == nullptr ) itemValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetArrayItem ( schemaNS, arrayName, itemIndex, itemValue, valueSize, options );
@@ -463,14 +463,14 @@ WXMPMeta_GetStructField_1 ( XMPMetaRef		 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetStructField_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (structName == 0) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (structName == nullptr) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
 		
-		if ( fieldValue == 0 ) fieldValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( fieldValue == nullptr ) fieldValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetStructField ( schemaNS, structName, fieldNS, fieldName, fieldValue, valueSize, options );
@@ -494,14 +494,14 @@ WXMPMeta_GetQualifier_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetQualifier_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
-		if ( (qualNS == 0) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
-		if ( (qualName == 0) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (qualNS == nullptr) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
+		if ( (qualName == nullptr) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
 		
-		if ( qualValue == 0 ) qualValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( qualValue == nullptr ) qualValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetQualifier ( schemaNS, propName, qualNS, qualName, qualValue, valueSize, options );
@@ -522,8 +522,8 @@ WXMPMeta_SetProperty_1 ( XMPMetaRef		xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty ( schemaNS, propName, propValue, options );
@@ -544,8 +544,8 @@ WXMPMeta_SetArrayItem_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetArrayItem_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetArrayItem ( schemaNS, arrayName, itemIndex, itemValue, options );
@@ -566,8 +566,8 @@ WXMPMeta_AppendArrayItem_1 ( XMPMetaRef		xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_AppendArrayItem_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->AppendArrayItem ( schemaNS, arrayName, arrayOptions, itemValue, options );
@@ -589,10 +589,10 @@ WXMPMeta_SetStructField_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetStructField_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (structName == 0) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (structName == nullptr) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetStructField ( schemaNS, structName, fieldNS, fieldName, fieldValue, options );
@@ -614,10 +614,10 @@ WXMPMeta_SetQualifier_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetQualifier_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
-		if ( (qualNS == 0) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
-		if ( (qualName == 0) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (qualNS == nullptr) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
+		if ( (qualName == nullptr) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetQualifier ( schemaNS, propName, qualNS, qualName, qualValue, options );
@@ -635,8 +635,8 @@ WXMPMeta_DeleteProperty_1 ( XMPMetaRef	  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteProperty_1" )
  
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->DeleteProperty ( schemaNS, propName );
@@ -655,8 +655,8 @@ WXMPMeta_DeleteArrayItem_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteArrayItem_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->DeleteArrayItem ( schemaNS, arrayName, itemIndex );
@@ -676,10 +676,10 @@ WXMPMeta_DeleteStructField_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteStructField_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (structName == 0) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (structName == nullptr) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->DeleteStructField ( schemaNS, structName, fieldNS, fieldName );
@@ -699,10 +699,10 @@ WXMPMeta_DeleteQualifier_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DeleteQualifier_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
-		if ( (qualNS == 0) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
-		if ( (qualName == 0) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (qualNS == nullptr) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
+		if ( (qualName == nullptr) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->DeleteQualifier ( schemaNS, propName, qualNS, qualName );
@@ -720,8 +720,8 @@ WXMPMeta_DoesPropertyExist_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DoesPropertyExist_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.DoesPropertyExist ( schemaNS, propName );
@@ -741,8 +741,8 @@ WXMPMeta_DoesArrayItemExist_1 ( XMPMetaRef	  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DoesArrayItemExist_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.DoesArrayItemExist ( schemaNS, arrayName, itemIndex );
@@ -763,10 +763,10 @@ WXMPMeta_DoesStructFieldExist_1 ( XMPMetaRef	xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DoesStructFieldExist_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (structName == 0) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (structName == nullptr) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.DoesStructFieldExist ( schemaNS, structName, fieldNS, fieldName );
@@ -787,10 +787,10 @@ WXMPMeta_DoesQualifierExist_1 ( XMPMetaRef	  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DoesQualifierExist_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
-		if ( (qualNS == 0) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
-		if ( (qualName == 0) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (qualNS == nullptr) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
+		if ( (qualName == nullptr) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.DoesQualifierExist ( schemaNS, propName, qualNS, qualName );
@@ -816,16 +816,16 @@ WXMPMeta_GetLocalizedText_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetLocalizedText_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
-		if ( genericLang == 0 ) genericLang = "";
-		if ( (specificLang == 0) ||(*specificLang == 0) ) XMP_Throw ( "Empty specific language", kXMPErr_BadParam );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( genericLang == nullptr ) genericLang = "";
+		if ( (specificLang == nullptr) ||(*specificLang == 0) ) XMP_Throw ( "Empty specific language", kXMPErr_BadParam );
 		
-		if ( actualLang == 0 ) actualLang = &voidStringPtr;
-		if ( langSize == 0 ) langSize = &voidStringLen;
-		if ( itemValue == 0 ) itemValue = &voidStringPtr;
-		if ( valueSize == 0 ) valueSize = &voidStringLen;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( actualLang == nullptr ) actualLang = &voidStringPtr;
+		if ( langSize == nullptr ) langSize = &voidStringLen;
+		if ( itemValue == nullptr ) itemValue = &voidStringPtr;
+		if ( valueSize == nullptr ) valueSize = &voidStringLen;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetLocalizedText ( schemaNS, arrayName, genericLang, specificLang,
@@ -849,11 +849,11 @@ WXMPMeta_SetLocalizedText_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetLocalizedText_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
-		if ( genericLang == 0 ) genericLang = "";
-		if ( (specificLang == 0) ||(*specificLang == 0) ) XMP_Throw ( "Empty specific language", kXMPErr_BadParam );
-		if ( itemValue == 0 ) itemValue = "";
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( genericLang == nullptr ) genericLang = "";
+		if ( (specificLang == nullptr) ||(*specificLang == 0) ) XMP_Throw ( "Empty specific language", kXMPErr_BadParam );
+		if ( itemValue == nullptr ) itemValue = "";
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetLocalizedText ( schemaNS, arrayName, genericLang, specificLang, itemValue, options );
@@ -873,16 +873,16 @@ WXMPMeta_GetProperty_Bool_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_Bool_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
-		if ( propValue == 0 ) propValue = &voidByte;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidByte;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool value;
 		bool found = meta.GetProperty_Bool ( schemaNS, propName, &value, options );
-		if ( propValue != 0 ) *propValue = value;
+		if ( propValue != nullptr ) *propValue = value;
 		wResult->int32Result = found;
 		
 	XMP_EXIT_WRAPPER
@@ -900,11 +900,11 @@ WXMPMeta_GetProperty_Int_1 ( XMPMetaRef		  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_Int_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
-		if ( propValue == 0 ) propValue = &voidInt32;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidInt32;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetProperty_Int ( schemaNS, propName, propValue, options );
@@ -925,11 +925,11 @@ WXMPMeta_GetProperty_Int64_1 ( XMPMetaRef		  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_Int64_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
-		if ( propValue == 0 ) propValue = &voidInt64;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidInt64;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetProperty_Int64 ( schemaNS, propName, propValue, options );
@@ -950,11 +950,11 @@ WXMPMeta_GetProperty_Float_1 ( XMPMetaRef		xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_Float_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
-		if ( propValue == 0 ) propValue = &voidDouble;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidDouble;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetProperty_Float ( schemaNS, propName, propValue, options );
@@ -975,11 +975,11 @@ WXMPMeta_GetProperty_Date_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetProperty_Date_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
-		if ( propValue == 0 ) propValue = &voidDateTime;
-		if ( options == 0 ) options = &voidOptionBits;
+		if ( propValue == nullptr ) propValue = &voidDateTime;
+		if ( options == nullptr ) options = &voidOptionBits;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		bool found = meta.GetProperty_Date ( schemaNS, propName, propValue, options );
@@ -1000,8 +1000,8 @@ WXMPMeta_SetProperty_Bool_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_Bool_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty_Bool ( schemaNS, propName, propValue, options );
@@ -1021,8 +1021,8 @@ WXMPMeta_SetProperty_Int_1 ( XMPMetaRef		xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_Int_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty_Int ( schemaNS, propName, propValue, options );
@@ -1042,8 +1042,8 @@ WXMPMeta_SetProperty_Int64_1 ( XMPMetaRef	  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_Int64_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty_Int64 ( schemaNS, propName, propValue, options );
@@ -1063,8 +1063,8 @@ WXMPMeta_SetProperty_Float_1 ( XMPMetaRef	  xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_Float_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty_Float ( schemaNS, propName, propValue, options );
@@ -1084,8 +1084,8 @@ WXMPMeta_SetProperty_Date_1 ( XMPMetaRef		   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetProperty_Date_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetProperty_Date ( schemaNS, propName, propValue, options );
@@ -1103,7 +1103,7 @@ WXMPMeta_DumpObject_1 ( XMPMetaRef		   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_DumpObject_1" )
 
-		if ( outProc == 0 ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
+		if ( outProc == nullptr ) XMP_Throw ( "Null client output routine", kXMPErr_BadParam );
 		
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		XMP_Status status = meta.DumpObject ( outProc, refCon );
@@ -1168,8 +1168,8 @@ WXMPMeta_CountArrayItems_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_CountArrayItems_1" )
 		
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		XMP_Index count = meta.CountArrayItems ( schemaNS, arrayName );
@@ -1203,8 +1203,8 @@ WXMPMeta_GetObjectName_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_GetObjectName_1" )
 
-		if ( namePtr == 0 ) namePtr = &voidStringPtr;
-		if ( nameLen == 0 ) nameLen = &voidStringLen;
+		if ( namePtr == nullptr ) namePtr = &voidStringPtr;
+		if ( nameLen == nullptr ) nameLen = &voidStringLen;
 
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		meta.GetObjectName ( namePtr, nameLen );
@@ -1221,7 +1221,7 @@ WXMPMeta_SetObjectName_1 ( XMPMetaRef	 xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SetObjectName_1" )
 
-		if ( name == 0 ) name = "";
+		if ( name == nullptr ) name = "";
 
 		XMPMeta * meta = WtoXMPMeta_Ptr ( xmpRef );
 		meta->SetObjectName ( name );
@@ -1291,11 +1291,11 @@ WXMPMeta_SerializeToBuffer_1 ( XMPMetaRef	   xmpRef,
 {
 	XMP_ENTER_WRAPPER ( "WXMPMeta_SerializeToBuffer_1" )
 
-		if ( rdfString == 0 ) rdfString = &voidStringPtr;
-		if ( rdfSize == 0 ) rdfSize = &voidStringLen;
+		if ( rdfString == nullptr ) rdfString = &voidStringPtr;
+		if ( rdfSize == nullptr ) rdfSize = &voidStringLen;
 		
-		if ( newline == 0 ) newline = "";
-		if ( indent == 0 ) indent = "";
+		if ( newline == nullptr ) newline = "";
+		if ( indent == nullptr ) indent = "";
 		
 		const XMPMeta & meta = WtoXMPMeta_Ref ( xmpRef );
 		meta.SerializeToBuffer ( rdfString, rdfSize, options, padding, newline, indent, baseIndent );

--- a/xmpsdk/src/WXMPUtils.cpp
+++ b/xmpsdk/src/WXMPUtils.cpp
@@ -56,11 +56,11 @@ WXMPUtils_ComposeArrayItemPath_1 ( XMP_StringPtr   schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ComposeArrayItemPath_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 		
-		if ( fullPath == 0 ) fullPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
+		if ( fullPath == nullptr ) fullPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
 
 		XMPUtils::ComposeArrayItemPath ( schemaNS, arrayName, itemIndex, fullPath, pathSize );
 
@@ -80,13 +80,13 @@ WXMPUtils_ComposeStructFieldPath_1 ( XMP_StringPtr	 schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ComposeStructFieldPath_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (structName == 0) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (structName == nullptr) || (*structName == 0) ) XMP_Throw ( "Empty struct name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
 		
-		if ( fullPath == 0 ) fullPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
+		if ( fullPath == nullptr ) fullPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
 
 		XMPUtils::ComposeStructFieldPath ( schemaNS, structName, fieldNS, fieldName, fullPath, pathSize );
 
@@ -106,13 +106,13 @@ WXMPUtils_ComposeQualifierPath_1 ( XMP_StringPtr   schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ComposeQualifierPath_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (propName == 0) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
-		if ( (qualNS == 0) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
-		if ( (qualName == 0) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (propName == nullptr) || (*propName == 0) ) XMP_Throw ( "Empty property name", kXMPErr_BadXPath );
+		if ( (qualNS == nullptr) || (*qualNS == 0) ) XMP_Throw ( "Empty qualifier namespace URI", kXMPErr_BadSchema );
+		if ( (qualName == nullptr) || (*qualName == 0) ) XMP_Throw ( "Empty qualifier name", kXMPErr_BadXPath );
 		
-		if ( fullPath == 0 ) fullPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
+		if ( fullPath == nullptr ) fullPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
 
 		XMPUtils::ComposeQualifierPath ( schemaNS, propName, qualNS, qualName, fullPath, pathSize );
 
@@ -131,12 +131,12 @@ WXMPUtils_ComposeLangSelector_1 ( XMP_StringPtr	  schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ComposeLangSelector_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
-		if ( (langName == 0) || (*langName == 0) ) XMP_Throw ( "Empty language name", kXMPErr_BadParam );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (langName == nullptr) || (*langName == 0) ) XMP_Throw ( "Empty language name", kXMPErr_BadParam );
 		
-		if ( fullPath == 0 ) fullPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
+		if ( fullPath == nullptr ) fullPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
 
 		XMPUtils::ComposeLangSelector ( schemaNS, arrayName, langName, fullPath, pathSize );
 
@@ -157,14 +157,14 @@ WXMPUtils_ComposeFieldSelector_1 ( XMP_StringPtr   schemaNS,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ComposeFieldSelector_1" )
 	
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
-		if ( (fieldNS == 0) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
-		if ( (fieldName == 0) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
-		if ( fieldValue == 0 ) fieldValue = "";
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (fieldNS == nullptr) || (*fieldNS == 0) ) XMP_Throw ( "Empty field namespace URI", kXMPErr_BadSchema );
+		if ( (fieldName == nullptr) || (*fieldName == 0) ) XMP_Throw ( "Empty field name", kXMPErr_BadXPath );
+		if ( fieldValue == nullptr ) fieldValue = "";
 		
-		if ( fullPath == 0 ) fullPath = &voidStringPtr;
-		if ( pathSize == 0 ) pathSize = &voidStringLen;
+		if ( fullPath == nullptr ) fullPath = &voidStringPtr;
+		if ( pathSize == nullptr ) pathSize = &voidStringLen;
 
 		XMPUtils::ComposeFieldSelector ( schemaNS, arrayName, fieldNS, fieldName, fieldValue, fullPath, pathSize );
 
@@ -181,8 +181,8 @@ WXMPUtils_ConvertFromBool_1 ( XMP_Bool		  binValue,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ConvertFromBool_1" )
 
-		if ( strValue == 0 ) strValue = &voidStringPtr;
-		if ( strSize == 0 ) strSize = &voidStringLen;
+		if ( strValue == nullptr ) strValue = &voidStringPtr;
+		if ( strSize == nullptr ) strSize = &voidStringLen;
 
 		XMPUtils::ConvertFromBool ( binValue, strValue, strSize );
 
@@ -200,10 +200,10 @@ WXMPUtils_ConvertFromInt_1 ( XMP_Int32		 binValue,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ConvertFromInt_1" )
 
-		if ( format == 0 ) format = "";
+		if ( format == nullptr ) format = "";
 		
-		if ( strValue == 0 ) strValue = &voidStringPtr;
-		if ( strSize == 0 ) strSize = &voidStringLen;
+		if ( strValue == nullptr ) strValue = &voidStringPtr;
+		if ( strSize == nullptr ) strSize = &voidStringLen;
 
 		XMPUtils::ConvertFromInt ( binValue, format, strValue, strSize );
 
@@ -221,10 +221,10 @@ WXMPUtils_ConvertFromInt64_1 ( XMP_Int64	   binValue,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ConvertFromInt64_1" )
 
-		if ( format == 0 ) format = "";
+		if ( format == nullptr ) format = "";
 		
-		if ( strValue == 0 ) strValue = &voidStringPtr;
-		if ( strSize == 0 ) strSize = &voidStringLen;
+		if ( strValue == nullptr ) strValue = &voidStringPtr;
+		if ( strSize == nullptr ) strSize = &voidStringLen;
 
 		XMPUtils::ConvertFromInt64 ( binValue, format, strValue, strSize );
 
@@ -242,10 +242,10 @@ WXMPUtils_ConvertFromFloat_1 ( double		   binValue,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ConvertFromFloat_1" )
 
-		if ( format == 0 ) format = "";
+		if ( format == nullptr ) format = "";
 		
-		if ( strValue == 0 ) strValue = &voidStringPtr;
-		if ( strSize == 0 ) strSize = &voidStringLen;
+		if ( strValue == nullptr ) strValue = &voidStringPtr;
+		if ( strSize == nullptr ) strSize = &voidStringLen;
 
 		XMPUtils::ConvertFromFloat ( binValue, format, strValue, strSize );
 
@@ -262,8 +262,8 @@ WXMPUtils_ConvertFromDate_1 ( const XMP_DateTime & binValue,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_ConvertFromDate_1" )
 
-		if ( strValue == 0 ) strValue = &voidStringPtr;
-		if ( strSize == 0 ) strSize = &voidStringLen;
+		if ( strValue == nullptr ) strValue = &voidStringPtr;
+		if ( strSize == nullptr ) strSize = &voidStringLen;
 
 		XMPUtils::ConvertFromDate( binValue, strValue, strSize );
 
@@ -278,7 +278,7 @@ WXMPUtils_ConvertToBool_1 ( XMP_StringPtr strValue,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToBool_1" )
 
-		if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
+		if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
 		XMP_Bool result = XMPUtils::ConvertToBool ( strValue );
 		wResult->int32Result = result;
 
@@ -293,7 +293,7 @@ WXMPUtils_ConvertToInt_1 ( XMP_StringPtr strValue,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToInt_1" )
 
-		if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
+		if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
 		XMP_Int32 result = XMPUtils::ConvertToInt ( strValue );
 		wResult->int32Result = result;
 
@@ -308,7 +308,7 @@ WXMPUtils_ConvertToInt64_1 ( XMP_StringPtr strValue,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToInt64_1" )
 
-		if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
+		if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
 		XMP_Int64 result = XMPUtils::ConvertToInt64 ( strValue );
 		wResult->int64Result = result;
 
@@ -323,7 +323,7 @@ WXMPUtils_ConvertToFloat_1 ( XMP_StringPtr strValue,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToFloat_1")
 
-		if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
+		if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty string value", kXMPErr_BadParam);
 		double result = XMPUtils::ConvertToFloat ( strValue );
 		wResult->floatResult = result;
 
@@ -339,7 +339,7 @@ WXMPUtils_ConvertToDate_1 ( XMP_StringPtr  strValue,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToDate_1" )
 
-		if ( binValue == 0 ) XMP_Throw ( "Null output date", kXMPErr_BadParam); // ! Pointer is from the client.
+		if ( binValue == nullptr ) XMP_Throw ( "Null output date", kXMPErr_BadParam); // ! Pointer is from the client.
 		XMPUtils::ConvertToDate ( strValue, binValue );
 
 	XMP_EXIT_WRAPPER
@@ -353,7 +353,7 @@ WXMPUtils_CurrentDateTime_1 ( XMP_DateTime * time,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_CurrentDateTime_1" )
 	
-		if ( time == 0 ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
+		if ( time == nullptr ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
 		XMPUtils::CurrentDateTime ( time );
 
 	XMP_EXIT_WRAPPER
@@ -367,7 +367,7 @@ WXMPUtils_SetTimeZone_1 ( XMP_DateTime * time,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_SetTimeZone_1" )
 
-		if ( time == 0 ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
+		if ( time == nullptr ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
 		XMPUtils::SetTimeZone ( time );
 
 	XMP_EXIT_WRAPPER
@@ -381,7 +381,7 @@ WXMPUtils_ConvertToUTCTime_1 ( XMP_DateTime * time,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToUTCTime_1" )
 
-		if ( time == 0 ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
+		if ( time == nullptr ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
 		XMPUtils::ConvertToUTCTime ( time );
 
 	XMP_EXIT_WRAPPER
@@ -395,7 +395,7 @@ WXMPUtils_ConvertToLocalTime_1 ( XMP_DateTime * time,
 {
 	XMP_ENTER_WRAPPER_NO_LOCK ( "WXMPUtils_ConvertToLocalTime_1" )
 
-		if ( time == 0 ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
+		if ( time == nullptr ) XMP_Throw ( "Null output date", kXMPErr_BadParam);
 		XMPUtils::ConvertToLocalTime ( time );
 
 	XMP_EXIT_WRAPPER
@@ -427,8 +427,8 @@ WXMPUtils_EncodeToBase64_1 ( XMP_StringPtr	 rawStr,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_EncodeToBase64_1" )
 	
-		if ( encodedStr == 0 ) encodedStr = &voidStringPtr;
-		if ( encodedLen == 0 ) encodedLen = &voidStringLen;
+		if ( encodedStr == nullptr ) encodedStr = &voidStringPtr;
+		if ( encodedLen == nullptr ) encodedLen = &voidStringLen;
 
 		XMPUtils::EncodeToBase64 ( rawStr, rawLen, encodedStr, encodedLen );
 
@@ -446,8 +446,8 @@ WXMPUtils_DecodeFromBase64_1 ( XMP_StringPtr   encodedStr,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_DecodeFromBase64_1" )
 
-		if ( rawStr == 0 ) rawStr = &voidStringPtr;
-		if ( rawLen == 0 ) rawLen = &voidStringLen;
+		if ( rawStr == nullptr ) rawStr = &voidStringPtr;
+		if ( rawLen == nullptr ) rawLen = &voidStringLen;
 
 		XMPUtils::DecodeFromBase64 ( encodedStr, encodedLen, rawStr, rawLen );
 
@@ -468,12 +468,12 @@ WXMPUtils_PackageForJPEG_1 ( XMPMetaRef      wxmpObj,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_PackageForJPEG_1" )
 
-		if ( stdStr == 0 ) stdStr = &voidStringPtr;
-		if ( stdLen == 0 ) stdLen = &voidStringLen;
-		if ( extStr == 0 ) extStr = &voidStringPtr;
-		if ( extLen == 0 ) extLen = &voidStringLen;
-		if ( digestStr == 0 ) digestStr = &voidStringPtr;
-		if ( digestLen == 0 ) digestLen = &voidStringLen;
+		if ( stdStr == nullptr ) stdStr = &voidStringPtr;
+		if ( stdLen == nullptr ) stdLen = &voidStringLen;
+		if ( extStr == nullptr ) extStr = &voidStringPtr;
+		if ( extLen == nullptr ) extLen = &voidStringLen;
+		if ( digestStr == nullptr ) digestStr = &voidStringPtr;
+		if ( digestLen == nullptr ) digestLen = &voidStringLen;
 
 		const XMPMeta & xmpObj = WtoXMPMeta_Ref ( wxmpObj );
 		XMPUtils::PackageForJPEG ( xmpObj, stdStr, stdLen, extStr, extLen, digestStr, digestLen );
@@ -490,7 +490,7 @@ WXMPUtils_MergeFromJPEG_1 ( XMPMetaRef    wfullXMP,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_MergeFromJPEG_1" )
 
-		if ( wfullXMP == 0 ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
+		if ( wfullXMP == nullptr ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
 
 		XMPMeta * fullXMP = WtoXMPMeta_Ptr ( wfullXMP );
 		const XMPMeta & extendedXMP = WtoXMPMeta_Ref ( wextendedXMP );
@@ -514,14 +514,14 @@ WXMPUtils_CatenateArrayItems_1 ( XMPMetaRef 	 wxmpObj,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_CatenateArrayItems_1" )
 
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
 		
-		if ( separator == 0 ) separator = "; ";
-		if ( quotes == 0 ) quotes = "\"";
+		if ( separator == nullptr ) separator = "; ";
+		if ( quotes == nullptr ) quotes = "\"";
 		
-		if ( catedStr == 0 ) catedStr = &voidStringPtr;
-		if ( catedLen == 0 ) catedLen = &voidStringLen;
+		if ( catedStr == nullptr ) catedStr = &voidStringPtr;
+		if ( catedLen == nullptr ) catedLen = &voidStringLen;
 
 		const XMPMeta & xmpObj = WtoXMPMeta_Ref ( wxmpObj );
 		XMPUtils::CatenateArrayItems ( xmpObj, schemaNS, arrayName, separator, quotes, options, catedStr, catedLen );
@@ -541,10 +541,10 @@ WXMPUtils_SeparateArrayItems_1 ( XMPMetaRef 	wxmpObj,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_SeparateArrayItems_1" )
 
-		if ( wxmpObj == 0 ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
-		if ( (schemaNS == 0) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
-		if ( (arrayName == 0) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
-		if ( catedStr == 0 ) catedStr = "";
+		if ( wxmpObj == nullptr ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
+		if ( (schemaNS == nullptr) || (*schemaNS == 0) ) XMP_Throw ( "Empty schema namespace URI", kXMPErr_BadSchema );
+		if ( (arrayName == nullptr) || (*arrayName == 0) ) XMP_Throw ( "Empty array name", kXMPErr_BadXPath );
+		if ( catedStr == nullptr ) catedStr = "";
 		
 		XMPMeta * xmpObj = WtoXMPMeta_Ptr ( wxmpObj );
 		XMPUtils::SeparateArrayItems ( xmpObj, schemaNS, arrayName, options, catedStr );
@@ -563,9 +563,9 @@ WXMPUtils_RemoveProperties_1 ( XMPMetaRef 	  wxmpObj,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_RemoveProperties_1" )
 
-		if ( wxmpObj == 0 ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
-		if ( schemaNS == 0 ) schemaNS = "";
-		if ( propName == 0 ) propName = "";
+		if ( wxmpObj == nullptr ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
+		if ( schemaNS == nullptr ) schemaNS = "";
+		if ( propName == nullptr ) propName = "";
 		
 		XMPMeta * xmpObj = WtoXMPMeta_Ptr ( wxmpObj );
 		XMPUtils::RemoveProperties ( xmpObj, schemaNS, propName, options );
@@ -583,7 +583,7 @@ WXMPUtils_AppendProperties_1 ( XMPMetaRef     wSource,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_AppendProperties_1" )
 
-		if ( wDest == 0 ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
+		if ( wDest == nullptr ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
 
 		const XMPMeta & source = WtoXMPMeta_Ref ( wSource );
 		XMPMeta * dest = WtoXMPMeta_Ptr ( wDest );
@@ -606,11 +606,11 @@ WXMPUtils_DuplicateSubtree_1 ( XMPMetaRef     wSource,
 {
 	XMP_ENTER_WRAPPER ( "WXMPUtils_DuplicateSubtree_1" )
 	
-		if ( wDest == 0 ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
-		if ( (sourceNS == 0) || (*sourceNS == 0) ) XMP_Throw ( "Empty source schema URI", kXMPErr_BadSchema );
-		if ( (sourceRoot == 0) || (*sourceRoot == 0) ) XMP_Throw ( "Empty source root name", kXMPErr_BadXPath );
-		if ( destNS == 0 ) destNS = sourceNS;
-		if ( destRoot == 0 ) destRoot = sourceRoot;
+		if ( wDest == nullptr ) XMP_Throw ( "Output XMP pointer is null", kXMPErr_BadParam );
+		if ( (sourceNS == nullptr) || (*sourceNS == 0) ) XMP_Throw ( "Empty source schema URI", kXMPErr_BadSchema );
+		if ( (sourceRoot == nullptr) || (*sourceRoot == 0) ) XMP_Throw ( "Empty source root name", kXMPErr_BadXPath );
+		if ( destNS == nullptr ) destNS = sourceNS;
+		if ( destRoot == nullptr ) destRoot = sourceRoot;
 
 		const XMPMeta & source = WtoXMPMeta_Ref ( wSource );
 		XMPMeta * dest = WtoXMPMeta_Ptr ( wDest );

--- a/xmpsdk/src/XMLParserAdapter.hpp
+++ b/xmpsdk/src/XMLParserAdapter.hpp
@@ -96,7 +96,7 @@ public:
 
 private:
 
-	XML_Node() : kind(0), parent(0)	{};	// ! Hidden to make sure parent pointer is always set.
+	XML_Node() : kind(0), parent(nullptr)	{};	// ! Hidden to make sure parent pointer is always set.
 
 };
 
@@ -109,7 +109,7 @@ class XMLParserAdapter {
 public:
 
 	XMLParserAdapter()
-		: tree(0,"",kRootNode), rootNode(0), rootCount(0), charEncoding(XMP_OptionBits(-1)), pendingCount(0)
+		: tree(nullptr,"",kRootNode), rootNode(nullptr), rootCount(0), charEncoding(XMP_OptionBits(-1)), pendingCount(0)
 	{
 		#if XMP_DebugBuild
 			parseLog = 0;

--- a/xmpsdk/src/XML_Node.cpp
+++ b/xmpsdk/src/XML_Node.cpp
@@ -90,7 +90,7 @@ XMP_StringPtr XML_Node::GetAttrValue ( XMP_StringPtr attrName ) const
 		if ( attrPtr->name == attrName ) return attrPtr->value.c_str();
 	}
 	
-	return 0;	// Not found.
+	return nullptr;	// Not found.
 
 }	// XML_Node::GetAttrValue
 
@@ -177,7 +177,7 @@ XML_NodePtr XML_Node::GetNamedElement ( XMP_StringPtr nsURI, XMP_StringPtr local
 		--which;
 	}
 	
-	return 0;	/// Not found.
+	return nullptr;	/// Not found.
 
 }	// XML_Node::GetNamedElement
 

--- a/xmpsdk/src/XMPCore_Impl.cpp
+++ b/xmpsdk/src/XMPCore_Impl.cpp
@@ -50,14 +50,14 @@ using namespace std;
 
 XMP_Int32 sXMP_InitCount = 0;
 
-XMP_StringMap *	sNamespaceURIToPrefixMap = 0;
-XMP_StringMap *	sNamespacePrefixToURIMap = 0;
+XMP_StringMap *	sNamespaceURIToPrefixMap = nullptr;
+XMP_StringMap *	sNamespacePrefixToURIMap = nullptr;
 
-XMP_AliasMap *	sRegisteredAliasMap = 0;	// Needed by XMPIterator.
+XMP_AliasMap *	sRegisteredAliasMap = nullptr;	// Needed by XMPIterator.
 
-XMP_VarString *	sOutputNS  = 0;
-XMP_VarString *	sOutputStr = 0;
-XMP_VarString * sExceptionMessage = 0;
+XMP_VarString *	sOutputNS  = nullptr;
+XMP_VarString *	sOutputStr = nullptr;
+XMP_VarString * sExceptionMessage = nullptr;
 
 XMP_Mutex sXMPCoreLock;
 int sLockCount = 0;
@@ -66,8 +66,8 @@ int sLockCount = 0;
 	FILE * xmpOut = stderr;
 #endif
 
-void *              voidVoidPtr    = 0;	// Used to backfill null output parameters.
-XMP_StringPtr		voidStringPtr  = 0;
+void *              voidVoidPtr    = nullptr;	// Used to backfill null output parameters.
+XMP_StringPtr		voidStringPtr  = nullptr;
 XMP_StringLen		voidStringLen  = 0;
 XMP_OptionBits		voidOptionBits = 0;
 XMP_Uns8			voidByte       = 0;
@@ -112,7 +112,7 @@ WXMP_Result 		void_wResult;
 	// ! Would be OK but overkill to specify PTHREAD_MUTEX_RECURSIVE.
 
 	bool XMP_InitMutex ( XMP_Mutex * mutex ) {
-		int err = pthread_mutex_init ( mutex, 0 );
+		int err = pthread_mutex_init ( mutex, nullptr );
 		return (err == 0 );
 	}
 	
@@ -392,7 +392,7 @@ FollowXPathStep	( XMP_Node *	   parentNode,
 				  XMP_NodePtrPos * ptrPos,
 				  bool			   aliasedArrayItem = false )
 {
-	XMP_Node * nextNode = 0;
+	XMP_Node * nextNode = nullptr;
 	const XPathStepInfo & nextStep = fullPath[stepNum];
 	XMP_Index      index    = 0;
 	XMP_OptionBits stepKind = nextStep.options & kXMP_StepKindMask;
@@ -461,11 +461,11 @@ FollowXPathStep	( XMP_Node *	   parentNode,
 
 		}
 		
-		if ( (nextNode != 0) && (ptrPos != 0) ) *ptrPos = parentNode->children.begin() + index;
+		if ( (nextNode != nullptr) && (ptrPos != nullptr) ) *ptrPos = parentNode->children.begin() + index;
 	
 	}
 
-	if ( (nextNode != 0) && (nextNode->options & kXMP_NewImplicitNode) ) {
+	if ( (nextNode != nullptr) && (nextNode->options & kXMP_NewImplicitNode) ) {
 		nextNode->options |= (nextStep.options & kXMP_PropArrayFormMask);
 	}
 	
@@ -578,7 +578,7 @@ VerifySetOptions ( XMP_OptionBits options, XMP_StringPtr propValue )
 		XMP_Throw ( "Structs and arrays can't have \"value\" options", kXMPErr_BadOptions );
 	}
 	
-	if ( (propValue != 0) && (options & kXMP_PropCompositeMask) ) {
+	if ( (propValue != nullptr) && (options & kXMP_PropCompositeMask) ) {
 		XMP_Throw ( "Structs and arrays can't have string values", kXMPErr_BadOptions );
 	}
 
@@ -826,7 +826,7 @@ FindSchemaNode	( XMP_Node *		xmpTree,
 				  bool				createNodes,
 				  XMP_NodePtrPos *	ptrPos /* = 0 */ )
 {
-	XMP_Node * schemaNode = 0;
+	XMP_Node * schemaNode = nullptr;
 	
 	XMP_Assert ( xmpTree->parent == 0 );
 	
@@ -835,12 +835,12 @@ FindSchemaNode	( XMP_Node *		xmpTree,
 		XMP_Assert ( currSchema->parent == xmpTree );
 		if ( currSchema->name == nsURI ) {
 			schemaNode = currSchema;
-			if ( ptrPos != 0 ) *ptrPos = xmpTree->children.begin() + schemaNum;
+			if ( ptrPos != nullptr ) *ptrPos = xmpTree->children.begin() + schemaNum;
 			break;
 		}
 	}
 	
-	if ( (schemaNode == 0) && createNodes ) {
+	if ( (schemaNode == nullptr) && createNodes ) {
 
 		schemaNode = new XMP_Node ( xmpTree, nsURI, (kXMP_SchemaNode | kXMP_NewImplicitNode) );
 		XMP_StringPtr prefixPtr;
@@ -851,7 +851,7 @@ FindSchemaNode	( XMP_Node *		xmpTree,
 
 		schemaNode->value.assign ( prefixPtr, prefixLen );
 		xmpTree->children.push_back ( schemaNode );
-		if ( ptrPos != 0 ) *ptrPos = xmpTree->children.end() - 1;
+		if ( ptrPos != nullptr ) *ptrPos = xmpTree->children.end() - 1;
 
 		#if 0	// *** XMP_DebugBuild
 			schemaNode->_valuePtr = schemaNode->value.c_str();
@@ -879,7 +879,7 @@ FindChildNode	( XMP_Node *		parent,
 				  bool				createNodes,
 				  XMP_NodePtrPos *	ptrPos /* = 0 */ )
 {
-	XMP_Node * childNode = 0;
+	XMP_Node * childNode = nullptr;
 
 	if ( ! (parent->options & (kXMP_SchemaNode | kXMP_PropValueIsStruct)) ) {
 		if ( ! (parent->options & kXMP_NewImplicitNode) ) {
@@ -899,15 +899,15 @@ FindChildNode	( XMP_Node *		parent,
 		XMP_Assert ( currChild->parent == parent );
 		if ( currChild->name == childName ) {
 			childNode = currChild;
-			if ( ptrPos != 0 ) *ptrPos = parent->children.begin() + childNum;
+			if ( ptrPos != nullptr ) *ptrPos = parent->children.begin() + childNum;
 			break;
 		}
 	}
 	
-	if ( (childNode == 0) && createNodes ) {
+	if ( (childNode == nullptr) && createNodes ) {
 		childNode = new XMP_Node ( parent, childName, kXMP_NewImplicitNode );
 		parent->children.push_back ( childNode );
-		if ( ptrPos != 0 ) *ptrPos = parent->children.end() - 1;
+		if ( ptrPos != nullptr ) *ptrPos = parent->children.end() - 1;
 	}
 	
 	XMP_Assert ( (ptrPos == 0) || (childNode == 0) || (childNode == **ptrPos) );
@@ -932,7 +932,7 @@ FindQualifierNode	( XMP_Node *		parent,
 					  bool				createNodes,
 					  XMP_NodePtrPos *	ptrPos /* = 0 */ )	// *** Require ptrPos internally & remove checks?
 {
-	XMP_Node * qualNode = 0;
+	XMP_Node * qualNode = nullptr;
 	
 	XMP_Assert ( *qualName != '?' );
 	
@@ -941,12 +941,12 @@ FindQualifierNode	( XMP_Node *		parent,
 		XMP_Assert ( currQual->parent == parent );
 		if ( currQual->name == qualName ) {
 			qualNode = currQual;
-			if ( ptrPos != 0 ) *ptrPos = parent->qualifiers.begin() + qualNum;
+			if ( ptrPos != nullptr ) *ptrPos = parent->qualifiers.begin() + qualNum;
 			break;
 		}
 	}
 	
-	if ( (qualNode == 0) && createNodes ) {
+	if ( (qualNode == nullptr) && createNodes ) {
 
 		qualNode = new XMP_Node ( parent, qualName, (kXMP_PropIsQualifier | kXMP_NewImplicitNode) );
 		parent->options |= kXMP_PropHasQualifiers;
@@ -963,12 +963,12 @@ FindQualifierNode	( XMP_Node *		parent,
 		
 		if ( parent->qualifiers.empty() || (! isSpecial) ) {
 			parent->qualifiers.push_back ( qualNode );
-			if ( ptrPos != 0 ) *ptrPos = parent->qualifiers.end() - 1;
+			if ( ptrPos != nullptr ) *ptrPos = parent->qualifiers.end() - 1;
 		} else {
 			XMP_NodePtrPos insertPos = parent->qualifiers.begin();	// ! Lang goes first, type after.
 			if ( isType && (parent->options & kXMP_PropHasLang) ) ++insertPos;	// *** Does insert at end() work?
 			insertPos = parent->qualifiers.insert ( insertPos, qualNode );
-			if ( ptrPos != 0 ) *ptrPos = insertPos;
+			if ( ptrPos != nullptr ) *ptrPos = insertPos;
 		}
 
 	}
@@ -1060,7 +1060,7 @@ FindNode ( XMP_Node *		xmpTree,
 		   XMP_OptionBits	leafOptions /* = 0 */,
 	 	   XMP_NodePtrPos * ptrPos /* = 0 */ )
 {
-	XMP_Node *     currNode = 0;
+	XMP_Node *     currNode = nullptr;
 	XMP_NodePtrPos currPos;
 	XMP_NodePtrPos newSubPos;	// Root of implicitly created subtree. Valid only if leaf is new.
 	bool           leafIsNew = false;
@@ -1081,7 +1081,7 @@ FindNode ( XMP_Node *		xmpTree,
 	if ( ! (expandedXPath[kRootPropStep].options & kXMP_StepIsAlias) ) {
 		
 		currNode = FindSchemaNode ( xmpTree, expandedXPath[kSchemaStep].step.c_str(), createNodes, &currPos );
-		if ( currNode == 0 ) return 0;
+		if ( currNode == nullptr ) return nullptr;
 
 		if ( currNode->options & kXMP_NewImplicitNode ) {
 			currNode->options ^= kXMP_NewImplicitNode;	// Clear the implicit node bit.
@@ -1097,7 +1097,7 @@ FindNode ( XMP_Node *		xmpTree,
 		XMP_Assert ( aliasPos != sRegisteredAliasMap->end() );
 		
 		currNode = FindSchemaNode ( xmpTree, aliasPos->second[kSchemaStep].step.c_str(), createNodes, &currPos );
-		if ( currNode == 0 ) goto EXIT;
+		if ( currNode == nullptr ) goto EXIT;
 		if ( currNode->options & kXMP_NewImplicitNode ) {
 			currNode->options ^= kXMP_NewImplicitNode;	// Clear the implicit node bit.
 			if ( ! leafIsNew ) newSubPos = currPos;	// Save the top most implicit node.
@@ -1105,7 +1105,7 @@ FindNode ( XMP_Node *		xmpTree,
 		}
 
 		currNode = FollowXPathStep ( currNode, aliasPos->second, 1, createNodes, &currPos );
-		if ( currNode == 0 ) goto EXIT;
+		if ( currNode == nullptr ) goto EXIT;
 		if ( currNode->options & kXMP_NewImplicitNode ) {
 			currNode->options ^= kXMP_NewImplicitNode;	// Clear the implicit node bit.
 			CheckImplicitStruct ( currNode, expandedXPath, 2, stepLim );
@@ -1119,7 +1119,7 @@ FindNode ( XMP_Node *		xmpTree,
 		
 		if ( arrayForm != 0 ) { 
 			currNode = FollowXPathStep ( currNode, aliasPos->second, 2, createNodes, &currPos, true );
-			if ( currNode == 0 ) goto EXIT;
+			if ( currNode == nullptr ) goto EXIT;
 			if ( currNode->options & kXMP_NewImplicitNode ) {
 				currNode->options ^= kXMP_NewImplicitNode;	// Clear the implicit node bit.
 				CheckImplicitStruct ( currNode, expandedXPath, 2, stepLim );
@@ -1137,7 +1137,7 @@ FindNode ( XMP_Node *		xmpTree,
 	try {
 		for ( ; stepNum < stepLim; ++stepNum ) {
 			currNode = FollowXPathStep ( currNode, expandedXPath, stepNum, createNodes, &currPos );
-			if ( currNode == 0 ) goto EXIT;
+			if ( currNode == nullptr ) goto EXIT;
 			if ( currNode->options & kXMP_NewImplicitNode ) {
 				currNode->options ^= kXMP_NewImplicitNode;	// Clear the implicit node bit.
 				CheckImplicitStruct ( currNode, expandedXPath, stepNum+1, stepLim );
@@ -1158,14 +1158,14 @@ EXIT:
 	XMP_Assert ( (currNode != 0) || (! createNodes) );
 
 	if ( leafIsNew ) {
-		if ( currNode != 0 ) {
+		if ( currNode != nullptr ) {
 			currNode->options |= leafOptions;
 		} else {
 			DeleteSubtree ( newSubPos );
 		}
 	}
 
-	if ( (currNode != 0) && (ptrPos != 0) ) *ptrPos = currPos;
+	if ( (currNode != nullptr) && (ptrPos != nullptr) ) *ptrPos = currPos;
 	return currNode;
 	
 }	// FindNode
@@ -1260,16 +1260,16 @@ CompareSubtrees ( const XMP_Node & leftNode, const XMP_Node & rightNode )
 	for ( size_t qualNum = 0, qualLim = leftNode.qualifiers.size(); qualNum != qualLim; ++qualNum ) {
 		const XMP_Node * leftQual  = leftNode.qualifiers[qualNum];
 		const XMP_Node * rightQual = FindConstQualifier ( &rightNode, leftQual->name.c_str() );
-		if ( (rightQual == 0) || (! CompareSubtrees ( *leftQual, *rightQual )) ) return false;
+		if ( (rightQual == nullptr) || (! CompareSubtrees ( *leftQual, *rightQual )) ) return false;
 	}
 	
-	if ( (leftNode.parent == 0) || (leftNode.options & (kXMP_SchemaNode | kXMP_PropValueIsStruct)) ) {
+	if ( (leftNode.parent == nullptr) || (leftNode.options & (kXMP_SchemaNode | kXMP_PropValueIsStruct)) ) {
 
 		// The parent node is a tree root, a schema, or a struct.
 		for ( size_t childNum = 0, childLim = leftNode.children.size(); childNum != childLim; ++childNum ) {
 			const XMP_Node * leftChild  = leftNode.children[childNum];
 			const XMP_Node * rightChild = FindConstChild ( &rightNode, leftChild->name.c_str() );
-			if ( (rightChild == 0) || (! CompareSubtrees ( *leftChild, *rightChild )) ) return false;
+			if ( (rightChild == nullptr) || (! CompareSubtrees ( *leftChild, *rightChild )) ) return false;
 		}
 
 	} else if ( leftNode.options & kXMP_PropArrayIsAltText ) {

--- a/xmpsdk/src/XMPCore_Impl.hpp
+++ b/xmpsdk/src/XMPCore_Impl.hpp
@@ -220,8 +220,8 @@ extern void XMP_ExitCriticalRegion ( XMP_Mutex & mutex );
 class XMP_AutoMutex {
 public:
 	XMP_AutoMutex() : mutex(&sXMPCoreLock) { XMP_EnterCriticalRegion ( *mutex ); ReportLock(); };
-	~XMP_AutoMutex() { if ( mutex != 0 ) { ReportUnlock(); XMP_ExitCriticalRegion ( *mutex ); mutex = 0; } };
-	void KeepLock() { ReportKeepLock(); mutex = 0; };
+	~XMP_AutoMutex() { if ( mutex != nullptr ) { ReportUnlock(); XMP_ExitCriticalRegion ( *mutex ); mutex = nullptr; } };
+	void KeepLock() { ReportKeepLock(); mutex = nullptr; };
 private:
 	XMP_Mutex * mutex;
 };
@@ -316,26 +316,26 @@ extern XMP_Node *
 FindSchemaNode ( XMP_Node *		  xmpTree,
 				 XMP_StringPtr	  nsURI,
 				 bool			  createNodes,
-				 XMP_NodePtrPos * ptrPos = 0 );
+				 XMP_NodePtrPos * ptrPos = nullptr );
 
 extern XMP_Node *
 FindChildNode ( XMP_Node *		 parent,
 				XMP_StringPtr	 childName,
 				bool			 createNodes,
-				XMP_NodePtrPos * ptrPos = 0 );
+				XMP_NodePtrPos * ptrPos = nullptr );
 
 extern XMP_Node *
 FindQualifierNode ( XMP_Node *		 parent,
 					XMP_StringPtr	 qualName,
 					bool			 createNodes,
-					XMP_NodePtrPos * ptrPos = 0 );
+					XMP_NodePtrPos * ptrPos = nullptr );
 
 extern XMP_Node *
 FindNode ( XMP_Node *		xmpTree,
 		   const XMP_ExpandedXPath & expandedXPath,
 		   bool				createNodes,
 		   XMP_OptionBits	leafOptions = 0,
-		   XMP_NodePtrPos * ptrPos = 0 );
+		   XMP_NodePtrPos * ptrPos = nullptr );
 
 extern XMP_Index
 LookupLangItem ( const XMP_Node * arrayNode, XMP_VarString & lang );	// ! Lang must be normalized!
@@ -477,7 +477,7 @@ public:
 	void RemoveChildren()
 	{
 		for ( size_t i = 0, vLim = children.size(); i < vLim; ++i ) {
-			if ( children[i] != 0 ) delete children[i];
+			if ( children[i] != nullptr ) delete children[i];
 		}
 		children.clear();
 	}
@@ -485,7 +485,7 @@ public:
 	void RemoveQualifiers()
 	{
 		for ( size_t i = 0, vLim = qualifiers.size(); i < vLim; ++i ) {
-			if ( qualifiers[i] != 0 ) delete qualifiers[i];
+			if ( qualifiers[i] != nullptr ) delete qualifiers[i];
 		}
 		qualifiers.clear();
 	}
@@ -502,7 +502,7 @@ public:
 	virtual ~XMP_Node() { RemoveChildren(); RemoveQualifiers(); };
 
 private:
-	XMP_Node() : options(0), parent(0)	// ! Make sure parent pointer is always set.
+	XMP_Node() : options(0), parent(nullptr)	// ! Make sure parent pointer is always set.
 	{
 		#if XMP_DebugBuild
 			// *** _namePtr  = name.c_str();
@@ -515,8 +515,8 @@ private:
 class XMP_AutoNode {	// Used to hold a child during subtree construction.
 public:
 	XMP_Node * nodePtr;
-	XMP_AutoNode() : nodePtr(0) {};
-	~XMP_AutoNode() { if ( nodePtr != 0 ) delete ( nodePtr ); nodePtr = 0; };
+	XMP_AutoNode() : nodePtr(nullptr) {};
+	~XMP_AutoNode() { if ( nodePtr != nullptr ) delete ( nodePtr ); nodePtr = nullptr; };
 	XMP_AutoNode ( XMP_Node * _parent, XMP_StringPtr _name, XMP_OptionBits _options )
 		: nodePtr ( new XMP_Node ( _parent, _name, _options ) ) {};
 	XMP_AutoNode ( XMP_Node * _parent, const XMP_VarString & _name, XMP_OptionBits _options )

--- a/xmpsdk/src/XMPIterator.cpp
+++ b/xmpsdk/src/XMPIterator.cpp
@@ -35,7 +35,7 @@
 	static const char * sStageNames[] = { "before", "self", "qualifiers", "children" };
 #endif
 
-static XMP_Node * sDummySchema = 0;	// ! Used for some ugliness with aliases.
+static XMP_Node * sDummySchema = nullptr;	// ! Used for some ugliness with aliases.
 
 // -------------------------------------------------------------------------------------------------
 // AddSchemaProps
@@ -92,7 +92,7 @@ AddSchemaAliases ( IterInfo & info, IterNode & iterSchema, XMP_StringPtr schemaU
 	for ( ; currAlias != endAlias; ++currAlias ) {
 		if ( XMP_LitNMatch ( currAlias->first.c_str(), nsPrefix, nsLen ) ) {
 			const XMP_Node * actualProp = FindConstNode ( &info.xmpObj->tree, currAlias->second );
-			if ( actualProp != 0 ) {
+			if ( actualProp != nullptr ) {
 				iterSchema.children.push_back ( IterNode ( (actualProp->options | kXMP_PropIsAlias), currAlias->first, 0 ) );
 				#if TraceIterators
 					printf ( "        %s  =>  %s\n", currAlias->first.c_str(), actualProp->name.c_str() );
@@ -306,7 +306,7 @@ AdvanceIterPos ( IterInfo & info )
 static const XMP_Node *
 GetNextXMPNode ( IterInfo & info )
 {
-	const XMP_Node * xmpNode = 0;
+	const XMP_Node * xmpNode = nullptr;
 
 	// ----------------------------------------------------------------------------------------------
 	// On entry currPos points to an iteration node whose state is either before-visit or visit-self.
@@ -330,12 +330,12 @@ GetNextXMPNode ( IterInfo & info )
 		if ( isSchemaNode ) {
 			SetCurrSchema ( info, info.currPos->fullPath );
 			xmpNode = FindConstSchema ( &info.xmpObj->tree, info.currPos->fullPath.c_str() );
-			if ( xmpNode == 0 ) xmpNode = sDummySchema;
+			if ( xmpNode == nullptr ) xmpNode = sDummySchema;
 		} else {
 			ExpandXPath ( info.currSchema.c_str(), info.currPos->fullPath.c_str(), &expPath );
 			xmpNode = FindConstNode ( &info.xmpObj->tree, expPath );
 		}
-		if ( xmpNode != 0 ) break;	// Exit the loop, we found a live XMP node.
+		if ( xmpNode != nullptr ) break;	// Exit the loop, we found a live XMP node.
 
 		info.currPos->visitStage = kIter_VisitChildren;	// Make AdvanceIterPos move to the next sibling.
 		info.currPos->children.clear();
@@ -344,7 +344,7 @@ GetNextXMPNode ( IterInfo & info )
 
 	}
 
-	if ( info.currPos == info.endPos ) return 0;
+	if ( info.currPos == info.endPos ) return nullptr;
 	
 	// -------------------------------------------------------------------------------------------
 	// Now we've got the iteration node and corresponding XMP node. Add the iteration children for
@@ -374,7 +374,7 @@ GetNextXMPNode ( IterInfo & info )
 /* class static */ bool
 XMPIterator::Initialize()
 {
-	sDummySchema = new XMP_Node ( 0, "dummy:schema/", kXMP_SchemaNode);
+	sDummySchema = new XMP_Node ( nullptr, "dummy:schema/", kXMP_SchemaNode);
 	return true;
 	
 }	// Initialize
@@ -387,7 +387,7 @@ XMPIterator::Initialize()
 XMPIterator::Terminate() RELEASE_NO_THROW
 {
 	delete ( sDummySchema );
-	sDummySchema = 0;
+	sDummySchema = nullptr;
 	return;
 	
 }	// Terminate
@@ -445,7 +445,7 @@ XMPIterator::XMPIterator ( const XMPMeta & xmpObj,
 		ExpandXPath ( schemaNS, propName, &propPath );
 		XMP_Node * propNode = FindConstNode ( &xmpObj.tree, propPath );	// If not found get empty iteration.
 		
-		if ( propNode != 0 ) {
+		if ( propNode != nullptr ) {
 
 			XMP_VarString rootName ( propPath[1].step );	// The schema is [0].
 			for ( size_t i = 2; i < propPath.size(); ++i ) {
@@ -480,7 +480,7 @@ XMPIterator::XMPIterator ( const XMPMeta & xmpObj,
 		IterNode & iterSchema = info.tree.children.back();
 		
 		XMP_Node * xmpSchema = FindConstSchema ( &xmpObj.tree, schemaNS );
-		if ( xmpSchema != 0 ) AddSchemaProps ( info, iterSchema, xmpSchema );
+		if ( xmpSchema != nullptr ) AddSchemaProps ( info, iterSchema, xmpSchema );
 		
 		if ( info.options & kXMP_IterIncludeAliases ) AddSchemaAliases ( info, iterSchema, schemaNS );
 		
@@ -533,7 +533,7 @@ XMPIterator::XMPIterator ( const XMPMeta & xmpObj,
 			XMP_cStringMapPos endNS  = sNamespaceURIToPrefixMap->end();
 			for ( ; currNS != endNS; ++currNS ) {
 				XMP_StringPtr schemaName = currNS->first.c_str();
-				if ( FindConstSchema ( &xmpObj.tree, schemaName ) != 0 ) continue;
+				if ( FindConstSchema ( &xmpObj.tree, schemaName ) != nullptr ) continue;
 				info.tree.children.push_back ( IterNode ( kXMP_SchemaNode, schemaName, 0 ) );
 				IterNode & iterSchema = info.tree.children.back();
 				AddSchemaAliases ( info, iterSchema, schemaName );
@@ -576,7 +576,7 @@ XMPIterator::XMPIterator ( const XMPMeta & xmpObj,
 
 XMPIterator::XMPIterator ( XMP_StringPtr  /*schemaNS*/,
                            XMP_StringPtr  /*propName*/,
-                           XMP_OptionBits options ) : clientRefs(0), info(IterInfo(options,0))
+                           XMP_OptionBits options ) : clientRefs(0), info(IterInfo(options,nullptr))
 {
 
 	XMP_Throw ( "Unimplemented XMPIterator constructor for global tables", kXMPErr_Unimplemented );
@@ -628,14 +628,14 @@ XMPIterator::Next ( XMP_StringPtr *	 schemaNS,
 	#endif
 	
 	const XMP_Node * xmpNode = GetNextXMPNode ( info );
-	if ( xmpNode == 0 ) return false;
+	if ( xmpNode == nullptr ) return false;
 	bool isSchemaNode = XMP_NodeIsSchema ( info.currPos->options );
 	
 	if ( info.options & kXMP_IterJustLeafNodes ) {
 		while ( isSchemaNode || (! xmpNode->children.empty()) ) {
 			info.currPos->visitStage = kIter_VisitQualifiers;	// Skip to this node's children.
 			xmpNode = GetNextXMPNode ( info );
-			if ( xmpNode == 0 ) return false;
+			if ( xmpNode == nullptr ) return false;
 			isSchemaNode = XMP_NodeIsSchema ( info.currPos->options );
 		}
 	}

--- a/xmpsdk/src/XMPIterator.hpp
+++ b/xmpsdk/src/XMPIterator.hpp
@@ -70,7 +70,7 @@ struct IterInfo {
 		XMP_StringPtr	_schemaPtr;	// *** Not working, need operator=?
 	#endif
 
-	IterInfo() : options(0), xmpObj(0)
+	IterInfo() : options(0), xmpObj(nullptr)
 	{
 		#if 0	// *** XMP_DebugBuild
 			_schemaPtr = 0;

--- a/xmpsdk/src/XMPMeta-GetSet.cpp
+++ b/xmpsdk/src/XMPMeta-GetSet.cpp
@@ -125,7 +125,7 @@ SetNode	( XMP_Node * node, XMP_StringPtr value, XMP_OptionBits options )
 	
 	node->options |= options;	// Keep options set by FindNode when creating a new node.
 
-	if ( value != 0 ) {
+	if ( value != nullptr ) {
 	
 		// This is setting the value of a leaf node.
 		if ( node->options & kXMP_PropCompositeMask ) XMP_Throw ( "Composite nodes can't have values", kXMPErr_BadXPath );
@@ -169,7 +169,7 @@ DoSetArrayItem ( XMP_Node *		arrayNode,
 	// The order of the normalization checks is important. If the array is empty we end up with an
 	// index and location to set item size+1.
 	
-	XMP_Node * itemNode = 0;
+	XMP_Node * itemNode = nullptr;
 	
 	if ( itemIndex == kXMP_ArrayLastItem ) itemIndex = arraySize;
 	if ( (itemIndex == 0) && (itemLoc == kXMP_InsertAfterItem) ) {
@@ -223,7 +223,7 @@ ChooseLocalizedText ( const XMP_Node *	 arrayNode,
 					  XMP_StringPtr		 specificLang,
 					  const XMP_Node * * itemNode )
 {
-	const XMP_Node * currItem = 0;
+	const XMP_Node * currItem = nullptr;
 	const size_t itemLim = arrayNode->children.size();
 	size_t itemNum;
 	
@@ -235,7 +235,7 @@ ChooseLocalizedText ( const XMP_Node *	 arrayNode,
 		XMP_Throw ( "Localized text array is not alt-text", kXMPErr_BadXPath );
 	}
 	if ( arrayNode->children.empty() ) {
-		*itemNode = 0;
+		*itemNode = nullptr;
 		return kXMP_CLT_NoValues;
 	}
 
@@ -355,7 +355,7 @@ XMPMeta::GetProperty ( XMP_StringPtr	schemaNS,
 	ExpandXPath ( schemaNS, propName, &expPath );
 	
 	XMP_Node * propNode = FindConstNode ( &tree, expPath );
-	if ( propNode == 0 ) return false;
+	if ( propNode == nullptr ) return false;
 	
 	*propValue = propNode->value.c_str();
 	*valueSize = propNode->value.size();
@@ -460,7 +460,7 @@ XMPMeta::SetProperty ( XMP_StringPtr  schemaNS,
 	ExpandXPath ( schemaNS, propName, &expPath );
 
 	XMP_Node * propNode = FindNode ( &tree, expPath, kXMP_CreateNodes, options );
-	if ( propNode == 0 ) XMP_Throw ( "Specified property does not exist", kXMPErr_BadXPath );
+	if ( propNode == nullptr ) XMP_Throw ( "Specified property does not exist", kXMPErr_BadXPath );
 	
 	SetNode ( propNode, propValue, options );
 	
@@ -483,7 +483,7 @@ XMPMeta::SetArrayItem ( XMP_StringPtr  schemaNS,
 	XMP_ExpandedXPath arrayPath;
 	ExpandXPath ( schemaNS, arrayName, &arrayPath );
 	XMP_Node * arrayNode = FindNode ( &tree, arrayPath, kXMP_ExistingOnly );	// Just lookup, don't try to create.
-	if ( arrayNode == 0 ) XMP_Throw ( "Specified array does not exist", kXMPErr_BadXPath );
+	if ( arrayNode == nullptr ) XMP_Throw ( "Specified array does not exist", kXMPErr_BadXPath );
 	
 	DoSetArrayItem ( arrayNode, itemIndex, itemValue, options );
 	
@@ -503,7 +503,7 @@ XMPMeta::AppendArrayItem ( XMP_StringPtr  schemaNS,
 {
 	XMP_Assert ( (schemaNS != 0) && (arrayName != 0) );	// Enforced by wrapper.
 
-	arrayOptions = VerifySetOptions ( arrayOptions, 0 );
+	arrayOptions = VerifySetOptions ( arrayOptions, nullptr );
 	if ( (arrayOptions & ~kXMP_PropArrayFormMask) != 0 ) {
 		XMP_Throw ( "Only array form flags allowed for arrayOptions", kXMPErr_BadOptions );
 	}
@@ -515,7 +515,7 @@ XMPMeta::AppendArrayItem ( XMP_StringPtr  schemaNS,
 	ExpandXPath ( schemaNS, arrayName, &arrayPath );
 	XMP_Node * arrayNode = FindNode ( &tree, arrayPath, kXMP_ExistingOnly );	// Just lookup, don't try to create.
 	
-	if ( arrayNode != 0 ) {
+	if ( arrayNode != nullptr ) {
 		// The array exists, make sure the form is compatible. Zero arrayForm means take what exists.
 		if ( ! (arrayNode->options & kXMP_PropValueIsArray) ) {
 			XMP_Throw ( "The named property is not an array", kXMPErr_BadXPath );
@@ -530,7 +530,7 @@ XMPMeta::AppendArrayItem ( XMP_StringPtr  schemaNS,
 		// The array does not exist, try to create it.
 		if ( arrayOptions == 0 ) XMP_Throw ( "Explicit arrayOptions required to create new array", kXMPErr_BadOptions );
 		arrayNode = FindNode ( &tree, arrayPath, kXMP_CreateNodes, arrayOptions );
-		if ( arrayNode == 0 ) XMP_Throw ( "Failure creating array node", kXMPErr_BadXPath );
+		if ( arrayNode == nullptr ) XMP_Throw ( "Failure creating array node", kXMPErr_BadXPath );
 	}
 	
 	DoSetArrayItem ( arrayNode, kXMP_ArrayLastItem, itemValue, (options | kXMP_InsertAfterItem) );
@@ -581,7 +581,7 @@ XMPMeta::SetQualifier ( XMP_StringPtr  schemaNS,
 	XMP_ExpandedXPath expPath;
 	ExpandXPath ( schemaNS, propName, &expPath );
 	XMP_Node * propNode = FindNode ( &tree, expPath, kXMP_ExistingOnly );
-	if ( propNode == 0 ) XMP_Throw ( "Specified property does not exist", kXMPErr_BadXPath );
+	if ( propNode == nullptr ) XMP_Throw ( "Specified property does not exist", kXMPErr_BadXPath );
 
 	XMPUtils::ComposeQualifierPath ( schemaNS, propName, qualNS, qualName, &qualPath, &pathLen );
 	SetProperty ( schemaNS, qualPath, qualValue, options );
@@ -604,7 +604,7 @@ XMPMeta::DeleteProperty	( XMP_StringPtr	schemaNS,
 	
 	XMP_NodePtrPos ptrPos;
 	XMP_Node * propNode = FindNode ( &tree, expPath, kXMP_ExistingOnly, kXMP_NoOptions, &ptrPos );
-	if ( propNode == 0 ) return;
+	if ( propNode == nullptr ) return;
 	XMP_Node * parentNode = propNode->parent;
 	
 	// Erase the pointer from the parent's vector, then delete the node and all below it.
@@ -711,7 +711,7 @@ XMPMeta::DoesPropertyExist ( XMP_StringPtr schemaNS,
 	ExpandXPath ( schemaNS, propName, &expPath );
 
 	XMP_Node * propNode = FindConstNode ( &tree, expPath );
-	return (propNode != 0);
+	return (propNode != nullptr);
 	
 }	// DoesPropertyExist
 
@@ -809,7 +809,7 @@ XMPMeta::GetLocalizedText ( XMP_StringPtr	 schemaNS,
 	ExpandXPath ( schemaNS, arrayName, &arrayPath );
 	
 	const XMP_Node * arrayNode = FindConstNode ( &tree, arrayPath );	// *** This expand/find idiom is used in 3 Getters.
-	if ( arrayNode == 0 ) return false;			// *** Should extract it into a local utility.
+	if ( arrayNode == nullptr ) return false;			// *** Should extract it into a local utility.
 	
 	XMP_CLTMatch match;
 	const XMP_Node * itemNode;
@@ -858,7 +858,7 @@ XMPMeta::SetLocalizedText ( XMP_StringPtr  schemaNS,
 	// Find the array node and set the options if it was just created.
 	XMP_Node * arrayNode = FindNode ( &tree, arrayPath, kXMP_CreateNodes,
 									  (kXMP_PropValueIsArray | kXMP_PropArrayIsOrdered | kXMP_PropArrayIsAlternate) );
-	if ( arrayNode == 0 ) XMP_Throw ( "Failed to find or create array node", kXMPErr_BadXPath );
+	if ( arrayNode == nullptr ) XMP_Throw ( "Failed to find or create array node", kXMPErr_BadXPath );
 	if ( ! XMP_ArrayIsAltText(arrayNode->options) ) {
 		if ( arrayNode->children.empty() && XMP_ArrayIsAlternate(arrayNode->options) ) {
 			arrayNode->options |= kXMP_PropArrayIsAltText;
@@ -870,7 +870,7 @@ XMPMeta::SetLocalizedText ( XMP_StringPtr  schemaNS,
 	// Make sure the x-default item, if any, is first.
 	
 	size_t itemNum, itemLim;
-	XMP_Node * xdItem = 0;
+	XMP_Node * xdItem = nullptr;
 	bool haveXDefault = false;
 	
 	for ( itemNum = 0, itemLim = arrayNode->children.size(); itemNum < itemLim; ++itemNum ) {

--- a/xmpsdk/src/XMPMeta-Parse.cpp
+++ b/xmpsdk/src/XMPMeta-Parse.cpp
@@ -129,10 +129,10 @@ static const XML_Node * PickBestRoot ( const XML_Node & xmlParent, XMP_OptionBit
 	// Recurse into the content.
 	for ( size_t childNum = 0, childLim = xmlParent.content.size(); childNum < childLim; ++childNum ) {
 		const XML_Node * foundRoot = PickBestRoot ( *xmlParent.content[childNum], options );
-		if ( foundRoot != 0 ) return foundRoot;
+		if ( foundRoot != nullptr ) return foundRoot;
 	}
 	
-	return 0;
+	return nullptr;
 
 }	// PickBestRoot
 
@@ -152,7 +152,7 @@ static const XML_Node * FindRootNode ( XMPMeta * thiz, const XMLParserAdapter & 
 	const XML_Node * rootNode = xmlParser.rootNode;
 	
 	if ( xmlParser.rootCount > 1 ) rootNode = PickBestRoot ( xmlParser.tree, options );
-	if ( rootNode == 0 ) return 0;
+	if ( rootNode == nullptr ) return nullptr;
 	
 	// We have a root node. Try to extract previous toolkit version number.
 	
@@ -161,8 +161,8 @@ static const XML_Node * FindRootNode ( XMPMeta * thiz, const XMLParserAdapter & 
 		XMP_Assert ( rootNode->name == "rdf:RDF" );
 	
 		if ( (options & kXMP_RequireXMPMeta) &&
-		     ((rootNode->parent == 0) ||
-		      ((rootNode->parent->name != "x:xmpmeta") && (rootNode->parent->name != "x:xapmeta"))) ) return 0;
+		     ((rootNode->parent == nullptr) ||
+		      ((rootNode->parent->name != "x:xmpmeta") && (rootNode->parent->name != "x:xapmeta"))) ) return nullptr;
 
 		for ( size_t attrNum = 0, attrLim = rootNode->parent->attrs.size(); attrNum < attrLim; ++attrNum ) {
 			const XML_Node * currAttr =rootNode->parent->attrs[attrNum];
@@ -230,7 +230,7 @@ static void
 NormalizeDCArrays ( XMP_Node * xmpTree )
 {
 	XMP_Node * dcSchema = FindSchemaNode ( xmpTree, kXMP_NS_DC, kXMP_ExistingOnly );
-	if ( dcSchema == 0 ) return;
+	if ( dcSchema == nullptr ) return;
 	
 	for ( size_t propNum = 0, propLimit = dcSchema->children.size(); propNum < propLimit; ++propNum ) {
 		XMP_Node *     currProp  = dcSchema->children[propNum];
@@ -257,7 +257,7 @@ NormalizeDCArrays ( XMP_Node * xmpTree )
 		}
 		if ( arrayForm == 0 ) continue;	// Nothing to do if it isn't supposed to be an array.
 		
-		arrayForm = VerifySetOptions ( arrayForm, 0 );	// Set the implicit array bits.
+		arrayForm = VerifySetOptions ( arrayForm, nullptr );	// Set the implicit array bits.
 		XMP_Node * newArray = new XMP_Node ( dcSchema, currProp->name.c_str(), arrayForm );
 		dcSchema->children[propNum] = newArray;
 		newArray->children.push_back ( currProp );
@@ -410,7 +410,7 @@ MoveExplicitAliases ( XMP_Node * tree, XMP_OptionBits parseOptions )
 			if ( baseSchema->options & kXMP_NewImplicitNode ) baseSchema->options ^= kXMP_NewImplicitNode;
 			XMP_Node * baseNode = FindChildNode ( baseSchema, basePath[kRootPropStep].step.c_str(), kXMP_ExistingOnly );
 
-			if ( baseNode == 0 ) {
+			if ( baseNode == nullptr ) {
 			
 				if ( basePath.size() == 2 ) {
 					// A top-to-top alias, transplant the property.
@@ -435,7 +435,7 @@ MoveExplicitAliases ( XMP_Node * tree, XMP_OptionBits parseOptions )
 				// This is an alias to an array item and the array exists. Look for the aliased item.
 				// Then transplant or check & delete as appropriate.
 				
-				XMP_Node * itemNode = 0;
+				XMP_Node * itemNode = nullptr;
 				if ( arrayOptions & kXMP_PropArrayIsAltText ) {
 					XMP_Index xdIndex = LookupLangItem ( baseNode, *xdefaultName );
 					if ( xdIndex != -1 ) itemNode = baseNode->children[xdIndex];
@@ -443,7 +443,7 @@ MoveExplicitAliases ( XMP_Node * tree, XMP_OptionBits parseOptions )
 					itemNode = baseNode->children[0];
 				}
 				
-				if ( itemNode == 0 ) {
+				if ( itemNode == nullptr ) {
 					TransplantArrayItemAlias ( currSchema, propNum, baseNode );
 				} else {
 					if ( strictAliasing ) CompareAliasedSubtrees ( currProp, itemNode );
@@ -484,8 +484,8 @@ FixGPSTimeStamp ( XMP_Node * exifSchema, XMP_Node * gpsDateTime )
 	if ( (binGPSStamp.year != 0) || (binGPSStamp.month != 0) || (binGPSStamp.day != 0) ) return;
 	
 	XMP_Node * otherDate = FindChildNode ( exifSchema, "exif:DateTimeOriginal", kXMP_ExistingOnly );
-	if ( otherDate == 0 ) otherDate = FindChildNode ( exifSchema, "exif:DateTimeDigitized", kXMP_ExistingOnly );
-	if ( otherDate == 0 ) return;
+	if ( otherDate == nullptr ) otherDate = FindChildNode ( exifSchema, "exif:DateTimeDigitized", kXMP_ExistingOnly );
+	if ( otherDate == nullptr ) return;
 
 	XMP_DateTime binOtherDate;
 	try {
@@ -542,7 +542,7 @@ MigrateAudioCopyright ( XMPMeta * xmp, XMP_Node * dmCopyright )
 		XMP_Node * dcSchema = FindSchemaNode ( &xmp->tree, kXMP_NS_DC, kXMP_CreateNodes );
 		XMP_Node * dcRightsArray = FindChildNode ( dcSchema, "dc:rights", kXMP_ExistingOnly );
 		
-		if ( (dcRightsArray == 0) || dcRightsArray->children.empty() ) {
+		if ( (dcRightsArray == nullptr) || dcRightsArray->children.empty() ) {
 		
 			// 1. No dc:rights array, create from double linefeed and xmpDM:copyright.
 			dmValue.insert ( 0, kDoubleLF );
@@ -608,10 +608,10 @@ static void
 RepairAltText ( XMP_Node & tree, XMP_StringPtr schemaNS, XMP_StringPtr arrayName )
 {
 	XMP_Node * schemaNode = FindSchemaNode ( &tree, schemaNS, kXMP_ExistingOnly );
-	if ( schemaNode == 0 ) return;
+	if ( schemaNode == nullptr ) return;
 	
 	XMP_Node * arrayNode = FindChildNode ( schemaNode, arrayName, kXMP_ExistingOnly );
-	if ( (arrayNode == 0) || XMP_ArrayIsAltText ( arrayNode->options ) ) return;	// Already OK.
+	if ( (arrayNode == nullptr) || XMP_ArrayIsAltText ( arrayNode->options ) ) return;	// Already OK.
 	
 	if ( ! XMP_PropIsArray ( arrayNode->options ) ) return;	// ! Not even an array, leave it alone.
 	// *** Should probably change simple values to LangAlt with 'x-default' item.
@@ -667,19 +667,19 @@ TouchUpDataModel ( XMPMeta * xmp )
 	
 	// Do special case touch ups for certain schema.
 
-	XMP_Node * currSchema = 0;
+	XMP_Node * currSchema = nullptr;
 
 	currSchema = FindSchemaNode ( &tree, kXMP_NS_EXIF, kXMP_ExistingOnly );
-	if ( currSchema != 0 ) {
+	if ( currSchema != nullptr ) {
 
 		// Do a special case fix for exif:GPSTimeStamp.
 		XMP_Node * gpsDateTime = FindChildNode ( currSchema, "exif:GPSTimeStamp", kXMP_ExistingOnly );
-		if ( gpsDateTime != 0 ) FixGPSTimeStamp ( currSchema, gpsDateTime );
+		if ( gpsDateTime != nullptr ) FixGPSTimeStamp ( currSchema, gpsDateTime );
 	
 		// *** Should probably have RepairAltText change simple values to LangAlt with 'x-default' item.
 		// *** For now just do this for exif:UserComment, the one case we know about, late in cycle fix.
 		XMP_Node * userComment = FindChildNode ( currSchema, "exif:UserComment", kXMP_ExistingOnly );
-		if ( (userComment != 0) && XMP_PropIsSimple ( userComment->options ) ) {
+		if ( (userComment != nullptr) && XMP_PropIsSimple ( userComment->options ) ) {
 			XMP_Node * newChild = new XMP_Node ( userComment, kXMP_ArrayItemName,
 												 userComment->value.c_str(), userComment->options );
 			newChild->qualifiers.swap ( userComment->qualifiers );
@@ -696,18 +696,18 @@ TouchUpDataModel ( XMPMeta * xmp )
 	}
 
 	currSchema = FindSchemaNode ( &tree, kXMP_NS_DM, kXMP_ExistingOnly );
-	if ( currSchema != 0 ) {
+	if ( currSchema != nullptr ) {
 		// Do a special case migration of xmpDM:copyright to dc:rights['x-default']. Do this before
 		// the dc: touch up since it can affect the dc: schema.
 		XMP_Node * dmCopyright = FindChildNode ( currSchema, "xmpDM:copyright", kXMP_ExistingOnly );
-		if ( dmCopyright != 0 ) MigrateAudioCopyright ( xmp, dmCopyright );
+		if ( dmCopyright != nullptr ) MigrateAudioCopyright ( xmp, dmCopyright );
 	}
 
 	currSchema = FindSchemaNode ( &tree, kXMP_NS_DC, kXMP_ExistingOnly );
-	if ( currSchema != 0 ) {
+	if ( currSchema != nullptr ) {
 		// Do a special case fix for dc:subject, make sure it is an unordered array.
 		XMP_Node * dcSubject = FindChildNode ( currSchema, "dc:subject", kXMP_ExistingOnly );
-		if ( dcSubject != 0 ) {
+		if ( dcSubject != nullptr ) {
                         XMP_OptionBits keepMask = static_cast<XMP_OptionBits>(~(kXMP_PropArrayIsOrdered | kXMP_PropArrayIsAlternate | kXMP_PropArrayIsAltText));
 			dcSubject->options &= keepMask;	// Make sure any ordered array bits are clear.
 		}
@@ -760,7 +760,7 @@ TouchUpDataModel ( XMPMeta * xmp )
 			XMP_ExpandedXPath expPath;
 			ExpandXPath ( kXMP_NS_XMP_MM, "InstanceID", &expPath );
 			XMP_Node * idNode = FindNode ( &tree, expPath, kXMP_CreateNodes, 0 );
-			if ( idNode == 0 ) XMP_Throw ( "Failure creating xmpMM:InstanceID", kXMPErr_InternalFailure );
+			if ( idNode == nullptr ) XMP_Throw ( "Failure creating xmpMM:InstanceID", kXMPErr_InternalFailure );
 
 			idNode->options = 0;	// Clobber any existing xmpMM:InstanceID.
 			idNode->value = tree.name;
@@ -1079,14 +1079,14 @@ XMPMeta::ParseFromBuffer ( XMP_StringPtr  buffer,
 						   XMP_StringLen  xmpSize,
 						   XMP_OptionBits options )
 {
-	if ( (buffer == 0) && (xmpSize != 0) ) XMP_Throw ( "Null parse buffer", kXMPErr_BadParam );
+	if ( (buffer == nullptr) && (xmpSize != 0) ) XMP_Throw ( "Null parse buffer", kXMPErr_BadParam );
 	if ( xmpSize == kXMP_UseNullTermination ) xmpSize = strlen ( buffer );
 	
 	const bool lastClientCall = ((options & kXMP_ParseMoreBuffers) == 0);	// *** Could use FlagIsSet & FlagIsClear macros.
 	
 	this->tree.ClearNode();	// Make sure the target XMP object is totally empty.
 
-	if ( this->xmlParser == 0 ) {
+	if ( this->xmlParser == nullptr ) {
 		if ( (xmpSize == 0) && lastClientCall ) return;	// Tolerate empty parse. Expat complains if there are no XML elements.
 		this->xmlParser = XMP_NewExpatAdapter();
 	}
@@ -1250,7 +1250,7 @@ XMPMeta::ParseFromBuffer ( XMP_StringPtr  buffer,
 
 			const XML_Node * xmlRoot = FindRootNode ( this, *this->xmlParser, options );
 
-			if ( xmlRoot != 0 ) {
+			if ( xmlRoot != nullptr ) {
 
 				ProcessRDF ( &this->tree, *xmlRoot, options );
 				NormalizeDCArrays ( &this->tree );
@@ -1272,14 +1272,14 @@ XMPMeta::ParseFromBuffer ( XMP_StringPtr  buffer,
 			}
 
 			delete this->xmlParser;
-			this->xmlParser = 0;
+			this->xmlParser = nullptr;
 
 		}
 		
 	} catch ( ... ) {
 
 		delete this->xmlParser;
-		this->xmlParser = 0;
+		this->xmlParser = nullptr;
 		prevTkVer = 0;
 		this->tree.ClearNode();
 		throw;

--- a/xmpsdk/src/XMPMeta.cpp
+++ b/xmpsdk/src/XMPMeta.cpp
@@ -53,7 +53,7 @@ using namespace std;
 // Static Variables
 // ================
 
-XMP_VarString * xdefaultName = 0;
+XMP_VarString * xdefaultName = nullptr;
 
 // These are embedded version strings.
 
@@ -585,7 +585,7 @@ SortWithinOffspring ( XMP_NodeOffspring & nodeVec )
 // ============
 
 
-XMPMeta::XMPMeta() : clientRefs(0), prevTkVer(0), tree(XMP_Node(0,"",0)), xmlParser(0)
+XMPMeta::XMPMeta() : clientRefs(0), prevTkVer(0), tree(XMP_Node(nullptr,"",0)), xmlParser(nullptr)
 {
 	// Nothing more to do, clientRefs is incremented in wrapper.
 	#if XMP_TraceCTorDTor
@@ -602,8 +602,8 @@ XMPMeta::~XMPMeta() RELEASE_NO_THROW
 	#endif
 
 	XMP_Assert ( this->clientRefs <= 0 );
-	if ( xmlParser != 0 ) delete ( xmlParser );
-	xmlParser = 0;
+	if ( xmlParser != nullptr ) delete ( xmlParser );
+	xmlParser = nullptr;
 
 }	// ~XMPMeta
 
@@ -1161,7 +1161,7 @@ XMPMeta::RegisterAlias ( XMP_StringPtr 	aliasNS,
 {
 	XMP_ExpandedXPath	expAlias, expActual;
 	XMP_AliasMapPos		mapPos;
-	XMP_ExpandedXPath *	regActual = 0;
+	XMP_ExpandedXPath *	regActual = nullptr;
 
 	XMP_Assert ( (aliasNS != 0) && (aliasProp != 0) && (actualNS != 0) && (actualProp != 0) );	// Enforced by wrapper.
 		
@@ -1175,7 +1175,7 @@ XMPMeta::RegisterAlias ( XMP_StringPtr 	aliasNS,
 		XMP_Throw ( "Alias and actual property names must be simple", kXMPErr_BadXPath );
 	}
 	
-	arrayForm = VerifySetOptions ( arrayForm, 0 );
+	arrayForm = VerifySetOptions ( arrayForm, nullptr );
 	if ( arrayForm != 0 ) {
 		if ( (arrayForm & ~kXMP_PropArrayFormMask) != 0 ) XMP_Throw ( "Only array form flags are allowed", kXMPErr_BadOptions );
 		expActual[1].options |= arrayForm;	// Set the array form for the top level step.
@@ -1515,7 +1515,7 @@ XMPMeta::CountArrayItems ( XMP_StringPtr schemaNS,
 	
 	const XMP_Node * arrayNode = FindConstNode ( &tree, expPath );
 
-	if ( arrayNode == 0 ) return 0;
+	if ( arrayNode == nullptr ) return 0;
 	if ( ! (arrayNode->options & kXMP_PropValueIsArray) ) XMP_Throw ( "The named property is not an array", kXMPErr_BadXPath );
 	return arrayNode->children.size();
 	
@@ -1615,9 +1615,9 @@ XMPMeta::Erase()
 {
 
 	this->prevTkVer = 0;
-	if ( this->xmlParser != 0 ) {
+	if ( this->xmlParser != nullptr ) {
 		delete ( this->xmlParser );
-		this->xmlParser = 0;
+		this->xmlParser = nullptr;
 	}
 	this->tree.ClearNode();
 
@@ -1631,7 +1631,7 @@ XMPMeta::Erase()
 void
 XMPMeta::Clone ( XMPMeta * clone, XMP_OptionBits options ) const
 {
-	if ( clone == 0 ) XMP_Throw ( "Null clone pointer", kXMPErr_BadParam );
+	if ( clone == nullptr ) XMP_Throw ( "Null clone pointer", kXMPErr_BadParam );
 	if ( options != 0 ) XMP_Throw ( "No options are defined yet", kXMPErr_BadOptions );
 	XMP_Assert ( this->tree.parent == 0 );
 

--- a/xmpsdk/src/XMPMeta.hpp
+++ b/xmpsdk/src/XMPMeta.hpp
@@ -405,7 +405,7 @@ public:
 private:
   
 	// ! These are hidden on purpose:
-	XMPMeta ( const XMPMeta & /* original */ ) : clientRefs(0), prevTkVer(0), tree(XMP_Node(0,"",0)), xmlParser(0)
+	XMPMeta ( const XMPMeta & /* original */ ) : clientRefs(0), prevTkVer(0), tree(XMP_Node(nullptr,"",0)), xmlParser(nullptr)
 		{ XMP_Throw ( "Call to hidden constructor", kXMPErr_InternalFailure ); };
 	void operator= ( const XMPMeta & /* rhs */ )  
 		{ XMP_Throw ( "Call to hidden operator=", kXMPErr_InternalFailure ); };

--- a/xmpsdk/src/XMPUtils-FileInfo.cpp
+++ b/xmpsdk/src/XMPUtils-FileInfo.cpp
@@ -599,7 +599,7 @@ ItemValuesMatch ( const XMP_Node * leftNode, const XMP_Node * rightNode )
 		for ( size_t leftNum = 0, leftLim = leftNode->children.size(); leftNum != leftLim; ++leftNum ) {
 			const XMP_Node * leftField	= leftNode->children[leftNum];
 			const XMP_Node * rightField = FindConstChild ( rightNode, leftField->name.c_str() );
-			if ( (rightField == 0) || (! ItemValuesMatch ( leftField, rightField )) ) return false;
+			if ( (rightField == nullptr) || (! ItemValuesMatch ( leftField, rightField )) ) return false;
 		}
 		
 	} else {
@@ -652,12 +652,12 @@ AppendSubtree ( const XMP_Node * sourceNode, XMP_Node * destParent, const bool r
 	
 	if ( deleteEmpty & valueIsEmpty ) {
 	
-		if ( destNode != 0 ) {
+		if ( destNode != nullptr ) {
 			delete ( destNode );
 			destParent->children.erase ( destPos );
 		}
 	
-	} else if ( destNode == 0 ) {
+	} else if ( destNode == nullptr ) {
 	
 		// The one easy case, the destination does not exist.
 		CloneSubtree ( sourceNode, destParent );
@@ -789,9 +789,9 @@ XMPUtils::CatenateArrayItems ( const XMPMeta & xmpObj,
 	
 	const bool allowCommas = ((options & kXMPUtil_AllowCommas) != 0);
 	
-	const XMP_Node * arrayNode = 0; // ! Move up to avoid gcc complaints.
+	const XMP_Node * arrayNode = nullptr; // ! Move up to avoid gcc complaints.
 	XMP_OptionBits	 arrayForm = 0;
-	const XMP_Node * currItem  = 0;
+	const XMP_Node * currItem  = nullptr;
 
 	// Make sure the separator is OK. It must be one semicolon surrounded by zero or more spaces.
 	// Any of the recognized semicolons or spaces are allowed.
@@ -836,7 +836,7 @@ XMPUtils::CatenateArrayItems ( const XMPMeta & xmpObj,
 	ExpandXPath ( schemaNS, arrayName, &arrayPath );
 
 	arrayNode = FindConstNode ( &xmpObj.tree, arrayPath );
-	if ( arrayNode == 0 ) goto EXIT;	// ! Need to set the output pointer and length.
+	if ( arrayNode == nullptr ) goto EXIT;	// ! Need to set the output pointer and length.
 
 	arrayForm = arrayNode->options & kXMP_PropCompositeMask;
 	if ( (! (arrayForm & kXMP_PropValueIsArray)) || (arrayForm & kXMP_PropArrayIsAlternate) ) {
@@ -896,7 +896,7 @@ XMPUtils::SeparateArrayItems ( XMPMeta *	  xmpObj,
 		options ^= kXMPUtil_AllowCommas;
 	}
 
-	options = VerifySetOptions ( options, 0 );	// Keep a zero value, has special meaning below.
+	options = VerifySetOptions ( options, nullptr );	// Keep a zero value, has special meaning below.
 	if ( options & ~kXMP_PropArrayFormMask ) XMP_Throw ( "Options can only provide array form", kXMPErr_BadOptions );
 	
 	// Find the array node, make sure it is OK. Move the current children aside, to be readded later if kept.
@@ -905,7 +905,7 @@ XMPUtils::SeparateArrayItems ( XMPMeta *	  xmpObj,
 	ExpandXPath ( schemaNS, arrayName, &arrayPath );
 	XMP_Node * arrayNode = FindNode ( &xmpObj->tree, arrayPath, kXMP_ExistingOnly );
 	
-	if ( arrayNode != 0 ) {
+	if ( arrayNode != nullptr ) {
 		// The array exists, make sure the form is compatible. Zero arrayForm means take what exists.
 		XMP_OptionBits arrayForm = arrayNode->options & kXMP_PropArrayFormMask;
 		if ( (arrayForm == 0) || (arrayForm & kXMP_PropArrayIsAlternate) ) {
@@ -915,7 +915,7 @@ XMPUtils::SeparateArrayItems ( XMPMeta *	  xmpObj,
 	} else {
 		// The array does not exist, try to create it.
 		arrayNode = FindNode ( &xmpObj->tree, arrayPath, kXMP_CreateNodes, (options | kXMP_PropValueIsArray) );
-		if ( arrayNode == 0 ) XMP_Throw ( "Failed to create named array", kXMPErr_BadXPath );
+		if ( arrayNode == nullptr ) XMP_Throw ( "Failed to create named array", kXMPErr_BadXPath );
 	}
 
 	XMP_NodeOffspring oldChildren ( arrayNode->children );
@@ -1016,15 +1016,15 @@ XMPUtils::SeparateArrayItems ( XMPMeta *	  xmpObj,
 		
 		size_t oldChild;
 		for ( oldChild = 0; oldChild < oldChildCount; ++oldChild ) {
-			if ( (oldChildren[oldChild] != 0) && (itemValue == oldChildren[oldChild]->value) ) break;
+			if ( (oldChildren[oldChild] != nullptr) && (itemValue == oldChildren[oldChild]->value) ) break;
 		}
 		
-		XMP_Node * newItem = 0;
+		XMP_Node * newItem = nullptr;
 		if ( oldChild == oldChildCount ) {
 			newItem = new XMP_Node ( arrayNode, kXMP_ArrayItemName, itemValue.c_str(), 0 );
 		} else {
 			newItem = oldChildren[oldChild];
-			oldChildren[oldChild] = 0;	// ! Don't match again, let duplicates be seen.
+			oldChildren[oldChild] = nullptr;	// ! Don't match again, let duplicates be seen.
 		}
 		arrayNode->children.push_back ( newItem );
 		
@@ -1032,7 +1032,7 @@ XMPUtils::SeparateArrayItems ( XMPMeta *	  xmpObj,
 
 	// Delete any of the old children that were not kept.
 	for ( size_t i = 0; i < oldChildCount; ++i ) {
-		if ( oldChildren[i] != 0 ) delete oldChildren[i];
+		if ( oldChildren[i] != nullptr ) delete oldChildren[i];
 	}
 	
 }	// SeparateArrayItems
@@ -1065,7 +1065,7 @@ XMPUtils::RemoveProperties ( XMPMeta *		xmpObj,
 		
 		XMP_NodePtrPos propPos;
 		XMP_Node * propNode = FindNode ( &(xmpObj->tree), expPath, kXMP_ExistingOnly, kXMP_NoOptions, &propPos );
-		if ( propNode != 0 ) {
+		if ( propNode != nullptr ) {
 			if ( doAll || IsExternalProperty ( expPath[kSchemaStep].step, expPath[kRootPropStep].step ) ) {
 				XMP_Node * parent = propNode->parent;	// *** Should have XMP_Node::RemoveChild(pos).
 				delete propNode;	// ! Both delete the node and erase the pointer from the parent.
@@ -1081,7 +1081,7 @@ XMPUtils::RemoveProperties ( XMPMeta *		xmpObj,
 
 		XMP_NodePtrPos schemaPos;
 		XMP_Node * schemaNode = FindSchemaNode ( &xmpObj->tree, schemaNS, kXMP_ExistingOnly, &schemaPos );
-		if ( schemaNode != 0 ) RemoveSchemaChildren ( schemaPos, doAll );
+		if ( schemaNode != nullptr ) RemoveSchemaChildren ( schemaPos, doAll );
 		
 		if ( includeAliases ) {
 		
@@ -1101,7 +1101,7 @@ XMPUtils::RemoveProperties ( XMPMeta *		xmpObj,
 				if ( strncmp ( currAlias->first.c_str(), nsPrefix, nsLen ) == 0 ) {
 					XMP_NodePtrPos actualPos;
 					XMP_Node * actualProp = FindNode ( &xmpObj->tree, currAlias->second, kXMP_ExistingOnly, kXMP_NoOptions, &actualPos );
-					if ( actualProp != 0 ) {
+					if ( actualProp != nullptr ) {
 						XMP_Node * rootProp = actualProp;
 						while ( ! XMP_NodeIsSchema ( rootProp->parent->options ) ) rootProp = rootProp->parent;
 						if ( doAll || IsExternalProperty ( rootProp->parent->name, rootProp->name ) ) {
@@ -1159,7 +1159,7 @@ XMPUtils::AppendProperties ( const XMPMeta & source,
 		// Make sure we have a destination schema node. Remember if it is newly created.
 		
 		XMP_Node * destSchema = FindSchemaNode ( &dest->tree, sourceSchema->name.c_str(), kXMP_ExistingOnly );
-		const bool newDestSchema = (destSchema == 0);
+		const bool newDestSchema = (destSchema == nullptr);
 		if ( newDestSchema ) {
 			destSchema = new XMP_Node ( &dest->tree, sourceSchema->name, sourceSchema->value, kXMP_SchemaNode );
 			dest->tree.children.push_back ( destSchema );
@@ -1209,8 +1209,8 @@ XMPUtils::DuplicateSubtree ( const XMPMeta & source,
 	
 	XMP_ExpandedXPath sourcePath, destPath; 
 
-	const XMP_Node * sourceNode = 0;
-	XMP_Node * destNode = 0;
+	const XMP_Node * sourceNode = nullptr;
+	XMP_Node * destNode = nullptr;
 	
 	XMP_Assert ( (sourceNS != 0) && (*sourceNS != 0) );
 	XMP_Assert ( (sourceRoot != 0) && (*sourceRoot != 0) );
@@ -1235,7 +1235,7 @@ XMPUtils::DuplicateSubtree ( const XMPMeta & source,
 		ExpandXPath ( destNS, destRoot, &destPath );
 		destNode = FindNode ( &dest->tree, destPath, kXMP_ExistingOnly );
 
-		if ( (destNode == 0) || (! XMP_PropIsStruct ( destNode->options )) ) {
+		if ( (destNode == nullptr) || (! XMP_PropIsStruct ( destNode->options )) ) {
 			XMP_Throw ( "Destination must be an existing struct", kXMPErr_BadXPath );
 		}
 		
@@ -1268,7 +1268,7 @@ XMPUtils::DuplicateSubtree ( const XMPMeta & source,
 		ExpandXPath ( sourceNS, sourceRoot, &sourcePath );
 		sourceNode = FindConstNode ( &source.tree, sourcePath );
 
-		if ( (sourceNode == 0) || (! XMP_PropIsStruct ( sourceNode->options )) ) {
+		if ( (sourceNode == nullptr) || (! XMP_PropIsStruct ( sourceNode->options )) ) {
 			XMP_Throw ( "Source must be an existing struct", kXMPErr_BadXPath );
 		}
 		
@@ -1296,7 +1296,7 @@ XMPUtils::DuplicateSubtree ( const XMPMeta & source,
 			if ( ! nsOK ) XMP_Throw ( "Source field namespace is not global", kXMPErr_BadSchema );
 			
 			XMP_Node * destSchema = FindSchemaNode ( &dest->tree, nsURI, kXMP_CreateNodes );
-			if ( destSchema == 0 ) XMP_Throw ( "Failed to find destination schema", kXMPErr_BadSchema );
+			if ( destSchema == nullptr ) XMP_Throw ( "Failed to find destination schema", kXMPErr_BadSchema );
 
 			XMP_Node * copyNode = new XMP_Node ( destSchema, currField->name, currField->value, currField->options );
 			destSchema->children.push_back ( copyNode );
@@ -1312,19 +1312,19 @@ XMPUtils::DuplicateSubtree ( const XMPMeta & source,
 		ExpandXPath ( destNS, destRoot, &destPath );
 	
 		sourceNode = FindConstNode ( &source.tree, sourcePath );
-		if ( sourceNode == 0 ) XMP_Throw ( "Can't find source subtree", kXMPErr_BadXPath );
+		if ( sourceNode == nullptr ) XMP_Throw ( "Can't find source subtree", kXMPErr_BadXPath );
 		
 		destNode = FindNode ( &dest->tree, destPath, kXMP_ExistingOnly );	// Dest must not yet exist.
-		if ( destNode != 0 ) XMP_Throw ( "Destination subtree must not exist", kXMPErr_BadXPath );
+		if ( destNode != nullptr ) XMP_Throw ( "Destination subtree must not exist", kXMPErr_BadXPath );
 		
 		destNode = FindNode ( &dest->tree, destPath, kXMP_CreateNodes );	// Now create the dest.
-		if ( destNode == 0 ) XMP_Throw ( "Can't create destination root node", kXMPErr_BadXPath );
+		if ( destNode == nullptr ) XMP_Throw ( "Can't create destination root node", kXMPErr_BadXPath );
 		
 		// Make sure the destination is not within the source! The source can't be inside the destination
 		// because the source already existed and the destination was just created.
 		
 		if ( &source == dest ) {
-			for ( XMP_Node * testNode = destNode; testNode != 0; testNode = testNode->parent ) {
+			for ( XMP_Node * testNode = destNode; testNode != nullptr; testNode = testNode->parent ) {
 				if ( testNode == sourceNode ) {
 					// *** delete the just-created dest root node
 					XMP_Throw ( "Destination subtree is within the source subtree", kXMPErr_BadXPath );

--- a/xmpsdk/src/XMPUtils.cpp
+++ b/xmpsdk/src/XMPUtils.cpp
@@ -41,13 +41,13 @@ static const char * sBase64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // Static Variables
 // ================
 
-XMP_VarString * sComposedPath = 0;		// *** Only really need 1 string. Shrink periodically?
-XMP_VarString * sConvertedValue = 0;
-XMP_VarString * sBase64Str = 0;
-XMP_VarString * sCatenatedItems = 0;
-XMP_VarString * sStandardXMP = 0;
-XMP_VarString * sExtendedXMP = 0;
-XMP_VarString * sExtendedDigest = 0;
+XMP_VarString * sComposedPath = nullptr;		// *** Only really need 1 string. Shrink periodically?
+XMP_VarString * sConvertedValue = nullptr;
+XMP_VarString * sBase64Str = nullptr;
+XMP_VarString * sCatenatedItems = nullptr;
+XMP_VarString * sStandardXMP = nullptr;
+XMP_VarString * sExtendedXMP = nullptr;
+XMP_VarString * sExtendedDigest = nullptr;
 
 // =================================================================================================
 // Local Utilities
@@ -522,14 +522,14 @@ static bool MoveOneProperty ( XMPMeta & stdXMP, XMPMeta * extXMP,
 							  XMP_StringPtr schemaURI, XMP_StringPtr propName )
 {
 
-	XMP_Node * propNode = 0;
+	XMP_Node * propNode = nullptr;
 	XMP_NodePtrPos stdPropPos;
 
-	XMP_Node * stdSchema = FindSchemaNode ( &stdXMP.tree, schemaURI, kXMP_ExistingOnly, 0 );
-	if ( stdSchema != 0 ) {
+	XMP_Node * stdSchema = FindSchemaNode ( &stdXMP.tree, schemaURI, kXMP_ExistingOnly, nullptr );
+	if ( stdSchema != nullptr ) {
 		propNode = FindChildNode ( stdSchema, propName, kXMP_ExistingOnly, &stdPropPos );
 	}
-	if ( propNode == 0 ) return false;
+	if ( propNode == nullptr ) return false;
 
 	XMP_Node * extSchema = FindSchemaNode ( &extXMP->tree, schemaURI, kXMP_CreateNodes );
 
@@ -1153,7 +1153,7 @@ XMPUtils::ConvertFromDate ( const XMP_DateTime & binValue,
 /* class static */ bool
 XMPUtils::ConvertToBool ( XMP_StringPtr strValue )
 {
-	if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
+	if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
 
 	bool result = false;
 	XMP_VarString strObj ( strValue );
@@ -1182,7 +1182,7 @@ XMPUtils::ConvertToBool ( XMP_StringPtr strValue )
 /* class static */ XMP_Int32
 XMPUtils::ConvertToInt ( XMP_StringPtr strValue )
 {
-	if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
+	if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
 
 	int count;
 	char nextCh;
@@ -1211,7 +1211,7 @@ XMPUtils::ConvertToInt64 ( XMP_StringPtr strValue )
 #if defined(__MINGW32__)// || defined(__MINGW64__)
     return ConvertToInt(strValue);
 #else
-	if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
+	if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
 
 	int count;
 	char nextCh;
@@ -1237,11 +1237,11 @@ XMPUtils::ConvertToInt64 ( XMP_StringPtr strValue )
 /* class static */ double
 XMPUtils::ConvertToFloat ( XMP_StringPtr strValue )
 {
-	if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
+	if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue );
 
 	XMP_VarString oldLocale;	// Try to make sure number conversion uses '.' as the decimal point.
-	XMP_StringPtr oldLocalePtr = setlocale ( LC_ALL, 0 );
-	if ( oldLocalePtr != 0 ) {
+	XMP_StringPtr oldLocalePtr = setlocale ( LC_ALL, nullptr );
+	if ( oldLocalePtr != nullptr ) {
 		oldLocale.assign ( oldLocalePtr );
 		setlocale ( LC_ALL, "C" );
 	}
@@ -1250,7 +1250,7 @@ XMPUtils::ConvertToFloat ( XMP_StringPtr strValue )
 	char * numEnd;
 	double result = strtod ( strValue, &numEnd );
 
-	if ( oldLocalePtr != 0 ) setlocale ( LC_ALL, oldLocalePtr );	// ! Reset locale before possible throw!
+	if ( oldLocalePtr != nullptr ) setlocale ( LC_ALL, oldLocalePtr );	// ! Reset locale before possible throw!
 	if ( (errno != 0) || (*numEnd != 0) ) XMP_Throw ( "Invalid float string", kXMPErr_BadParam );
 
 	return result;
@@ -1291,7 +1291,7 @@ XMPUtils::ConvertToFloat ( XMP_StringPtr strValue )
 XMPUtils::ConvertToDate ( XMP_StringPtr	 strValue,
 						  XMP_DateTime * binValue )
 {
-	if ( (strValue == 0) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue);
+	if ( (strValue == nullptr) || (*strValue == 0) ) XMP_Throw ( "Empty convert-from string", kXMPErr_BadValue);
 
 	size_t	 pos = 0;
 	XMP_Int32 temp;
@@ -1444,9 +1444,9 @@ XMPUtils::EncodeToBase64 ( XMP_StringPtr   rawStr,
 						   XMP_StringPtr * encodedStr,
 						   XMP_StringLen * encodedLen )
 {
-	if ( (rawStr == 0) && (rawLen != 0) ) XMP_Throw ( "Null raw data buffer", kXMPErr_BadParam );
+	if ( (rawStr == nullptr) && (rawLen != 0) ) XMP_Throw ( "Null raw data buffer", kXMPErr_BadParam );
 	if ( rawLen == 0 ) {
-		*encodedStr = 0;
+		*encodedStr = nullptr;
 		*encodedLen = 0;
 		return;
 	}
@@ -1552,9 +1552,9 @@ XMPUtils::DecodeFromBase64 ( XMP_StringPtr	 encodedStr,
 							 XMP_StringPtr * rawStr,
 							 XMP_StringLen * rawLen )
 {
-	if ( (encodedStr == 0) && (encodedLen != 0) ) XMP_Throw ( "Null encoded data buffer", kXMPErr_BadParam );
+	if ( (encodedStr == nullptr) && (encodedLen != 0) ) XMP_Throw ( "Null encoded data buffer", kXMPErr_BadParam );
 	if ( encodedLen == 0 ) {
-		*rawStr = 0;
+		*rawStr = nullptr;
 		*rawLen = 0;
 		return;
 	}
@@ -1727,7 +1727,7 @@ XMPUtils::PackageForJPEG ( const XMPMeta & origXMP,
 		XMP_NodePtrPos crSchemaPos;
 		XMP_Node * crSchema = FindSchemaNode ( &stdXMP.tree, kXMP_NS_CameraRaw, kXMP_ExistingOnly, &crSchemaPos );
 
-		if ( crSchema != 0 ) {
+		if ( crSchema != nullptr ) {
 			crSchema->parent = &extXMP.tree;
 			extXMP.tree.children.push_back ( crSchema );
 			stdXMP.tree.children.erase ( crSchemaPos );
@@ -1861,7 +1861,7 @@ XMPUtils::PackageForJPEG ( const XMPMeta & origXMP,
 	// Adjust the standard XMP padding to be up to 2KB.
 
 	XMP_Assert ( (sStandardXMP->size() > kTrailerLen) && (sStandardXMP->size() <= kStdXMPLimit) );
-	const char * packetEnd = 0;
+	const char * packetEnd = nullptr;
     packetEnd = sStandardXMP->c_str() + sStandardXMP->size() - kTrailerLen;
 	XMP_Assert ( XMP_LitMatch ( packetEnd, kPacketTrailer ) );
 	UNUSED(packetEnd);
@@ -1911,7 +1911,7 @@ XMPUtils::CurrentDateTime ( XMP_DateTime * xmpTime )
 {
 	XMP_Assert ( xmpTime != 0 );	// ! Enforced by wrapper.
 
-	ansi_tt binTime = ansi_time(0);
+	ansi_tt binTime = ansi_time(nullptr);
 	if ( binTime == -1 ) XMP_Throw ( "Failure from ANSI C time function", kXMPErr_ExternalFailure );
 	ansi_tm currTime;
 	ansi_localtime ( &binTime, &currTime );
@@ -1956,7 +1956,7 @@ XMPUtils::SetTimeZone ( XMP_DateTime * xmpTime )
 	ansi_tm tmLocal, tmUTC;
 
 	if ( (xmpTime->year == 0) && (xmpTime->month == 0) && (xmpTime->day == 0) ) {
-		ansi_tt now = ansi_time(0);
+		ansi_tt now = ansi_time(nullptr);
 		if ( now == -1 ) XMP_Throw ( "Failure from ANSI C time function", kXMPErr_ExternalFailure );
 		ansi_localtime ( &now, &tmLocal );
 	} else {
@@ -1997,7 +1997,7 @@ XMPUtils::SetTimeZone ( XMP_DateTime * xmpTime )
 		#else
 			// Win and UNIX don't have a visible offset. Make sure we know about the failure,
 			// then try using the current date/time as a close fallback.
-			ttTime = ansi_time(0);
+			ttTime = ansi_time(nullptr);
 			if ( ttTime == -1 ) XMP_Throw ( "Failure from ANSI C time function", kXMPErr_ExternalFailure );
 			ansi_localtime ( &ttTime, &tmx );
 			ansi_gmtime ( &ttTime, &tmy );


### PR DESCRIPTION
Found with modernize-use-nullptr

Signed-off-by: Rosen Penev <rosenp@gmail.com>