### PR TITLE
clang-tidy: use override and remove virtual

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -539,7 +539,7 @@ constexpr size_t operator"" _z(unsigned long long n)
     class EXIV2API RemoteIo : public BasicIo {
     public:
         //! Destructor. Releases all managed memory.
-        virtual ~RemoteIo();
+        ~RemoteIo() override;
         //@}
 
         //! @name Manipulators
@@ -683,7 +683,7 @@ constexpr size_t operator"" _z(unsigned long long n)
         //! @name Creators
         //@{
         //! Default Destructor
-        virtual ~HttpIo(){}
+        ~HttpIo() override{}
         //@}
     };
 

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -294,7 +294,7 @@ namespace Exiv2 {
         //! Copy constructor
         IptcKey(const IptcKey& rhs);
         //! Destructor
-        virtual ~IptcKey();
+        ~IptcKey() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -176,7 +176,7 @@ namespace Exiv2 {
         AnyError();
         AnyError(const AnyError& o);
 
-        virtual ~AnyError() noexcept;
+        ~AnyError() noexcept override;
         ///@brief  Return the error code.
         virtual int code() const noexcept =0;
     };
@@ -280,7 +280,7 @@ namespace Exiv2 {
         BasicError(ErrorCode code, const A& arg1, const B& arg2, const C& arg3);
 
         //! Virtual destructor. (Needed because of noexcept)
-        virtual ~BasicError() noexcept;
+        ~BasicError() noexcept override;
         //@}
 
         //! @name Accessors

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -66,7 +66,7 @@ namespace Exiv2
 
         Exifdatum(const Exifdatum& rhs);
 
-        virtual ~Exifdatum();
+        ~Exifdatum() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
         //! Copy constructor
         Iptcdatum(const Iptcdatum& rhs);
         //! Destructor
-        virtual ~Iptcdatum();
+        ~Iptcdatum() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -274,7 +274,7 @@ namespace Exiv2 {
         XmpKey(const XmpKey& rhs);
 
         //! Virtual destructor.
-        virtual ~XmpKey();
+        ~XmpKey() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -70,7 +70,7 @@ namespace Exiv2 {
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -p{S|R} as a file debugging aid
          */
-        virtual void printStructure(std::ostream& out, PrintStructureOption option,int depth=0) override;
+        void printStructure(std::ostream& out, PrintStructureOption option,int depth=0) override;
 
         /*!
           @brief Not supported. TIFF format does not contain a comment.

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -267,7 +267,7 @@ namespace Exiv2 {
 
         DataValue(const byte* buf, size_t len, ByteOrder byteOrder = invalidByteOrder, TypeId typeId = undefined);
 
-        virtual ~DataValue();
+        ~DataValue() override;
 
         //! @name Manipulators
         //@{
@@ -351,7 +351,7 @@ namespace Exiv2 {
         //! Copy constructor
         StringValueBase(const StringValueBase& rhs);
         //! Virtual destructor.
-        virtual ~StringValueBase();
+        ~StringValueBase() override;
         //@}
 
         //! @name Manipulators
@@ -431,7 +431,7 @@ namespace Exiv2 {
         //! Constructor
         explicit StringValue(const std::string& buf);
         //! Virtual destructor.
-        virtual ~StringValue();
+        ~StringValue() override;
         //@}
 
         //! @name Accessors
@@ -463,7 +463,7 @@ namespace Exiv2 {
         //! Constructor
         explicit AsciiValue(const std::string& buf);
         //! Virtual destructor.
-        virtual ~AsciiValue();
+        ~AsciiValue() override;
         //@}
 
         //! @name Manipulators
@@ -989,7 +989,7 @@ namespace Exiv2 {
         //! Constructor
         DateValue(int year, int month, int day);
         //! Virtual destructor.
-        virtual ~DateValue();
+        ~DateValue() override;
         //@}
 
         //! Simple Date helper structure
@@ -1096,7 +1096,7 @@ namespace Exiv2 {
                   int tzHour =0, int tzMinute =0);
 
         //! Virtual destructor.
-        virtual ~TimeValue();
+        ~TimeValue() override;
         //@}
 
         //! Simple Time helper structure
@@ -1260,7 +1260,7 @@ namespace Exiv2 {
         //! Copy constructor
         ValueType(const ValueType<T>& rhs);
         //! Virtual destructor.
-        virtual ~ValueType();
+        ~ValueType() override;
         //@}
 
         //! @name Manipulators

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
         //! Copy constructor
         Xmpdatum(const Xmpdatum& rhs);
         //! Destructor
-        virtual ~Xmpdatum();
+        ~Xmpdatum() override;
         //@}
 
         //! @name Manipulators

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -170,21 +170,21 @@ namespace Jzon
         Value(const float value);
         Value(const double value);
         Value(const bool value);
-        virtual ~Value();
+        ~Value() override;
 
-        virtual Type GetType() const;
+        Type GetType() const override;
         ValueType GetValueType() const;
 
-        virtual inline bool IsNull() const { return (type == VT_NULL); }
-        virtual inline bool IsString() const { return (type == VT_STRING); }
-        virtual inline bool IsNumber() const { return (type == VT_NUMBER); }
-        virtual inline bool IsBool() const { return (type == VT_BOOL); }
+        inline bool IsNull() const override { return (type == VT_NULL); }
+        inline bool IsString() const override { return (type == VT_STRING); }
+        inline bool IsNumber() const override { return (type == VT_NUMBER); }
+        inline bool IsBool() const override { return (type == VT_BOOL); }
 
-        virtual std::string ToString() const;
-        virtual int ToInt() const;
-        virtual float ToFloat() const;
-        virtual double ToDouble() const;
-        virtual bool ToBool() const;
+        std::string ToString() const override;
+        int ToInt() const override;
+        float ToFloat() const override;
+        double ToDouble() const override;
+        bool ToBool() const override;
 
         void SetNull();
         void Set(const Value &value);
@@ -212,7 +212,7 @@ namespace Jzon
         static std::string UnescapeString(const std::string &value);
 
     protected:
-        virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
     private:
         std::string valueStr;
@@ -262,9 +262,9 @@ namespace Jzon
         Object();
         Object(const Object &other);
         Object(const Node &other);
-        virtual ~Object();
+        ~Object() override;
 
-        virtual Type GetType() const;
+        Type GetType() const override;
 
         void Add(const std::string &name, Node &node);
         void Add(const std::string &name, Value node);
@@ -276,13 +276,13 @@ namespace Jzon
         iterator end();
         const_iterator end() const;
 
-        virtual bool Has(const std::string &name) const;
-        virtual size_t GetCount() const;
-        virtual Node &Get(const std::string &name) const;
+        bool Has(const std::string &name) const override;
+        size_t GetCount() const override;
+        Node &Get(const std::string &name) const override;
         using Node::Get;
 
     protected:
-        virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
     private:
         typedef std::vector<NamedNodePtr> ChildList;
@@ -330,9 +330,9 @@ namespace Jzon
         Array();
         Array(const Array &other);
         Array(const Node &other);
-        virtual ~Array();
+        ~Array() override;
 
-        virtual Type GetType() const;
+        Type GetType() const override;
 
         void Add(Node &node);
         void Add(Value node);
@@ -344,12 +344,12 @@ namespace Jzon
         iterator end();
         const_iterator end() const;
 
-        virtual size_t GetCount() const;
-        virtual Node &Get(size_t index) const;
+        size_t GetCount() const override;
+        Node &Get(size_t index) const override;
         using Node::Get;
 
     protected:
-        virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
     private:
         typedef std::vector<Node*> ChildList;

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -61,7 +61,7 @@ public:
     }
 
     //! Handle options and their arguments.
-    int option(int opt, const std::string& optarg, int optopt)
+    int option(int opt, const std::string& optarg, int optopt) override
     {
     	std::cout << "Params::option()"
     	          << " opt = "    << opt
@@ -72,7 +72,7 @@ public:
     }
 
     //! Handle non-option parameters.
-    int nonoption(const std::string& argv)
+    int nonoption(const std::string& argv) override
     {
     	std::cout << "Params::nonoption()"
     	          << " " << argv

--- a/samples/metacopy.hpp
+++ b/samples/metacopy.hpp
@@ -66,10 +66,10 @@ public:
     int getopt(int argc, char* const argv[]);
 
     //! Handle options and their arguments.
-    virtual int option(int opt, const std::string& optarg, int optopt);
+    int option(int opt, const std::string& optarg, int optopt) override;
 
     //! Handle non-option parameters.
-    virtual int nonoption(const std::string& argv);
+    int nonoption(const std::string& argv) override;
 
     //! Print a minimal usage note to an output stream.
     void usage(std::ostream& os =std::cout) const;

--- a/src/RemoteIo.cpp
+++ b/src/RemoteIo.cpp
@@ -598,7 +598,7 @@ namespace Exiv2
           length of remote file (in bytes).
           @throw Error if the server returns the error code.
          */
-        long getFileLength();
+        long getFileLength() override;
         /*!
           @brief Get the data by range.
           @param lowBlock The start block index.
@@ -608,7 +608,7 @@ namespace Exiv2
           @note Set lowBlock = -1 and highBlock = -1 to get the whole file
           content.
          */
-        void getDataByRange(long lowBlock, long highBlock, std::string& response);
+        void getDataByRange(long lowBlock, long highBlock, std::string& response) override;
         /*!
           @brief Submit the data to the remote machine. The data replace a part
           of the remote file. The replaced part of remote file is indicated by
@@ -626,7 +626,7 @@ namespace Exiv2
           http://dev.exiv2.org/wiki/exiv2
           @throw Error if it fails.
          */
-        void writeRemote(const byte* data, size_t size, long from, long to);
+        void writeRemote(const byte* data, size_t size, long from, long to) override;
 
         HttpImpl& operator=(const HttpImpl& rhs) = delete;
         HttpImpl& operator=(const HttpImpl&& rhs) = delete;

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -160,25 +160,25 @@ namespace Exiv2
                     dataSize_ = header_.format() == Header::StandardTiff? 4 : 8;
                 }
 
-                virtual ~BigTiffImage() {}
+                ~BigTiffImage() override {}
 
                 // overrides
-                void readMetadata()
+                void readMetadata() override
                 {
 
                 }
 
-                void writeMetadata()
+                void writeMetadata() override
                 {
 
                 }
 
-                std::string mimeType() const
+                std::string mimeType() const override
                 {
                     return std::string();
                 }
 
-                void printStructure(std::ostream& os, PrintStructureOption option, int depth)
+                void printStructure(std::ostream& os, PrintStructureOption option, int depth) override
                 {
                     printIFD(os, option, header_.dirOffset(), depth - 1);
                 }

--- a/src/orfimage_int.hpp
+++ b/src/orfimage_int.hpp
@@ -50,7 +50,7 @@ namespace Exiv2 {
         //! Default constructor
         explicit OrfHeader(ByteOrder byteOrder =littleEndian);
         //! Destructor.
-        ~OrfHeader();
+        ~OrfHeader() override;
         //@}
 
         //! @name Manipulators

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -267,7 +267,7 @@ private:
     Params();
 
     //! Destructor, frees any allocated regexes in greps_
-    ~Params();
+    ~Params() override;
 
     //! @name Helpers
     //@{

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -420,7 +420,7 @@ namespace Exiv2 {
         //! Default constructor.
         TiffEntryBase(uint16_t tag, IfdId group, TiffType tiffType =ttUndefined);
         //! Virtual destructor.
-        virtual ~TiffEntryBase();
+        ~TiffEntryBase() override;
         //@}
 
         //! @name Manipulators
@@ -559,7 +559,7 @@ namespace Exiv2 {
         //! Constructor
         TiffEntry(uint16_t tag, IfdId group) : TiffEntryBase(tag, group) {}
         //! Virtual destructor.
-        virtual ~TiffEntry();
+        ~TiffEntry() override;
         //@}
 
     protected:
@@ -593,7 +593,7 @@ namespace Exiv2 {
             : TiffEntryBase(tag, group),
               szTag_(szTag), szGroup_(szGroup) {}
         //! Virtual destructor.
-        virtual ~TiffDataEntryBase();
+        ~TiffDataEntryBase() override;
         //@}
 
         //! @name Manipulators
@@ -649,7 +649,7 @@ namespace Exiv2 {
             : TiffDataEntryBase(tag, group, szTag, szGroup),
               pDataArea_(nullptr), sizeDataArea_(0) {}
         //! Virtual destructor.
-        virtual ~TiffDataEntry();
+        ~TiffDataEntry() override;
         //@}
 
         //! @name Manipulators
@@ -728,7 +728,7 @@ namespace Exiv2 {
         TiffImageEntry(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup)
             : TiffDataEntryBase(tag, group, szTag, szGroup) {}
         //! Virtual destructor.
-        virtual ~TiffImageEntry();
+        ~TiffImageEntry() override;
         //@}
 
         //! @name Manipulators
@@ -807,7 +807,7 @@ namespace Exiv2 {
         TiffSizeEntry(uint16_t tag, IfdId group, uint16_t dtTag, IfdId dtGroup)
             : TiffEntryBase(tag, group), dtTag_(dtTag), dtGroup_(dtGroup) {}
         //! Virtual destructor.
-        virtual ~TiffSizeEntry();
+        ~TiffSizeEntry() override;
         //@}
 
         //! @name Accessors
@@ -850,7 +850,7 @@ namespace Exiv2 {
         TiffDirectory(uint16_t tag, IfdId group, bool hasNext =true)
             : TiffComponent(tag, group), hasNext_(hasNext), pNext_(nullptr) {}
         //! Virtual destructor
-        virtual ~TiffDirectory();
+        ~TiffDirectory() override;
         //@}
 
         //! @name Accessors
@@ -966,7 +966,7 @@ namespace Exiv2 {
         //! Default constructor
         TiffSubIfd(uint16_t tag, IfdId group, IfdId newGroup);
         //! Virtual destructor
-        virtual ~TiffSubIfd();
+        ~TiffSubIfd() override;
         //@}
 
     protected:
@@ -1055,7 +1055,7 @@ namespace Exiv2 {
         //! Default constructor
         TiffMnEntry(uint16_t tag, IfdId group, IfdId mnGroup);
         //! Virtual destructor
-        virtual ~TiffMnEntry();
+        ~TiffMnEntry() override;
         //@}
 
     protected:
@@ -1129,7 +1129,7 @@ namespace Exiv2 {
                          MnHeader* pHeader,
                          bool      hasNext =true);
         //! Virtual destructor
-        virtual ~TiffIfdMakernote();
+        ~TiffIfdMakernote() override;
         //@}
 
         //! @name Manipulators
@@ -1331,7 +1331,7 @@ namespace Exiv2 {
                         int setSize,
                         CfgSelFct cfgSelFct);
         //! Virtual destructor
-        virtual ~TiffBinaryArray();
+        ~TiffBinaryArray() override;
         //@}
 
         //! @name Manipulators
@@ -1459,7 +1459,7 @@ namespace Exiv2 {
         //! Constructor
         TiffBinaryElement(uint16_t tag, IfdId group);
         //! Virtual destructor.
-        virtual ~TiffBinaryElement();
+        ~TiffBinaryElement() override;
         //@}
 
         //! @name Manipulators

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -154,7 +154,7 @@ namespace Exiv2 {
                    uint32_t  offset       =0x00000008,
                    bool      hasImageTags =true);
         //! Destructor
-        ~TiffHeader();
+        ~TiffHeader() override;
         //@}
         //@{
         //! @name Accessors

--- a/xmpsdk/src/ExpatAdapter.hpp
+++ b/xmpsdk/src/ExpatAdapter.hpp
@@ -37,9 +37,9 @@ public:
 	#endif
 	
 	ExpatAdapter();
-	virtual ~ExpatAdapter();
+	~ExpatAdapter() override;
 	
-	void ParseBuffer ( const void * buffer, size_t length, bool last = true );
+	void ParseBuffer ( const void * buffer, size_t length, bool last = true ) override;
 
 };
 


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>