### PR TITLE
clang-tidy: use braced init list

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1700,14 +1700,14 @@ namespace Exiv2 {
     inline Rational ValueType<Rational>::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n].first, value_[n].second);
+        return {value_[n].first, value_[n].second};
     }
     // Specialization for unsigned rational
     template<>
     inline Rational ValueType<URational>::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n].first, value_[n].second);
+        return {value_[n].first, value_[n].second};
     }
     // Specialization for float.
     template<>

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -87,7 +87,7 @@ namespace Exiv2
                 byteOrder = bigEndian;
 
             if (byteOrder == invalidByteOrder)
-                return Header();
+                return {};
 
             byte version[2] = {0, 0};
             io.read(version, 2);
@@ -95,7 +95,7 @@ namespace Exiv2
             const uint16_t magic = getUShort(version, byteOrder);
 
             if (magic != 0x2A && magic != 0x2B)
-                return Header();
+                return {};
 
             Header result;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -234,13 +234,13 @@ namespace Exiv2 {
     Slice<byte*> makeSlice(DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return Slice<byte*>(buf.pData_, begin, end);
+        return {buf.pData_, begin, end};
     }
 
     Slice<const byte*> makeSlice(const DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return Slice<const byte*>(buf.pData_, begin, end);
+        return {buf.pData_, begin, end};
     }
 
     std::ostream& operator<<(std::ostream& os, const Rational& r)
@@ -756,7 +756,8 @@ namespace Exiv2 {
         if (ok) return ret;
 
         long l = stringTo<long>(s, ok);
-        if (ok) return Rational(l, 1);
+        if (ok)
+            return {l, 1};
 
         float f = stringTo<float>(s, ok);
         if (ok) return floatToRationalCast(f);
@@ -793,7 +794,7 @@ namespace Exiv2 {
         const int32_t nom = static_cast<int32_t>(f * den + rnd);
         const int32_t g = gcd(nom, den);
 
-        return Rational(nom / g, den / g);
+        return {nom / g, den / g};
     }
 
 }                                       // namespace Exiv2

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -287,7 +287,7 @@ namespace Exiv2 {
     Rational DataValue::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n], 1);
+        return {value_[n], 1};
     }
 
     StringValueBase::StringValueBase(TypeId typeId)
@@ -371,7 +371,7 @@ namespace Exiv2 {
     Rational StringValueBase::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n], 1);
+        return {value_[n], 1};
     }
 
     StringValue::StringValue()
@@ -932,7 +932,7 @@ namespace Exiv2 {
     Rational LangAltValue::toRational(long /*n*/) const
     {
         ok_ = false;
-        return Rational(0, 0);
+        return {0, 0};
     }
 
     LangAltValue* LangAltValue::clone_() const
@@ -1069,7 +1069,7 @@ namespace Exiv2 {
 
     Rational DateValue::toRational(long n) const
     {
-        return Rational(toLong(n), 1);
+        return {toLong(n), 1};
     }
 
     TimeValue::TimeValue()
@@ -1253,7 +1253,7 @@ namespace Exiv2 {
 
     Rational TimeValue::toRational(long n) const
     {
-        return Rational(toLong(n), 1);
+        return {toLong(n), 1};
     }
 
 }                                       // namespace Exiv2


### PR DESCRIPTION
Found with modernize-return-braced-init-list

Signed-off-by: Rosen Penev <rosenp@gmail.com>