### PR TITLE
clang-tidy: use bool literals

### DIFF
--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -172,7 +172,7 @@ namespace Exiv2 {
     class EXIV2API XmpData {
     public:
         //! Default constructor
-        XmpData() : xmpMetadata_(), xmpPacket_(), usePacket_(0) {}
+        XmpData() : xmpMetadata_(), xmpPacket_(), usePacket_(false) {}
 
         //! XmpMetadata iterator type
         typedef XmpMetadata::iterator iterator;


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>