### PR TITLE
clang-tidy: use delete

### DIFF
--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -415,7 +415,7 @@ namespace Jzon
         const Node &root;
 
         // Disable assignment operator
-        Writer &operator=(const Writer&);
+        Writer &operator=(const Writer &) = delete;
     };
 
     class JzonAPI Parser
@@ -466,6 +466,6 @@ namespace Jzon
         std::string error;
 
         // Disable assignment operator
-        Parser &operator=(const Parser&);
+        Parser &operator=(const Parser &) = delete;
     };
 }


### PR DESCRIPTION
Found with modernize-use-equals-delete

Signed-off-by: Rosen Penev <rosenp@gmail.com>