### PR TITLE
clang-tidy: convert loops to range based

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -442,7 +442,7 @@ namespace Jzon
     {
         std::string unescaped;
 
-		for (std::string::const_iterator it = value.begin(); it != value.end(); ++it)
+        for (std::string::const_iterator it = value.begin(); it != value.end(); ++it)
 		{
 			const char &c = (*it);
 			char c2 = '\0';
@@ -465,8 +465,9 @@ namespace Jzon
 		return unescaped;
     }
 
-    Object::Object() : Node()
-	{
+    Object::Object()
+        : Node()
+    {
 	}
 	Object::Object(const Object &other) : Node()
 	{
@@ -490,10 +491,10 @@ namespace Jzon
 
     Node::Type Object::GetType() const
     {
-		return T_OBJECT;
-	}
+        return T_OBJECT;
+    }
 
-	void Object::Add(const std::string &name, Node &node)
+    void Object::Add(const std::string &name, Node &node)
 	{
 		children.push_back(NamedNodePtr(name, node.GetCopy()));
 	}
@@ -525,12 +526,12 @@ namespace Jzon
     Object::iterator Object::begin()
     {
         if (!children.empty())
-			return Object::iterator(&children.front());
+            return Object::iterator(&children.front());
 		else
 			return Object::iterator(nullptr);
     }
     Object::const_iterator Object::begin() const
-	{
+    {
 		if (!children.empty())
 			return Object::const_iterator(&children.front());
 		else
@@ -565,7 +566,7 @@ namespace Jzon
         return children.size();
     }
     Node &Object::Get(const std::string &name) const
-	{
+    {
         for (const auto &child : children) {
             if (child.first == name) {
                 return *child.second;
@@ -580,8 +581,9 @@ namespace Jzon
         return new Object(*this);
     }
 
-    Array::Array() : Node()
-	{
+    Array::Array()
+        : Node()
+    {
 	}
 	Array::Array(const Array &other) : Node()
 	{
@@ -605,10 +607,10 @@ namespace Jzon
 
     Node::Type Array::GetType() const
     {
-		return T_ARRAY;
-	}
+        return T_ARRAY;
+    }
 
-	void Array::Add(Node &node)
+    void Array::Add(Node &node)
 	{
 		children.push_back(node.GetCopy());
 	}
@@ -637,12 +639,12 @@ namespace Jzon
     Array::iterator Array::begin()
     {
         if (!children.empty())
-			return Array::iterator(&children.front());
+            return Array::iterator(&children.front());
 		else
 			return Array::iterator(nullptr);
     }
     Array::const_iterator Array::begin() const
-	{
+    {
 		if (!children.empty())
 			return Array::const_iterator(&children.front());
 		else

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -56,15 +56,14 @@ try {
     image->readMetadata();
     Exiv2::ExifData& ed = image->exifData();
 
-    for (unsigned int i = 0; i < EXV_COUNTOF(easyAccess); ++i) {
-        Exiv2::ExifData::const_iterator pos = easyAccess[i].findFct_(ed);
-        std::cout << std::setw(20) << std::left << easyAccess[i].label_;
+    for (auto easyAcces : easyAccess) {
+        Exiv2::ExifData::const_iterator pos = easyAcces.findFct_(ed);
+        std::cout << std::setw(20) << std::left << easyAcces.label_;
         if (pos != ed.end()) {
-            std::cout << " (" << std::setw(35) << pos->key() << ") : "
-                      << pos->print(&ed) << "\n";
-        }
-        else {
-            std::cout << " (" << std::setw(35) << " " << ") : \n";
+            std::cout << " (" << std::setw(35) << pos->key() << ") : " << pos->print(&ed) << "\n";
+        } else {
+            std::cout << " (" << std::setw(35) << " "
+                      << ") : \n";
         }
     }
 

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -42,9 +42,10 @@ std::string escapeCSV(Exiv2::ExifData::const_iterator it,bool bValue)
     if ( bValue ) os << it->value() ; else os << it->key() ;
 
     std::string s = os.str();
-    for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-        if ( s[i] == ',' ) result += '\\';
-        result += s[i];
+    for (char i : s) {
+        if (i == ',')
+            result += '\\';
+        result += i;
     }
 
     return result ;
@@ -92,9 +93,10 @@ std::string escapeJSON(Exiv2::ExifData::const_iterator it,bool bValue=true)
     if ( bValue ) os << it->value() ; else os << it->key() ;
 
     std::string s = os.str();
-    for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-        if ( s[i] == '"' ) result += "\\\"";
-        result += s[i];
+    for (char i : s) {
+        if (i == '"')
+            result += "\\\"";
+        result += i;
     }
 
     std::string q = "\"";
@@ -124,10 +126,12 @@ std::string escapeXML(Exiv2::ExifData::const_iterator it,bool bValue=true)
     if ( bValue ) os << it->value() ; else os << it->key() ;
 
     std::string s = os.str();
-    for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-        if ( s[i] == '<' ) result += "&lg;";
-        if ( s[i] == '>' ) result += "&gt;";
-        result += s[i];
+    for (char i : s) {
+        if (i == '<')
+            result += "&lg;";
+        if (i == '>')
+            result += "&gt;";
+        result += i;
     }
 
     return result ;

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -196,14 +196,11 @@ void push(Jzon::Node& node,const std::string& key,T i)
              ABORT_IF_I_EMTPY
              Jzon::Object l ;
              const Exiv2::LangAltValue& langs = dynamic_cast<const Exiv2::LangAltValue&>(i->value());
-             for ( Exiv2::LangAltValue::ValueType::const_iterator lang = langs.value_.begin()
-                 ; lang != langs.value_.end()
-                 ; lang++
-             ) {
-                l.Add(lang->first,lang->second);
+             for (const auto& lang : langs.value_) {
+                 l.Add(lang.first, lang.second);
              }
-             Jzon::Object o ;
-             o.Add("lang",l);
+             Jzon::Object o;
+             o.Add("lang", l);
              STORE(node,key,o);
         }
         break;
@@ -332,14 +329,13 @@ int main(int argc, char* const argv[])
 
                 // create and populate a Jzon::Object for the namespaces
                 Jzon::Object    xmlns;
-                for ( Exiv2::StringSet_i it = namespaces.begin() ; it != namespaces.end() ; it++ ) {
-                    std::string ns  = *it       ;
+                for (auto ns : namespaces) {
                     std::string uri = nsDict[ns];
-                    xmlns.Add(ns,uri);
+                    xmlns.Add(ns, uri);
                 }
 
                 // add xmlns as Xmp.xmlns
-                root.Get("Xmp").AsObject().Add("xmlns",xmlns);
+                root.Get("Xmp").AsObject().Add("xmlns", xmlns);
             }
         }
     #endif

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -889,40 +889,42 @@ int main(int argc,const char* argv[])
             }
         }
 */
-        for ( size_t p = 0 ; p < gFiles.size() ; p++ ) {
-            std::string path  = gFiles[p] ;
-            std::string stamp ;
+        for (auto path : gFiles) {
+            std::string stamp;
             try {
-                time_t t       = readImageTime(path,&stamp) ;
-                Position* pPos = searchTimeDict(gTimeDict,t,Position::deltaMax_);
+                time_t t = readImageTime(path, &stamp);
+                Position* pPos = searchTimeDict(gTimeDict, t, Position::deltaMax_);
                 Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
-                if ( image.get() ) {
+                if (image.get()) {
                     image->readMetadata();
                     Exiv2::ExifData& exifData = image->exifData();
-                    if ( pPos ) {
-                        exifData["Exif.GPSInfo.GPSProcessingMethod" ] = "65 83 67 73 73 0 0 0 72 89 66 82 73 68 45 70 73 88"; // ASCII HYBRID-FIX
-                        exifData["Exif.GPSInfo.GPSVersionID"        ] = "2 2 0 0";
-                        exifData["Exif.GPSInfo.GPSMapDatum"         ] = "WGS-84";
+                    if (pPos) {
+                        exifData["Exif.GPSInfo.GPSProcessingMethod"] =
+                            "65 83 67 73 73 0 0 0 72 89 66 82 73 68 45 70 73 88";  // ASCII HYBRID-FIX
+                        exifData["Exif.GPSInfo.GPSVersionID"] = "2 2 0 0";
+                        exifData["Exif.GPSInfo.GPSMapDatum"] = "WGS-84";
 
-                        exifData["Exif.GPSInfo.GPSLatitude"         ] = Position::toExifString(pPos->lat(),true,true);
-                        exifData["Exif.GPSInfo.GPSLongitude"        ] = Position::toExifString(pPos->lon(),true,false);
-                        exifData["Exif.GPSInfo.GPSAltitude"         ] = Position::toExifString(pPos->ele());
+                        exifData["Exif.GPSInfo.GPSLatitude"] = Position::toExifString(pPos->lat(), true, true);
+                        exifData["Exif.GPSInfo.GPSLongitude"] = Position::toExifString(pPos->lon(), true, false);
+                        exifData["Exif.GPSInfo.GPSAltitude"] = Position::toExifString(pPos->ele());
 
-                        exifData["Exif.GPSInfo.GPSAltitudeRef"      ] = pPos->ele()<0.0?"1":"0";
-                        exifData["Exif.GPSInfo.GPSLatitudeRef"      ] = pPos->lat()>0?"N":"S";
-                        exifData["Exif.GPSInfo.GPSLongitudeRef"     ] = pPos->lon()>0?"E":"W";
+                        exifData["Exif.GPSInfo.GPSAltitudeRef"] = pPos->ele() < 0.0 ? "1" : "0";
+                        exifData["Exif.GPSInfo.GPSLatitudeRef"] = pPos->lat() > 0 ? "N" : "S";
+                        exifData["Exif.GPSInfo.GPSLongitudeRef"] = pPos->lon() > 0 ? "E" : "W";
 
-                        exifData["Exif.GPSInfo.GPSDateStamp"        ] = stamp;
-                        exifData["Exif.GPSInfo.GPSTimeStamp"        ] = Position::toExifTimeStamp(stamp);
-                        exifData["Exif.Image.GPSTag"                ] = 4908;
+                        exifData["Exif.GPSInfo.GPSDateStamp"] = stamp;
+                        exifData["Exif.GPSInfo.GPSTimeStamp"] = Position::toExifTimeStamp(stamp);
+                        exifData["Exif.Image.GPSTag"] = 4908;
 
-                        printf("%s %s % 2d\n",path.c_str(),pPos->toString().c_str(),pPos->delta());
+                        printf("%s %s % 2d\n", path.c_str(), pPos->toString().c_str(), pPos->delta());
                     } else {
-                        printf("%s *** not in time dict ***\n",path.c_str());
+                        printf("%s *** not in time dict ***\n", path.c_str());
                     }
-                    if ( !options.dryrun ) image->writeMetadata();
+                    if (!options.dryrun)
+                        image->writeMetadata();
                 }
-            } catch ( ... ) {};
+            } catch (...) {
+            };
         }
     }
 

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -25,17 +25,13 @@ try {
 
     Exiv2::PreviewManager loader(*image);
     Exiv2::PreviewPropertiesList list = loader.getPreviewProperties();
-    for (Exiv2::PreviewPropertiesList::iterator pos = list.begin(); pos != list.end(); pos++) {
-        std::cout << pos->mimeType_
-                  << " preview, type " << pos->id_ << ", "
-                  << pos->size_ << " bytes, "
-                  << pos->width_ << 'x' << pos->height_ << " pixels"
+    for (auto& pos : list) {
+        std::cout << pos.mimeType_ << " preview, type " << pos.id_ << ", " << pos.size_ << " bytes, " << pos.width_
+                  << 'x' << pos.height_ << " pixels"
                   << "\n";
 
-        Exiv2::PreviewImage preview = loader.getPreviewImage(*pos);
-        preview.writeFile(filename + "_"
-                          + Exiv2::toString(pos->width_) + "x"
-                          + Exiv2::toString(pos->height_));
+        Exiv2::PreviewImage preview = loader.getPreviewImage(pos);
+        preview.writeFile(filename + "_" + Exiv2::toString(pos.width_) + "x" + Exiv2::toString(pos.height_));
     }
 
     // Cleanup

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -52,29 +52,37 @@ int main()
 
     std::cout << std::endl;
 
-    for (unsigned int i = 0; i < EXV_COUNTOF(testcases); ++i) try {
-        std::string s(testcases[i]);
-        std::cout << std::setw(12) << std::left << s;
-        bool ok;
+    for (auto &testcase : testcases)
+        try {
+            std::string s(testcase);
+            std::cout << std::setw(12) << std::left << s;
+            bool ok;
 
-        long l = Exiv2::parseLong(s, ok);
-        std::cout << std::setw(12) << std::left;
-        if (ok) std::cout << l; else std::cout << "nok";
+            long l = Exiv2::parseLong(s, ok);
+            std::cout << std::setw(12) << std::left;
+            if (ok)
+                std::cout << l;
+            else
+                std::cout << "nok";
 
-        float f = Exiv2::parseFloat(s, ok);
-        std::cout << std::setw(12) << std::left;
-        if (ok) std::cout << f; else std::cout << "nok";
+            float f = Exiv2::parseFloat(s, ok);
+            std::cout << std::setw(12) << std::left;
+            if (ok)
+                std::cout << f;
+            else
+                std::cout << "nok";
 
-        Exiv2::Rational r = Exiv2::parseRational(s, ok);
-        if (ok) std::cout << r.first << "/" << r.second;
-        else std::cout << "nok";
+            Exiv2::Rational r = Exiv2::parseRational(s, ok);
+            if (ok)
+                std::cout << r.first << "/" << r.second;
+            else
+                std::cout << "nok";
 
-        std::cout << std::endl;
-    }
-    catch (Exiv2::AnyError& e) {
-        std::cout << "Caught Exiv2 exception '" << e << "'\n";
-        return -1;
-    }
+            std::cout << std::endl;
+        } catch (Exiv2::AnyError &e) {
+            std::cout << "Caught Exiv2 exception '" << e << "'\n";
+            return -1;
+        }
 
     return 0;
 }

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -31,18 +31,10 @@ try {
         error += ": No XMP properties found in the XMP packet";
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+    for (const auto& md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.value() << std::endl;
     }
     Exiv2::XmpParser::terminate();
     return 0;

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -33,18 +33,10 @@ try {
         error += ": No XMP properties found in the XMP packet";
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+    for (const auto& md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.value() << std::endl;
     }
     filename += "-new";
     std::cerr << "-----> Encoding XMP data to write to " << filename << " <-----\n";

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -44,19 +44,10 @@ int main(int argc, char** argv)
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
       }
 
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) 
-      {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+      for (const auto& md : xmpData) {
+          std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                    << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                    << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.value() << std::endl;
       }
 
     Exiv2::XmpParser::terminate();

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -193,18 +193,10 @@ try {
 
     // -------------------------------------------------------------------------
     // Output XMP properties
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-        md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+    for (const auto &md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.value() << std::endl;
     }
 
     // -------------------------------------------------------------------------

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -174,8 +174,8 @@ std::unique_ptr<Task> Task::clone() const {
 
     TaskFactory::~TaskFactory()
     {
-        for (auto it = registry_.begin(); it != registry_.end(); ++it) {
-            delete it->second;
+        for (auto& it : registry_) {
+            delete it.second;
         }
     }
 
@@ -490,8 +490,8 @@ std::unique_ptr<Task> Task::clone() const {
         bool noExif = false;
         if (Params::instance().printTags_ & Exiv2::mdExif) {
             const Exiv2::ExifData& exifData = image->exifData();
-            for (auto md = exifData.begin(); md != exifData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (const auto& md : exifData) {
+                ret |= printMetadatum(md, image);
             }
             if (exifData.empty())
                 noExif = true;
@@ -500,8 +500,8 @@ std::unique_ptr<Task> Task::clone() const {
         bool noIptc = false;
         if (Params::instance().printTags_ & Exiv2::mdIptc) {
             const Exiv2::IptcData& iptcData = image->iptcData();
-            for (auto md = iptcData.begin(); md != iptcData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (const auto& md : iptcData) {
+                ret |= printMetadatum(md, image);
             }
             if (iptcData.empty())
                 noIptc = true;
@@ -510,8 +510,8 @@ std::unique_ptr<Task> Task::clone() const {
         bool noXmp = false;
         if (Params::instance().printTags_ & Exiv2::mdXmp) {
             const Exiv2::XmpData& xmpData = image->xmpData();
-            for (auto md = xmpData.begin(); md != xmpData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (const auto& md : xmpData) {
+                ret |= printMetadatum(md, image);
             }
             if (xmpData.empty())
                 noXmp = true;
@@ -736,15 +736,15 @@ std::unique_ptr<Task> Task::clone() const {
         int cnt = 0;
         Exiv2::PreviewManager pm(*image);
         Exiv2::PreviewPropertiesList list = pm.getPreviewProperties();
-        for (auto pos = list.begin(); pos != list.end(); ++pos) {
+        for (auto& pos : list) {
             if (manyFiles) {
                 std::cout << std::setfill(' ') << std::left << std::setw(20) << path_ << "  ";
             }
-            std::cout << _("Preview") << " " << ++cnt << ": " << pos->mimeType_ << ", ";
-            if (pos->width_ != 0 && pos->height_ != 0) {
-                std::cout << pos->width_ << "x" << pos->height_ << " " << _("pixels") << ", ";
+            std::cout << _("Preview") << " " << ++cnt << ": " << pos.mimeType_ << ", ";
+            if (pos.width_ != 0 && pos.height_ != 0) {
+                std::cout << pos.width_ << "x" << pos.height_ << " " << _("pixels") << ", ";
             }
-            std::cout << pos->size_ << " " << _("bytes") << "\n";
+            std::cout << pos.size_ << " " << _("bytes") << "\n";
         }
         return 0;
     }
@@ -1047,19 +1047,19 @@ std::unique_ptr<Task> Task::clone() const {
         Exiv2::PreviewPropertiesList pvList = pvMgr.getPreviewProperties();
 
         const Params::PreviewNumbers& numbers = Params::instance().previewNumbers_;
-        for (auto n = numbers.cbegin(); n != numbers.cend(); ++n) {
-            if (*n == 0) {
+        for (int number : numbers) {
+            if (number == 0) {
                 // Write all previews
                 for (int num = 0; num < static_cast<int>(pvList.size()); ++num) {
                     writePreviewFile(pvMgr.getPreviewImage(pvList[num]), num + 1);
                 }
                 break;
             }
-            if (*n > static_cast<int>(pvList.size())) {
-                std::cerr << path_ << ": " << _("Image does not have preview") << " " << *n << "\n";
+            if (number > static_cast<int>(pvList.size())) {
+                std::cerr << path_ << ": " << _("Image does not have preview") << " " << number << "\n";
                 continue;
             }
-            writePreviewFile(pvMgr.getPreviewImage(pvList[*n - 1]), *n);
+            writePreviewFile(pvMgr.getPreviewImage(pvList[number - 1]), number);
         }
         return 0;
     }
@@ -1955,8 +1955,8 @@ namespace
                           << std::endl;
             }
             if (preserve) {
-                for (auto i = sourceImage->exifData().begin(); i != sourceImage->exifData().end(); ++i) {
-                    targetImage->exifData()[i->key()] = i->value();
+                for (auto& i : sourceImage->exifData()) {
+                    targetImage->exifData()[i.key()] = i.value();
                 }
             } else {
                 targetImage->setExifData(sourceImage->exifData());
@@ -1968,8 +1968,8 @@ namespace
                           << std::endl;
             }
             if (preserve) {
-                for (auto i = sourceImage->iptcData().begin(); i != sourceImage->iptcData().end(); ++i) {
-                    targetImage->iptcData()[i->key()] = i->value();
+                for (auto& i : sourceImage->iptcData()) {
+                    targetImage->iptcData()[i.key()] = i.value();
                 }
             } else {
                 targetImage->setIptcData(sourceImage->iptcData());
@@ -1994,8 +1994,8 @@ namespace
                 os.close();
                 rc = 0;
             } else if (preserve) {
-                for (auto i = sourceImage->xmpData().begin(); i != sourceImage->xmpData().end(); ++i) {
-                    targetImage->xmpData()[i->key()] = i->value();
+                for (auto& i : sourceImage->xmpData()) {
+                    targetImage->xmpData()[i.key()] = i.value();
                 }
             } else {
                 // std::cout << "long cut" << std::endl;

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -452,22 +452,20 @@ namespace Exiv2 {
 
     void Converter::cnvToXmp()
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
-            if (   (c.metadataId_ == mdExif && exifData_)
-                || (c.metadataId_ == mdIptc && iptcData_)) {
-                EXV_CALL_MEMBER_FN(*this, c.key1ToKey2_)(c.key1_, c.key2_);
+        for (const auto& c : conversion_) {
+            if ((c.metadataId_ == mdExif && exifData_) || (c.metadataId_ == mdIptc && iptcData_)) {
+                EXV_CALL_MEMBER_FN(*this, c.key1ToKey2_)
+                (c.key1_, c.key2_);
             }
         }
     }
 
     void Converter::cnvFromXmp()
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
-            if (   (c.metadataId_ == mdExif && exifData_)
-                || (c.metadataId_ == mdIptc && iptcData_)) {
-                EXV_CALL_MEMBER_FN(*this, c.key2ToKey1_)(c.key2_, c.key1_);
+        for (const auto& c : conversion_) {
+            if ((c.metadataId_ == mdExif && exifData_) || (c.metadataId_ == mdIptc && iptcData_)) {
+                EXV_CALL_MEMBER_FN(*this, c.key2ToKey1_)
+                (c.key2_, c.key1_);
             }
         }
     }
@@ -972,12 +970,13 @@ namespace Exiv2 {
             return;
         }
 
-        for (unsigned i = 0; i < value.length(); ++i) {
-            if (value[i] == '.') value[i] = ' ';
+        for (char& i : value) {
+            if (i == '.')
+                i = ' ';
         }
         (*exifData_)[to] = value;
-        if (erase_) xmpData_->erase(pos);
-
+        if (erase_)
+            xmpData_->erase(pos);
     }
 
     void Converter::cnvXmpFlash(const char* from, const char* to)
@@ -1178,27 +1177,30 @@ namespace Exiv2 {
         unsigned char digest[16];
 
         MD5Init ( &context );
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
+        for (const auto& c : conversion_) {
             if (c.metadataId_ == mdExif) {
                 Exiv2::ExifKey key(c.key1_);
-                if (tiff && key.groupName() != "Image") continue;
-                if (!tiff && key.groupName() == "Image") continue;
+                if (tiff && key.groupName() != "Image")
+                    continue;
+                if (!tiff && key.groupName() == "Image")
+                    continue;
 
-                if (!res.str().empty()) res << ',';
+                if (!res.str().empty())
+                    res << ',';
                 res << key.tag();
                 Exiv2::ExifData::iterator pos = exifData_->findKey(key);
-                if (pos == exifData_->end()) continue;
+                if (pos == exifData_->end())
+                    continue;
                 DataBuf data(pos->size());
                 pos->copy(data.pData_, littleEndian /* FIXME ? */);
-                MD5Update ( &context, data.pData_, (uint32_t)data.size_);
+                MD5Update(&context, data.pData_, (uint32_t)data.size_);
             }
         }
         MD5Final(digest, &context);
         res << ';';
         res << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
-        for (int i = 0; i < 16; ++i) {
-            res << static_cast<int>(digest[i]);
+        for (unsigned char i : digest) {
+            res << static_cast<int>(i);
         }
         return res.str();
     }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -173,14 +173,11 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -172,10 +172,8 @@ namespace Exiv2 {
 
     CiffDirectory::~CiffDirectory()
     {
-        Components::iterator b = components_.begin();
-        Components::iterator e = components_.end();
-        for (Components::iterator i = b; i != e; ++i) {
-            delete *i;
+        for (auto& component : components_) {
+            delete component;
         }
     }
 
@@ -343,10 +341,8 @@ namespace Exiv2 {
 
     void CiffDirectory::doDecode(Image& image, ByteOrder byteOrder) const
     {
-        Components::const_iterator b = components_.begin();
-        Components::const_iterator e = components_.end();
-        for (Components::const_iterator i = b; i != e; ++i) {
-            (*i)->decode(image, byteOrder);
+        for (const auto& component : components_) {
+            component->decode(image, byteOrder);
         }
     } // CiffDirectory::doDecode
 
@@ -429,10 +425,8 @@ namespace Exiv2 {
         uint32_t dirOffset = 0;
 
         // Value data
-        const Components::iterator b = components_.begin();
-        const Components::iterator e = components_.end();
-        for (Components::iterator i = b; i != e; ++i) {
-            dirOffset = (*i)->write(blob, byteOrder, dirOffset);
+        for (auto& component : components_) {
+            dirOffset = component->write(blob, byteOrder, dirOffset);
         }
         const uint32_t dirStart = dirOffset;
 
@@ -443,8 +437,8 @@ namespace Exiv2 {
         dirOffset += 2;
 
         // Directory entries
-        for (Components::iterator i = b; i != e; ++i) {
-            (*i)->writeDirEntry(blob, byteOrder);
+        for (auto& component : components_) {
+            component->writeDirEntry(blob, byteOrder);
             dirOffset += 10;
         }
 
@@ -549,10 +543,8 @@ namespace Exiv2 {
                                 const std::string& prefix) const
     {
         CiffComponent::doPrint(os, byteOrder, prefix);
-        Components::const_iterator b = components_.begin();
-        Components::const_iterator e = components_.end();
-        for (Components::const_iterator i = b; i != e; ++i) {
-            (*i)->print(os, byteOrder, prefix + "   ");
+        for (const auto& component : components_) {
+            component->print(os, byteOrder, prefix + "   ");
         }
     } // CiffDirectory::doPrint
 
@@ -627,11 +619,10 @@ namespace Exiv2 {
                                                   uint16_t crwDir) const
     {
         CiffComponent* cc = nullptr;
-        const Components::const_iterator b = components_.begin();
-        const Components::const_iterator e = components_.end();
-        for (Components::const_iterator i = b; i != e; ++i) {
-            cc = (*i)->findComponent(crwTagId, crwDir);
-            if (cc) return cc;
+        for (const auto& component : components_) {
+            cc = component->findComponent(crwTagId, crwDir);
+            if (cc)
+                return cc;
         }
         return nullptr;
     } // CiffDirectory::doFindComponent
@@ -675,16 +666,13 @@ namespace Exiv2 {
               if not found, create it
               set value
         */
-        const Components::iterator b = components_.begin();
-        const Components::iterator e = components_.end();
-
         if (!crwDirs.empty()) {
             CrwSubDir csd = crwDirs.top();
             crwDirs.pop();
             // Find the directory
-            for (Components::iterator i = b; i != e; ++i) {
-                if ((*i)->tag() == csd.crwDir_) {
-                    cc_ = *i;
+            for (const auto& component : components_) {
+                if (component->tag() == csd.crwDir_) {
+                    cc_ = component;
                     break;
                 }
             }
@@ -696,12 +684,11 @@ namespace Exiv2 {
             }
             // Recursive call to next lower level directory
             cc_ = cc_->add(crwDirs, crwTagId);
-        }
-        else {
+        } else {
             // Find the tag
-            for (Components::iterator i = b; i != e; ++i) {
-                if ((*i)->tagId() == crwTagId) {
-                    cc_ = *i;
+            for (const auto& component : components_) {
+                if (component->tagId() == crwTagId) {
+                    cc_ = component;
                     break;
                 }
             }

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -574,10 +574,8 @@ namespace Exiv2 {
 
     void IptcDataSets::dataSetList(std::ostream& os)
     {
-        const int count = sizeof(records_)/sizeof(records_[0]);
-        for (int i=0; i < count; ++i) {
-            const DataSet *record = records_[i];
-            for (int j=0; record != nullptr && record[j].number_ != 0xffff; ++j) {
+        for (auto record : records_) {
+            for (int j = 0; record != nullptr && record[j].number_ != 0xffff; ++j) {
                 os << record[j] << "\n";
             }
         }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -667,8 +667,8 @@ namespace Exiv2 {
             "Exif.Canon.AFPointsSelected",
             "Exif.Canon.AFPrimaryPoint",
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfd0Tags); ++i) {
-            ExifData::iterator pos = ed.findKey(ExifKey(filteredIfd0Tags[i]));
+        for (auto& filteredIfd0Tag : filteredIfd0Tags) {
+            ExifData::iterator pos = ed.findKey(ExifKey(filteredIfd0Tag));
             if (pos != ed.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Warning: Exif tag " << pos->key() << " not encoded\n";
@@ -678,26 +678,14 @@ namespace Exiv2 {
         }
 
         // Delete IFDs which do not occur in JPEGs
-        static const IfdId filteredIfds[] = {
-            subImage1Id,
-            subImage2Id,
-            subImage3Id,
-            subImage4Id,
-            subImage5Id,
-            subImage6Id,
-            subImage7Id,
-            subImage8Id,
-            subImage9Id,
-            subThumb1Id,
-            panaRawId,
-            ifd2Id,
-            ifd3Id
-        };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        static const IfdId filteredIfds[] = {subImage1Id, subImage2Id, subImage3Id, subImage4Id, subImage5Id,
+                                             subImage6Id, subImage7Id, subImage8Id, subImage9Id, subThumb1Id,
+                                             panaRawId,   ifd2Id,      ifd3Id};
+        for (auto filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            eraseIfd(ed, filteredIfds[i]);
+            eraseIfd(ed, filteredIfd);
         }
 
         // IPTC and XMP are stored elsewhere, not in the Exif APP1 segment.
@@ -759,22 +747,22 @@ namespace Exiv2 {
         };
         bool delTags = false;
         ExifData::iterator pos;
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredPvTags); ++i) {
-            switch (filteredPvTags[i].ptt_) {
-            case pttLen:
-                delTags = false;
-                pos = ed.findKey(ExifKey(filteredPvTags[i].key_));
-                if (pos != ed.end() && sumToLong(*pos) > 32768) {
-                    delTags = true;
+        for (auto filteredPvTag : filteredPvTags) {
+            switch (filteredPvTag.ptt_) {
+                case pttLen:
+                    delTags = false;
+                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
+                    if (pos != ed.end() && sumToLong(*pos) > 32768) {
+                        delTags = true;
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Exif tag " << pos->key() << " not encoded\n";
 #endif
                     ed.erase(pos);
-                }
-                break;
+                    }
+                    break;
             case pttTag:
                 if (delTags) {
-                    pos = ed.findKey(ExifKey(filteredPvTags[i].key_));
+                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
                     if (pos != ed.end()) {
 #ifndef SUPPRESS_WARNINGS
                         EXV_WARNING << "Exif tag " << pos->key() << " not encoded\n";
@@ -786,16 +774,16 @@ namespace Exiv2 {
             case pttIfd:
                 if (delTags) {
 #ifndef SUPPRESS_WARNINGS
-                    EXV_WARNING << "Exif IFD " << filteredPvTags[i].key_ << " not encoded\n";
+                    EXV_WARNING << "Exif IFD " << filteredPvTag.key_ << " not encoded\n";
 #endif
-                    eraseIfd(ed, Internal::groupId(filteredPvTags[i].key_));
+                    eraseIfd(ed, Internal::groupId(filteredPvTag.key_));
                 }
                 break;
             }
         }
 
         // Delete unknown tags larger than 4kB and known tags larger than 20kB.
-        for (ExifData::iterator tag_iter = ed.begin(); tag_iter != ed.end(); ) {
+        for (ExifData::iterator tag_iter = ed.begin(); tag_iter != ed.end();) {
             if ( (tag_iter->size() > 4096 && tag_iter->tagName().substr(0, 2) == "0x") ||
                   tag_iter->size() > 20480) {
 #ifndef SUPPRESS_WARNINGS
@@ -890,10 +878,10 @@ namespace {
     {
         Exiv2::ExifData thumb;
         // Copy all Thumbnail (IFD1) tags from exifData to Image (IFD0) tags in thumb
-        for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != exifData.end(); ++i) {
-            if (i->groupName() == "Thumbnail") {
-                std::string key = "Exif.Image." + i->tagName();
-                thumb.add(Exiv2::ExifKey(key), &i->value());
+        for (const auto& i : exifData) {
+            if (i.groupName() == "Thumbnail") {
+                std::string key = "Exif.Image." + i.tagName();
+                thumb.add(Exiv2::ExifKey(key), &i.value());
             }
         }
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -72,12 +72,12 @@ int main(int argc, char* const argv[])
         int n = 1;
         int s = static_cast<int>(params.files_.size());
         int w = s > 9 ? s > 99 ? 3 : 2 : 1;
-        for (Params::Files::const_iterator i = params.files_.begin(); i != params.files_.end(); ++i) {
+        for (const auto& file : params.files_) {
             if (params.verbose_) {
-                std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << s << ": " << *i
+                std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << s << ": " << file
                           << std::endl;
             }
-            int ret = task->run(*i);
+            int ret = task->run(file);
             if (rc == EXIT_SUCCESS)
                 rc = ret;
         }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -112,9 +112,10 @@ namespace Exiv2 {
                           long        sizePsData)
     {
         if (sizePsData < 4) return false;
-        for (size_t i = 0; i < (sizeof irbId_) / (sizeof *irbId_); i++) {
-            assert(strlen(irbId_[i]) == 4);
-            if (memcmp(pPsData, irbId_[i], 4) == 0) return true;
+        for (auto& i : irbId_) {
+            assert(strlen(i) == 4);
+            if (memcmp(pPsData, i, 4) == 0)
+                return true;
         }
         return false;
     }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -112,12 +112,8 @@ namespace Exiv2 {
                           long        sizePsData)
     {
         if (sizePsData < 4) return false;
-        for (auto& i : irbId_) {
-            assert(strlen(i) == 4);
-            if (memcmp(pPsData, i, 4) == 0)
-                return true;
-        }
-        return false;
+        return std::any_of(std::begin(irbId_), std::end(irbId_),
+                           [=](const char* irb) { return (strlen(irb) == 4) && memcmp(pPsData, irb, 4) == 0; });
     }
 
     bool Photoshop::valid(const byte* pPsData,

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -185,27 +185,16 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
-        return TiffParserWorker::encode(io,
-                                        pData,
-                                        size,
-                                        ed,
-                                        iptcData,
-                                        xmpData,
-                                        Tag::root,
-                                        TiffMapping::findEncoder,
-                                        header.get(),
-                                        nullptr);
+        return TiffParserWorker::encode(io, pData, size, ed, iptcData, xmpData, Tag::root, TiffMapping::findEncoder,
+                                        header.get(), nullptr);
     }
 
     // *************************************************************************

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -615,8 +615,8 @@ int Params::evalPrintFlags(const std::string& optarg)
         case Action::none:
             action_ = Action::print;
             printMode_ = pmList;
-            for (std::size_t i = 0; i < optarg.length(); ++i) {
-                switch (optarg[i]) {
+            for (char i : optarg) {
+                switch (i) {
                     case 'E':
                         printTags_ |= Exiv2::mdExif;
                         break;
@@ -663,7 +663,7 @@ int Params::evalPrintFlags(const std::string& optarg)
                         printItems_ |= prSet | prValue;
                         break;
                     default:
-                        std::cerr << progname() << ": " << _("Unrecognized print item") << " `" << optarg[i] << "'\n";
+                        std::cerr << progname() << ": " << _("Unrecognized print item") << " `" << i << "'\n";
                         rc = 1;
                         break;
                 }
@@ -1285,9 +1285,9 @@ namespace
     {
         try {
             int num = 0;
-            for (auto line = cmdLines.cbegin(); line != cmdLines.cend(); ++line) {
+            for (const auto& cmdLine : cmdLines) {
                 ModifyCmd modifyCmd;
-                if (parseLine(modifyCmd, *line, ++num)) {
+                if (parseLine(modifyCmd, cmdLine, ++num)) {
                     modifyCmds.push_back(modifyCmd);
                 }
             }

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -152,8 +152,8 @@ namespace Exiv2
         static int value[256];
         static bool bFirst = true;
         if (bFirst) {
-            for (int i = 0; i < 256; i++)
-                value[i] = 0;
+            for (int& i : value)
+                i = 0;
             for (int i = 0; i < 16; i++) {
                 value[tolower(hexdigits[i])] = i + 1;
                 value[toupper(hexdigits[i])] = i + 1;

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -765,23 +765,23 @@ namespace {
         ExifData preview;
 
         // copy tags
-        for (ExifData::const_iterator pos = exifData.begin(); pos != exifData.end(); ++pos) {
-            if (pos->groupName() == group_) {
+        for (const auto &pos : exifData) {
+            if (pos.groupName() == group_) {
                 /*
-                   Write only the necessary TIFF image tags
-                   tags that especially could cause problems are:
-                   "NewSubfileType" - the result is no longer a thumbnail, it is a standalone image
-                   "Orientation" - this tag typically appears only in the "Image" group. Deleting it ensures
-                                   consistent result for all previews, including JPEG
-                */
-                uint16_t tag = pos->tag();
+                       Write only the necessary TIFF image tags
+                       tags that especially could cause problems are:
+                       "NewSubfileType" - the result is no longer a thumbnail, it is a standalone image
+                       "Orientation" - this tag typically appears only in the "Image" group. Deleting it ensures
+                                       consistent result for all previews, including JPEG
+                    */
+                uint16_t tag = pos.tag();
                 if (tag != 0x00fe && tag != 0x00ff && Internal::isTiffImageTag(tag, Internal::ifd0Id)) {
-                    preview.add(ExifKey(tag, "Image"), &pos->value());
+                    preview.add(ExifKey(tag, "Image"), &pos.value());
                 }
             }
         }
 
-        Value &dataValue = const_cast<Value&>(preview["Exif.Image." + offsetTag_].value());
+        Value &dataValue = const_cast<Value &>(preview["Exif.Image." + offsetTag_].value());
 
         if (dataValue.sizeDataArea() == 0) {
             // image data are not available via exifData, read them from image_.io()
@@ -897,9 +897,12 @@ namespace {
         // create decoding table
         byte invalid = 16;
         byte decodeHexTable[256];
-        for (long i = 0; i < 256; i++) decodeHexTable[i] = invalid;
-        for (byte i = 0; i < 10; i++) decodeHexTable[static_cast<byte>('0') + i] = i;
-        for (byte i = 0; i < 6; i++) decodeHexTable[static_cast<byte>('A') + i] = i + 10;
+        for (unsigned char &i : decodeHexTable)
+            i = invalid;
+        for (byte i = 0; i < 10; i++)
+            decodeHexTable[static_cast<byte>('0') + i] = i;
+        for (byte i = 0; i < 6; i++)
+            decodeHexTable[static_cast<byte>('A') + i] = i + 10;
         for (byte i = 0; i < 6; i++) decodeHexTable[static_cast<byte>('a') + i] = i + 10;
 
         // calculate dest size
@@ -935,8 +938,8 @@ namespace {
         // create decoding table
         unsigned long invalid = 64;
         unsigned long decodeBase64Table[256] = {};
-        for (unsigned long i = 0; i < 256; i++)
-            decodeBase64Table[i] = invalid;
+        for (unsigned long &i : decodeBase64Table)
+            i = invalid;
         for (unsigned long i = 0; i < 64; i++)
             decodeBase64Table[(unsigned char)encodeBase64Table[i]] = i;
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2660,8 +2660,8 @@ namespace Exiv2 {
 
     void XmpProperties::registeredNamespaces(Exiv2::Dictionary& nsDict)
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(xmpNsInfo); ++i) {
-             Exiv2::XmpParser::registerNs(xmpNsInfo[i].ns_,xmpNsInfo[i].prefix_);
+        for (const auto& i : xmpNsInfo) {
+            Exiv2::XmpParser::registerNs(i.ns_, i.prefix_);
         }
         Exiv2::XmpParser::registeredNamespaces(nsDict);
     }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2492,9 +2492,9 @@ namespace Exiv2 {
 
     const XmpNsInfo* XmpProperties::lookupNsRegistryUnsafe(const XmpNsInfo::Prefix& prefix)
     {
-        for (NsRegistry::const_iterator i = nsRegistry_.begin();
-             i != nsRegistry_.end(); ++i) {
-            if (i->second == prefix) return &(i->second);
+        for (const auto& ns : nsRegistry_) {
+            if (ns.second == prefix)
+                return &(ns.second);
         }
         return nullptr;
     }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -200,8 +200,8 @@ namespace Exiv2 {
             "Exif.Image.PrintImageMatching",
             "Exif.Image.YCbCrPositioning"
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredTags); ++i) {
-            ExifData::iterator pos = prevData.findKey(ExifKey(filteredTags[i]));
+        for (auto& filteredTag : filteredTags) {
+            ExifData::iterator pos = prevData.findKey(ExifKey(filteredTag));
             if (pos != prevData.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Exif tag " << pos->key() << " removed\n";

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2891,9 +2891,11 @@ namespace Exiv2 {
         if (stringValue[19] == 'Z') {
             stringValue = stringValue.substr(0, 19);
         }
-        for (unsigned int i = 0; i < stringValue.length(); ++i) {
-            if (stringValue[i] == 'T') stringValue[i] = ' ';
-            if (stringValue[i] == '-') stringValue[i] = ':';
+        for (char& i : stringValue) {
+            if (i == 'T')
+                i = ' ';
+            if (i == '-')
+                i = ':';
         }
 
         return os << stringValue;

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -180,16 +180,16 @@ namespace Exiv2 {
 
     TiffDirectory::~TiffDirectory()
     {
-        for (Components::iterator i = components_.begin(); i != components_.end(); ++i) {
-            delete *i;
+        for (auto& component : components_) {
+            delete component;
         }
         delete pNext_;
     }
 
     TiffSubIfd::~TiffSubIfd()
     {
-        for (Ifds::iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            delete *i;
+        for (auto& ifd : ifds_) {
+            delete ifd;
         }
     }
 
@@ -223,8 +223,8 @@ namespace Exiv2 {
 
     TiffBinaryArray::~TiffBinaryArray()
     {
-        for (Components::iterator i = elements_.begin(); i != elements_.end(); ++i) {
-            delete *i;
+        for (auto& element : elements_) {
+            delete element;
         }
     }
 
@@ -651,9 +651,9 @@ namespace Exiv2 {
                 tc = pNext_;
             }
             else {
-                for (Components::iterator i = components_.begin(); i != components_.end(); ++i) {
-                    if ((*i)->tag() == tpi.tag() && (*i)->group() == tpi.group()) {
-                        tc = *i;
+                for (auto& component : components_) {
+                    if (component->tag() == tpi.tag() && component->group() == tpi.group()) {
+                        tc = component;
                         break;
                     }
                 }
@@ -699,17 +699,16 @@ namespace Exiv2 {
         const TiffPathItem tpi2 = tiffPath.top();
         tiffPath.push(tpi1);
         TiffComponent* tc = nullptr;
-        for (Ifds::iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            if ((*i)->group() == tpi2.group()) {
-                tc = *i;
+        for (auto& ifd : ifds_) {
+            if (ifd->group() == tpi2.group()) {
+                tc = ifd;
                 break;
             }
         }
         if (tc == nullptr) {
             if (tiffPath.size() == 1 && object.get() != nullptr) {
                 tc = addChild(std::move(object));
-            }
-            else {
+            } else {
                 TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
                 tc = addChild(std::move(atc));
             }
@@ -767,9 +766,9 @@ namespace Exiv2 {
         // To allow duplicate entries, we only check if the new component already
         // exists if there is still at least one composite tag on the stack
         if (tiffPath.size() > 1) {
-            for (Components::iterator i = elements_.begin(); i != elements_.end(); ++i) {
-                if ((*i)->tag() == tpi.tag() && (*i)->group() == tpi.group()) {
-                    tc = *i;
+            for (auto& element : elements_) {
+                if (element->tag() == tpi.tag() && element->group() == tpi.group()) {
+                    tc = element;
                     break;
                 }
             }
@@ -1104,16 +1103,16 @@ namespace Exiv2 {
         // Size of IFD values and additional data
         uint32_t sizeValue = 0;
         uint32_t sizeData = 0;
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            uint32_t sv = (*i)->size();
+        for (auto component : components_) {
+            uint32_t sv = component->size();
             if (sv > 4) {
-                sv += sv & 1;               // Align value to word boundary
+                sv += sv & 1;  // Align value to word boundary
                 sizeValue += sv;
             }
             // Also add the size of data, but only if needed
             if (isRootDir) {
-                uint32_t sd = (uint32_t)(*i)->sizeData();
-                sd += sd & 1;               // Align data to word boundary
+                uint32_t sd = (uint32_t)component->sizeData();
+                sd += sd & 1;  // Align data to word boundary
                 sizeData += sd;
             }
         }
@@ -1132,15 +1131,15 @@ namespace Exiv2 {
         ioWrapper.write(buf, 2);
         idx += 2;
         // b) Directory entries - may contain pointers to the value or data
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            idx += writeDirEntry(ioWrapper, byteOrder, offset, *i, valueIdx, dataIdx, imageIdx);
-            uint32_t sv = (*i)->size();
+        for (auto component : components_) {
+            idx += writeDirEntry(ioWrapper, byteOrder, offset, component, valueIdx, dataIdx, imageIdx);
+            uint32_t sv = component->size();
             if (sv > 4) {
-                sv += sv & 1;               // Align value to word boundary
+                sv += sv & 1;  // Align value to word boundary
                 valueIdx += sv;
             }
-            uint32_t sd = (uint32_t)(*i)->sizeData();
-            sd += sd & 1;                   // Align data to word boundary
+            uint32_t sd = (uint32_t)component->sizeData();
+            sd += sd & 1;  // Align data to word boundary
             dataIdx += sd;
         }
         // c) Pointer to the next IFD
@@ -1157,20 +1156,20 @@ namespace Exiv2 {
         // 2nd: Write IFD values - may contain pointers to additional data
         valueIdx = sizeDir;
         dataIdx = sizeDir + sizeValue;
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            uint32_t sv = (*i)->size();
+        for (auto component : components_) {
+            uint32_t sv = component->size();
             if (sv > 4) {
-                uint32_t d = (*i)->write(ioWrapper, byteOrder, offset, valueIdx, dataIdx, imageIdx);
+                uint32_t d = component->write(ioWrapper, byteOrder, offset, valueIdx, dataIdx, imageIdx);
                 enforce(sv == d, kerImageWriteFailed);
                 if ((sv & 1) == 1) {
-                    ioWrapper.putb(0x0);    // Align value to word boundary
+                    ioWrapper.putb(0x0);  // Align value to word boundary
                     sv += 1;
                 }
                 idx += sv;
                 valueIdx += sv;
             }
-            uint32_t sd = (uint32_t)(*i)->sizeData();
-            sd += sd & 1;                   // Align data to word boundary
+            uint32_t sd = (uint32_t)component->sizeData();
+            sd += sd & 1;  // Align data to word boundary
             dataIdx += sd;
         }
         assert(idx == sizeDir + sizeValue);
@@ -1310,13 +1309,13 @@ namespace Exiv2 {
         DataBuf buf(static_cast<long>(strips_.size()) * 4);
         memset(buf.pData_, 0x0, buf.size_);
         uint32_t idx = 0;
-        for (Strips::const_iterator i = strips_.begin(); i != strips_.end(); ++i) {
+        for (const auto& strip : strips_) {
             idx += writeOffset(buf.pData_ + idx, o2, tiffType(), byteOrder);
-            o2 += i->second;
-            o2 += i->second & 1;                // Align strip data to word boundary
-            if (!(group() > mnId)) {            // Todo: FIX THIS!! SHOULDN'T USE >
-                imageIdx += i->second;
-                imageIdx += i->second & 1;      // Align strip data to word boundary
+            o2 += strip.second;
+            o2 += strip.second & 1;   // Align strip data to word boundary
+            if (!(group() > mnId)) {  // Todo: FIX THIS!! SHOULDN'T USE >
+                imageIdx += strip.second;
+                imageIdx += strip.second & 1;  // Align strip data to word boundary
             }
         }
         ioWrapper.write(buf.pData_, buf.size_);
@@ -1334,9 +1333,9 @@ namespace Exiv2 {
         uint32_t idx = 0;
         // Sort IFDs by group, needed if image data tags were copied first
         std::sort(ifds_.begin(), ifds_.end(), cmpGroupLt);
-        for (Ifds::const_iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
+        for (auto ifd : ifds_) {
             idx += writeOffset(buf.pData_ + idx, offset + dataIdx, tiffType(), byteOrder);
-            dataIdx += (*i)->size();
+            dataIdx += ifd->size();
         }
         ioWrapper.write(buf.pData_, buf.size_);
         return (uint32_t)buf.size_;
@@ -1408,12 +1407,13 @@ namespace Exiv2 {
             mioWrapper.write(buf, elSize);
         }
         // write all tags of the array (Todo: assumes that there are no duplicates, need check)
-        for (Components::const_iterator i = elements_.begin(); i != elements_.end(); ++i) {
+        for (auto element : elements_) {
             // Skip the manufactured tag, if it exists
-            if (cfg()->hasSize_ && (*i)->tag() == 0) continue;
-            uint32_t newIdx = (*i)->tag() * cfg()->tagStep();
+            if (cfg()->hasSize_ && element->tag() == 0)
+                continue;
+            uint32_t newIdx = element->tag() * cfg()->tagStep();
             idx += fillGap(mioWrapper, idx, newIdx);
-            idx += (*i)->write(mioWrapper, byteOrder, offset + newIdx, valueIdx, dataIdx, imageIdx);
+            idx += element->write(mioWrapper, byteOrder, offset + newIdx, valueIdx, dataIdx, imageIdx);
         }
         if (cfg()->hasFillers_ && def()) {
             const ArrayDef* lastDef = def() + defSize() - 1;
@@ -1465,8 +1465,8 @@ namespace Exiv2 {
                                         uint32_t& imageIdx) const
     {
         uint32_t len = 0;
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            len += (*i)->writeData(ioWrapper, byteOrder, offset, dataIdx + len, imageIdx);
+        for (auto component : components_) {
+            len += component->writeData(ioWrapper, byteOrder, offset, dataIdx + len, imageIdx);
         }
         return len;
     } // TiffDirectory::doWriteData
@@ -1518,8 +1518,8 @@ namespace Exiv2 {
                                      uint32_t& imageIdx) const
     {
         uint32_t len = 0;
-        for (Ifds::const_iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            len  += (*i)->write(ioWrapper, byteOrder, offset + dataIdx + len, uint32_t(-1), uint32_t(-1), imageIdx);
+        for (auto ifd : ifds_) {
+            len += ifd->write(ioWrapper, byteOrder, offset + dataIdx + len, uint32_t(-1), uint32_t(-1), imageIdx);
         }
         // Align data to word boundary
         uint32_t align = (len & 1);
@@ -1549,14 +1549,14 @@ namespace Exiv2 {
     {
         uint32_t len = 0;
         TiffComponent* pSubIfd = nullptr;
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            if ((*i)->tag() == 0x014a) {
+        for (auto component : components_) {
+            if (component->tag() == 0x014a) {
                 // Hack: delay writing of sub-IFD image data to get the order correct
                 assert(pSubIfd == nullptr);
-                pSubIfd = *i;
+                pSubIfd = component;
                 continue;
             }
-            len += (*i)->writeImage(ioWrapper, byteOrder);
+            len += component->writeImage(ioWrapper, byteOrder);
         }
         if (pSubIfd) {
             len += pSubIfd->writeImage(ioWrapper, byteOrder);
@@ -1577,8 +1577,8 @@ namespace Exiv2 {
                                       ByteOrder byteOrder) const
     {
         uint32_t len = 0;
-        for (Ifds::const_iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            len  += (*i)->writeImage(ioWrapper, byteOrder);
+        for (auto ifd : ifds_) {
+            len += ifd->writeImage(ioWrapper, byteOrder);
         }
         return len;
     } // TiffSubIfd::doWriteImage
@@ -1620,11 +1620,12 @@ namespace Exiv2 {
                       << ": Writing " << strips_.size() << " strips";
 #endif
             len = 0;
-            for (Strips::const_iterator i = strips_.begin(); i != strips_.end(); ++i) {
-                ioWrapper.write(i->first, i->second);
-                len += i->second;
-                uint32_t align = i->second & 1; // Align strip data to word boundary
-                if (align) ioWrapper.putb(0x0);
+            for (const auto& strip : strips_) {
+                ioWrapper.write(strip.first, strip.second);
+                len += strip.second;
+                uint32_t align = strip.second & 1;  // Align strip data to word boundary
+                if (align)
+                    ioWrapper.putb(0x0);
                 len += align;
             }
         }
@@ -1645,14 +1646,14 @@ namespace Exiv2 {
         // Size of the directory, without values and additional data
         uint32_t len = 2 + 12 * compCount + (hasNext_ ? 4 : 0);
         // Size of IFD values and data
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            uint32_t sv = (*i)->size();
+        for (auto component : components_) {
+            uint32_t sv = component->size();
             if (sv > 4) {
-                sv += sv & 1;               // Align value to word boundary
+                sv += sv & 1;  // Align value to word boundary
                 len += sv;
             }
-            uint32_t sd = (uint32_t)(*i)->sizeData();
-            sd += sd & 1;                   // Align data to word boundary
+            uint32_t sd = (uint32_t)component->sizeData();
+            sd += sd & 1;  // Align data to word boundary
             len += sd;
         }
         // Size of next-IFD, if any
@@ -1705,10 +1706,10 @@ namespace Exiv2 {
         // - no duplicate tags in the array
         uint32_t idx = 0;
         uint32_t sz = cfg()->tagStep();
-        for (Components::const_iterator i = elements_.begin(); i != elements_.end(); ++i) {
-            if ((*i)->tag() > idx) {
-                idx = (*i)->tag();
-                sz = (*i)->size();
+        for (auto element : elements_) {
+            if (element->tag() > idx) {
+                idx = element->tag();
+                sz = element->size();
             }
         }
         idx = idx * cfg()->tagStep() + sz;
@@ -1764,8 +1765,8 @@ namespace Exiv2 {
     size_t TiffSubIfd::doSizeData() const
     {
         uint32_t len = 0;
-        for (Ifds::const_iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            len += (*i)->size();
+        for (auto ifd : ifds_) {
+            len += ifd->size();
         }
         return len;
     } // TiffSubIfd::doSizeData
@@ -1784,8 +1785,8 @@ namespace Exiv2 {
     uint32_t TiffDirectory::doSizeImage() const
     {
         uint32_t len = 0;
-        for (Components::const_iterator i = components_.begin(); i != components_.end(); ++i) {
-            len += (*i)->sizeImage();
+        for (auto component : components_) {
+            len += component->sizeImage();
         }
         if (pNext_) {
             len += pNext_->sizeImage();
@@ -1796,8 +1797,8 @@ namespace Exiv2 {
     uint32_t TiffSubIfd::doSizeImage() const
     {
         uint32_t len = 0;
-        for (Ifds::const_iterator i = ifds_.begin(); i != ifds_.end(); ++i) {
-            len += (*i)->sizeImage();
+        for (auto ifd : ifds_) {
+            len += ifd->sizeImage();
         }
         return len;
     } // TiffSubIfd::doSizeImage
@@ -1817,8 +1818,8 @@ namespace Exiv2 {
         if (!pValue()) return 0;
         uint32_t len = (uint32_t)pValue()->sizeDataArea();
         if (len == 0) {
-            for (Strips::const_iterator i = strips_.begin(); i != strips_.end(); ++i) {
-                len += i->second;
+            for (const auto& strip : strips_) {
+                len += strip.second;
             }
         }
         return len;

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -123,14 +123,15 @@ namespace Exiv2 {
         };
         // Find the group of the primary image, default to "Image"
         primaryGroup_ = std::string("Image");
-        for (unsigned int i = 0; i < EXV_COUNTOF(keys); ++i) {
-            ExifData::const_iterator md = exifData_.findKey(ExifKey(keys[i]));
+        for (auto& i : keys) {
+            ExifData::const_iterator md = exifData_.findKey(ExifKey(i));
             // Is it the primary image?
             if (md != exifData_.end() && md->count() > 0 && md->toLong() == 0) {
                 // Sometimes there is a JPEG primary image; that's not our first choice
                 primaryGroup_ = md->groupName();
                 std::string key = "Exif." + primaryGroup_ + ".JPEGInterchangeFormat";
-                if (exifData_.findKey(ExifKey(key)) == exifData_.end()) break;
+                if (exifData_.findKey(ExifKey(key)) == exifData_.end())
+                    break;
             }
         }
         return primaryGroup_;
@@ -282,27 +283,16 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
-        return TiffParserWorker::encode(io,
-                                        pData,
-                                        size,
-                                        ed,
-                                        iptcData,
-                                        xmpData,
-                                        Tag::root,
-                                        TiffMapping::findEncoder,
-                                        header.get(),
-                                        nullptr);
+        return TiffParserWorker::encode(io, pData, size, ed, iptcData, xmpData, Tag::root, TiffMapping::findEncoder,
+                                        header.get(), nullptr);
     } // TiffParser::encode
 
     // *************************************************************************

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1752,8 +1752,8 @@ namespace Exiv2 {
             subImage9Id
         };
 
-        for (unsigned int i = 0; i < EXV_COUNTOF(imageGroups); ++i) {
-            TiffFinder finder(0x00fe, imageGroups[i]);
+        for (auto imageGroup : imageGroups) {
+            TiffFinder finder(0x00fe, imageGroup);
             pSourceDir->accept(finder);
             TiffEntryBase* te = dynamic_cast<TiffEntryBase*>(finder.result());
             const Value* pV = te != nullptr ? te->pValue() : nullptr;
@@ -2015,10 +2015,10 @@ namespace Exiv2 {
 
     void OffsetWriter::writeOffsets(BasicIo& io) const
     {
-        for (OffsetList::const_iterator it = offsetList_.begin(); it != offsetList_.end(); ++it) {
-            io.seek(it->second.origin_, BasicIo::beg);
-            byte buf[4] = { 0, 0, 0, 0 };
-            l2Data(buf, it->second.target_, it->second.byteOrder_);
+        for (auto it : offsetList_) {
+            io.seek(it.second.origin_, BasicIo::beg);
+            byte buf[4] = {0, 0, 0, 0};
+            l2Data(buf, it.second.target_, it.second.byteOrder_);
             io.write(buf, 4);
         }
     }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -84,9 +84,7 @@ namespace Exiv2 {
 
     TiffVisitor::TiffVisitor()
     {
-        for (bool& i : go_) {
-            i = true;
-        }
+        std::fill(std::begin(go_), std::end(go_), true);
     }
 
     TiffVisitor::~TiffVisitor() = default;

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -84,8 +84,8 @@ namespace Exiv2 {
 
     TiffVisitor::TiffVisitor()
     {
-        for (int i = 0; i < events_; ++i) {
-            go_[i] = true;
+        for (bool& i : go_) {
+            i = true;
         }
     }
 
@@ -743,9 +743,8 @@ namespace Exiv2 {
         assert(object != nullptr);
 
         byte* p = object->start() + 2;
-        for (TiffDirectory::Components::iterator i = object->components_.begin();
-             i != object->components_.end(); ++i) {
-            p += updateDirEntry(p, byteOrder(), *i);
+        for (auto& component : object->components_) {
+            p += updateDirEntry(p, byteOrder(), component);
         }
     }
 
@@ -811,8 +810,8 @@ namespace Exiv2 {
             static const char* synthesizedTags[] = {
                 "Exif.MakerNote.Offset",
             };
-            for (unsigned int i = 0; i < EXV_COUNTOF(synthesizedTags); ++i) {
-                pos = exifData_.findKey(ExifKey(synthesizedTags[i]));
+            for (auto& synthesizedTag : synthesizedTags) {
+                pos = exifData_.findKey(ExifKey(synthesizedTag));
                 if (pos != exifData_.end())
                     exifData_.erase(pos);
             }
@@ -1314,8 +1313,8 @@ namespace Exiv2 {
     {
         setMnState(); // All components to be post-processed must be from the Makernote
         postProc_ = true;
-        for (PostList::const_iterator pos = postList_.begin(); pos != postList_.end(); ++pos) {
-            (*pos)->accept(*this);
+        for (auto pos : postList_) {
+            pos->accept(*this);
         }
         postProc_ = false;
         setOrigState();

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -105,10 +105,10 @@ namespace Exiv2 {
         }
 
         // #1112 - store dates to deal with loss of TZ information during conversions
-        for (Exiv2::XmpData::const_iterator it = xmpData_.begin(); it != xmpData_.end(); ++it) {
-            std::string  key(it->key());
-            if ( key.find("Date") != std::string::npos ) {
-                std::string value(it->value().toString());
+        for (const auto& it : xmpData_) {
+            std::string key(it.key());
+            if (key.find("Date") != std::string::npos) {
+                std::string value(it.value().toString());
                 dates_[key] = value;
             }
         }
@@ -120,9 +120,8 @@ namespace Exiv2 {
     // lower case string
     static std::string toLowerCase(std::string a)
     {
-        for(size_t i=0 ; i < a.length() ; i++)
-        {
-            a[i]=tolower(a[i]);
+        for (char& i : a) {
+            i = tolower(i);
         }
         return a;
     }
@@ -143,9 +142,9 @@ namespace Exiv2 {
         if (writeXmpFromPacket() == false) {
             // #589 copy XMP tags
             Exiv2::XmpData  copy   ;
-            for (Exiv2::XmpData::const_iterator it = xmpData_.begin(); it != xmpData_.end(); ++it) {
-                if ( !matchi(it->key(),"exif") && !matchi(it->key(),"iptc") ) {
-                    copy[it->key()] = it->value();
+            for (const auto& it : xmpData_) {
+                if (!matchi(it.key(), "exif") && !matchi(it.key(), "iptc")) {
+                    copy[it.key()] = it.value();
                 }
             }
 
@@ -154,12 +153,12 @@ namespace Exiv2 {
             copyIptcToXmp(iptcData_, xmpData_);
 
             // #589 - restore tags which were modified by the convertors
-            for (Exiv2::XmpData::const_iterator it = copy.begin(); it != copy.end(); ++it) {
-                xmpData_[it->key()] = it->value() ;
+            for (const auto& it : copy) {
+                xmpData_[it.key()] = it.value();
             }
 
             // #1112 - restore dates if they lost their TZ info
-            for ( Exiv2::Dictionary_i it = dates_.begin() ; it != dates_.end() ; ++it ) {
+            for (Exiv2::Dictionary_i it = dates_.begin(); it != dates_.end(); ++it) {
                 std::string   sKey = it->first;
                 Exiv2::XmpKey key(sKey);
                 if ( xmpData_.findKey(key) != xmpData_.end() ) {


### PR DESCRIPTION
Found with modernize-loop-convert

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Manually converted several C arrays to std::array to get the various methods.

A lot of the changes are dominated by git clang-format.