### PR TITLE
Master - Fix CI failing distros

### DIFF
--- a/.github/workflows/linux_distribution_check.yml
+++ b/.github/workflows/linux_distribution_check.yml
@@ -10,7 +10,7 @@ jobs:
       # FIXME
       fail-fast: false
       matrix:
-        container_image: ["fedora:latest", "debian:9", "archlinux/base", "ubuntu:18.10", "centos:7", "opensuse/tumbleweed", "alpine:latest"]
+        container_image: ["fedora:latest", "debian:9", "archlinux/base", "ubuntu:18.04", "centos:7", "opensuse/tumbleweed", "alpine:latest"]
         compiler: [g++, clang++]
         build_type: [Release, Debug]
         shared_libraries: [ON, OFF]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ Archlinux:
   <<: *distro_build
 
 Ubuntu:
-  image: ubuntu:18.10
+  image: ubuntu:18.04
   <<: *default_config
   <<: *distro_build
 

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -40,7 +40,7 @@ case "$distro_id" in
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libgmock-dev libxml2-utils locales locales-all
+        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libxml2-utils locales locales-all
         debian_build_gtest
         ;;
 

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -58,7 +58,7 @@ case "$distro_id" in
 
     'opensuse'|'opensuse-tumbleweed')
         zypper --non-interactive refresh
-        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel libcurl-devel gtest gmock which dos2unix libxml2-tools
+        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel libcurl-devel gtest gmock which dos2unix libxml2-tools diffutils
         ;;
 
     'alpine')

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -25,7 +25,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
 
         # This fails under Fedora - MinGW - Gcc 8.3
-        if (NOT MINGW)
+        if (NOT (MINGW OR CMAKE_HOST_SOLARIS))
 	    check_c_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
 	    check_c_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
 	    check_c_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -1,5 +1,5 @@
 # These flags applies to exiv2lib, the applications, and to the xmp code
-include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
@@ -26,16 +26,16 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
         # This fails under Fedora - MinGW - Gcc 8.3
         if (NOT (MINGW OR CMAKE_HOST_SOLARIS))
-	    check_c_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
-	    check_c_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
-	    check_c_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)
-	    if(HAS_FSTACK_CLASH_PROTECTION)
+            check_cxx_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
+            check_cxx_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
+            check_cxx_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)
+            if(HAS_FSTACK_CLASH_PROTECTION)
                 add_compile_options(-fstack-clash-protection)
             endif()
-	    if(GCC_HAS_FCF_PROTECTION)
-		add_compile_options(-fcf-protection)
-	    endif()
-	    if(GCC_HAS_FSTACK_PROTECTOR_STRONG)
+            if(HAS_FCF_PROTECTION)
+                add_compile_options(-fcf-protection)
+            endif()
+            if(HAS_FSTACK_PROTECTOR_STRONG)
                 add_compile_options(-fstack-protector-strong)
             endif()
         endif()


### PR DESCRIPTION
I have been digging a bit in why some of the gitlab builders where failing, and it was mostly due to "easy to fix" stuff.

I think I still need to deal with the issues observed with clang + the `-fstack-clash-protection` flag. I will keep investigating while this PR is open. 