### PR TITLE
cmake: Fix include_directories for exiv2lib target (0.27->master)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 target_include_directories(exiv2lib PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/exiv2>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_include_directories(exiv2lib_int PUBLIC


### PR DESCRIPTION
One more fixup we discovered in Nixpkgs (https://github.com/NixOS/nixpkgs/pull/97161#issuecomment-689426419).

﻿The headers are installed to `${CMAKE_INSTALL_INCLUDEDIR}` but the CMake config was hardcoded to `include` directory.
