### PR TITLE
clang-tidy: pass by value

### DIFF
--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -283,13 +283,13 @@ namespace Exiv2 {
                  the remaining parts of the key cannot be parsed and
                  converted to a record name and a dataset name.
         */
-        explicit IptcKey(const std::string& key);
+        explicit IptcKey(std::string key);
 
         /*!
-          @brief Constructor to create an IPTC key from dataset and record ids.
-          @param tag Dataset id
-          @param record Record id
-         */
+              @brief Constructor to create an IPTC key from dataset and record ids.
+              @param tag Dataset id
+              @param record Record id
+             */
         IptcKey(uint16_t tag, uint16_t record);
         //! Copy constructor
         IptcKey(const IptcKey& rhs);
@@ -300,8 +300,8 @@ namespace Exiv2 {
         //! @name Manipulators
         //@{
         /*!
-          @brief Assignment operator.
-         */
+              @brief Assignment operator.
+             */
         IptcKey& operator=(const IptcKey& rhs);
         //@}
 
@@ -310,9 +310,9 @@ namespace Exiv2 {
         std::string key() const override;
         const char* familyName() const override;
         /*!
-          @brief Return the name of the group (the second part of the key).
-                 For IPTC keys, the group name is the record name.
-        */
+              @brief Return the name of the group (the second part of the key).
+                     For IPTC keys, the group name is the record name.
+            */
         std::string groupName() const override;
         std::string tagName() const override;
         std::string tagLabel() const override;

--- a/include/exiv2/preview.hpp
+++ b/include/exiv2/preview.hpp
@@ -149,11 +149,11 @@ namespace Exiv2 {
 
     private:
         //! Private constructor
-        PreviewImage(const PreviewProperties& properties, DataBuf data);
+        PreviewImage(PreviewProperties properties, DataBuf data);
 
-        PreviewProperties properties_;          //!< Preview image properties
-        byte* pData_;                           //!< Pointer to the preview image data
-        size_t size_;                           //!< Size of the preview image data
+        PreviewProperties properties_;  //!< Preview image properties
+        byte* pData_;                   //!< Pointer to the preview image data
+        size_t size_;                   //!< Size of the preview image data
 
     }; // class PreviewImage
 

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -69,14 +69,15 @@ namespace Exiv2 {
         //! For comparison with prefix
         struct Prefix {
             //! Constructor.
-            explicit Prefix(const std::string& prefix);
+            explicit Prefix(std::string prefix);
             //! The prefix string.
             std::string prefix_;
         };
         //! For comparison with namespace
-        struct Ns {
+        struct Ns
+        {
             //! Constructor.
-            explicit Ns(const std::string& ns);
+            explicit Ns(std::string ns);
             //! The namespace string
             std::string ns_;
         };
@@ -85,10 +86,10 @@ namespace Exiv2 {
         //! Comparison operator for prefix
         bool operator==(const Prefix& prefix) const;
 
-        const char* ns_;                //!< Namespace
-        const char* prefix_;            //!< (Preferred) prefix
-        const XmpPropertyInfo* xmpPropertyInfo_; //!< List of known properties
-        const char* desc_;              //!< Brief description of the namespace
+        const char* ns_;                          //!< Namespace
+        const char* prefix_;                      //!< (Preferred) prefix
+        const XmpPropertyInfo* xmpPropertyInfo_;  //!< List of known properties
+        const char* desc_;                        //!< Brief description of the namespace
     };
 
     //! XMP property reference, implemented as a static class.

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -73,8 +73,8 @@ namespace Exiv2 {
 
     //! Search key to find a GroupInfo by its group name.
     struct EXIV2API GroupInfo::GroupName {
-        explicit GroupName(const std::string& groupName);
-        std::string g_;                          //!< Group name
+        explicit GroupName(std::string groupName);
+        std::string g_;  //!< Group name
     };
 
     //! Tag information

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -40,6 +40,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 // MSVC macro to convert a string to a wide string
@@ -184,7 +185,10 @@ namespace Exiv2 {
      */
     struct EXIV2API DataBufRef {
         //! Constructor
-        explicit DataBufRef(std::pair<byte*, size_t> rhs) : p(rhs) {}
+        explicit DataBufRef(std::pair<byte*, size_t> rhs)
+            : p(std::move(rhs))
+        {
+        }
         //! Pointer to a byte array and its size
         std::pair<byte*, size_t> p;
     };

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -26,10 +26,11 @@ THE SOFTWARE.
 
 #include "Jzon.h"
 
-#include <sstream>
-#include <fstream>
-#include <stack>
 #include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <stack>
+#include <utility>
 
 namespace Jzon
 {
@@ -708,30 +709,29 @@ namespace Jzon
 		return new Array(*this);
 	}
 
+    FileWriter::FileWriter(std::string filename)
+        : filename(std::move(filename))
+    {
+    }
+    FileWriter::~FileWriter() = default;
 
-	FileWriter::FileWriter(const std::string &filename) : filename(filename)
-	{
-	}
-        FileWriter::~FileWriter() = default;
+    void FileWriter::WriteFile(const std::string &filename, const Node &root, const Format &format)
+    {
+        FileWriter writer(filename);
+        writer.Write(root, format);
+    }
 
-        void FileWriter::WriteFile(const std::string &filename, const Node &root, const Format &format)
-	{
-		FileWriter writer(filename);
-		writer.Write(root, format);
-	}
-
-	void FileWriter::Write(const Node &root, const Format &format)
-	{
-		Writer writer(root, format);
+    void FileWriter::Write(const Node &root, const Format &format)
+    {
+        Writer writer(root, format);
 		writer.Write();
 
 		std::fstream file(filename.c_str(), std::ios::out | std::ios::trunc);
 		file << writer.GetResult();
 		file.close();
-	}
+    }
 
-
-	FileReader::FileReader(const std::string &filename)
+    FileReader::FileReader(const std::string &filename)
 	{
 		if (!loadFile(filename, json))
 		{

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -31,11 +31,12 @@ THE SOFTWARE.
 # endif
 #endif
 
-#include <string>
-#include <vector>
-#include <queue>
 #include <iterator>
+#include <queue>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Jzon
 {
@@ -46,7 +47,9 @@ namespace Jzon
     template<typename T1, typename T2>
     struct Pair
     {
-        Pair(T1 first, T2 second) : first(first), second(second)
+        Pair(T1 first, T2 second)
+            : first(std::move(first))
+            , second(second)
         {}
 
         Pair &operator=(const Pair &rhs)
@@ -359,7 +362,7 @@ namespace Jzon
     class JzonAPI FileWriter
     {
     public:
-        FileWriter(const std::string &filename);
+        FileWriter(std::string filename);
         ~FileWriter();
 
         static void WriteFile(const std::string &filename, const Node &root, const Format &format = NoFormat);

--- a/src/FileIo.cpp
+++ b/src/FileIo.cpp
@@ -44,12 +44,14 @@ typedef short nlink_t;
 #include <windows.h>
 #endif
 
+#include <fcntl.h>  // _O_BINARY in FileIo::FileIo
+
+#include <cassert>  /// \todo check usages of assert and try to cover the negative case with unit tests.
 #include <cstdio>   // for remove, rename
-#include <cassert>      /// \todo check usages of assert and try to cover the negative case with unit tests.
-#include <fcntl.h>      // _O_BINARY in FileIo::FileIo
-#include <ctime>        // timestamp for the name of temporary file
+#include <ctime>    // timestamp for the name of temporary file
+#include <fstream>  // write the temporary file
 #include <iostream>
-#include <fstream>      // write the temporary file
+#include <utility>
 
 #define mode_t unsigned short
 
@@ -60,7 +62,7 @@ namespace Exiv2
     {
     public:
         //! Constructor
-        explicit Impl(const std::string& path);
+        explicit Impl(std::string path);
 #ifdef EXV_UNICODE_PATH
         //! Constructor accepting a unicode path in an std::wstring
         explicit Impl(const std::wstring& wpath);
@@ -126,8 +128,8 @@ namespace Exiv2
         Impl(const Impl&& rhs) = delete;
     };
 
-    FileIo::Impl::Impl(const std::string& path)
-        : path_(path)
+    FileIo::Impl::Impl(std::string path)
+        : path_(std::move(path))
 #ifdef EXV_UNICODE_PATH
         , wpMode_(wpStandard)
 #endif

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -26,15 +26,17 @@
 // *****************************************************************************
 // included header files
 #include "datasets.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
 #include "error.hpp"
+#include "i18n.h"  // NLS support.
+#include "metadatum.hpp"
 #include "types.hpp"
 #include "value.hpp"
-#include "metadatum.hpp"
-#include "i18n.h"                // NLS support.
-
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 
 // *****************************************************************************
 // class member definitions
@@ -585,8 +587,8 @@ namespace Exiv2 {
 
     const char* IptcKey::familyName_ = "Iptc";
 
-    IptcKey::IptcKey(const std::string& key)
-        : key_(key)
+    IptcKey::IptcKey(std::string key)
+        : key_(std::move(key))
     {
         decomposeKey();
     }

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -24,19 +24,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
+#include "preview.hpp"
 
 #include <climits>
 #include <string>
+#include <utility>
 
-#include "preview.hpp"
-#include "futils.hpp"
-#include "enforce.hpp"
-#include "safe_op.hpp"
-
-#include "image.hpp"
+#include "config.h"
 #include "cr2image.hpp"
+#include "enforce.hpp"
+#include "futils.hpp"
+#include "image.hpp"
 #include "jpgimage.hpp"
+#include "safe_op.hpp"
 #include "tiffimage.hpp"
 #include "tiffimage_int.hpp"
 #include "unused.h"
@@ -1035,9 +1035,8 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-
-    PreviewImage::PreviewImage(const PreviewProperties& properties, DataBuf data)
-        : properties_(properties)
+    PreviewImage::PreviewImage(PreviewProperties properties, DataBuf data)
+        : properties_(std::move(properties))
     {
         pData_ = data.pData_;
         size_ = (uint32_t)data.size_;

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -26,20 +26,22 @@
 // *****************************************************************************
 // included header files
 #include "properties.hpp"
-#include "tags_int.hpp"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
 #include "error.hpp"
+#include "i18n.h"  // NLS support.
+#include "metadatum.hpp"
+#include "tags_int.hpp"
 #include "types.hpp"
 #include "value.hpp"
-#include "metadatum.hpp"
-#include "i18n.h"                // NLS support.
 #include "xmp_exiv2.hpp"
-
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <cstring>
-#include <cstdlib>
-#include <cctype>
 
 // *****************************************************************************
 namespace {
@@ -2453,13 +2455,13 @@ namespace Exiv2 {
         {"Xmp.plus.Reuse",                       EXV_PRINT_VOCABULARY(plusReuse)                      }
     };
 
-    XmpNsInfo::Ns::Ns(const std::string& ns)
-        : ns_(ns)
+    XmpNsInfo::Ns::Ns(std::string ns)
+        : ns_(std::move(ns))
     {
     }
 
-    XmpNsInfo::Prefix::Prefix(const std::string& prefix)
-        : prefix_(prefix)
+    XmpNsInfo::Prefix::Prefix(std::string prefix)
+        : prefix_(std::move(prefix))
     {
     }
 

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -112,7 +112,8 @@ namespace Exiv2 {
 namespace Exiv2 {
 
     //! @cond IGNORE
-    GroupInfo::GroupName::GroupName(const std::string& groupName): g_(groupName)
+    GroupInfo::GroupName::GroupName(std::string groupName)
+        : g_(std::move(groupName))
     {
     }
     //! @endcond

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -33,10 +33,11 @@
 #include "types.hpp"
 
 // + standard includes
-#include <iosfwd>
-#include <vector>
-#include <string>
 #include <cassert>
+#include <iosfwd>
+#include <string>
+#include <utility>
+#include <vector>
 
 // *****************************************************************************
 // namespace extensions
@@ -398,7 +399,12 @@ namespace Exiv2 {
     //! Search key for TIFF mapping structures.
     struct TiffMappingInfo::Key {
         //! Constructor
-        Key(const std::string& m, uint32_t e, IfdId g) : m_(m), e_(e), g_(g) {}
+        Key(std::string m, uint32_t e, IfdId g)
+            : m_(std::move(m))
+            , e_(e)
+            , g_(g)
+        {
+        }
         std::string m_;                    //!< Camera make
         uint32_t    e_;                    //!< Extended tag
         IfdId       g_;                    //!< %Group

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -40,12 +40,13 @@
 #include "i18n.h"             // NLS support.
 
 // + standard includes
-#include <string>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <iomanip>
+#include <iostream>
 #include <limits>
 #include <ostream>
+#include <string>
+#include <utility>
 
 // *****************************************************************************
 namespace {
@@ -564,28 +565,21 @@ namespace Exiv2 {
         decodeTiffEntry(object);
     }
 
-    TiffEncoder::TiffEncoder(
-            const ExifData&      exifData,
-            const IptcData&      iptcData,
-            const XmpData&       xmpData,
-                  TiffComponent* pRoot,
-            const bool           isNewImage,
-            const PrimaryGroups* pPrimaryGroups,
-            const TiffHeaderBase* pHeader,
-                  FindEncoderFct findEncoderFct
-    )
-        : exifData_(exifData),
-          iptcData_(iptcData),
-          xmpData_(xmpData),
-          del_(true),
-          pHeader_(pHeader),
-          pRoot_(pRoot),
-          isNewImage_(isNewImage),
-          pPrimaryGroups_(pPrimaryGroups),
-          pSourceTree_(nullptr),
-          findEncoderFct_(findEncoderFct),
-          dirty_(false),
-          writeMethod_(wmNonIntrusive)
+    TiffEncoder::TiffEncoder(ExifData exifData, const IptcData& iptcData, const XmpData& xmpData, TiffComponent* pRoot,
+                             const bool isNewImage, const PrimaryGroups* pPrimaryGroups, const TiffHeaderBase* pHeader,
+                             FindEncoderFct findEncoderFct)
+        : exifData_(std::move(exifData))
+        , iptcData_(iptcData)
+        , xmpData_(xmpData)
+        , del_(true)
+        , pHeader_(pHeader)
+        , pRoot_(pRoot)
+        , isNewImage_(isNewImage)
+        , pPrimaryGroups_(pPrimaryGroups)
+        , pSourceTree_(nullptr)
+        , findEncoderFct_(findEncoderFct)
+        , dirty_(false)
+        , writeMethod_(wmNonIntrusive)
     {
         assert(pRoot != nullptr);
         assert(pPrimaryGroups != nullptr);

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -389,16 +389,9 @@ namespace Exiv2 {
                  to, the image with the metadata to encode and a function to
                  find special encoders.
          */
-        TiffEncoder(
-            const ExifData&      exifData,
-            const IptcData&      iptcData,
-            const XmpData&       xmpData,
-                  TiffComponent* pRoot,
-            const bool           isNewImage,
-            const PrimaryGroups* pPrimaryGroups,
-            const TiffHeaderBase* pHeader,
-                  FindEncoderFct findEncoderFct
-        );
+        TiffEncoder(ExifData exifData, const IptcData& iptcData, const XmpData& xmpData, TiffComponent* pRoot,
+                    const bool isNewImage, const PrimaryGroups* pPrimaryGroups, const TiffHeaderBase* pHeader,
+                    FindEncoderFct findEncoderFct);
         //! Virtual destructor
         ~TiffEncoder() override;
         //@}
@@ -451,10 +444,7 @@ namespace Exiv2 {
 
           @note Encoder functions may use metadata other than \em datum.
          */
-        void encodeTiffComponent(
-                  TiffEntryBase* object,
-            const Exifdatum*     datum =nullptr
-        );
+        void encodeTiffComponent(TiffEntryBase* object, const Exifdatum* datum = nullptr);
 
         //! Callback encoder function for an element of a binary array.
         void encodeBinaryElement(TiffBinaryElement* object, const Exifdatum* datum);
@@ -495,13 +485,9 @@ namespace Exiv2 {
           tree is then traversed and metadata from the image is used to encode
           each existing component.
         */
-        void add(
-            TiffComponent* pRootDir,
-            TiffComponent* pSourceDir,
-            uint32_t       root
-        );
+        void add(TiffComponent* pRootDir, TiffComponent* pSourceDir, uint32_t root);
         //! Set the dirty flag and end of traversing signal.
-        void setDirty(bool flag =true);
+        void setDirty(bool flag = true);
         //@}
 
         //! @name Accessors
@@ -510,14 +496,20 @@ namespace Exiv2 {
           @brief Return the applicable byte order. May be different for
                  the Makernote and the rest of the TIFF entries.
          */
-        ByteOrder byteOrder() const { return byteOrder_; }
+        ByteOrder byteOrder() const
+        {
+            return byteOrder_;
+        }
         /*!
           @brief True if any tag was deleted or allocated in the process of
                  visiting a TIFF composite tree.
          */
         bool dirty() const;
         //! Return the write method used.
-        WriteMethod writeMethod() const { return writeMethod_; }
+        WriteMethod writeMethod() const
+        {
+            return writeMethod_;
+        }
         //@}
 
     private:


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>