### PR TITLE
clang-tidy: use constexpr for unmodified structs

### DIFF
--- a/samples/tiffaddpath-test.cpp
+++ b/samples/tiffaddpath-test.cpp
@@ -32,7 +32,7 @@ struct TiffTagInfo {
     const char* name_;
 };
 
-extern const TiffTagInfo tiffTagInfo[] = {
+constexpr TiffTagInfo tiffTagInfo[] = {
     {   0x10000, "none" },
     {   0x20000, "root" },
     {   0x30000, "next" },

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! OffOn, multiple tags
-    extern const TagDetails canonOffOn[] = {
+    constexpr TagDetails canonOffOn[] = {
         {  0, N_("Off") },
         {  1, N_("On")  }
     };
@@ -72,7 +72,7 @@ namespace Exiv2 {
                                   const ExifData* metadata);
 
     //! ModelId, tag 0x0010
-    extern const TagDetails canonModelId[] = {
+    constexpr TagDetails canonModelId[] = {
         { (long int)0x1010000, "PowerShot A30" },
         { (long int)0x1040000, "PowerShot S300 / Digital IXUS 300 / IXY Digital 300" },
         { (long int)0x1060000, "PowerShot A20" },
@@ -388,25 +388,25 @@ namespace Exiv2 {
     };
 
     //! SerialNumberFormat, tag 0x0015
-    extern const TagDetails canonSerialNumberFormat[] = {
+    constexpr TagDetails canonSerialNumberFormat[] = {
         {  (long int)0x90000000, N_("Format 1") },
         {  (long int)0xa0000000, N_("Format 2") },
     };
 
     //! SuperMacro, tag 0x001a
-    extern const TagDetails canonSuperMacro[] = {
+    constexpr TagDetails canonSuperMacro[] = {
         {  0, N_("Off")     },
         {  1, N_("On (1)")  },
         {  2, N_("On (2)")  }
     };
 
     //! ColorSpace, tag 0x00b4
-    extern const TagDetails canonColorSpace[] = {
+    constexpr TagDetails canonColorSpace[] = {
         {  1, N_("sRGB")      },
         {  2, N_("Adobe RGB") }
     };
 
-    extern const TagDetails canonAFAreaMode[] = {
+    constexpr TagDetails canonAFAreaMode[] = {
          {   0, N_("Off (Manual Focus)")           },
          {   1, N_("AF Point Expansion (surround)")},
          {   2, N_("Single-point AF")              },
@@ -485,13 +485,13 @@ namespace Exiv2 {
     }
 
     //! Macro, tag 0x0001
-    extern const TagDetails canonCsMacro[] = {
+    constexpr TagDetails canonCsMacro[] = {
         { 1, N_("On")  },
         { 2, N_("Off") }
     };
 
     //! Quality, tag 0x0003
-    extern const TagDetails canonCsQuality[] = {
+    constexpr TagDetails canonCsQuality[] = {
         { 1,   N_("Economy")      },
         { 2,   N_("Normal")       },
         { 3,   N_("Fine")         },
@@ -502,7 +502,7 @@ namespace Exiv2 {
     };
 
     //! FlashMode, tag 0x0004
-    extern const TagDetails canonCsFlashMode[] = {
+    constexpr TagDetails canonCsFlashMode[] = {
         {  0, N_("Off")            },
         {  1, N_("Auto")           },
         {  2, N_("On")             },
@@ -515,7 +515,7 @@ namespace Exiv2 {
     };
 
     //! DriveMode, tag 0x0005
-    extern const TagDetails canonCsDriveMode[] = {
+    constexpr TagDetails canonCsDriveMode[] = {
         {  0, N_("Single / timer")             },
         {  1, N_("Continuous")                 },
         {  2, N_("Movie")                      },
@@ -528,7 +528,7 @@ namespace Exiv2 {
     };
 
     //! FocusMode, tag 0x0007
-    extern const TagDetails canonCsFocusMode[] = {
+    constexpr TagDetails canonCsFocusMode[] = {
         {   0, N_("One shot AF")      },
         {   1, N_("AI servo AF")      },
         {   2, N_("AI focus AF")      },
@@ -544,7 +544,7 @@ namespace Exiv2 {
     };
 
     //! ImageSize, tag 0x000a
-    extern const TagDetails canonCsImageSize[] = {
+    constexpr TagDetails canonCsImageSize[] = {
         {   0, N_("Large")             },
         {   1, N_("Medium")            },
         {   2, N_("Small")             },
@@ -565,7 +565,7 @@ namespace Exiv2 {
     };
 
     //! EasyMode, tag 0x000b
-    extern const TagDetails canonCsEasyMode[] = {
+    constexpr TagDetails canonCsEasyMode[] = {
         {   0, N_("Full auto")              },
         {   1, N_("Manual")                 },
         {   2, N_("Landscape")              },
@@ -640,7 +640,7 @@ namespace Exiv2 {
     };
 
     //! DigitalZoom, tag 0x000c
-    extern const TagDetails canonCsDigitalZoom[] = {
+    constexpr TagDetails canonCsDigitalZoom[] = {
         { 0, N_("None")  },
         { 1, "2x"        },
         { 2, "4x"        },
@@ -649,14 +649,14 @@ namespace Exiv2 {
     };
 
     //! Contrast, Saturation Sharpness, tags 0x000d, 0x000e, 0x000f
-    extern const TagDetails canonCsLnh[] = {
+    constexpr TagDetails canonCsLnh[] = {
         { 0xffff, N_("Low")    },
         { 0x0000, N_("Normal") },
         { 0x0001, N_("High")   }
     };
 
     //! ISOSpeeds, tag 0x0010
-    extern const TagDetails canonCsISOSpeed[] = {
+    constexpr TagDetails canonCsISOSpeed[] = {
         {     0, N_("n/a")       },
         {    14, N_("Auto High") },
         {    15, N_("Auto")      },
@@ -691,7 +691,7 @@ namespace Exiv2 {
     };
 
     //! MeteringMode, tag 0x0011
-    extern const TagDetails canonCsMeteringMode[] = {
+    constexpr TagDetails canonCsMeteringMode[] = {
         { 0, N_("Default")                 },
         { 1, N_("Spot")                    },
         { 2, N_("Average")                 },
@@ -701,7 +701,7 @@ namespace Exiv2 {
     };
 
     //! FocusType, tag 0x0012
-    extern const TagDetails canonCsFocusType[] = {
+    constexpr TagDetails canonCsFocusType[] = {
         {  0, N_("Manual")       },
         {  1, N_("Auto")         },
         {  2, N_("Not known")    },
@@ -716,7 +716,7 @@ namespace Exiv2 {
     };
 
     //! AFPoint, tag 0x0013
-    extern const TagDetails canonCsAfPoint[] = {
+    constexpr TagDetails canonCsAfPoint[] = {
         { 0x2005, N_("Manual AF point selection") },
         { 0x3000, N_("None (MF)")                 },
         { 0x3001, N_("Auto-selected")             },
@@ -728,7 +728,7 @@ namespace Exiv2 {
     };
 
     //! ExposureProgram, tag 0x0014
-    extern const TagDetails canonCsExposureProgram[] = {
+    constexpr TagDetails canonCsExposureProgram[] = {
         { 0, N_("Easy shooting (Auto)")   },
         { 1, N_("Program (P)")            },
         { 2, N_("Shutter priority (Tv)")  },
@@ -740,7 +740,7 @@ namespace Exiv2 {
     };
 
     //! LensType, tag 0x0016
-    extern const TagDetails canonCsLensType[] = {
+    constexpr TagDetails canonCsLensType[] = {
         {   1, "Canon EF 50mm f/1.8"                                        },
         {   2, "Canon EF 28mm f/2.8"                                        },
         {   3, "Canon EF 135mm f/2.8 Soft"                                  },
@@ -1170,13 +1170,13 @@ namespace Exiv2 {
     };
 
     //! FlashActivity, tag 0x001c
-    extern const TagDetails canonCsFlashActivity[] = {
+    constexpr TagDetails canonCsFlashActivity[] = {
         { 0, N_("Did not fire") },
         { 1, N_("Fired")        }
     };
 
     //! FlashDetails, tag 0x001d
-    extern const TagDetailsBitmask canonCsFlashDetails[] = {
+    constexpr TagDetailsBitmask canonCsFlashDetails[] = {
         { 0x4000, N_("External flash")        },
         { 0x2000, N_("Internal flash")        },
         { 0x0001, N_("Manual")                },
@@ -1189,14 +1189,14 @@ namespace Exiv2 {
     };
 
     //! FocusContinuous, tag 0x0020
-    extern const TagDetails canonCsFocusContinuous[] = {
+    constexpr TagDetails canonCsFocusContinuous[] = {
         { 0, N_("Single")     },
         { 1, N_("Continuous") },
         { 8, N_("Manual")     }
     };
 
     //! AESetting, tag 0x0021
-    extern const TagDetails canonCsAESetting[] = {
+    constexpr TagDetails canonCsAESetting[] = {
         { 0, N_("Normal AE")                       },
         { 1, N_("Exposure compensation")           },
         { 2, N_("AE lock")                         },
@@ -1205,7 +1205,7 @@ namespace Exiv2 {
     };
 
     //! ImageStabilization, tag 0x0022
-    extern const TagDetails canonCsImageStabilization[] = {
+    constexpr TagDetails canonCsImageStabilization[] = {
         {   0, N_("Off")            },
         {   1, N_("On")             },
         {   2, N_("Shoot Only")     },
@@ -1219,13 +1219,13 @@ namespace Exiv2 {
     };
 
     //! SpotMeteringMode, tag 0x0027
-    extern const TagDetails canonCsSpotMeteringMode[] = {
+    constexpr TagDetails canonCsSpotMeteringMode[] = {
         { 0,   N_("Center")   },
         { 1,   N_("AF Point") }
     };
 
     //! PhotoEffect, tag 0x0028
-    extern const TagDetails canonCsPhotoEffect[] = {
+    constexpr TagDetails canonCsPhotoEffect[] = {
         { 0,   N_("Off")           },
         { 1,   N_("Vivid")         },
         { 2,   N_("Neutral")       },
@@ -1238,7 +1238,7 @@ namespace Exiv2 {
     };
 
     //! ManualFlashOutput, tag 0x0029
-    extern const TagDetails canonCsManualFlashOutput[] = {
+    constexpr TagDetails canonCsManualFlashOutput[] = {
         { 0x0000, N_("n/a")    },
         { 0x0500, N_("Full")   },
         { 0x0502, N_("Medium") },
@@ -1247,7 +1247,7 @@ namespace Exiv2 {
     };
 
     //! SRAWQuality, tag 0x002e
-    extern const TagDetails canonCsSRAWQuality[] = {
+    constexpr TagDetails canonCsSRAWQuality[] = {
         { 0, N_("n/a")          },
         { 1, N_("sRAW1 (mRAW)") },
         { 2, N_("sRAW2 (sRAW)") }
@@ -1308,7 +1308,7 @@ namespace Exiv2 {
     }
 
     //! WhiteBalance, multiple tags
-    extern const TagDetails canonSiWhiteBalance[] = {
+    constexpr TagDetails canonSiWhiteBalance[] = {
         {  0, N_("Auto")                        },
         {  1, N_("Daylight")                    },
         {  2, N_("Cloudy")                      },
@@ -1334,14 +1334,14 @@ namespace Exiv2 {
     };
 
     //! AFPointUsed, tag 0x000e
-    extern const TagDetailsBitmask canonSiAFPointUsed[] = {
+    constexpr TagDetailsBitmask canonSiAFPointUsed[] = {
         { 0x0004, N_("left")   },
         { 0x0002, N_("center") },
         { 0x0001, N_("right")  }
     };
 
     //! FlashBias, tag 0x000f
-    extern const TagDetails canonSiFlashBias[] = {
+    constexpr TagDetails canonSiFlashBias[] = {
         { 0xffc0, "-2 EV"    },
         { 0xffcc, "-1.67 EV" },
         { 0xffd0, "-1.50 EV" },
@@ -1399,7 +1399,7 @@ namespace Exiv2 {
     }
 
     //! PanoramaDirection, tag 0x0005
-    extern const TagDetails canonPaDirection[] = {
+    constexpr TagDetails canonPaDirection[] = {
         { 0, N_("Left to right")          },
         { 1, N_("Right to left")          },
         { 2, N_("Bottom to top")          },
@@ -1447,7 +1447,7 @@ namespace Exiv2 {
     }
 
     //! AFPointsUsed, tag 0x0016
-    extern const TagDetailsBitmask canonPiAFPointsUsed[] = {
+    constexpr TagDetailsBitmask canonPiAFPointsUsed[] = {
         { 0x01, N_("right")     },
         { 0x02, N_("mid-right") },
         { 0x04, N_("bottom")    },
@@ -1458,7 +1458,7 @@ namespace Exiv2 {
     };
 
     //! AFPointsUsed20D, tag 0x001a
-    extern const TagDetailsBitmask canonPiAFPointsUsed20D[] = {
+    constexpr TagDetailsBitmask canonPiAFPointsUsed20D[] = {
         { 0x001, N_("top")         },
         { 0x002, N_("upper-left")  },
         { 0x004, N_("upper-right") },
@@ -1488,7 +1488,7 @@ namespace Exiv2 {
     }
 
     //! BracketMode, tag 0x0003
-    extern const TagDetails canonBracketMode[] = {
+    constexpr TagDetails canonBracketMode[] = {
         { 0, N_("Off") },
         { 1, N_("AEB") },
         { 2, N_("FEB") },
@@ -1497,7 +1497,7 @@ namespace Exiv2 {
     };
 
     //! RawJpgSize, tag 0x0007
-    extern const TagDetails canonRawJpgSize[] = {
+    constexpr TagDetails canonRawJpgSize[] = {
         {   0, N_("Large")             },
         {   1, N_("Medium")            },
         {   2, N_("Small")             },
@@ -1518,7 +1518,7 @@ namespace Exiv2 {
     };
 
     //! NoiseReduction, tag 0x0008
-    extern const TagDetails canonNoiseReduction[] = {
+    constexpr TagDetails canonNoiseReduction[] = {
         { 0, N_("Off")  },
         { 1, N_("On 1") },
         { 2, N_("On 2") },
@@ -1527,14 +1527,14 @@ namespace Exiv2 {
     };
 
     //! WBBracketMode, tag 0x0009
-    extern const TagDetails canonWBBracketMode[] = {
+    constexpr TagDetails canonWBBracketMode[] = {
         { 0, N_("Off")           },
         { 1, N_("On (shift AB)") },
         { 2, N_("On (shift GM)") }
     };
 
     //! FilterEffect, tag 0x000e
-    extern const TagDetails canonFilterEffect[] = {
+    constexpr TagDetails canonFilterEffect[] = {
         { 0, N_("None")   },
         { 1, N_("Yellow") },
         { 2, N_("Orange") },
@@ -1543,7 +1543,7 @@ namespace Exiv2 {
     };
 
     //! ToningEffect, tag 0x000e
-    extern const TagDetails canonToningEffect[] = {
+    constexpr TagDetails canonToningEffect[] = {
         { 0, N_("None")   },
         { 1, N_("Sepia")  },
         { 2, N_("Blue")   },
@@ -1580,14 +1580,14 @@ namespace Exiv2 {
     }
 
     //! Tone Curve Values
-    extern const TagDetails canonToneCurve[] = {
+    constexpr TagDetails canonToneCurve[] = {
         { 0, N_("Standard") },
         { 1, N_("Manual")   },
         { 2, N_("Custom")   }
     };
 
     //! Sharpness Frequency Values
-    extern const TagDetails canonSharpnessFrequency[] = {
+    constexpr TagDetails canonSharpnessFrequency[] = {
         { 0, N_("n/a")      },
         { 1, N_("Lowest")   },
         { 2, N_("Low")      },
@@ -1597,7 +1597,7 @@ namespace Exiv2 {
     };
 
     //! PictureStyle Values
-    extern const TagDetails canonPictureStyle[] = {
+    constexpr TagDetails canonPictureStyle[] = {
         { 0x00, N_("None")            },
         { 0x01, N_("Standard")        },
         { 0x02, N_("Portrait")        },
@@ -1646,7 +1646,7 @@ namespace Exiv2 {
     }
 
     //! canonTimeZoneCity - array of cityID/cityName used by Canon
-    extern const TagDetails canonTimeZoneCity[] = {
+    constexpr TagDetails canonTimeZoneCity[] = {
         { 0x0000, N_("n/a")                 },
         { 0x0001, N_("Chatham Islands")     },
         { 0x0002, N_("Wellington")          },

--- a/src/casiomn_int.cpp
+++ b/src/casiomn_int.cpp
@@ -44,7 +44,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! RecordingMode, tag 0x0001
-    extern const TagDetails casioRecordingMode[] = {
+    constexpr TagDetails casioRecordingMode[] = {
         {  1, N_("Single Shutter") },
         {  2, N_("Panorama")       },
         {  3, N_("Night Scene")    },
@@ -57,14 +57,14 @@ namespace Exiv2 {
     };
 
     //! Quality, tag 0x0002
-    extern const TagDetails casioQuality[] = {
+    constexpr TagDetails casioQuality[] = {
         { 1, N_("Economy") },
         { 2, N_("Normal")  },
         { 3, N_("Fine")    }
     };
 
     //! Focus Mode, tag 0x0003
-    extern const TagDetails casioFocusMode[] = {
+    constexpr TagDetails casioFocusMode[] = {
         { 2, N_("Macro")    },
         { 3, N_("Auto")     },
         { 4, N_("Manual")   },
@@ -73,7 +73,7 @@ namespace Exiv2 {
     };
 
     //! FlashMode, tag 0x0004
-    extern const TagDetails casioFlashMode[] = {
+    constexpr TagDetails casioFlashMode[] = {
         { 1, N_("Auto")              },
         { 2, N_("On")                },
         { 3, N_("Off")               },
@@ -82,7 +82,7 @@ namespace Exiv2 {
     };
 
     //! Flash intensity, tag 0x0005
-    extern const TagDetails casioFlashIntensity[] = {
+    constexpr TagDetails casioFlashIntensity[] = {
         { 11, N_("Weak")   },
         { 12, N_("Low")    },
         { 13, N_("Normal") },
@@ -91,7 +91,7 @@ namespace Exiv2 {
     };
 
     //! white balance, tag 0x0007
-    extern const TagDetails casioWhiteBalance[] = {
+    constexpr TagDetails casioWhiteBalance[] = {
         {   1, N_("Auto")        },
         {   2, N_("Tungsten")    },
         {   3, N_("Daylight")    },
@@ -101,7 +101,7 @@ namespace Exiv2 {
     };
 
     //! Flash intensity, tag 0x0005
-    extern const TagDetails casioDigitalZoom[] = {
+    constexpr TagDetails casioDigitalZoom[] = {
         { 0x10000, N_("Off")   },
         { 0x10001, N_("2x")    },
         { 0x13333, N_("1.2x")  },
@@ -113,7 +113,7 @@ namespace Exiv2 {
     };
 
     //! Sharpness, tag 0x000b
-    extern const TagDetails casioSharpness[] = {
+    constexpr TagDetails casioSharpness[] = {
         {  0, N_("Normal") },
         {  1, N_("Soft")   },
         {  2, N_("Hard")   },
@@ -123,7 +123,7 @@ namespace Exiv2 {
     };
 
     //! Contrast, tag 0x000c
-    extern const TagDetails casioContrast[] = {
+    constexpr TagDetails casioContrast[] = {
         {  0, N_("Normal") },
         {  1, N_("Low")   },
         {  2, N_("High")   },
@@ -133,7 +133,7 @@ namespace Exiv2 {
     };
 
     //! Saturation, tag 0x000d
-    extern const TagDetails casioSaturation[] = {
+    constexpr TagDetails casioSaturation[] = {
         {  0, N_("Normal") },
         {  1, N_("Low")   },
         {  2, N_("High")   },
@@ -143,7 +143,7 @@ namespace Exiv2 {
     };
 
     //! Enhancement, tag 0x0016
-    extern const TagDetails casioEnhancement[] = {
+    constexpr TagDetails casioEnhancement[] = {
         { 1, N_("Off")         },
         { 2, N_("Red")         },
         { 3, N_("Green")       },
@@ -152,7 +152,7 @@ namespace Exiv2 {
     };
 
     //! Color filter, tag 0x0017
-    extern const TagDetails casioColorFilter[] = {
+    constexpr TagDetails casioColorFilter[] = {
         { 1, N_("Off")           },
         { 2, N_("Black & White") },
         { 3, N_("Sepia")         },
@@ -165,14 +165,14 @@ namespace Exiv2 {
     };
 
     //! flash intensity 2, tag 0x0019
-    extern const TagDetails casioFlashIntensity2[] = {
+    constexpr TagDetails casioFlashIntensity2[] = {
         { 1, N_("Normal") },
         { 2, N_("Weak")   },
         { 3, N_("Strong") }
     };
 
     //! CCD Sensitivity intensity, tag 0x0020
-    extern const TagDetails casioCCDSensitivity[] = {
+    constexpr TagDetails casioCCDSensitivity[] = {
         {  64, N_("Normal")                     },
         { 125, N_("+1.0")                       },
         { 250, N_("+2.0")                       },
@@ -263,14 +263,14 @@ namespace Exiv2 {
 
     //Casio Makernotes, Type 2
     //! Quality Mode, tag 0x0004
-    extern const TagDetails casio2QualityMode[] = {
+    constexpr TagDetails casio2QualityMode[] = {
         { 0, N_("Economy") },
         { 1, N_("Normal")  },
         { 2, N_("Fine")    }
     };
 
     //! Image Size, tag 0x0009
-    extern const TagDetails casio2ImageSize[] = {
+    constexpr TagDetails casio2ImageSize[] = {
         {  0, "640x480"   },
         {  4, "1600x1200" },
         {  5, "2048x1536" },
@@ -281,13 +281,13 @@ namespace Exiv2 {
     };
 
     //! Focus Mode, tag 0x000d
-    extern const TagDetails casio2FocusMode[] = {
+    constexpr TagDetails casio2FocusMode[] = {
         { 0, N_("Normal") },
         { 1, N_("Macro") }
     };
 
     //! ISO Speed, tag 0x0014
-    extern const TagDetails casio2IsoSpeed[] = {
+    constexpr TagDetails casio2IsoSpeed[] = {
         { 3, "50"  },
         { 4, "64"  },
         { 6, "100" },
@@ -295,7 +295,7 @@ namespace Exiv2 {
     };
 
     //! White Balance, tag 0x0019
-    extern const TagDetails casio2WhiteBalance[] = {
+    constexpr TagDetails casio2WhiteBalance[] = {
         { 0, N_("Auto")        },
         { 1, N_("Daylight")    },
         { 2, N_("Shade")       },
@@ -305,28 +305,28 @@ namespace Exiv2 {
     };
 
     //! Saturation, tag 0x001f
-    extern const TagDetails casio2Saturation[] = {
+    constexpr TagDetails casio2Saturation[] = {
         { 0, N_("Low")    },
         { 1, N_("Normal") },
         { 2, N_("High")   }
     };
 
     //! Contrast, tag 0x0020
-    extern const TagDetails casio2Contrast[] = {
+    constexpr TagDetails casio2Contrast[] = {
         { 0, N_("Low")    },
         { 1, N_("Normal") },
         { 2, N_("High")   }
     };
 
     //! Sharpness, tag 0x0021
-    extern const TagDetails casio2Sharpness[] = {
+    constexpr TagDetails casio2Sharpness[] = {
         { 0, N_("Soft")    },
         { 1, N_("Normal") },
         { 2, N_("Hard")   }
     };
 
     //! White Balance2, tag 0x2012
-    extern const TagDetails casio2WhiteBalance2[] = {
+    constexpr TagDetails casio2WhiteBalance2[] = {
         {  0, N_("Manual")      },
         {  1, N_("Daylight")    },
         {  2, N_("Cloudy")      },
@@ -339,7 +339,7 @@ namespace Exiv2 {
     };
 
     //! Release Mode, tag 0x3001
-    extern const TagDetails casio2ReleaseMode[] = {
+    constexpr TagDetails casio2ReleaseMode[] = {
         {  1, N_("Normal")              },
         {  3, N_("AE Bracketing")       },
         { 11, N_("WB Bracketing")       },
@@ -348,14 +348,14 @@ namespace Exiv2 {
     };
 
     //! Quality, tag 0x3002
-    extern const TagDetails casio2Quality[] = {
+    constexpr TagDetails casio2Quality[] = {
         { 1, N_("Economy") },
         { 2, N_("Normal")  },
         { 3, N_("Fine")    }
     };
 
     //! Focus Mode 2, tag 0x3003
-    extern const TagDetails casio2FocusMode2[] = {
+    constexpr TagDetails casio2FocusMode2[] = {
         { 0, N_("Manual")                 },
         { 1, N_("Focus Lock")             },
         { 2, N_("Macro")                  },
@@ -366,7 +366,7 @@ namespace Exiv2 {
     };
 
     //! AutoISO, tag 0x3008
-    extern const TagDetails casio2AutoISO[] = {
+    constexpr TagDetails casio2AutoISO[] = {
         {  1, N_("On")                   },
         {  2, N_("Off")                  },
         {  7, N_("On (high sensitiviy)") },
@@ -375,7 +375,7 @@ namespace Exiv2 {
     };
 
     //! AFMode, tag 0x3009
-    extern const TagDetails casio2AFMode[] = {
+    constexpr TagDetails casio2AFMode[] = {
         { 0, N_("Off")            },
         { 1, N_("Spot")           },
         { 2, N_("Multi")          },
@@ -385,14 +385,14 @@ namespace Exiv2 {
     };
 
     //! ColorMode, tag 0x3015
-    extern const TagDetails casio2ColorMode[] = {
+    constexpr TagDetails casio2ColorMode[] = {
         { 0, N_("Off")           },
         { 2, N_("Black & White") },
         { 3, N_("Sepia")         }
     };
 
     //! Enhancement, tag 0x3016
-    extern const TagDetails casio2Enhancement[] = {
+    constexpr TagDetails casio2Enhancement[] = {
         { 0, N_("Off")         },
         { 1, N_("Scenery")     },
         { 3, N_("Green")       },
@@ -402,7 +402,7 @@ namespace Exiv2 {
     };
 
     //! Color Filter, tag 0x3017
-    extern const TagDetails casio2ColorFilter[] = {
+    constexpr TagDetails casio2ColorFilter[] = {
         { 0, N_("Off")    },
         { 1, N_("Blue")   },
         { 3, N_("Green")  },
@@ -413,7 +413,7 @@ namespace Exiv2 {
     };
 
     //! Art Mode, tag 0x301b
-    extern const TagDetails casio2ArtMode[] = {
+    constexpr TagDetails casio2ArtMode[] = {
         {  0, N_("Normal")                },
         {  8, N_("Silent Movie")          },
         { 39, N_("HDR")                   },
@@ -430,7 +430,7 @@ namespace Exiv2 {
     };
 
     //! Lighting Mode, tag 0x302a
-    extern const TagDetails casio2LightingMode[] = {
+    constexpr TagDetails casio2LightingMode[] = {
         { 0, N_("Off")                 },
         { 1, N_("High Dynamic Range")  },
         { 5, N_("Shadow Enhance Low")  },
@@ -438,14 +438,14 @@ namespace Exiv2 {
     };
 
     //! Portrait Refiner, tag 0x302b
-    extern const TagDetails casio2PortraitRefiner[] = {
+    constexpr TagDetails casio2PortraitRefiner[] = {
         { 0, N_("Off") },
         { 1, N_("+1")  },
         { 2, N_("+2")  }
     };
 
     //! Special Effect Setting, tag 0x3031
-    extern const TagDetails casio2SpecialEffectSetting[] = {
+    constexpr TagDetails casio2SpecialEffectSetting[] = {
         {  0, N_("Off")             },
         {  1, N_("Makeup")          },
         {  2, N_("Mist Removal")    },
@@ -454,7 +454,7 @@ namespace Exiv2 {
     };
 
     //! Drive Mode, tag 0x3103
-    extern const TagDetails casio2DriveMode[] = {
+    constexpr TagDetails casio2DriveMode[] = {
         {   0, N_("Single Shot")         },
         {   1, N_("Continuous Shooting") },
         {   2, N_("Continuous (2 fps)")  },
@@ -474,7 +474,7 @@ namespace Exiv2 {
     };
 
     //! Video Quality, tag 0x4003
-    extern const TagDetails casio2VideoQuality[] = {
+    constexpr TagDetails casio2VideoQuality[] = {
         { 1, N_("Standard")        },
         { 3, N_("HD (720p)")       },
         { 4, N_("Full HD (1080p)") },

--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -46,13 +46,13 @@ namespace Exiv2 {
     namespace Internal {
 
     //! OffOn, multiple tags
-    extern const TagDetails fujiOffOn[] = {
+    constexpr TagDetails fujiOffOn[] = {
         { 0, N_("Off") },
         { 1, N_("On")  }
     };
 
     //! Sharpness, tag 0x1001
-    extern const TagDetails fujiSharpness[] = {
+    constexpr TagDetails fujiSharpness[] = {
         { 1, N_("Soft mode 1") },
         { 2, N_("Soft mode 2") },
         { 3, N_("Normal")      },
@@ -61,7 +61,7 @@ namespace Exiv2 {
     };
 
     //! WhiteBalance, tag 0x1002
-    extern const TagDetails fujiWhiteBalance[] = {
+    constexpr TagDetails fujiWhiteBalance[] = {
         {    0, N_("Auto")                     },
         {  256, N_("Daylight")                 },
         {  512, N_("Cloudy")                   },
@@ -74,7 +74,7 @@ namespace Exiv2 {
     };
 
     //! Color, tag 0x1003
-    extern const TagDetails fujiColor[] = {
+    constexpr TagDetails fujiColor[] = {
         {   0, N_("Normal")                 },
         { 256, N_("High")                   },
         { 512, N_("Low")                    },
@@ -87,14 +87,14 @@ namespace Exiv2 {
     };
 
     //! Tone, tag 0x1004
-    extern const TagDetails fujiTone[] = {
+    constexpr TagDetails fujiTone[] = {
         {   0, N_("Normal") },
         { 256, N_("High")   },
         { 512, N_("Low")    }
     };
 
     //! FlashMode, tag 0x1010
-    extern const TagDetails fujiFlashMode[] = {
+    constexpr TagDetails fujiFlashMode[] = {
         {  0, N_("Auto")              },
         {  1, N_("On")                },
         {  2, N_("Off")               },
@@ -105,13 +105,13 @@ namespace Exiv2 {
     };
 
     //! FocusMode, tag 0x1021
-    extern const TagDetails fujiFocusMode[] = {
+    constexpr TagDetails fujiFocusMode[] = {
         { 0, N_("Auto")   },
         { 1, N_("Manual") }
     };
 
     //! PictureMode, tag 0x1031
-    extern const TagDetails fujiPictureMode[] = {
+    constexpr TagDetails fujiPictureMode[] = {
         {   0, N_("Auto")                      },
         {   1, N_("Portrait")                  },
         {   2, N_("Landscape")                 },
@@ -137,7 +137,7 @@ namespace Exiv2 {
 
     //! ShadowTone, tag 0x1040
     //! HighlightTone, tag 0x041
-    extern const TagDetails fujiSHTone[] = {
+    constexpr TagDetails fujiSHTone[] = {
         { -64, N_("+4") },
         { -48, N_("+3") },
         { -32, N_("+2") },
@@ -148,27 +148,27 @@ namespace Exiv2 {
     };
 
     //! Continuous, tag 0x1100
-    extern const TagDetails fujiContinuous[] = {
+    constexpr TagDetails fujiContinuous[] = {
         { 0, N_("Off")              },
         { 1, N_("On")               },
         { 2, N_("No flash & flash") }
     };
 
     //! FinePixColor, tag 0x1210
-    extern const TagDetails fujiFinePixColor[] = {
+    constexpr TagDetails fujiFinePixColor[] = {
         { 0,  N_("Standard")      },
         { 16, N_("Chrome")        },
         { 48, N_("Black & white") }
     };
 
     //! DynamicRange, tag 0x1400
-    extern const TagDetails fujiDynamicRange[] = {
+    constexpr TagDetails fujiDynamicRange[] = {
         { 1, N_("Standard") },
         { 3, N_("Wide")     }
     };
 
     //! FilmMode, tag 0x1401
-    extern const TagDetails fujiFilmMode[] = {
+    constexpr TagDetails fujiFilmMode[] = {
         {    0, N_("F0/Standard (Provia)")                         },
         {  256, N_("F1/Studio Portrait")                           },
         {  272, N_("F1a/Studio Portrait Enhanced Saturation")      },
@@ -183,7 +183,7 @@ namespace Exiv2 {
     };
 
     //! DynamicRange, tag 0x1402
-    extern const TagDetails fujiDynamicRangeSetting[] = {
+    constexpr TagDetails fujiDynamicRangeSetting[] = {
         {     0, N_("Auto (100-400%)")      },
         {     1, N_("Raw")                  },
         {   256, N_("Standard (100%)")      },
@@ -193,19 +193,19 @@ namespace Exiv2 {
     };
 
     //! DRangePriority, tag 0x1443
-    extern const TagDetails fujiDRangePriority[] = {
+    constexpr TagDetails fujiDRangePriority[] = {
         {     0, N_("Auto")  },
         {     1, N_("Fixed") }
     };
 
     //! DRangePriorityAuto, tag 0x1444
-    extern const TagDetails fujiDRangePriorityAuto[] = {
+    constexpr TagDetails fujiDRangePriorityAuto[] = {
         {     1, N_("Weak")  },
         {     2, N_("Strong") }
     };
 
     //! DRangePriorityFixed, tag 0x1445
-    extern const TagDetails fujiDRangePriorityFixed[] = {
+    constexpr TagDetails fujiDRangePriorityFixed[] = {
         {     1, N_("Weak")  },
         {     2, N_("Strong") }
     };

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1077,7 +1077,7 @@ namespace Exiv2 {
 #define NA ((uint32_t)-1)
 
     //! Nikon binary array version lookup table
-    extern const NikonArrayIdx nikonArrayIdx[] = {
+    constexpr NikonArrayIdx nikonArrayIdx[] = {
         // NikonSi
         { 0x0091, "0208",    0, 0,   4 }, // D80
         { 0x0091, "0209",    0, 1,   4 }, // D40

--- a/src/minoltamn_int.cpp
+++ b/src/minoltamn_int.cpp
@@ -51,7 +51,7 @@ namespace Exiv2 {
     // -- Standard Minolta Makernotes tags ---------------------------------------------------------------
 
     //! Lookup table to translate Minolta color mode values to readable labels
-    extern const TagDetails minoltaColorMode[] = {
+    constexpr TagDetails minoltaColorMode[] = {
         { 0,  N_("Natural Color")  },
         { 1,  N_("Black & White")  },
         { 2,  N_("Vivid Color")    },
@@ -69,7 +69,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta image quality values to readable labels
-    extern const TagDetails minoltaImageQuality[] = {
+    constexpr TagDetails minoltaImageQuality[] = {
         { 0, N_("Raw")        },
         { 1, N_("Super Fine") },
         { 2, N_("Fine")       },
@@ -79,7 +79,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta image stabilization values
-    extern const TagDetails minoltaImageStabilization[] = {
+    constexpr TagDetails minoltaImageStabilization[] = {
         { 1, N_("Off") },
         { 5, N_("On")  }
     };
@@ -196,7 +196,7 @@ namespace Exiv2 {
     // -- Standard Minolta camera settings ---------------------------------------------------------------
 
     //! Lookup table to translate Minolta Std camera settings exposure mode values to readable labels
-    extern const TagDetails minoltaExposureModeStd[] = {
+    constexpr TagDetails minoltaExposureModeStd[] = {
         { 0, N_("Program")           },
         { 1, N_("Aperture priority") },
         { 2, N_("Shutter priority")  },
@@ -204,7 +204,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings flash mode values to readable labels
-    extern const TagDetails minoltaFlashModeStd[] = {
+    constexpr TagDetails minoltaFlashModeStd[] = {
         { 0, N_("Fill flash")        },
         { 1, N_("Red-eye reduction") },
         { 2, N_("Rear flash sync")   },
@@ -213,7 +213,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings white balance values to readable labels
-    extern const TagDetails minoltaWhiteBalanceStd[] = {
+    constexpr TagDetails minoltaWhiteBalanceStd[] = {
         { 0,  N_("Auto")          },
         { 1,  N_("Daylight")      },
         { 2,  N_("Cloudy")        },
@@ -226,7 +226,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings image size values to readable labels
-    extern const TagDetails minoltaImageSizeStd[] = {
+    constexpr TagDetails minoltaImageSizeStd[] = {
         { 0, N_("Full size") },
         { 1, "1600x1200"     },
         { 2, "1280x960"      },
@@ -237,7 +237,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings image quality values to readable labels
-    extern const TagDetails minoltaImageQualityStd[] = {
+    constexpr TagDetails minoltaImageQualityStd[] = {
         { 0, N_("Raw")        },
         { 1, N_("Super fine") },
         { 2, N_("Fine")       },
@@ -247,7 +247,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings drive mode values to readable labels
-    extern const TagDetails minoltaDriveModeStd[] = {
+    constexpr TagDetails minoltaDriveModeStd[] = {
         { 0, N_("Single Frame")   },
         { 1, N_("Continuous")     },
         { 2, N_("Self-timer")     },
@@ -258,28 +258,28 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings metering mode values to readable labels
-    extern const TagDetails minoltaMeteringModeStd[] = {
+    constexpr TagDetails minoltaMeteringModeStd[] = {
         { 0, N_("Multi-segment")           },
         { 1, N_("Center weighted average") },
         { 2, N_("Spot")                    }
     };
 
     //! Lookup table to translate Minolta Std camera settings digital zoom values to readable labels
-    extern const TagDetails minoltaDigitalZoomStd[] = {
+    constexpr TagDetails minoltaDigitalZoomStd[] = {
         { 0, N_("Off")                      },
         { 1, N_("Electronic magnification") },
         { 2, "2x"                           }
     };
 
     //! Lookup table to translate Minolta Std camera bracket step mode values to readable labels
-    extern const TagDetails minoltaBracketStepStd[] = {
+    constexpr TagDetails minoltaBracketStepStd[] = {
         { 0, "1/3 EV" },
         { 1, "2/3 EV" },
         { 2, "1 EV"   }
     };
 
     //! Lookup table to translate Minolta Std camera settings AF points values to readable labels
-    extern const TagDetails minoltaAFPointsStd[] = {
+    constexpr TagDetails minoltaAFPointsStd[] = {
         { 0, N_("Center")       },
         { 1, N_("Top")          },
         { 2, N_("Top-right")    },
@@ -292,20 +292,20 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings flash fired values to readable labels
-    extern const TagDetails minoltaFlashFired[] = {
+    constexpr TagDetails minoltaFlashFired[] = {
         { 0, N_("Did not fire") },
         { 1, N_("Fired")        }
     };
 
     //! Lookup table to translate Minolta Std camera settings sharpness values to readable labels
-    extern const TagDetails minoltaSharpnessStd[] = {
+    constexpr TagDetails minoltaSharpnessStd[] = {
         { 0, N_("Hard")   },
         { 1, N_("Normal") },
         { 2, N_("Soft")   }
     };
 
     //! Lookup table to translate Minolta Std camera settings subject program values to readable labels
-    extern const TagDetails minoltaSubjectProgramStd[] = {
+    constexpr TagDetails minoltaSubjectProgramStd[] = {
         { 0, N_("None")           },
         { 1, N_("Portrait")       },
         { 2, N_("Text")           },
@@ -315,7 +315,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings ISO settings values to readable labels
-    extern const TagDetails minoltaISOSettingStd[] = {
+    constexpr TagDetails minoltaISOSettingStd[] = {
         { 0, "100"      },
         { 1, "200"      },
         { 2, "400"      },
@@ -325,7 +325,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings model values to readable labels
-    extern const TagDetails minoltaModelStd[] = {
+    constexpr TagDetails minoltaModelStd[] = {
         { 0, "DiMAGE 7 | X1 | X21 | X31" },
         { 1, "DiMAGE 5"                  },
         { 2, "DiMAGE S304"               },
@@ -338,19 +338,19 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings interval mode values to readable labels
-    extern const TagDetails minoltaIntervalModeStd[] = {
+    constexpr TagDetails minoltaIntervalModeStd[] = {
         { 0, N_("Still image")      },
         { 1, N_("Time-lapse movie") }
     };
 
     //! Lookup table to translate Minolta Std camera settings folder name values to readable labels
-    extern const TagDetails minoltaFolderNameStd[] = {
+    constexpr TagDetails minoltaFolderNameStd[] = {
         { 0, N_("Standard form") },
         { 1, N_("Data form")     }
     };
 
     //! Lookup table to translate Minolta Std camera settings color mode values to readable labels
-    extern const TagDetails minoltaColorModeStd[] = {
+    constexpr TagDetails minoltaColorModeStd[] = {
         { 0, N_("Natural color")   },
         { 1, N_("Black and white") },
         { 2, N_("Vivid color")     },
@@ -359,7 +359,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings wide focus zone values to readable labels
-    extern const TagDetails minoltaWideFocusZoneStd[] = {
+    constexpr TagDetails minoltaWideFocusZoneStd[] = {
         { 0, N_("No zone")                              },
         { 1, N_("Center zone (horizontal orientation)") },
         { 1, N_("Center zone (vertical orientation)")   },
@@ -368,19 +368,19 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings focus mode values to readable labels
-    extern const TagDetails minoltaFocusModeStd[] = {
+    constexpr TagDetails minoltaFocusModeStd[] = {
         { 0, N_("Auto focus")   },
         { 1, N_("Manual focus") }
     };
 
     //! Lookup table to translate Minolta Std camera settings focus area values to readable labels
-    extern const TagDetails minoltaFocusAreaStd[] = {
+    constexpr TagDetails minoltaFocusAreaStd[] = {
         { 0, N_("Wide focus (normal)") },
         { 1, N_("Spot focus")          }
     };
 
     //! Lookup table to translate Minolta Std camera settings DEC switch position values to readable labels
-    extern const TagDetails minoltaDECPositionStd[] = {
+    constexpr TagDetails minoltaDECPositionStd[] = {
         { 0, N_("Exposure")   },
         { 1, N_("Contrast")   },
         { 2, N_("Saturation") },
@@ -388,13 +388,13 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings color profile values to readable labels
-    extern const TagDetails minoltaColorProfileStd[] = {
+    constexpr TagDetails minoltaColorProfileStd[] = {
         { 0, N_("Not embedded") },
         { 1, N_("Embedded")     }
     };
 
     //! Lookup table to translate Minolta Std camera settings data Imprint values to readable labels
-    extern const TagDetails minoltaDataImprintStd[] = {
+    constexpr TagDetails minoltaDataImprintStd[] = {
         { 0, N_("None")       },
         { 1, "YYYY/MM/DD"     },
         { 2, "MM/DD/HH:MM"    },
@@ -403,7 +403,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Std camera settings flash metering values to readable labels
-    extern const TagDetails minoltaFlashMeteringStd[] = {
+    constexpr TagDetails minoltaFlashMeteringStd[] = {
         { 0, N_("ADI (Advanced Distance Integration)") },
         { 1, N_("Pre-flash TTl")                       },
         { 2, N_("Manual flash control")                }
@@ -650,7 +650,7 @@ namespace Exiv2 {
     // -- Minolta Dynax 7D camera settings ---------------------------------------------------------------
 
     //! Lookup table to translate Minolta Dynax 7D camera settings exposure mode values to readable labels
-    extern const TagDetails minoltaExposureMode7D[] = {
+    constexpr TagDetails minoltaExposureMode7D[] = {
         { 0, N_("Program")           },
         { 1, N_("Aperture priority") },
         { 2, N_("Shutter priority")  },
@@ -661,14 +661,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings image size values to readable labels
-    extern const TagDetails minoltaImageSize7D[] = {
+    constexpr TagDetails minoltaImageSize7D[] = {
         { 0, N_("Large")  },
         { 1, N_("Medium") },
         { 2, N_("Small")  }
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings image quality values to readable labels
-    extern const TagDetails minoltaImageQuality7D[] = {
+    constexpr TagDetails minoltaImageQuality7D[] = {
         { 0,  N_("Raw")      },
         { 16, N_("Fine")     },
         { 32, N_("Normal")   },
@@ -677,7 +677,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings white balance values to readable labels
-    extern const TagDetails minoltaWhiteBalance7D[] = {
+    constexpr TagDetails minoltaWhiteBalance7D[] = {
         { 0,   N_("Auto")        },
         { 1,   N_("Daylight")    },
         { 2,   N_("Shade")       },
@@ -690,7 +690,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings focus mode values to readable labels
-    extern const TagDetails minoltaFocusMode7D[] = {
+    constexpr TagDetails minoltaFocusMode7D[] = {
         { 0, N_("Single-shot AF") },
         { 1, N_("Continuous AF")  },
         { 3, N_("Manual")         },
@@ -698,7 +698,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings AF points values to readable labels
-    extern const TagDetails minoltaAFPoints7D[] = {
+    constexpr TagDetails minoltaAFPoints7D[] = {
         { 1,   N_("Center")       },
         { 2,   N_("Top")          },
         { 4,   N_("Top-right")    },
@@ -711,7 +711,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings ISO settings values to readable labels
-    extern const TagDetails minoltaISOSetting7D[] = {
+    constexpr TagDetails minoltaISOSetting7D[] = {
         { 0, N_("Auto") },
         { 1, "100"      },
         { 3, "200"      },
@@ -722,14 +722,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings color space values to readable labels
-    extern const TagDetails minoltaColorSpace7D[] = {
+    constexpr TagDetails minoltaColorSpace7D[] = {
         { 0, N_("sRGB (Natural)")  },
         { 1, N_("sRGB (Natural+)") },
         { 4, N_("Adobe RGB")       }
     };
 
     //! Lookup table to translate Minolta Dynax 7D camera settings rotation values to readable labels
-    extern const TagDetails minoltaRotation7D[] = {
+    constexpr TagDetails minoltaRotation7D[] = {
         { 72, N_("Horizontal (normal)") },
         { 76, N_("Rotate 90 CW")        },
         { 82, N_("Rotate 270 CW")       }
@@ -830,7 +830,7 @@ namespace Exiv2 {
     // -- Minolta Dynax 5D camera settings ---------------------------------------------------------------
 
     //! Lookup table to translate Minolta Dynax 5D camera settings exposure mode values to readable labels
-    extern const TagDetails minoltaExposureMode5D[] = {
+    constexpr TagDetails minoltaExposureMode5D[] = {
         { 0,      N_("Program")             },
         { 1,      N_("Aperture priority")   },
         { 2,      N_("Shutter priority")    },
@@ -847,14 +847,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings image size values to readable labels
-    extern const TagDetails minoltaImageSize5D[] = {
+    constexpr TagDetails minoltaImageSize5D[] = {
         { 0, N_("Large")  },
         { 1, N_("Medium") },
         { 2, N_("Small")  }
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings image quality values to readable labels
-    extern const TagDetails minoltaImageQuality5D[] = {
+    constexpr TagDetails minoltaImageQuality5D[] = {
         { 0,  N_("Raw")      },
         { 16, N_("Fine")     },
         { 32, N_("Normal")   },
@@ -863,7 +863,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings white balance values to readable labels
-    extern const TagDetails minoltaWhiteBalance5D[] = {
+    constexpr TagDetails minoltaWhiteBalance5D[] = {
         { 0,   N_("Auto")        },
         { 1,   N_("Daylight")    },
         { 2,   N_("Cloudy")      },
@@ -876,14 +876,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings metering mode values to readable labels
-    extern const TagDetails minoltaMeteringMode5D[] = {
+    constexpr TagDetails minoltaMeteringMode5D[] = {
         { 0, N_("Multi-segment")   },
         { 1, N_("Center weighted") },
         { 2, N_("Spot")            }
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings ISO settings values to readable labels
-    extern const TagDetails minoltaISOSetting5D[] = {
+    constexpr TagDetails minoltaISOSetting5D[] = {
         { 0,  N_("Auto")                     },
         { 1,  "100"                          },
         { 3,  "200"                          },
@@ -896,7 +896,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings color space values to readable labels
-    extern const TagDetails minoltaColorSpace5D[] = {
+    constexpr TagDetails minoltaColorSpace5D[] = {
         { 0, N_("sRGB (Natural)")  },
         { 1, N_("sRGB (Natural+)") },
         { 2, N_("Monochrome")      },
@@ -905,14 +905,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings rotation values to readable labels
-    extern const TagDetails minoltaRotation5D[] = {
+    constexpr TagDetails minoltaRotation5D[] = {
         { 72, N_("Horizontal (normal)") },
         { 76, N_("Rotate 90 CW")        },
         { 82, N_("Rotate 270 CW")       }
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings focus position values to readable labels
-    extern const TagDetails minoltaFocusPosition5D[] = {
+    constexpr TagDetails minoltaFocusPosition5D[] = {
         { 0, N_("Wide")       },
         { 1, N_("Central")    },
         { 2, N_("Up")         },
@@ -926,14 +926,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings focus area values to readable labels
-    extern const TagDetails minoltaFocusArea5D[] = {
+    constexpr TagDetails minoltaFocusArea5D[] = {
         { 0, N_("Wide")      },
         { 1, N_("Selection") },
         { 2, N_("Spot")      }
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings focus mode values to readable labels
-    extern const TagDetails minoltaAFMode5D[] = {
+    constexpr TagDetails minoltaAFMode5D[] = {
         { 0, "AF-A" },
         { 1, "AF-S" },
         { 2, "AF-D" },
@@ -941,7 +941,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Minolta Dynax 5D camera settings picture finish values to readable labels
-    extern const TagDetails minoltaPictureFinish5D[] = {
+    constexpr TagDetails minoltaPictureFinish5D[] = {
         { 0, N_("Natural")         },
         { 1, N_("Natural+")        },
         { 2, N_("Portrait")        },
@@ -1095,7 +1095,7 @@ namespace Exiv2 {
     // -- Sony A100 camera settings ---------------------------------------------------------------
 
     //! Lookup table to translate Sony A100 camera settings drive mode 2 values to readable labels
-    extern const TagDetails sonyDriveMode2A100[] = {
+    constexpr TagDetails sonyDriveMode2A100[] = {
         { 0,    N_("Self-timer 10 sec")             },
         { 1,    N_("Continuous")                    },
         { 4,    N_("Self-timer 2 sec")              },
@@ -1109,7 +1109,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings focus mode values to readable labels
-    extern const TagDetails sonyFocusModeA100[] = {
+    constexpr TagDetails sonyFocusModeA100[] = {
         { 0, "AF-S"   },
         { 1, "AF-C"   },
         { 4, "AF-A"   },
@@ -1118,7 +1118,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings flash mode values to readable labels
-    extern const TagDetails sonyFlashModeA100[] = {
+    constexpr TagDetails sonyFlashModeA100[] = {
         { 0, N_("Auto")            },
         { 2, N_("Rear flash sync") },
         { 3, N_("Wireless")        },
@@ -1126,14 +1126,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings metering mode values to readable labels
-    extern const TagDetails sonyMeteringModeA100[] = {
+    constexpr TagDetails sonyMeteringModeA100[] = {
         { 0, N_("Multi-segment")           },
         { 1, N_("Center weighted average") },
         { 2, N_("Spot")                    }
     };
 
     //! Lookup table to translate Sony A100 camera settings zone matching mode values to readable labels
-    extern const TagDetails sonyZoneMatchingModeA100[] = {
+    constexpr TagDetails sonyZoneMatchingModeA100[] = {
         { 0,    N_("Off")      },
         { 1,    N_("Standard") },
         { 2,    N_("Advanced") }
@@ -1141,13 +1141,13 @@ namespace Exiv2 {
 
     //! Lookup table to translate Sony A100 camera settings color space values to readable labels
 
-    extern const TagDetails sonyColorSpaceA100[] = {
+    constexpr TagDetails sonyColorSpaceA100[] = {
         { 0, N_("sRGB")      },
         { 5, N_("Adobe RGB") }
     };
 
     //! Lookup table to translate Sony A100 camera settings drive mode values to readable labels
-    extern const TagDetails sonyDriveModeA100[] = {
+    constexpr TagDetails sonyDriveModeA100[] = {
         { 0, N_("Single Frame")             },
         { 1, N_("Continuous")               },
         { 2, N_("Self-timer")               },
@@ -1157,31 +1157,31 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings self timer time values to readable labels
-    extern const TagDetails sonySelfTimerTimeA100[] = {
+    constexpr TagDetails sonySelfTimerTimeA100[] = {
         { 0, "10s" },
         { 4, "2s"  }
     };
 
     //! Lookup table to translate Sony A100 camera settings continuous bracketing values to readable labels
-    extern const TagDetails sonyContinuousBracketingA100[] = {
+    constexpr TagDetails sonyContinuousBracketingA100[] = {
         { 0x303, N_("Low")  },
         { 0x703, N_("High") }
     };
 
     //! Lookup table to translate Sony A100 camera settings single frame bracketing values to readable labels
-    extern const TagDetails sonySingleFrameBracketingA100[] = {
+    constexpr TagDetails sonySingleFrameBracketingA100[] = {
         { 0x302, N_("Low")  },
         { 0x702, N_("High") }
     };
 
     //! Lookup table to translate Sony A100 camera settings white balance bracketing values to readable labels
-    extern const TagDetails sonyWhiteBalanceBracketingA100[] = {
+    constexpr TagDetails sonyWhiteBalanceBracketingA100[] = {
         { 0x8, N_("Low")  },
         { 0x9, N_("High") }
     };
 
     //! Lookup table to translate Sony A100 camera settings white balance setting values to readable labels
-    extern const TagDetails sonyWhiteBalanceSettingA100[] = {
+    constexpr TagDetails sonyWhiteBalanceSettingA100[] = {
         { 0x0000, N_("Auto")                           },
         { 0x0001, N_("Preset")                         },
         { 0x0002, N_("Custom")                         },
@@ -1192,7 +1192,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings preset white balance values to readable labels
-    extern const TagDetails sonyPresetWhiteBalanceA100[] = {
+    constexpr TagDetails sonyPresetWhiteBalanceA100[] = {
         { 1, N_("Daylight")    },
         { 2, N_("Cloudy")      },
         { 3, N_("Shade")       },
@@ -1202,57 +1202,57 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings color temperature setting values to readable labels
-    extern const TagDetails sonyColorTemperatureSettingA100[] = {
+    constexpr TagDetails sonyColorTemperatureSettingA100[] = {
         { 0, N_("Temperature")  },
         { 2, N_("Color Filter") }
     };
 
     //! Lookup table to translate Sony A100 camera settings custom WB setting values to readable labels
-    extern const TagDetails sonyCustomWBSettingA100[] = {
+    constexpr TagDetails sonyCustomWBSettingA100[] = {
         { 0, N_("Setup")  },
         { 2, N_("Recall") }
     };
 
     //! Lookup table to translate Sony A100 camera settings custom WB error values to readable labels
-    extern const TagDetails sonyCustomWBErrorA100[] = {
+    constexpr TagDetails sonyCustomWBErrorA100[] = {
         { 0, N_("Ok")    },
         { 2, N_("Error") }
     };
 
     //! Lookup table to translate Sony A100 camera settings image size values to readable labels
-    extern const TagDetails sonyImageSizeA100[] = {
+    constexpr TagDetails sonyImageSizeA100[] = {
         { 0, N_("Standard") },
         { 1, N_("Medium")   },
         { 2, N_("Small")    }
     };
 
     //! Lookup table to translate Sony A100 camera settings instant playback setup values to readable labels
-    extern const TagDetails sonyInstantPlaybackSetupA100[] = {
+    constexpr TagDetails sonyInstantPlaybackSetupA100[] = {
         { 0, N_("Image and Information") },
         { 1, N_("Image Only")            },
         { 3, N_("Image and Histogram")   }
     };
 
     //! Lookup table to translate Sony A100 camera settings flash default setup values to readable labels
-    extern const TagDetails sonyFlashDefaultA100[] = {
+    constexpr TagDetails sonyFlashDefaultA100[] = {
         { 0, N_("Auto")       },
         { 1, N_("Fill Flash") }
     };
 
     //! Lookup table to translate Sony A100 camera settings auto bracket order values to readable labels
-    extern const TagDetails sonyAutoBracketOrderA100[] = {
+    constexpr TagDetails sonyAutoBracketOrderA100[] = {
         { 0, "0-+" },
         { 1, "-0+" }
     };
 
     //! Lookup table to translate Sony A100 camera settings focus hold button values to readable labels
-    extern const TagDetails sonyFocusHoldButtonA100[] = {
+    constexpr TagDetails sonyFocusHoldButtonA100[] = {
         { 0, N_("Focus Hold")  },
         { 1, N_("DOF Preview") }
     };
 
     //! Lookup table to translate Sony A100 camera settings AEL button values to readable labels
-    extern const TagDetails sonyAELButtonA100[] = {
+    constexpr TagDetails sonyAELButtonA100[] = {
         { 0, N_("Hold")        },
         { 1, N_("Toggle")      },
         { 2, N_("Spot Hold")   },
@@ -1260,51 +1260,51 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings control dial set values to readable labels
-    extern const TagDetails sonyControlDialSetA100[] = {
+    constexpr TagDetails sonyControlDialSetA100[] = {
         { 0, N_("Shutter Speed") },
         { 1, N_("Aperture")      }
     };
 
     //! Lookup table to translate Sony A100 camera settings exposure compensation mode values to readable labels
-    extern const TagDetails sonyExposureCompensationModeA100[] = {
+    constexpr TagDetails sonyExposureCompensationModeA100[] = {
         { 0, N_("Ambient and Flash") },
         { 1, N_("Ambient Only")      }
     };
 
     //! Lookup table to translate Sony A100 camera settings sony AF area illumination values to readable labels
-    extern const TagDetails sonyAFAreaIlluminationA100[] = {
+    constexpr TagDetails sonyAFAreaIlluminationA100[] = {
         { 0, N_("0.3 seconds") },
         { 1, N_("0.6 seconds") },
         { 2, N_("Off")         }
     };
 
     //! Lookup table to translate Sony A100 camera settings monitor display off values to readable labels
-    extern const TagDetails sonyMonitorDisplayOffA100[] = {
+    constexpr TagDetails sonyMonitorDisplayOffA100[] = {
         { 0, N_("Automatic") },
         { 1, N_("Manual")    }
     };
 
     //! Lookup table to translate Sony A100 camera settings record display values to readable labels
-    extern const TagDetails sonyRecordDisplayA100[] = {
+    constexpr TagDetails sonyRecordDisplayA100[] = {
         { 0, N_("Auto-rotate") },
         { 1, N_("Horizontal")  }
     };
 
     //! Lookup table to translate Sony A100 camera settings play display values to readable labels
-    extern const TagDetails sonyPlayDisplayA100[] = {
+    constexpr TagDetails sonyPlayDisplayA100[] = {
         { 0, N_("Auto-rotate")   },
         { 1, N_("Manual Rotate") }
     };
 
     //! Lookup table to translate Sony A100 camera settings metering off scale indicator values to readable labels
-    extern const TagDetails sonyMeteringOffScaleIndicatorA100[] = {
+    constexpr TagDetails sonyMeteringOffScaleIndicatorA100[] = {
         { 0,   N_("Within Range")     },
         { 1,   N_("Under/Over Range") },
         { 255, N_("Out of Range")     }
     };
 
     //! Lookup table to translate Sony A100 camera settings exposure indicator values to readable labels
-    extern const TagDetails sonyExposureIndicatorA100[] = {
+    constexpr TagDetails sonyExposureIndicatorA100[] = {
         { 0,   N_("Not Indicated")   },
         { 1,   N_("Under Scale")     },
         { 119, N_("Bottom of Scale") },
@@ -1330,20 +1330,20 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony A100 camera settings focus mode switch values to readable labels
-    extern const TagDetails sonyFocusModeSwitchA100[] = {
+    constexpr TagDetails sonyFocusModeSwitchA100[] = {
         { 0, N_("AM") },
         { 1, N_("MF") }
     };
 
     //! Lookup table to translate Sony A100 camera settings flash type switch values to readable labels
-    extern const TagDetails sonyFlashTypeA100[] = {
+    constexpr TagDetails sonyFlashTypeA100[] = {
         { 0, N_("Off")      },
         { 1, N_("Built-in") },
         { 2, N_("External") }
     };
 
     //! Lookup table to translate Sony A100 camera settings battery level switch values to readable labels
-    extern const TagDetails sonyBatteryLevelA100[] = {
+    constexpr TagDetails sonyBatteryLevelA100[] = {
         { 3, N_("Very Low")                   },
         { 4, N_("Low")                        },
         { 5, N_("Half Full")                  },
@@ -2246,7 +2246,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Minolta A100 and all other Sony Alpha camera color mode values to readable labels
-    extern const TagDetails minoltaSonyColorMode[] = {
+    constexpr TagDetails minoltaSonyColorMode[] = {
         { 0,   N_("Standard")            },
         { 1,   N_("Vivid Color")         },
         { 2,   N_("Portrait")            },
@@ -2272,7 +2272,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Minolta/Sony bool function values to readable labels
-    extern const TagDetails minoltaSonyBoolFunction[] = {
+    constexpr TagDetails minoltaSonyBoolFunction[] = {
         { 0, N_("Off") },
         { 1, N_("On")  }
     };
@@ -2285,7 +2285,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Minolta/Sony bool inverse function values to readable labels
-    extern const TagDetails minoltaSonyBoolInverseFunction[] = {
+    constexpr TagDetails minoltaSonyBoolInverseFunction[] = {
         { 0, N_("On")  },
         { 1, N_("Off") }
     };
@@ -2298,7 +2298,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings focus mode values to readable labels
-    extern const TagDetails minoltaSonyAFAreaMode[] = {
+    constexpr TagDetails minoltaSonyAFAreaMode[] = {
         { 0, N_("Wide")  },
         { 1, N_("Local") },
         { 2, N_("Spot")  }
@@ -2312,7 +2312,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings Local AF Area Point values to readable labels
-    extern const TagDetails minoltaSonyLocalAFAreaPoint[] = {
+    constexpr TagDetails minoltaSonyLocalAFAreaPoint[] = {
         { 1,  N_("Center")       },
         { 2,  N_("Top")          },
         { 3,  N_("Top-Right")    },
@@ -2334,7 +2334,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings dynamic range optimizer mode values to readable labels
-    extern const TagDetails minoltaSonyDynamicRangeOptimizerMode[] = {
+    constexpr TagDetails minoltaSonyDynamicRangeOptimizerMode[] = {
         { 0,    N_("Off")            },
         { 1,    N_("Standard")       },
         { 2,    N_("Advanced Auto")  },
@@ -2350,7 +2350,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings priority setup shutter release values to readable labels
-    extern const TagDetails minoltaSonyPrioritySetupShutterRelease[] = {
+    constexpr TagDetails minoltaSonyPrioritySetupShutterRelease[] = {
         { 0, N_("AF")      },
         { 1, N_("Release") }
     };
@@ -2363,7 +2363,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings quality values to readable labels
-    extern const TagDetails minoltaSonyQualityCs[] = {
+    constexpr TagDetails minoltaSonyQualityCs[] = {
         { 0,   N_("RAW")        },
         { 2,   N_("CRAW")       },
         { 16,  N_("Extra Fine") },
@@ -2381,7 +2381,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings rotation values to readable labels
-    extern const TagDetails minoltaSonyRotation[] = {
+    constexpr TagDetails minoltaSonyRotation[] = {
         { 0, N_("Horizontal (normal)") },
         { 1, N_("Rotate 90 CW")        },
         { 2, N_("Rotate 270 CW")       }
@@ -2395,7 +2395,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Minolta/Sony scene mode values to readable labels
-    extern const TagDetails minoltaSonySceneMode[] = {
+    constexpr TagDetails minoltaSonySceneMode[] = {
         { 0,  N_("Standard")            },
         { 1,  N_("Portrait")            },
         { 2,  N_("Text")                },
@@ -2418,7 +2418,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony/Minolta image quality values to readable labels
-    extern const TagDetails minoltaSonyImageQuality[] = {
+    constexpr TagDetails minoltaSonyImageQuality[] = {
         { 0, N_("Raw")                   },
         { 1, N_("Super Fine")            },
         { 2, N_("Fine")                  },
@@ -2438,7 +2438,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony/Minolta teleconverter model values to readable labels
-    extern const TagDetails minoltaSonyTeleconverterModel[] = {
+    constexpr TagDetails minoltaSonyTeleconverterModel[] = {
         { 0x00, N_("None")                                },
         { 0x04, N_("Minolta/Sony AF 1.4x APO (D) (0x04)") },
         { 0x05, N_("Minolta/Sony AF 2x APO (D) (0x05)")   },
@@ -2458,7 +2458,7 @@ namespace Exiv2 {
     // ----------------------------------------------------------------------------------------------------
 
     //! Lookup table to translate Sony/Minolta Std camera settings white balance values to readable labels
-    extern const TagDetails minoltaSonyWhiteBalanceStd[] = {
+    constexpr TagDetails minoltaSonyWhiteBalanceStd[] = {
         { 0x00,  N_("Auto")                           },
         { 0x01,  N_("Color Temperature/Color Filter") },
         { 0x10,  N_("Daylight")                       },
@@ -2476,7 +2476,7 @@ namespace Exiv2 {
     }
 
     //! Lookup table to translate Sony/Minolta zone matching values to readable labels
-    extern const TagDetails minoltaSonyZoneMatching[] = {
+    constexpr TagDetails minoltaSonyZoneMatching[] = {
         { 0, N_("ISO Setting Used") },
         { 1, N_("High Key") },
         { 2, N_("Low Key")  }

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -53,13 +53,13 @@ namespace Exiv2 {
     namespace Internal {
 
     //! OffOn, multiple tags
-    extern const TagDetails nikonOffOn[] = {
+    constexpr TagDetails nikonOffOn[] = {
         {  0, N_("Off") },
         {  1, N_("On")  }
     };
 
     //! Off, Low, Normal, High, multiple tags
-    extern const TagDetails nikonOlnh[] = {
+    constexpr TagDetails nikonOlnh[] = {
         {  0, N_("Off")    },
         {  1, N_("Low")    },
         {  3, N_("Normal") },
@@ -67,7 +67,7 @@ namespace Exiv2 {
     };
 
     //! Off, Low, Normal, High, multiple tags
-    extern const TagDetails nikonActiveDLighning[] = {
+    constexpr TagDetails nikonActiveDLighning[] = {
         {     0, N_("Off")        },
         {     1, N_("Low")        },
         {     3, N_("Normal")     },
@@ -77,7 +77,7 @@ namespace Exiv2 {
     };
 
     //! Focus area for Nikon cameras.
-    extern const char * const nikonFocusarea[] = {
+    constexpr const char *nikonFocusarea[] = {
         N_("Single area"),
         N_("Dynamic area"),
         N_("Dynamic area, closest subject"),
@@ -90,7 +90,7 @@ namespace Exiv2 {
     // module. Note that relative size and position will vary depending on if
     // "wide" or not
     //! Focus points for Nikon cameras, used for Nikon 1 and Nikon 3 makernotes.
-    extern const char * const nikonFocuspoints[] = {
+    constexpr const char *nikonFocuspoints[] = {
         N_("Center"),
         N_("Top"),
         N_("Bottom"),
@@ -105,7 +105,7 @@ namespace Exiv2 {
     };
 
     //! FlashComp, tag 0x0012
-    extern const TagDetails nikonFlashComp[] = {
+    constexpr TagDetails nikonFlashComp[] = {
         // From the PHP JPEG Metadata Toolkit
         { 0x06, "+1.0 EV" },
         { 0x04, "+0.7 EV" },
@@ -127,13 +127,13 @@ namespace Exiv2 {
     };
 
     //! ColorSpace, tag 0x001e
-    extern const TagDetails nikonColorSpace[] = {
+    constexpr TagDetails nikonColorSpace[] = {
         { 1, N_("sRGB")      },
         { 2, N_("Adobe RGB") }
     };
 
     //! FlashMode, tag 0x0087
-    extern const TagDetails nikonFlashMode[] = {
+    constexpr TagDetails nikonFlashMode[] = {
         { 0, N_("Did not fire")         },
         { 1, N_("Fire, manual")         },
         { 7, N_("Fire, external")       },
@@ -142,7 +142,7 @@ namespace Exiv2 {
     };
 
     //! ShootingMode, tag 0x0089
-    extern const TagDetailsBitmask nikonShootingMode[] = {
+    constexpr TagDetailsBitmask nikonShootingMode[] = {
         { 0x0001, N_("Continuous")               },
         { 0x0002, N_("Delay")                    },
         { 0x0004, N_("PC Control")               },
@@ -155,7 +155,7 @@ namespace Exiv2 {
     };
 
     //! ShootingMode D70, tag 0x0089
-    extern const TagDetailsBitmask nikonShootingModeD70[] = {
+    constexpr TagDetailsBitmask nikonShootingModeD70[] = {
         { 0x0001, N_("Continuous")               },
         { 0x0002, N_("Delay")                    },
         { 0x0004, N_("PC control")               },
@@ -166,14 +166,14 @@ namespace Exiv2 {
     };
 
     //! AutoBracketRelease, tag 0x008a
-    extern const TagDetails nikonAutoBracketRelease[] = {
+    constexpr TagDetails nikonAutoBracketRelease[] = {
         { 0, N_("None")           },
         { 1, N_("Auto release")   },
         { 2, N_("Manual release") }
     };
 
     //! NEFCompression, tag 0x0093
-    extern const TagDetails nikonNefCompression[] = {
+    constexpr TagDetails nikonNefCompression[] = {
         {  1, N_("Lossy (type 1)") },
         {  2, N_("Uncompressed")   },
         {  3, N_("Lossless")       },
@@ -181,7 +181,7 @@ namespace Exiv2 {
     };
 
     //! RetouchHistory, tag 0x009e
-    extern const TagDetails nikonRetouchHistory[] = {
+    constexpr TagDetails nikonRetouchHistory[] = {
         {  0, N_("None")          },
         {  3, N_("B & W")         },
         {  4, N_("Sepia")         },
@@ -197,7 +197,7 @@ namespace Exiv2 {
     };
 
     //! HighISONoiseReduction, tag 0x00b1
-    extern const TagDetails nikonHighISONoiseReduction[] = {
+    constexpr TagDetails nikonHighISONoiseReduction[] = {
         { 0, N_("Off")     },
         { 1, N_("Minimal") },
         { 2, N_("Low")     },
@@ -439,7 +439,7 @@ namespace Exiv2 {
     }
 
     //! Quality, tag 0x0003
-    extern const TagDetails nikon2Quality[] = {
+    constexpr TagDetails nikon2Quality[] = {
         { 1, N_("VGA Basic")   },
         { 2, N_("VGA Normal")  },
         { 3, N_("VGA Fine")    },
@@ -449,13 +449,13 @@ namespace Exiv2 {
     };
 
     //! ColorMode, tag 0x0004
-    extern const TagDetails nikon2ColorMode[] = {
+    constexpr TagDetails nikon2ColorMode[] = {
         { 1, N_("Color")      },
         { 2, N_("Monochrome") }
     };
 
     //! ImageAdjustment, tag 0x0005
-    extern const TagDetails nikon2ImageAdjustment[] = {
+    constexpr TagDetails nikon2ImageAdjustment[] = {
         { 0, N_("Normal")    },
         { 1, N_("Bright+")   },
         { 2, N_("Bright-")   },
@@ -464,7 +464,7 @@ namespace Exiv2 {
     };
 
     //! ISOSpeed, tag 0x0006
-    extern const TagDetails nikon2IsoSpeed[] = {
+    constexpr TagDetails nikon2IsoSpeed[] = {
         { 0, "80"  },
         { 2, "160" },
         { 4, "320" },
@@ -472,7 +472,7 @@ namespace Exiv2 {
     };
 
     //! WhiteBalance, tag 0x0007
-    extern const TagDetails nikon2WhiteBalance[] = {
+    constexpr TagDetails nikon2WhiteBalance[] = {
         { 0, N_("Auto")         },
         { 1, N_("Preset")       },
         { 2, N_("Daylight")     },
@@ -657,20 +657,20 @@ namespace Exiv2 {
     }
 
     //! YesNo, used for DaylightSavings, tag index 2
-    extern const TagDetails nikonYesNo[] = {
+    constexpr TagDetails nikonYesNo[] = {
         { 0, N_("No")    },
         { 1, N_("Yes")   }
     };
 
     //! DateDisplayFormat, tag index 3
-    extern const TagDetails nikonDateDisplayFormat[] = {
+    constexpr TagDetails nikonDateDisplayFormat[] = {
         { 0, N_("Y/M/D") },
         { 1, N_("M/D/Y") },
         { 2, N_("D/M/Y") }
     };
 
     //! OnOff
-    extern const TagDetails nikonOnOff[] = {
+    constexpr TagDetails nikonOnOff[] = {
         {  1, N_("On")  },
         {  2, N_("Off") }
     };
@@ -689,14 +689,14 @@ namespace Exiv2 {
     }
 
     //! Adjust
-    extern const TagDetails nikonAdjust[] = {
+    constexpr TagDetails nikonAdjust[] = {
         {  0, N_("Default Settings") },
         {  1, N_("Quick Adjust")     },
         {  2, N_("Full Control")     }
     };
 
     //! FilterEffect
-    extern const TagDetails nikonFilterEffect[] = {
+    constexpr TagDetails nikonFilterEffect[] = {
         { 0x80, N_("Off")    },
         { 0x81, N_("Yellow") },
         { 0x82, N_("Orange") },
@@ -706,7 +706,7 @@ namespace Exiv2 {
     };
 
     //! ToningEffect
-    extern const TagDetails nikonToningEffect[] = {
+    constexpr TagDetails nikonToningEffect[] = {
         { 0x80, N_("B&W")         },
         { 0x81, N_("Sepia")       },
         { 0x82, N_("Cyanotype")   },
@@ -745,7 +745,7 @@ namespace Exiv2 {
     }
 
     //! OnOff
-    extern const TagDetails aftOnOff[] = {
+    constexpr TagDetails aftOnOff[] = {
         {  0, N_("Off")  },
         {  1, N_("On") },
         {  2, N_("On") }
@@ -780,7 +780,7 @@ namespace Exiv2 {
     }
 
     //! ISOExpansion, tag index 4 and 10
-    extern const TagDetails nikonIsoExpansion[] = {
+    constexpr TagDetails nikonIsoExpansion[] = {
         { 0x000, N_("Off")    },
         { 0x101, N_("Hi 0.3") },
         { 0x102, N_("Hi 0.5") },
@@ -824,7 +824,7 @@ namespace Exiv2 {
     }
 
     //! AfAreaMode
-    extern const TagDetails nikonAfAreaMode[] = {
+    constexpr TagDetails nikonAfAreaMode[] = {
         { 0, N_("Single Area")                   },
         { 1, N_("Dynamic Area")                  },
         { 2, N_("Dynamic Area, Closest Subject") },
@@ -834,7 +834,7 @@ namespace Exiv2 {
     };
 
     //! AfPoint
-    extern const TagDetails nikonAfPoint[] = {
+    constexpr TagDetails nikonAfPoint[] = {
         { 0, N_("Center")      },
         { 1, N_("Top")         },
         { 2, N_("Bottom")      },
@@ -849,7 +849,7 @@ namespace Exiv2 {
     };
 
     //! AfPointsInFocus
-    extern const TagDetailsBitmask nikonAfPointsInFocus[] = {
+    constexpr TagDetailsBitmask nikonAfPointsInFocus[] = {
         { 0x0001, N_("Center")        },
         { 0x0002, N_("Top")           },
         { 0x0004, N_("Bottom")        },
@@ -878,7 +878,7 @@ namespace Exiv2 {
     }
 
     //! PhaseDetectAF
-    extern const TagDetails nikonPhaseDetectAF[] = {
+    constexpr TagDetails nikonPhaseDetectAF[] = {
         { 0, N_("Off")                },
         { 1, N_("On (51-point)")      },
         { 2, N_("On (11-point)")      },
@@ -952,7 +952,7 @@ namespace Exiv2 {
     }
 
     //! MultiExposureMode
-    extern const TagDetails nikonMultiExposureMode[] = {
+    constexpr TagDetails nikonMultiExposureMode[] = {
         { 0, N_("Off")               },
         { 1, N_("Multiple Exposure") },
         { 2, N_("Image Overlay")     }
@@ -974,14 +974,14 @@ namespace Exiv2 {
     }
 
     //! FlashSource
-    extern const TagDetails nikonFlashSource[] = {
+    constexpr TagDetails nikonFlashSource[] = {
         { 0, N_("None")     },
         { 1, N_("External") },
         { 2, N_("Internal") }
     };
 
     //! FlashFirmware
-    extern const TagDetails nikonFlashFirmware[] = {
+    constexpr TagDetails nikonFlashFirmware[] = {
         { 0x0000, N_("n/a")                            },
         { 0x0101, N_("1.01 (SB-800 or Metz 58 AF-1)")  },
         { 0x0103, "1.03 (SB-800)"                  },
@@ -999,7 +999,7 @@ namespace Exiv2 {
     };
 
     //! FlashGNDistance
-    extern const TagDetails nikonFlashGNDistance[] = {
+    constexpr TagDetails nikonFlashGNDistance[] = {
         {   0, N_("None")  },
         {   1, "0.1 m" },
         {   2, "0.2 m" },
@@ -1041,7 +1041,7 @@ namespace Exiv2 {
     };
 
     //! FlashControlMode
-    extern const TagDetails nikonFlashControlMode[] = {
+    constexpr TagDetails nikonFlashControlMode[] = {
         { 0, N_("Off")                    },
         { 1, N_("iTTL-BL")                },
         { 2, N_("iTTL")                   },
@@ -1054,14 +1054,14 @@ namespace Exiv2 {
     };
 
     //! ExternalFlashFlags
-    extern const TagDetails nikonExternalFlashFlags[] = {
+    constexpr TagDetails nikonExternalFlashFlags[] = {
         { 0, N_("Fired")              },
         { 2, N_("Bounce Flash")       },
         { 4, N_("Wide Flash Adapter") }
     };
 
     //! FlashColorFilter
-    extern const TagDetails nikonFlashColorFilter[] = {
+    constexpr TagDetails nikonFlashColorFilter[] = {
         {  0, N_("None")   },
         {  1, N_("FL-GL1") },
         {  2, N_("FL-GL2") },
@@ -1163,7 +1163,7 @@ namespace Exiv2 {
     }
 
     //! AfFineTuneAdj D300 (a)
-    extern const TagDetails nikonAfFineTuneAdj1[] = {
+    constexpr TagDetails nikonAfFineTuneAdj1[] = {
         { 0x0000, "0"   },
         { 0x003a, "+1"  },
         { 0x003b, "+2"  },
@@ -1223,7 +1223,7 @@ namespace Exiv2 {
     }
 
     //! AfFineTuneAdj D300 (b)
-    extern const TagDetails nikonAfFineTuneAdj2[] = {
+    constexpr TagDetails nikonAfFineTuneAdj2[] = {
         { 0x0000, "0"   },
         { 0x043e, "+13" },
         { 0x04c2, "-13" },
@@ -1283,7 +1283,7 @@ namespace Exiv2 {
     }
 
     //! VibrationReduction
-    extern const TagDetails nikonOffOn2[] = {
+    constexpr TagDetails nikonOffOn2[] = {
         { 0, N_("Off")    },
         { 1, N_("On (1)") },
         { 2, N_("On (2)") },
@@ -1291,7 +1291,7 @@ namespace Exiv2 {
     };
 
     //! VibrationReduction2
-    extern const TagDetails nikonOffOn3[] = {
+    constexpr TagDetails nikonOffOn3[] = {
         { 0x0, N_("n/a") },
         { 0xc, N_("Off") },
         { 0xf, N_("On")  }

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -50,19 +50,19 @@ namespace Exiv2 {
     namespace Internal {
 
     //! OffOn, multiple tags
-    extern const TagDetails olympusOffOn[] = {
+    constexpr TagDetails olympusOffOn[] = {
         {  0, N_("Off") },
         {  1, N_("On")  }
     };
 
     //! NoYes, multiple tags
-    extern const TagDetails olympusNoYes[] = {
+    constexpr TagDetails olympusNoYes[] = {
         {  0, N_("No") },
         {  1, N_("Yes")  }
     };
 
     //! Quality, tag 0x0201
-    extern const TagDetails olympusQuality[] = {
+    constexpr TagDetails olympusQuality[] = {
         { 1, N_("Standard Quality (SQ)")    },
         { 2, N_("High Quality (HQ)")        },
         { 3, N_("Super High Quality (SHQ)") },
@@ -70,21 +70,21 @@ namespace Exiv2 {
     };
 
     //! Macro, tag 0x0202
-    extern const TagDetails olympusMacro[] = {
+    constexpr TagDetails olympusMacro[] = {
         {  0, N_("Off")         },
         {  1, N_("On")          },
         {  2, N_("Super macro") }
     };
 
     //! OneTouchWB, tag 0x0302
-    extern const TagDetails olympusOneTouchWb[] = {
+    constexpr TagDetails olympusOneTouchWb[] = {
         {  0, N_("Off")         },
         {  1, N_("On")          },
         {  2, N_("On (preset)") }
     };
 
     //! SceneMode, tag 0x403 and CameraSettings tag 0x509
-    extern const TagDetails olympusSceneMode[] = {
+    constexpr TagDetails olympusSceneMode[] = {
         {  0, N_("Standard")                    },
         {  6, N_("Auto")                        },
         {  7, N_("Sport")                       },
@@ -133,7 +133,7 @@ namespace Exiv2 {
     };
 
     //! FlashDevice, tag 0x1005
-    extern const TagDetails olympusFlashDevice[] = {
+    constexpr TagDetails olympusFlashDevice[] = {
         {  0, N_("None")                },
         {  1, N_("Internal")            },
         {  4, N_("External")            },
@@ -141,33 +141,33 @@ namespace Exiv2 {
     };
 
     //! FocusRange, tag 0x100a
-    extern const TagDetails olympusFocusRange[] = {
+    constexpr TagDetails olympusFocusRange[] = {
         {  0, N_("Normal")   },
         {  1, N_("Macro") }
     };
 
     //! FocusMode, tag 0x100b
-    extern const TagDetails olympusFocusMode[] = {
+    constexpr TagDetails olympusFocusMode[] = {
         {  0, N_("Auto")   },
         {  1, N_("Manual") }
     };
 
     //! Sharpness, tag 0x100f
-    extern const TagDetails olympusSharpness[] = {
+    constexpr TagDetails olympusSharpness[] = {
         { 0, N_("Normal") },
         { 1, N_("Hard")   },
         { 2, N_("Soft")   }
     };
 
     //! Contrast, tag 0x1029
-    extern const TagDetails olympusContrast[] = {
+    constexpr TagDetails olympusContrast[] = {
         { 0, N_("High")   },
         { 1, N_("Normal") },
         { 2, N_("Low")    }
     };
 
     //! CCDScanMode, tag 0x1039
-    extern const TagDetails olympusCCDScanMode[] = {
+    constexpr TagDetails olympusCCDScanMode[] = {
         {  0, N_("Interlaced")  },
         {  1, N_("Progressive") }
     };
@@ -473,7 +473,7 @@ namespace Exiv2 {
 
 // Olympus CameraSettings Tags
     //! ExposureMode, tag 0x0200
-    extern const TagDetails olympusExposureMode[] = {
+    constexpr TagDetails olympusExposureMode[] = {
         { 1, N_("Manual")                    },
         { 2, N_("Program")                   },
         { 3, N_("Aperture-priority AE")      },
@@ -482,7 +482,7 @@ namespace Exiv2 {
     };
 
     //! MeteringMode, tag 0x0202
-    extern const TagDetails olympusMeteringMode[] = {
+    constexpr TagDetails olympusMeteringMode[] = {
         {    2, N_("Center-weighted average") },
         {    3, N_("Spot")                    },
         {    5, N_("ESP")                     },
@@ -492,14 +492,14 @@ namespace Exiv2 {
     };
 
     //! MacroMode, tag 0x0300
-    extern const TagDetails olympusMacroMode[] = {
+    constexpr TagDetails olympusMacroMode[] = {
         { 0, N_("Off")         },
         { 1, N_("On")          },
         { 2, N_("Super Macro") }
     };
 
     //! FocusMode, tag 0x0301
-    extern const TagDetails olympusCsFocusMode[] = {
+    constexpr TagDetails olympusCsFocusMode[] = {
         { 0, N_("Single AF")              },
         { 1, N_("Sequential shooting AF") },
         { 2, N_("Continuous AF")          },
@@ -508,19 +508,19 @@ namespace Exiv2 {
     };
 
     //! FocusProcess, tag 0x0302
-    extern const TagDetails olympusFocusProcess[] = {
+    constexpr TagDetails olympusFocusProcess[] = {
         { 0, N_("AF Not Used") },
         { 1, N_("AF Used")     }
     };
 
     //! AFSearch, tag 0x0303
-    extern const TagDetails olympusAFSearch[] = {
+    constexpr TagDetails olympusAFSearch[] = {
         { 0, N_("Not Ready") },
         { 1, N_("Ready")     }
     };
 
     //! FlashMode, tag 0x0400
-    extern const TagDetailsBitmask olympusFlashMode[] = {
+    constexpr TagDetailsBitmask olympusFlashMode[] = {
         { 0x0000, N_("Off")         },
         { 0x0001, N_("On")          },
         { 0x0002, N_("Fill-in")     },
@@ -531,7 +531,7 @@ namespace Exiv2 {
     };
 
     //! FlashRemoteControl, tag 0x0403
-    extern const TagDetails olympusFlashRemoteControl[] = {
+    constexpr TagDetails olympusFlashRemoteControl[] = {
         {  0x0, N_("Off")              },
         {  0x1, N_("Channel 1, Low")   },
         {  0x2, N_("Channel 2, Low")   },
@@ -548,7 +548,7 @@ namespace Exiv2 {
     };
 
     //! FlashControlMode, tag 0x0404
-    extern const TagDetails olympusFlashControlMode[] = {
+    constexpr TagDetails olympusFlashControlMode[] = {
         { 0, N_("Off")     },
         { 3, N_("TTL")     },
         { 4, N_("Auto")    },
@@ -556,7 +556,7 @@ namespace Exiv2 {
     };
 
     //! WhiteBalance, tag 0x0500
-    extern const TagDetails olympusWhiteBalance[] = {
+    constexpr TagDetails olympusWhiteBalance[] = {
         {   0, N_("Auto")                              },
         {   1, N_("Auto (Keep Warm Color Off")         },
         {  16, N_("7500K (Fine Weather with Shade)")   },
@@ -583,7 +583,7 @@ namespace Exiv2 {
     };
 
     //! ModifiedSaturation, tag 0x0504
-    extern const TagDetails olympusModifiedSaturation[] = {
+    constexpr TagDetails olympusModifiedSaturation[] = {
         { 0, N_("Off")                 },
         { 1, N_("CM1 (Red Enhance)")   },
         { 2, N_("CM2 (Green Enhance)") },
@@ -592,14 +592,14 @@ namespace Exiv2 {
     };
 
     //! ColorSpace, tag 0x0507
-    extern const TagDetails olympusColorSpace[] = {
+    constexpr TagDetails olympusColorSpace[] = {
         { 0, N_("sRGB")          },
         { 1, N_("Adobe RGB")     },
         { 2, N_("Pro Photo RGB") }
     };
 
     //! NoiseReduction, tag 0x050a
-    extern const TagDetailsBitmask olympusNoiseReduction[] = {
+    constexpr TagDetailsBitmask olympusNoiseReduction[] = {
         { 0x0001, N_("Noise Reduction")          },
         { 0x0002, N_("Noise Filter")             },
         { 0x0004, N_("Noise Filter (ISO Boost)") },
@@ -607,7 +607,7 @@ namespace Exiv2 {
     };
 
     //! PictureMode, tag 0x0520
-    extern const TagDetails olympusPictureMode[] = {
+    constexpr TagDetails olympusPictureMode[] = {
         {   1, N_("Vivid")                },
         {   2, N_("Natural")              },
         {   3, N_("Muted")                },
@@ -626,7 +626,7 @@ namespace Exiv2 {
     };
 
     //! PictureModeBWFilter, tag 0x0525
-    extern const TagDetails olympusPictureModeBWFilter[] = {
+    constexpr TagDetails olympusPictureModeBWFilter[] = {
         { 0, N_("n/a")     },
         { 1, N_("Neutral") },
         { 2, N_("Yellow")  },
@@ -636,7 +636,7 @@ namespace Exiv2 {
     };
 
     //! PictureModeTone, tag 0x0526
-    extern const TagDetails olympusPictureModeTone[] = {
+    constexpr TagDetails olympusPictureModeTone[] = {
         { 0, N_("n/a")     },
         { 1, N_("Neutral") },
         { 2, N_("Sepia")   },
@@ -646,7 +646,7 @@ namespace Exiv2 {
     };
 
     //! OlympusCs Quality, tag 0x0603
-    extern const TagDetails olympusCsQuality[] = {
+    constexpr TagDetails olympusCsQuality[] = {
         { 1, N_("SQ")  },
         { 2, N_("HQ")  },
         { 3, N_("SHQ") },
@@ -654,7 +654,7 @@ namespace Exiv2 {
     };
 
     //! Olympus ImageStabilization, tag 0x0604
-    extern const TagDetails olympusImageStabilization[] = {
+    constexpr TagDetails olympusImageStabilization[] = {
         { 0, N_("Off")        },
         { 1, N_("On, Mode 1") },
         { 2, N_("On, Mode 2") },
@@ -726,14 +726,14 @@ namespace Exiv2 {
     }
 
     //! OlympusEq FlashType, tag 0x1000
-    extern const TagDetails olympusEqFlashType[] = {
+    constexpr TagDetails olympusEqFlashType[] = {
         { 0, N_("None")            },
         { 2, N_("Simple E-System") },
         { 3, N_("E-System")        }
     };
 
     //! OlympusEq FlashModel, tag 0x1001
-    extern const TagDetails olympusEqFlashModel[] = {
+    constexpr TagDetails olympusEqFlashModel[] = {
         { 0, N_("None") },
         { 1, "FL-20"    },
         { 2, "FL-50"    },
@@ -783,14 +783,14 @@ namespace Exiv2 {
     }
 
     //! OlympusRd ColorSpace, tag 0x0108
-    extern const TagDetails olympusRdColorSpace[] = {
+    constexpr TagDetails olympusRdColorSpace[] = {
         { 0, N_("sRGB")          },
         { 1, N_("Adobe RGB")     },
         { 2, N_("Pro Photo RGB") }
     };
 
     //! OlympusRd Engine, tag 0x0109
-    extern const TagDetails olympusRdEngine[] = {
+    constexpr TagDetails olympusRdEngine[] = {
         { 0, N_("High Speed")             },
         { 1, N_("High Function")          },
         { 2, N_("Advanced High Speed")    },
@@ -798,7 +798,7 @@ namespace Exiv2 {
     };
 
     //! OlympusRd EditStatus, tag 0x010b
-    extern const TagDetails olympusRdEditStatus[] = {
+    constexpr TagDetails olympusRdEditStatus[] = {
         { 0, N_("Original")           },
         { 1, N_("Edited (Landscape)") },
         { 6, N_("Edited (Portrait)")  },
@@ -806,7 +806,7 @@ namespace Exiv2 {
     };
 
     //! OlympusRd Settings, tag 0x010c
-    extern const TagDetailsBitmask olympusRdSettings[] = {
+    constexpr TagDetailsBitmask olympusRdSettings[] = {
         { 0x0001, N_("WB Color Temp")   },
         { 0x0004, N_("WB Gray Point")   },
         { 0x0008, N_("Saturation")      },
@@ -842,26 +842,26 @@ namespace Exiv2 {
     }
 
     //! OlympusRd2 WhiteBalance, tag 0x0101
-    extern const TagDetails olympusRd2WhiteBalance[] = {
+    constexpr TagDetails olympusRd2WhiteBalance[] = {
         { 1, N_("Color Temperature") },
         { 2, N_("Gray Point")        }
     };
 
     //! OlympusRd2 ColorSpace, tag 0x0109
-    extern const TagDetails olympusRd2ColorSpace[] = {
+    constexpr TagDetails olympusRd2ColorSpace[] = {
         { 0, N_("sRGB")          },
         { 1, N_("Adobe RGB")     },
         { 2, N_("Pro Photo RGB") }
     };
 
     //! OlympusRd2 Engine, tag 0x010b
-    extern const TagDetails olympusRd2Engine[] = {
+    constexpr TagDetails olympusRd2Engine[] = {
         { 0, N_("High Speed")    },
         { 1, N_("High Function") }
     };
 
     //! OlympusRd2 PictureMode, tag 0x010c
-    extern const TagDetails olympusRd2PictureMode[] = {
+    constexpr TagDetails olympusRd2PictureMode[] = {
         {   1, N_("Vivid")    },
         {   2, N_("Natural")  },
         {   3, N_("Muted")    },
@@ -870,7 +870,7 @@ namespace Exiv2 {
     };
 
     //! OlympusRd2 PM_BWFilter, tag 0x0110
-    extern const TagDetails olympusRd2PM_BWFilter[] = {
+    constexpr TagDetails olympusRd2PM_BWFilter[] = {
         { 1, N_("Neutral") },
         { 2, N_("Yellow")  },
         { 3, N_("Orange")  },
@@ -879,7 +879,7 @@ namespace Exiv2 {
     };
 
     //! OlympusRd2 PMPictureTone, tag 0x0111
-    extern const TagDetails olympusRd2PMPictureTone[] = {
+    constexpr TagDetails olympusRd2PMPictureTone[] = {
         { 1, N_("Neutral") },
         { 2, N_("Sepia")   },
         { 3, N_("Blue")    },
@@ -921,14 +921,14 @@ namespace Exiv2 {
     }
 
     //! OlympusIp MultipleExposureMode, tag 0x101c
-    extern const TagDetails olympusIpMultipleExposureMode[] = {
+    constexpr TagDetails olympusIpMultipleExposureMode[] = {
         { 0, N_("Off")             },
         { 2, N_("On (2 frames)")   },
         { 3, N_("On (3 frames)")   }
     };
 
     //! OlympusIp olympusIpAspectRatio, tag 0x101c
-    extern const TagDetails olympusIpAspectRatio[] = {
+    constexpr TagDetails olympusIpAspectRatio[] = {
         { 1, "4:3"  },
         { 2, "3:2"  },
         { 3, "16:9" },
@@ -1002,7 +1002,7 @@ namespace Exiv2 {
     }
 
     //! OlympusFi ExternalFlashBounce, tag 0x1204
-    extern const TagDetails olympusFiExternalFlashBounce[] = {
+    constexpr TagDetails olympusFiExternalFlashBounce[] = {
         { 0, N_("Bounce or Off") },
         { 1, N_("Direct") }
     };
@@ -1048,7 +1048,7 @@ namespace Exiv2 {
     }
 
     //! OlympusRi LightSource, tag 0x1000
-    extern const TagDetails olympusRiLightSource[] = {
+    constexpr TagDetails olympusRiLightSource[] = {
         {   0, N_("Unknown")                                 },
         {  16, N_("Shade")                                   },
         {  17, N_("Cloudy")                                  },

--- a/src/panasonicmn_int.cpp
+++ b/src/panasonicmn_int.cpp
@@ -45,7 +45,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! Quality, tag 0x0001
-    extern const TagDetails panasonicQuality[] = {
+    constexpr TagDetails panasonicQuality[] = {
         {  1, N_("TIFF")           },
         {  2, N_("High")           },
         {  3, N_("Normal")         },
@@ -57,7 +57,7 @@ namespace Exiv2 {
     };
 
     //! WhiteBalance, tag 0x0003
-    extern const TagDetails panasonicWhiteBalance[] = {
+    constexpr TagDetails panasonicWhiteBalance[] = {
         {  1, N_("Auto")            },
         {  2, N_("Daylight")        },
         {  3, N_("Cloudy")          },
@@ -71,7 +71,7 @@ namespace Exiv2 {
     };
 
     //! FocusMode, tag 0x0007
-    extern const TagDetails panasonicFocusMode[] = {
+    constexpr TagDetails panasonicFocusMode[] = {
         {  1, N_("Auto")               },
         {  2, N_("Manual")             },
         {  4, N_("Auto, focus button") },
@@ -82,7 +82,7 @@ namespace Exiv2 {
     };
 
     //! ImageStabilizer, tag 0x001a
-    extern const TagDetails panasonicImageStabilizer[] = {
+    constexpr TagDetails panasonicImageStabilizer[] = {
         {  2, N_("On, Mode 1") },
         {  3, N_("Off")        },
         {  4, N_("On, Mode 2") },
@@ -91,7 +91,7 @@ namespace Exiv2 {
     };
 
     //! Macro, tag 0x001c
-    extern const TagDetails panasonicMacro[] = {
+    constexpr TagDetails panasonicMacro[] = {
         {   1, N_("On")         },
         {   2, N_("Off")        },
         { 257, N_("Tele-macro") },
@@ -99,7 +99,7 @@ namespace Exiv2 {
     };
 
     //! ShootingMode, tag 0x001f and SceneMode, tag 0x8001
-    extern const TagDetails panasonicShootingMode[] = {
+    constexpr TagDetails panasonicShootingMode[] = {
         {  0, N_("Off")                            }, // only SceneMode
         {  1, N_("Normal")                         },
         {  2, N_("Portrait")                       },
@@ -180,14 +180,14 @@ namespace Exiv2 {
     };
 
     //! Audio, tag 0x0020
-    extern const TagDetails panasonicAudio[] = {
+    constexpr TagDetails panasonicAudio[] = {
         { 1, N_("Yes")    },
         { 2, N_("No")     },
         { 3, N_("Stereo") }
     };
 
     //! ColorEffect, tag 0x0028
-    extern const TagDetails panasonicColorEffect[] = {
+    constexpr TagDetails panasonicColorEffect[] = {
         { 1, N_("Off")             },
         { 2, N_("Warm")            },
         { 3, N_("Cool")            },
@@ -197,14 +197,14 @@ namespace Exiv2 {
     };
 
     //! BustMode, tag 0x002a
-    extern const TagDetails panasonicBurstMode[] = {
+    constexpr TagDetails panasonicBurstMode[] = {
         { 0, N_("Off")              },
         { 1, N_("Low/High quality") },
         { 2, N_("Infinite")         }
     };
 
     //! Contrast, tag 0x002c
-    extern const TagDetails panasonicContrast[] = {
+    constexpr TagDetails panasonicContrast[] = {
         {   0, N_("Normal")      },
         {   1, N_("Low")         },
         {   2, N_("High")        },
@@ -217,7 +217,7 @@ namespace Exiv2 {
     };
 
     //! NoiseReduction, tag 0x002d
-    extern const TagDetails panasonicNoiseReduction[] = {
+    constexpr TagDetails panasonicNoiseReduction[] = {
         { 0, N_("Standard") },
         { 1, N_("Low (-1)")     },
         { 2, N_("High (+1)")    },
@@ -226,7 +226,7 @@ namespace Exiv2 {
     };
 
     //! SelfTimer, tag 0x002e
-    extern const TagDetails panasonicSelfTimer[] = {
+    constexpr TagDetails panasonicSelfTimer[] = {
         { 1, N_("Off")                },
         { 2, "10 s"               },
         { 3, "2 s"                },
@@ -234,7 +234,7 @@ namespace Exiv2 {
     };
 
     //! Rotation, tag 0x0030
-    extern const TagDetails panasonicRotation[] = {
+    constexpr TagDetails panasonicRotation[] = {
         { 1, N_("Horizontal (normal)") },
         { 3, N_("Rotate 180")          },
         { 6, N_("Rotate 90 CW")        },
@@ -242,7 +242,7 @@ namespace Exiv2 {
     };
 
     //! AFAssistLamp, tag 0x0031
-    extern const TagDetails panasonicAFAssistLamp[] = {
+    constexpr TagDetails panasonicAFAssistLamp[] = {
         { 1, N_("Fired")                     },
         { 2, N_("Enabled but Not Used")      },
         { 3, N_("Disabled but Required")     },
@@ -250,20 +250,20 @@ namespace Exiv2 {
     };
 
     //! ColorMode, tag 0x0032
-    extern const TagDetails panasonicColorMode[] = {
+    constexpr TagDetails panasonicColorMode[] = {
         { 0, N_("Normal")  },
         { 1, N_("Natural") },
         { 2, N_("Vivid")   }
     };
 
     //! OpticalZoomMode, tag 0x0034
-    extern const TagDetails panasonicOpticalZoomMode[] = {
+    constexpr TagDetails panasonicOpticalZoomMode[] = {
         { 1, N_("Standard")  },
         { 2, N_("EX optics") }
     };
 
     //! ConversionLens, tag 0x0035
-    extern const TagDetails panasonicConversionLens[] = {
+    constexpr TagDetails panasonicConversionLens[] = {
         { 1, N_("Off")       },
         { 2, N_("Wide")      },
         { 3, N_("Telephoto") },
@@ -272,19 +272,19 @@ namespace Exiv2 {
     };
 
     //! WorldTimeLocation, tag 0x003a
-    extern const TagDetails panasonicWorldTimeLocation[] = {
+    constexpr TagDetails panasonicWorldTimeLocation[] = {
         { 1, N_("Home")        },
         { 2, N_("Destination") }
     };
 
     //! TextStamp, tag 0x003b, 0x003e, 000x8008 and 0x8009
-    extern const TagDetails panasonicTextStamp[] = {
+    constexpr TagDetails panasonicTextStamp[] = {
         { 1, N_("Off") },
         { 2, N_("On")  }
     };
 
     //! FilmMode, tag 0x0042
-    extern const TagDetails panasonicFilmMode[] = {
+    constexpr TagDetails panasonicFilmMode[] = {
         {  1, N_("Standard (color)") },
         {  2, N_("Dynamic (color)")  },
         {  3, N_("Nature (color)")   },
@@ -297,7 +297,7 @@ namespace Exiv2 {
     };
 
     //! Bracket Settings, tag 0x0045
-    extern const TagDetails panasonicBracketSettings[] = {
+    constexpr TagDetails panasonicBracketSettings[] = {
         { 0, N_("No Bracket")               },
         { 1, N_("3 images, Sequence 0/-/+") },
         { 2, N_("3 images, Sequence -/0/+") },
@@ -308,20 +308,20 @@ namespace Exiv2 {
     };
 
     //! Flash curtain, tag 0x0048
-    extern const TagDetails panasonicFlashCurtain[] = {
+    constexpr TagDetails panasonicFlashCurtain[] = {
         { 0, N_("n/a") },
         { 1, N_("1st") },
         { 2, N_("2nd") }
     };
 
     //! Long Shutter Noise Reduction, tag 0x0049
-    extern const TagDetails panasonicLongShutterNoiseReduction[] = {
+    constexpr TagDetails panasonicLongShutterNoiseReduction[] = {
         { 1, N_("Off") },
         { 2, N_("On") }
     };
 
     //! Intelligent exposure, tag 0x005d
-    extern const TagDetails panasonicIntelligentExposure[] = {
+    constexpr TagDetails panasonicIntelligentExposure[] = {
         { 0, N_("Off")      },
         { 1, N_("Low")      },
         { 2, N_("Standard") },
@@ -329,13 +329,13 @@ namespace Exiv2 {
     };
 
     //! Flash warning, tag 0x0062
-    extern const TagDetails panasonicFlashWarning[] = {
+    constexpr TagDetails panasonicFlashWarning[] = {
         { 0, N_("No")                               },
         { 1, N_("Yes (flash required but disabled") }
     };
 
     //! Intelligent resolution, tag 0x0070
-    extern const TagDetails panasonicIntelligentResolution[] = {
+    constexpr TagDetails panasonicIntelligentResolution[] = {
         { 0, N_("Off")      },
         { 1, N_("Low")      },
         { 2, N_("Standard") },
@@ -344,7 +344,7 @@ namespace Exiv2 {
     };
 
     //! Intelligent D-Range, tag 0x0079
-    extern const TagDetails panasonicIntelligentDRange[] = {
+    constexpr TagDetails panasonicIntelligentDRange[] = {
         { 0, N_("Off")      },
         { 1, N_("Low")      },
         { 2, N_("Standard") },
@@ -352,13 +352,13 @@ namespace Exiv2 {
     };
 
     //! Clear Retouch, tag 0x007c
-    extern const TagDetails panasonicClearRetouch[] = {
+    constexpr TagDetails panasonicClearRetouch[] = {
         { 0, N_("Off") },
         { 1, N_("On") }
     };
 
     //! Photo Style, tag 0x0089
-    extern const TagDetails panasonicPhotoStyle[] = {
+    constexpr TagDetails panasonicPhotoStyle[] = {
         { 0, N_("NoAuto")             },
         { 1, N_("Standard or Custom") },
         { 2, N_("Vivid")              },
@@ -369,13 +369,13 @@ namespace Exiv2 {
     };
 
     //! Shading compensation, tag 0x008a
-    extern const TagDetails panasonicShadingCompensation[] = {
+    constexpr TagDetails panasonicShadingCompensation[] = {
         { 0, N_("Off") },
         { 1, N_("On") }
     };
 
     //! Camera orientation, tag 0x008f
-    extern const TagDetails panasonicCameraOrientation[] = {
+    constexpr TagDetails panasonicCameraOrientation[] = {
         { 0, N_("Normal")         },
         { 1, N_("Rotate CW")      },
         { 2, N_("Rotate 180")     },
@@ -385,7 +385,7 @@ namespace Exiv2 {
     };
 
     //! Sweep panorama direction, tag 0x0093
-    extern const TagDetails panasonicSweepPanoramaDirection[] = {
+    constexpr TagDetails panasonicSweepPanoramaDirection[] = {
         { 0, N_("Off")           },
         { 1, N_("Left to Right") },
         { 2, N_("Right to Left") },
@@ -394,14 +394,14 @@ namespace Exiv2 {
     };
 
     //! Timer recording, tag 0x0096
-    extern const TagDetails panasonicTimerRecording[] = {
+    constexpr TagDetails panasonicTimerRecording[] = {
         { 0, N_("Off")                   },
         { 1, N_("Time Lapse")            },
         { 2, N_("Stop-Motion Animation") }
     };
 
     //! HDR, tag 0x009e
-    extern const TagDetails panasonicHDR[] = {
+    constexpr TagDetails panasonicHDR[] = {
         {     0, N_("Off")         },
         {   100, N_("1 EV")        },
         {   200, N_("2 EV")        },
@@ -412,20 +412,20 @@ namespace Exiv2 {
     };
 
     //! Shutter Type, tag 0x009f
-    extern const TagDetails panasonicShutterType[] = {
+    constexpr TagDetails panasonicShutterType[] = {
         { 0, N_("Mechanical") },
         { 1, N_("Electronic") },
         { 2, N_("Hybrid")     }
     };
 
     //! Touch AE, tag 0x00ab
-    extern const TagDetails panasonicTouchAE[] = {
+    constexpr TagDetails panasonicTouchAE[] = {
         { 0, N_("Off") },
         { 1, N_("On")  }
     };
 
     //! Flash Fired, tag 0x8007
-    extern const TagDetails panasonicFlashFired[] = {
+    constexpr TagDetails panasonicFlashFired[] = {
         { 1, N_("No")  },
         { 2, N_("Yes") }
     };

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -40,14 +40,14 @@ namespace Exiv2 {
     namespace Internal {
 
     //! ShootingMode, tag 0x0001
-    extern const TagDetails pentaxShootingMode[] = {
+    constexpr TagDetails pentaxShootingMode[] = {
         {   0, N_("Auto")                      },
         {   1, N_("Night-Scene")               },
         {   2, N_("Manual")                    },
     };
 
     //! CameraModel, tag 0x0005
-    extern const TagDetails pentaxModel[] = {
+    constexpr TagDetails pentaxModel[] = {
         {    0x0000d, "Optio 330/430" },
         {    0x12926, "Optio 230" },
         {    0x12958, "Optio 330GS" },
@@ -188,7 +188,7 @@ namespace Exiv2 {
     };
 
     //! Quality, tag 0x0008
-    extern const TagDetails pentaxQuality[] = {
+    constexpr TagDetails pentaxQuality[] = {
         {   0, N_("Good") },
         {   1, N_("Better") },
         {   2, N_("Best") },
@@ -199,7 +199,7 @@ namespace Exiv2 {
     };
 
     //! Size, tag 0x0009
-    extern const TagDetails pentaxSize[] = {
+    constexpr TagDetails pentaxSize[] = {
         {    0, "640x480" },
         {    1, N_("Full") },
         {    2, "1024x768" },
@@ -236,7 +236,7 @@ namespace Exiv2 {
     };
 
     //! Flash, tag 0x000c
-    extern const TagDetails pentaxFlash[] = {
+    constexpr TagDetails pentaxFlash[] = {
         {    0x000, N_("Auto, Did not fire") },
         {    0x001, N_("Off, Did not fire") },
         {    0x002, N_("Off, Did not fire") },
@@ -256,7 +256,7 @@ namespace Exiv2 {
     };
 
     //! Focus, tag 0x000d
-    extern const TagDetails pentaxFocus[] = {
+    constexpr TagDetails pentaxFocus[] = {
         {    0, N_("Normal") },
         {    1, N_("Macro") },
         {    2, N_("Infinity") },
@@ -272,7 +272,7 @@ namespace Exiv2 {
     };
 
     //! AFPoint, tag 0x000e
-    extern const TagDetails pentaxAFPoint[] = {
+    constexpr TagDetails pentaxAFPoint[] = {
         {    0xffff, N_("Auto") },
         {    0xfffe, N_("Fixed Center") },
         {    0xfffd, N_("Automatic Tracking AF") },
@@ -293,7 +293,7 @@ namespace Exiv2 {
     };
 
     //! AFPointInFocus, tag 0x000f
-    extern const TagDetails pentaxAFPointFocus[] = {
+    constexpr TagDetails pentaxAFPointFocus[] = {
         {    0xffff, N_("None") },
         {    0, N_("Fixed Center or multiple") },
         {    1, N_("Top-left") },
@@ -308,7 +308,7 @@ namespace Exiv2 {
     };
 
     //! ISO, tag 0x0014
-    extern const TagDetails pentaxISO[] = {
+    constexpr TagDetails pentaxISO[] = {
         {    3, "50" },
         {    4, "64" },
         {    5, "80" },
@@ -392,26 +392,26 @@ namespace Exiv2 {
     };
 
     //! Generic for Off/On switches
-    extern const TagDetails pentaxOffOn[] = {
+    constexpr TagDetails pentaxOffOn[] = {
         {    0, N_("Off") },
         {    1, N_("On") },
     };
 
     //! Generic for Yes/No switches
-    extern const TagDetails pentaxYesNo[] = {
+    constexpr TagDetails pentaxYesNo[] = {
         {    0, N_("No") },
         {    1, N_("Yes") },
     };
 
     //! MeteringMode, tag 0x0017
-    extern const TagDetails pentaxMeteringMode[] = {
+    constexpr TagDetails pentaxMeteringMode[] = {
         {    0, N_("Multi Segment") },
         {    1, N_("Center Weighted") },
         {    2, N_("Spot") },
     };
 
     //! WhiteBalance, tag 0x0019
-    extern const TagDetails pentaxWhiteBalance[] = {
+    constexpr TagDetails pentaxWhiteBalance[] = {
         {    0, N_("Auto") },
         {    1, N_("Daylight") },
         {    2, N_("Shade") },
@@ -430,7 +430,7 @@ namespace Exiv2 {
     };
 
     //! WhiteBalance, tag 0x001a
-    extern const TagDetails pentaxWhiteBalanceMode[] = {
+    constexpr TagDetails pentaxWhiteBalanceMode[] = {
         {    1, N_("Auto (Daylight)") },
         {    2, N_("Auto (Shade)") },
         {    3, N_("Auto (Flash)") },
@@ -444,7 +444,7 @@ namespace Exiv2 {
     };
 
     //! Saturation, tag 0x001f
-    extern const TagDetails pentaxSaturation[] = {
+    constexpr TagDetails pentaxSaturation[] = {
         {     0, N_("Low")       },
         {     1, N_("Normal")    },
         {     2, N_("High")      },
@@ -459,7 +459,7 @@ namespace Exiv2 {
     };
 
     //! Contrast, tag 0x0020
-    extern const TagDetails pentaxContrast[] = {
+    constexpr TagDetails pentaxContrast[] = {
         {    0, N_("Low") },
         {    1, N_("Normal") },
         {    2, N_("High") },
@@ -472,7 +472,7 @@ namespace Exiv2 {
     };
 
     //! Sharpness, tag 0x0021
-    extern const TagDetails pentaxSharpness[] = {
+    constexpr TagDetails pentaxSharpness[] = {
         {    0, N_("Soft") },
         {    1, N_("Normal") },
         {    2, N_("Hard") },
@@ -485,13 +485,13 @@ namespace Exiv2 {
     };
 
     //! Location, tag 0x0022
-    extern const TagDetails pentaxLocation[] = {
+    constexpr TagDetails pentaxLocation[] = {
         {    0, N_("Home town") },
         {    1, N_("Destination") },
     };
 
     //! City names, tags 0x0023 and 0x0024
-    extern const TagDetails pentaxCities[] = {
+    constexpr TagDetails pentaxCities[] = {
         {    0, N_("Pago Pago") },
         {    1, N_("Honolulu") },
         {    2, N_("Anchorage") },
@@ -570,7 +570,7 @@ namespace Exiv2 {
     };
 
     //! ImageProcessing, combi-tag 0x0032 (4 bytes)
-    extern const TagDetails pentaxImageProcessing[] = {
+    constexpr TagDetails pentaxImageProcessing[] = {
         { 0x00000000, N_("Unprocessed") },
         { 0x00000004, N_("Digital Filter") },
         { 0x01000000, N_("Resized") },
@@ -581,7 +581,7 @@ namespace Exiv2 {
     };
 
     //! PictureMode, combi-tag 0x0033 (3 bytes)
-    extern const TagDetails pentaxPictureMode[] = {
+    constexpr TagDetails pentaxPictureMode[] = {
         { 0x000000, N_("Program") },
         { 0x000100, N_("Hi-speed Program") },
         { 0x000200, N_("DOF Program") },
@@ -662,7 +662,7 @@ namespace Exiv2 {
     };
 
     //! DriveMode, combi-tag 0x0034 (4 bytes)
-    extern const TagDetails pentaxDriveMode[] = {
+    constexpr TagDetails pentaxDriveMode[] = {
         { 0x00000000, N_("Single-frame") },
         { 0x01000000, N_("Continuous") },
         { 0x02000000, N_("Continuous (Hi)") },
@@ -686,13 +686,13 @@ namespace Exiv2 {
     };
 
     //! ColorSpace, tag 0x0037
-    extern const TagDetails pentaxColorSpace[] = {
+    constexpr TagDetails pentaxColorSpace[] = {
         {    0, N_("sRGB") },
         {    1, N_("Adobe RGB") },
     };
 
     //! LensType, combi-tag 0x003f (2 unsigned long)
-    extern const TagDetails pentaxLensType[] = {
+    constexpr TagDetails pentaxLensType[] = {
         { 0x0000, N_("M-42 or No Lens") },
         { 0x0100, N_("K or M Lens") },
         { 0x0200, N_("A Series Lens") },
@@ -984,7 +984,7 @@ namespace Exiv2 {
     };
 
     //! ImageTone, tag 0x004f
-    extern const TagDetails pentaxImageTone[] = {
+    constexpr TagDetails pentaxImageTone[] = {
         {    0, N_("Natural") },
         {    1, N_("Bright") },
         {    2, N_("Portrait") },
@@ -998,13 +998,13 @@ namespace Exiv2 {
     };
 
     //! DynamicRangeExpansion, tag 0x0069
-    extern const TagDetails pentaxDynamicRangeExpansion[] = {
+    constexpr TagDetails pentaxDynamicRangeExpansion[] = {
         {   0, N_("Off") },
         {   0x1000000, N_("On") },
     };
 
     //! HighISONoiseReduction, tag 0x0071
-    extern const TagDetails pentaxHighISONoiseReduction[] = {
+    constexpr TagDetails pentaxHighISONoiseReduction[] = {
         {   0, N_("Off") },
         {   1, N_("Weakest") },
         {   2, N_("Weak") },

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -103,7 +103,7 @@ namespace Exiv2 {
     extern const XmpPropertyInfo xmpAcdseeInfo[];
     extern const XmpPropertyInfo xmpGPanoInfo[];
 
-    extern const XmpNsInfo xmpNsInfo[] = {
+    constexpr XmpNsInfo xmpNsInfo[] = {
         // Schemas   -   NOTE: Schemas which the XMP-SDK doesn't know must be registered in XmpParser::initialize - Todo: Automate this
         { "http://purl.org/dc/elements/1.1/",             "dc",             xmpDcInfo,        N_("Dublin Core schema")                        },
         { "http://www.digikam.org/ns/1.0/",               "digiKam",        xmpDigikamInfo,   N_("digiKam Photo Management schema")           },
@@ -159,7 +159,7 @@ namespace Exiv2 {
         { "http://ns.adobe.com/xmp/Identifier/qual/1.0/", "xmpidq", nullptr, N_("Qualifier for xmp:Identifier") }
     };
 
-    extern const XmpPropertyInfo xmpDcInfo[] = {
+    const XmpPropertyInfo xmpDcInfo[] = {
         { "contributor",      N_("Contributor"),      "bag ProperName",  xmpBag,       xmpExternal, N_("Contributors to the resource (other than the authors).")                               },
         { "coverage",         N_("Coverage"),         "Text",            xmpText,      xmpExternal, N_("The spatial or temporal topic of the resource, the spatial applicability of the "
                                                                                                        "resource, or the jurisdiction under which the resource is relevant.")                      },
@@ -190,7 +190,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpDigikamInfo[] = {
+    const XmpPropertyInfo xmpDigikamInfo[] = {
         { "TagsList",               N_("Tags List"),                 "seq Text", xmpSeq,  xmpExternal, N_("The list of complete tags path as string. The path hierarchy is separated by '/' character (ex.: \"City/Paris/Monument/Eiffel Tower\".") },
         { "CaptionsAuthorNames",    N_("Captions Author Names"),     "Lang Alt", langAlt, xmpExternal, N_("The list of all captions author names for each language alternative captions set in standard XMP tags.") },
         { "CaptionsDateTimeStamps", N_("Captions Date Time Stamps"), "Lang Alt", langAlt, xmpExternal, N_("The list of all captions date time stamps for each language alternative captions set in standard XMP tags.") },
@@ -203,7 +203,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpKipiInfo[] = {
+    const XmpPropertyInfo xmpKipiInfo[] = {
         { "PanoramaInputFiles",     N_("Panorama Input Files"),      "Text",     xmpText, xmpExternal, N_("The list of files processed with Hugin program through Panorama tool.") },
         { "EnfuseInputFiles",       N_("Enfuse Input Files"),        "Text",     xmpText, xmpExternal, N_("The list of files processed with Enfuse program through ExpoBlending tool.") },
         { "EnfuseSettings",         N_("Enfuse Settings"),           "Text",     xmpText, xmpExternal, N_("The list of Enfuse settings used to blend image stack with ExpoBlending tool.") },
@@ -213,7 +213,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpInfo[] = {
+    const XmpPropertyInfo xmpXmpInfo[] = {
         { "Advisory",         N_("Advisory"),         "bag XPath",                xmpBag,    xmpExternal, N_("An unordered array specifying properties that were edited outside the authoring "
                                                                                                              "application. Each item should contain a single namespace and XPath separated by "
                                                                                                              "one ASCII space (U+0020).") },
@@ -248,7 +248,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpRightsInfo[] = {
+    const XmpPropertyInfo xmpXmpRightsInfo[] = {
         { "Certificate",      N_("Certificate"),   "URL",            xmpText,       xmpExternal, N_("Online rights management certificate.") },
         { "Marked",           N_("Marked"),        "Boolean",        xmpText,       xmpExternal, N_("Indicates that this is a rights-managed resource.") },
         { "Owner",            N_("Owner"),         "bag ProperName", xmpBag,        xmpExternal, N_("An unordered array specifying the legal owner(s) of a resource.") },
@@ -258,7 +258,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpMMInfo[] = {
+    const XmpPropertyInfo xmpXmpMMInfo[] = {
         { "DerivedFrom",      N_("Derived From"),      "ResourceRef",       xmpText,    xmpInternal, N_("A reference to the original document from which this one is derived. It is a "
                                                                                                         "minimal reference; missing components can be assumed to be unchanged. For example, "
                                                                                                         "a new version might only need to specify the instance ID and version number of the "
@@ -320,7 +320,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpBJInfo[] = {
+    const XmpPropertyInfo xmpXmpBJInfo[] = {
         { "JobRef",           N_("Job Reference"),     "bag Job",   xmpText,    xmpExternal, N_("References an external job management file for a job process in which the document is being used. Use of job "
                                                                                                 "names is under user control. Typical use would be to identify all documents that are part of a particular job or contract. "
                                                                                                 "There are multiple values because there can be more than one job using a particular document at any time, and it can "
@@ -329,7 +329,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpTPgInfo[] = {
+    const XmpPropertyInfo xmpXmpTPgInfo[] = {
         { "MaxPageSize",      N_("Maximum Page Size"), "Dimensions",   xmpText,    xmpInternal, N_("The size of the largest page in the document (including any in contained documents).") },
         { "NPages",           N_("Number of Pages"),   "Integer",      xmpText,    xmpInternal, N_("The number of pages in the document (including any in contained documents).") },
         { "Fonts",            N_("Fonts"),             "bag Font",     xmpText,    xmpInternal, N_("An unordered array of fonts that are used in the document (including any in contained documents).") },
@@ -339,7 +339,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpXmpDMInfo[] = {
+    const XmpPropertyInfo xmpXmpDMInfo[] = {
         { "absPeakAudioFilePath",         N_("Absolute Peak Audio File Path"),    "URI",                   xmpText, xmpInternal, N_("The absolute path to the file's peak audio file. If empty, no peak file exists.") },
         { "album",                        N_("Album"),                            "Text",                  xmpText, xmpExternal, N_("The name of the album.") },
         { "altTapeName",                  N_("Alternative Tape Name"),            "Text",                  xmpText, xmpExternal, N_("An alternative tape name, set via the project window or timecode dialog in Premiere. "
@@ -429,7 +429,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMicrosoftInfo[] = {
+    const XmpPropertyInfo xmpMicrosoftInfo[] = {
         { "CameraSerialNumber", N_("Camera Serial Number"), "Text",     xmpText, xmpExternal, N_("Camera Serial Number.") },
         { "DateAcquired",       N_("Date Acquired"),        "Date",     xmpText, xmpExternal, N_("Date Acquired.")        },
         { "FlashManufacturer",  N_("Flash Manufacturer"),   "Text",     xmpText, xmpExternal, N_("Flash Manufacturer.")   },
@@ -443,14 +443,14 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpLrInfo[] = {
+    const XmpPropertyInfo xmpLrInfo[] = {
         { "hierarchicalSubject",    N_("Hierarchical Subject"),    "bag Text",  xmpBag,      xmpExternal, N_("Adobe Lightroom hierarchical keywords.")   },
         { "privateRTKInfo",         N_("Private RTK Info"),        "Text",      xmpText,     xmpExternal, N_("Adobe Lightroom private RTK info.")        },
         // End of list marker
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpPdfInfo[] = {
+    const XmpPropertyInfo xmpPdfInfo[] = {
         { "Keywords",   N_("Keywords"),    "Text",      xmpText, xmpExternal, N_("Keywords.") },
         { "PDFVersion", N_("PDF Version"), "Text",      xmpText, xmpInternal, N_("The PDF file version (for example: 1.0, 1.3, and so on).") },
         { "Producer",   N_("Producer"),    "AgentName", xmpText, xmpInternal, N_("The name of the tool that created the PDF document.") },
@@ -459,7 +459,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpPhotoshopInfo[] = {
+    const XmpPropertyInfo xmpPhotoshopInfo[] = {
         { "DateCreated",            N_("Date Created"),            "Date",       xmpText, xmpExternal, N_("The date the intellectual content of the document was created (rather than the creation "
                                                                                                           "date of the physical representation), following IIM conventions. For example, a photo "
                                                                                                           "taken during the American Civil War would have a creation date during that epoch "
@@ -494,13 +494,13 @@ namespace Exiv2 {
     };
 
     //! XMP crs:CropUnits
-    extern const TagDetails crsCropUnits[] = {
+    constexpr TagDetails crsCropUnits[] = {
         { 0, N_("pixels") },
         { 1, N_("inches") },
         { 2, N_("cm")     }
     };
 
-    extern const XmpPropertyInfo xmpCrssInfo[] = {
+    const XmpPropertyInfo xmpCrssInfo[] = {
         { "SavedSettings", 	N_("Saved Settings"), 	"SavedSettings", 	xmpText, 	xmpInternal, N_("*Main structure* Camera Raw Saved Settings.") },
         { "Name",  			N_("Name"),   			"Text",            	xmpText,    xmpExternal, N_("Camera Raw Saved Settings Name.")              },
         { "Type",  			N_("Type"),   			"Text",            	xmpText,    xmpExternal, N_("Camera Raw Saved Settings Type.")              },
@@ -509,7 +509,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpCrsInfo[] = {
+    const XmpPropertyInfo xmpCrsInfo[] = {
         { "AutoBrightness",       N_("Auto Brightness"),           "Boolean",                          xmpText, xmpInternal, N_("When true, \"Brightness\" is automatically adjusted.") },
         { "AutoContrast",         N_("Auto Contrast"),             "Boolean",                          xmpText, xmpInternal, N_("When true, \"Contrast\" is automatically adjusted.") },
         { "AutoExposure",         N_("Auto Exposure"),             "Boolean",                          xmpText, xmpInternal, N_("When true, \"Exposure\" is automatically adjusted.") },
@@ -749,7 +749,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpTiffInfo[] = {
+    const XmpPropertyInfo xmpTiffInfo[] = {
         { "ImageWidth",                N_("Image Width"),                "Integer",                      xmpText, xmpInternal, N_("TIFF tag 256, 0x100. Image width in pixels.") },
         { "ImageLength",               N_("Image Length"),               "Integer",                      xmpText, xmpInternal, N_("TIFF tag 257, 0x101. Image height in pixels.") },
         { "BitsPerSample",             N_("Bits Per Sample"),            "seq Integer",                  xmpSeq,  xmpInternal, N_("TIFF tag 258, 0x102. Number of bits per component in each channel.") },
@@ -799,7 +799,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpExifInfo[] = {
+    const XmpPropertyInfo xmpExifInfo[] = {
         { "ExifVersion",              N_("Exif Version"),                        "Closed Choice of Text",        xmpText, xmpInternal, N_("EXIF tag 36864, 0x9000. EXIF version number.") },
         { "FlashpixVersion",          N_("Flashpix Version"),                    "Closed Choice of Text",        xmpText, xmpInternal, N_("EXIF tag 40960, 0xA000. Version of FlashPix.") },
         { "ColorSpace",               N_("Color Space"),                         "Closed Choice of Integer",     xmpText, xmpInternal, N_("EXIF tag 40961, 0xA001. Color space information") },
@@ -902,7 +902,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpExifEXInfo[] = {
+    const XmpPropertyInfo xmpExifEXInfo[] = {
         { "Gamma",                      N_("Gamma"),                    "Rational",                 xmpText, xmpInternal, N_("EXIF tag 42240, 0xA500. Indicates the value of coefficient gamma.") },
         { "PhotographicSensitivity",    N_("Photographic Sensitivity"), "Integer",                  xmpText, xmpInternal, N_("EXIF tag 34855, 0x8827. Indicates the sensitivity of the camera or input device when the image was shot up to the value of 65535 with one of the following parameters that are defined in ISO 12232: standard output sensitivity (SOS), recommended exposure index (REI), or ISO speed.") },
         { "SensitivityType",            N_("Sensitivity Type"),         "Closed Choice of Integer", xmpText, xmpInternal, N_("EXIF tag 34864, 0x8830. Indicates which one of the parameters of ISO12232 is used for PhotographicSensitivity:0 = Unknown "
@@ -933,14 +933,14 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpAuxInfo[] = {
+    const XmpPropertyInfo xmpAuxInfo[] = {
         { "Lens",             N_("Lens"),             "Text",        xmpText,          xmpInternal, N_("A description of the lens used to take the photograph. For example, \"70-200 mm f/2.8-4.0\".") },
         { "SerialNumber",     N_("Serial Number"),     "Text",       xmpText,          xmpInternal, N_("The serial number of the camera or camera body used to take the photograph.") },
         // End of list marker
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpIptcInfo[] = {
+    const XmpPropertyInfo xmpIptcInfo[] = {
         { "CreatorContactInfo", N_("Creator's Contact Info"),      "ContactInfo",               xmpText, xmpExternal, N_("The creator's contact information provides all necessary information to get in contact "
                                                                                                                          "with the creator of this news object and comprises a set of sub-properties for proper addressing.") },
         { "CiAdrExtadr",        N_("Contact Info-Address"),        "Text",                      xmpText, xmpExternal, N_("sub-key Creator Contact Info: address. Comprises an optional company name and all required "
@@ -971,7 +971,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpIptcExtInfo[] = {
+    const XmpPropertyInfo xmpIptcExtInfo[] = {
         { "AddlModelInfo",           N_("Additional model info"),           "Text",                       xmpText, xmpExternal, N_("Information about the ethnicity and other facts of the model(s) in a model-released image.") },
         { "OrganisationInImageCode", N_("Code of featured Organisation"),   "bag Text",                   xmpBag,  xmpExternal, N_("Code from controlled vocabulary for identifying the organisation or company which is featured in the image.") },
         { "CVterm",                  N_("Controlled Vocabulary Term"),      "bag URI",                    xmpBag,  xmpExternal, N_("A term to describe the content of the image by a value from a Controlled Vocabulary.") },
@@ -1007,7 +1007,7 @@ namespace Exiv2 {
     };
 
     //! XMP iptcExt:DigitalSourcefileType
-    extern const TagVocabulary iptcExtDigitalSourcefileType[] = {
+    constexpr TagVocabulary iptcExtDigitalSourcefileType[] = {
         { "scanfilm",         N_("Scan from film")                           },
         { "scantransparency", N_("Scan from transparency (including slide)") },
         { "scanprint",        N_("Scan from print")                          },
@@ -1016,7 +1016,7 @@ namespace Exiv2 {
         { "camerajpeg",       N_("Camera JPEG")                              }
     };
 
-    extern const XmpPropertyInfo xmpPlusInfo[] = {
+    const XmpPropertyInfo xmpPlusInfo[] = {
         // PLUS Version 1.2.0
         { "Version", N_("PLUS Version"), "Text", xmpText, xmpExternal, N_("The version number of the PLUS standards in place at the time of the transaction.") },
         { "Licensee", N_("Licensee"), "seq LicenseeDetail", xmpSeq, xmpExternal, N_("Party or parties to whom the license is granted by the Licensor/s under the license transaction.") },
@@ -1107,21 +1107,21 @@ namespace Exiv2 {
     };
 
     //! XMP plus:AdultContentWarning
-    extern const TagVocabulary plusAdultContentWarning[] = {
+    constexpr TagVocabulary plusAdultContentWarning[] = {
         { "CW-AWR", N_("Adult Content Warning Required") },
         { "CW-NRQ", N_("Not Required")                   },
         { "CW-UNK", N_("Unknown")                        }
     };
 
     //! XMP plus:CopyrightStatus
-    extern const TagVocabulary plusCopyrightStatus[] = {
+    constexpr TagVocabulary plusCopyrightStatus[] = {
         { "CS-PRO", N_("Protected")     },
         { "CS-PUB", N_("Public Domain") },
         { "CS-UNK", N_("Unknown")       }
     };
 
     //! XMP plus:CreditLineRequired
-    extern const TagVocabulary plusCreditLineRequired[] = {
+    constexpr TagVocabulary plusCreditLineRequired[] = {
         { "CR-CAI", N_("Credit Adjacent To Image") },
         { "CR-CCA", N_("Credit in Credits Area")   },
         { "CR-COI", N_("Credit on Image")          },
@@ -1129,7 +1129,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ImageAlterationConstraints
-    extern const TagVocabulary plusImageAlterationConstraints[] = {
+    constexpr TagVocabulary plusImageAlterationConstraints[] = {
         { "AL-CLR", N_("No Colorization")    },
         { "AL-CRP", N_("No Cropping")        },
         { "AL-DCL", N_("No De-Colorization") },
@@ -1139,14 +1139,14 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ImageDuplicationConstraints
-    extern const TagVocabulary plusImageDuplicationConstraints[] = {
+    constexpr TagVocabulary plusImageDuplicationConstraints[] = {
         { "DP-LIC", N_("Duplication Only as Necessary Under License") },
         { "DP-NDC", N_("No Duplication Constraints")                  },
         { "DP-NOD", N_("No Duplication")                              }
     };
 
     //! XMP plus:ImageFileConstraints
-    extern const TagVocabulary plusImageFileConstraints[] = {
+    constexpr TagVocabulary plusImageFileConstraints[] = {
         { "IF-MFN", N_("Maintain File Name")       },
         { "IF-MFT", N_("Maintain File Type")       },
         { "IF-MID", N_("Maintain ID in File Name") },
@@ -1154,7 +1154,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ImageFileFormatAsDelivered
-    extern const TagVocabulary plusImageFileFormatAsDelivered[] = {
+    constexpr TagVocabulary plusImageFileFormatAsDelivered[] = {
         { "FF-BMP", N_("Windows Bitmap (BMP)")                      },
         { "FF-DNG", N_("Digital Negative (DNG)")                    },
         { "FF-EPS", N_("Encapsulated PostScript (EPS)")             },
@@ -1170,7 +1170,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ImageFileSizeAsDelivered
-    extern const TagVocabulary plusImageFileSizeAsDelivered[] = {
+    constexpr TagVocabulary plusImageFileSizeAsDelivered[] = {
         { "SZ-G50", N_("Greater than 50 MB") },
         { "SZ-U01", N_("Up to 1 MB")         },
         { "SZ-U10", N_("Up to 10 MB")        },
@@ -1179,7 +1179,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ImageType
-    extern const TagVocabulary plusImageType[] = {
+    constexpr TagVocabulary plusImageType[] = {
         { "TY-ILL", N_("Illustrated Image")              },
         { "TY-MCI", N_("Multimedia or Composited Image") },
         { "TY-OTR", N_("Other")                          },
@@ -1188,7 +1188,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:LicensorTelephoneType
-    extern const TagVocabulary plusLicensorTelephoneType[] = {
+    constexpr TagVocabulary plusLicensorTelephoneType[] = {
         { "cell",  N_("Cell")  },
         { "fax",   N_("FAX")   },
         { "home",  N_("Home")  },
@@ -1197,7 +1197,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:MinorModelAgeDisclosure
-    extern const TagVocabulary plusMinorModelAgeDisclosure[] = {
+    constexpr TagVocabulary plusMinorModelAgeDisclosure[] = {
         { "AG-UNK", N_("Age Unknown")     },
         { "AG-A25", N_("Age 25 or Over")  },
         { "AG-A24", N_("Age 24")          },
@@ -1214,7 +1214,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:ModelReleaseStatus
-    extern const TagVocabulary plusModelReleaseStatus[] = {
+    constexpr TagVocabulary plusModelReleaseStatus[] = {
         { "MR-NON", N_("None")                                 },
         { "MR-NAP", N_("Not Applicable")                       },
         { "MR-UMR", N_("Unlimited Model Releases")             },
@@ -1222,7 +1222,7 @@ namespace Exiv2 {
     };
 
     //! XMP plus:PropertyReleaseStatus
-    extern const TagVocabulary plusPropertyReleaseStatus[] = {
+    constexpr TagVocabulary plusPropertyReleaseStatus[] = {
         { "PR-NON", N_("None")                                    },
         { "PR-NAP", N_("Not Applicable")                          },
         { "PR-UPR", N_("Unlimited Property Releases")             },
@@ -1230,12 +1230,12 @@ namespace Exiv2 {
     };
 
     //! XMP plus:Reuse
-    extern const TagVocabulary plusReuse[] = {
+    constexpr TagVocabulary plusReuse[] = {
         { "RE-NAP", N_("Not Applicable") },
         { "RE-REU", N_("Repeat Use")     }
     };
 
-    extern const XmpPropertyInfo xmpMediaProInfo[] = {
+    const XmpPropertyInfo xmpMediaProInfo[] = {
         { "Event",       N_("Event"),       "Text",     xmpText, xmpExternal, N_("Fixture Identification")                          },
         { "Status",      N_("Status"),      "Text",     xmpText, xmpExternal, N_("A notation making the image unique")              },
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
@@ -1244,7 +1244,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpExpressionMediaInfo[] = {
+    const XmpPropertyInfo xmpExpressionMediaInfo[] = {
         { "Event",       N_("Event"),       "Text",     xmpText, xmpExternal, N_("Fixture Identification")                          },
         { "Status",      N_("Status"),      "Text",     xmpText, xmpExternal, N_("A notation making the image unique")              },
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
@@ -1253,20 +1253,20 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMicrosoftPhotoInfo[] = {
+    const XmpPropertyInfo xmpMicrosoftPhotoInfo[] = {
         { "RegionInfo", N_("RegionInfo"), "RegionInfo", xmpText, xmpInternal, N_("Microsoft Photo people-tagging metadata root") },
         // End of list marker
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfoInfo[] = {
+    const XmpPropertyInfo xmpMicrosoftPhotoRegionInfoInfo[] = {
         { "Regions",          N_("Regions"),            "bag Region", xmpBag,  xmpExternal, N_("Contains Regions/person tags") },
         { "DateRegionsValid", N_("Date Regions Valid"), "Date",       xmpText, xmpExternal, N_("Date the last region was created")  },
         // End of list marker
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfo[] = {
+    const XmpPropertyInfo xmpMicrosoftPhotoRegionInfo[] = {
         { "PersonDisplayName", N_("Person Display Name"),   "Text", xmpText, xmpExternal, N_("Name of the person (in the given rectangle)")                               },
         { "Rectangle",         N_("Rectangle"),             "Text", xmpText, xmpExternal, N_("Rectangle that identifies the person within the photo")                     },
         { "PersonEmailDigest", N_("Person Email Digest"),   "Text", xmpText, xmpExternal, N_("SHA-1 encrypted message hash of the person's Windows Live e-mail address"), },
@@ -1275,7 +1275,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMWGRegionsInfo[] = {
+    const XmpPropertyInfo xmpMWGRegionsInfo[] = {
         { "Regions",             N_("Regions"),               "RegionInfo",       xmpText, xmpInternal,        N_("Main structure containing region based information")   },
         { "AppliedToDimensions", N_("Applied To Dimensions"), "Dimensions",       xmpText, xmpExternal,        N_("Width and height of image when storing region data")   },
         { "RegionList",          N_("Region List"),           "bag RegionStruct", xmpBag,  xmpExternal,        N_("List of Region structures")                            },
@@ -1290,7 +1290,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpMWGKeywordInfo[] = {
+    const XmpPropertyInfo xmpMWGKeywordInfo[] = {
         { "Keywords",       N_("Keywords"),     "KeywordInfo",          xmpText, xmpInternal,   N_("Main structure containing keyword based information")   },
         { "Hierarchy",      N_("Hierarchy"),    "bag KeywordStruct",    xmpBag,  xmpExternal,   N_("List of root keyword structures")   },
         { "Keyword",        N_("Keyword"),      "Text",                 xmpText, xmpExternal,   N_("Name of keyword (-node)")   },
@@ -1301,7 +1301,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpGPanoInfo[] = {
+    const XmpPropertyInfo xmpGPanoInfo[] = {
         { "UsePanoramaViewer",              N_("Use Panorama Viewer"),              "Boolean",              xmpText, xmpExternal,   N_("Whether to show this image in a panorama viewer rather than as a normal flat image. This may be specified based on user preferences or by the stitching software. The application displaying or ingesting the image may choose to ignore this.")   },
         { "CaptureSoftware",                N_("Capture Software"),                 "Text",                 xmpText, xmpExternal,   N_("If capture was done using an application on a mobile device, such as an Android phone, the name of the application that was used (such as \"Photo Sphere\"). This should be left blank if source images were captured manually, such as by using a DSLR on a tripod.")   },
         { "StitchingSoftware",              N_("Stitching Software"),               "Text",                 xmpText, xmpExternal,   N_("The software that was used to create the final panorama. This may sometimes be the same value as that of  GPano:CaptureSoftware.")   },
@@ -1329,7 +1329,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpVideoInfo[] = {
+    const XmpPropertyInfo xmpVideoInfo[] = {
         { "Album",                  N_("Album"),                            "Text",                     xmpText, xmpExternal, N_("The name of the album.")   },
         { "ArchivalLocation",       N_("Archival Location"),                "Text",                     xmpText, xmpExternal, N_("Information about the Archival Location.")   },
         { "Arranger",               N_("Arranger"),                         "Text",                     xmpText, xmpExternal, N_("Information about the Arranger.")   },
@@ -1672,7 +1672,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpAudioInfo[] = {
+    const XmpPropertyInfo xmpAudioInfo[] = {
         { "AvgBytePerSec",      N_("Average Bytes Per Second"),     "Integer",               xmpText, xmpExternal, N_("Average Bytes Per Second found in audio stream")   },
         { "Balance",            N_("Balance"),                      "Integer",               xmpText, xmpExternal, N_("Indicates the left-right balance of the audio")   },
         { "BitsPerSample",      N_("Bits Per Sample/ Bit Rate"),    "Integer",               xmpText, xmpExternal, N_("Bits per test sample")   },
@@ -1723,7 +1723,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpDctermsInfo[] = {
+    const XmpPropertyInfo xmpDctermsInfo[] = {
             // dcterms properties used by DwC under the Record Class.
             { "type",                   N_("Type"),                     "bag open Choice", xmpBag,       xmpExternal, N_("The nature or genre of the resource.")                         },
             { "modified",               N_("Date Modified"),            "seq Date",        xmpSeq,       xmpExternal, N_("Date on which the resource was changed.")                         },
@@ -1741,7 +1741,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-   extern const XmpPropertyInfo xmpDwCInfo[] = {
+   const XmpPropertyInfo xmpDwCInfo[] = {
 
         // Record Level Class
         { "Record",                         N_("Record"),                               "Record",    xmpText,   xmpInternal,
@@ -2376,7 +2376,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPropertyInfo xmpAcdseeInfo[] = {
+    const XmpPropertyInfo xmpAcdseeInfo[] = {
         { "caption",       N_("Caption"),     "Text",                 xmpText, xmpExternal,   N_("A brief description of the file")   },
         { "datetime",      N_("Date Time"),   "Text",                 xmpText, xmpExternal,   N_("Date and Time")   },
         { "author",        N_("Author"),      "Text",                 xmpText, xmpExternal,   N_("The name of the author or photographer")   },
@@ -2389,7 +2389,7 @@ namespace Exiv2 {
         { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
-    extern const XmpPrintInfo xmpPrintInfo[] = {
+    constexpr XmpPrintInfo xmpPrintInfo[] = {
         {"Xmp.crs.CropUnits",                 EXV_PRINT_TAG(crsCropUnits)   },
         {"Xmp.exif.ApertureValue",            print0x9202                   },
         {"Xmp.exif.BrightnessValue",          printFloat                    },

--- a/src/samsungmn_int.cpp
+++ b/src/samsungmn_int.cpp
@@ -43,7 +43,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! LensType, tag 0xa003
-    extern const TagDetails samsung2LensType[] = {
+    constexpr TagDetails samsung2LensType[] = {
         {  0, N_("Built-in")                                      },
         {  1, "Samsung NX 30mm F2 Pancake"                    },
         {  2, "Samsung NX 18-55mm F3.5-5.6 OIS"               },
@@ -65,13 +65,13 @@ namespace Exiv2 {
     };
 
     //! ColorSpace, tag 0xa011
-    extern const TagDetails samsung2ColorSpace[] = {
+    constexpr TagDetails samsung2ColorSpace[] = {
         { 0, N_("sRGB")      },
         { 1, N_("Adobe RGB") }
     };
 
     //! SmartRange, tag 0xa012
-    extern const TagDetails samsung2SmartRange[] = {
+    constexpr TagDetails samsung2SmartRange[] = {
         { 0, N_("Off") },
         { 1, N_("On")  }
     };
@@ -148,7 +148,7 @@ namespace Exiv2 {
     }
 
     //! PictureWizard Mode
-    extern const TagDetails samsungPwMode[] = {
+    constexpr TagDetails samsungPwMode[] = {
         {  0, N_("Standard")  },
         {  1, N_("Vivid")     },
         {  2, N_("Portrait")  },

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -47,7 +47,7 @@ namespace Exiv2 {
     // -- Standard Sony Makernotes tags ---------------------------------------------------------------
 
     //! Lookup table to translate Sony Auto HDR values to readable labels
-    extern const TagDetails sonyHDRMode[] = {
+    constexpr TagDetails sonyHDRMode[] = {
         { 0x00000, N_("Off")   },
         { 0x10001, N_("Auto")  },
         { 0x10010, "1"         },
@@ -58,7 +58,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony model ID values to readable labels
-    extern const TagDetails sonyModelId[] = {
+    constexpr TagDetails sonyModelId[] = {
         { 2, "DSC-R1"                   },
         { 256, "DSLR-A100"              },
         { 257, "DSLR-A900"              },
@@ -130,7 +130,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony dynamic range optimizer values to readable labels
-    extern const TagDetails print0xb025[] = {
+    constexpr TagDetails print0xb025[] = {
         { 0,  N_("Off")           },
         { 1,  N_("Standard")      },
         { 2,  N_("Advanced Auto") },
@@ -148,7 +148,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony exposure mode values to readable labels
-    extern const TagDetails sonyExposureMode[] = {
+    constexpr TagDetails sonyExposureMode[] = {
         { 0,     N_("Auto")                     },
         { 1,     N_("Portrait")                 },
         { 2,     N_("Beach")                    },
@@ -183,7 +183,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony JPEG Quality values to readable labels
-    extern const TagDetails sonyJPEGQuality[] = {
+    constexpr TagDetails sonyJPEGQuality[] = {
         { 0,     N_("Normal")       },
         { 1,     N_("Fine")         },
         { 2,     N_("Extra Fine")   },
@@ -191,7 +191,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony anti-blur values to readable labels
-    extern const TagDetails sonyAntiBlur[] = {
+    constexpr TagDetails sonyAntiBlur[] = {
         { 0,     N_("Off")             },
         { 1,     N_("On (Continuous)") },
         { 2,     N_("On (Shooting)")   },
@@ -199,21 +199,21 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony dynamic range optimizer values to readable labels
-    extern const TagDetails print0xb04f[] = {
+    constexpr TagDetails print0xb04f[] = {
         { 0, N_("Off")      },
         { 1, N_("Standard") },
         { 2, N_("Plus")     }
     };
 
     //! Lookup table to translate Sony Intelligent Auto values to readable labels
-    extern const TagDetails sonyIntelligentAuto[] = {
+    constexpr TagDetails sonyIntelligentAuto[] = {
         { 0, N_("Off")      },
         { 1, N_("On")       },
         { 2, N_("Advanced") }
     };
 
     //! Lookup table to translate Sony WB values to readable labels
-    extern const TagDetails sonyWhiteBalance[] = {
+    constexpr TagDetails sonyWhiteBalance[] = {
         { 0,  N_("Auto")                       },
         { 4,  N_("Manual")                     },
         { 5,  N_("Daylight")                   },
@@ -230,7 +230,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony AF mode values to readable labels
-    extern const TagDetails sonyFocusMode[] = {
+    constexpr TagDetails sonyFocusMode[] = {
         { 1,     "AF-S"             },
         { 2,     "AF-C"             },
         { 4,     N_("Permanent-AF") },
@@ -238,7 +238,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony AF mode values to readable labels
-    extern const TagDetails sonyAFMode[] = {
+    constexpr TagDetails sonyAFMode[] = {
         { 0,     N_("Default")          },
         { 1,     N_("Multi AF")         },
         { 2,     N_("Center AF")        },
@@ -251,14 +251,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony AF illuminator values to readable labels
-    extern const TagDetails sonyAFIlluminator[] = {
+    constexpr TagDetails sonyAFIlluminator[] = {
         { 0,     N_("Off") },
         { 1,     N_("Auto")  },
         { 65535, N_("n/a") }
     };
 
     //! Lookup table to translate Sony macro mode values to readable labels
-    extern const TagDetails sonyMacroMode[] = {
+    constexpr TagDetails sonyMacroMode[] = {
         { 0,     N_("Off")         },
         { 1,     N_("On")          },
         { 2,     N_("Close Focus") },
@@ -266,7 +266,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony flash level values to readable labels
-    extern const TagDetails sonyFlashLevel[] = {
+    constexpr TagDetails sonyFlashLevel[] = {
         { -32768, N_("Low")    },
         { -1,     N_("n/a")    },
         { 0,      N_("Normal") },
@@ -274,7 +274,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony release mode values to readable labels
-    extern const TagDetails sonyReleaseMode[] = {
+    constexpr TagDetails sonyReleaseMode[] = {
         { 0,     N_("Normal")                   },
         { 2,     N_("Burst")                    },
         { 5,     N_("Exposure Bracketing")      },
@@ -283,13 +283,13 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony sequence number values to readable labels
-    extern const TagDetails sonySequenceNumber[] = {
+    constexpr TagDetails sonySequenceNumber[] = {
         { 0,     N_("Single")                    },
         { 65535, N_("n/a")                       }
     };
 
     //! Lookup table to translate Sony long exposure noise reduction values to readable labels
-    extern const TagDetails sonyLongExposureNoiseReduction[] = {
+    constexpr TagDetails sonyLongExposureNoiseReduction[] = {
         { 0,     N_("Off") },
         { 1,     N_("On")  },
         { 65535, N_("n/a") }
@@ -502,7 +502,7 @@ namespace Exiv2 {
     // -- Sony camera settings ---------------------------------------------------------------
 
     //! Lookup table to translate Sony camera settings drive mode values to readable labels
-    extern const TagDetails sonyDriveModeStd[] = {
+    constexpr TagDetails sonyDriveModeStd[] = {
         { 0x01, N_("Single Frame")                      },
         { 0x02, N_("Continuous High")                   },
         { 0x04, N_("Self-timer 10 sec")                 },
@@ -520,7 +520,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony camera settings focus mode values to readable labels
-    extern const TagDetails sonyCSFocusMode[] = {
+    constexpr TagDetails sonyCSFocusMode[] = {
         { 0, N_("Manual") },
         { 1, "AF-S"       },
         { 2, "AF-C"       },
@@ -528,14 +528,14 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony camera settings metering mode values to readable labels
-    extern const TagDetails sonyMeteringMode[] = {
+    constexpr TagDetails sonyMeteringMode[] = {
         { 1, N_("Multi-segment")           },
         { 2, N_("Center weighted average") },
         { 4, N_("Spot")                    }
     };
 
     //! Lookup table to translate Sony camera settings creative style values to readable labels
-    extern const TagDetails sonyCreativeStyle[] = {
+    constexpr TagDetails sonyCreativeStyle[] = {
         { 1,    N_("Standard")            },
         { 2,    N_("Vivid")               },
         { 3,    N_("Portrait")            },
@@ -553,19 +553,19 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony camera settings flash mode values to readable labels
-    extern const TagDetails sonyFlashMode[] = {
+    constexpr TagDetails sonyFlashMode[] = {
         { 0, N_("ADI") },
         { 1, N_("TTL") },
     };
 
     //! Lookup table to translate Sony AF illuminator values to readable labels
-    extern const TagDetails sonyAFIlluminatorCS[] = {
+    constexpr TagDetails sonyAFIlluminatorCS[] = {
         { 0, N_("Auto") },
         { 1, N_("Off")  }
     };
 
     //! Lookup table to translate Sony camera settings image style values to readable labels
-    extern const TagDetails sonyImageStyle[] = {
+    constexpr TagDetails sonyImageStyle[] = {
         { 1,    N_("Standard")            },
         { 2,    N_("Vivid")               },
         { 3,    N_("Portrait")            },
@@ -584,7 +584,7 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony camera settings exposure program values to readable labels
-    extern const TagDetails sonyExposureProgram[] = {
+    constexpr TagDetails sonyExposureProgram[] = {
         { 0,    N_("Auto")                      },
         { 1,    N_("Manual")                    },
         { 2,    N_("Program AE")                },
@@ -602,20 +602,20 @@ namespace Exiv2 {
     };
 
     //! Lookup table to translate Sony camera settings image size values to readable labels
-    extern const TagDetails sonyImageSize[] = {
+    constexpr TagDetails sonyImageSize[] = {
         { 1, N_("Large")  },
         { 2, N_("Medium") },
         { 3, N_("Small")  }
     };
 
     //! Lookup table to translate Sony aspect ratio values to readable labels
-    extern const TagDetails sonyAspectRatio[] = {
+    constexpr TagDetails sonyAspectRatio[] = {
         { 1, "3:2"   },
         { 2, "16:9"  }
     };
 
     //! Lookup table to translate Sony exposure level increments values to readable labels
-    extern const TagDetails sonyExposureLevelIncrements[] = {
+    constexpr TagDetails sonyExposureLevelIncrements[] = {
         { 33, "1/3 EV" },
         { 50, "1/2 EV" }
     };

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -65,7 +65,7 @@ namespace Exiv2 {
 
 
     //! List of all defined Exif sections.
-    extern const SectionInfo sectionInfo[] = {
+    constexpr SectionInfo sectionInfo[] = {
         { sectionIdNotSet, "(UnknownSection)",     N_("Unknown section")              },
         { imgStruct,       "ImageStructure",       N_("Image data structure")         },
         { recOffset,       "RecordingOffset",      N_("Recording offset")             },

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -58,7 +58,7 @@ namespace Exiv2 {
     namespace Internal {
 
     //! List of all known Exif groups. Important: Group name (3rd column) must be unique!
-    extern const GroupInfo groupInfo[] = {
+    constexpr GroupInfo groupInfo[] = {
         { ifdIdNotSet,     "Unknown IFD", "Unknown", nullptr },
         { ifd0Id,          "IFD0",      "Image",        ifdTagList                     },
         { ifd1Id,          "IFD1",      "Thumbnail",    ifdTagList                     },
@@ -170,52 +170,52 @@ namespace Exiv2 {
     };
 
     //! Units for measuring X and Y resolution, tags 0x0128, 0xa210
-    extern const TagDetails exifUnit[] = {
+    constexpr TagDetails exifUnit[] = {
         { 1, N_("none") },
         { 2, N_("inch") },
         { 3, N_("cm")   }
     };
 
     //! GPS altitude reference, tag 0x0005
-    extern const TagDetails exifGPSAltitudeRef[] = {
+    constexpr TagDetails exifGPSAltitudeRef[] = {
         { 0, N_("Above sea level") },
         { 1, N_("Below sea level") }
     };
 
     //! GPS status, tag 0x0009
-    extern const TagDetails exifGPSStatus[] = {
+    constexpr TagDetails exifGPSStatus[] = {
         { 'A', N_("Measurement in progress")      },
         { 'V', N_("Measurement Interoperability") }
     };
 
     //! GPS measurement mode, tag 0x000a
-    extern const TagDetails exifGPSMeasureMode[] = {
+    constexpr TagDetails exifGPSMeasureMode[] = {
         { '2', N_("Two-dimensional measurement")   },
         { '3', N_("Three-dimensional measurement") }
     };
 
     //! GPS speed reference, tag 0x000c
-    extern const TagDetails exifGPSSpeedRef[] = {
+    constexpr TagDetails exifGPSSpeedRef[] = {
         { 'K', N_("km/h")  },
         { 'M', N_("mph")   },
         { 'N', N_("knots") }
     };
 
     //! GPS Destination distance ref, tag 0x0019
-    extern const TagDetails exifGPSDestDistanceRef[] = {
+    constexpr TagDetails exifGPSDestDistanceRef[] = {
         { 'K', N_("Kilometers") },
         { 'M', N_("Miles")      },
         { 'N', N_("Knots")      }
     };
 
     //! GPS Differential, tag 0x001e
-    extern const TagDetails exifGPSDifferential[] = {
+    constexpr TagDetails exifGPSDifferential[] = {
         { 0, N_("Without correction") },
         { 1, N_("Correction applied") }
     };
 
     //! Orientation, tag 0x0112
-    extern const TagDetails exifOrientation[] = {
+    constexpr TagDetails exifOrientation[] = {
         { 1, N_("top, left")     },
         { 2, N_("top, right")    },
         { 3, N_("bottom, right") },
@@ -228,19 +228,19 @@ namespace Exiv2 {
     };
 
     //! Predictor, tag 0x013d
-    extern const TagDetails exifPredictor[] = {
+    constexpr TagDetails exifPredictor[] = {
         { 1, N_("No prediction scheme used") },
         { 2, N_("Horizontal differencing")   }
     };
 
     //! InkSet, tag 0x014c
-    extern const TagDetails exifInkSet[] = {
+    constexpr TagDetails exifInkSet[] = {
         { 1, N_("CMYK")     },
         { 2, N_("not CMYK") }
     };
 
     //! NewSubfileType, TIFF tag 0x00fe - this is actually a bitmask
-    extern const TagDetails exifNewSubfileType[] = {
+    constexpr TagDetails exifNewSubfileType[] = {
         {  0, N_("Primary image")                                               },
         {  1, N_("Thumbnail/Preview image")                                     },
         {  2, N_("Primary image, Multi page file")                              },
@@ -253,14 +253,14 @@ namespace Exiv2 {
     };
 
     //! SubfileType, TIFF tag 0x00ff
-    extern const TagDetails exifSubfileType[] = {
+    constexpr TagDetails exifSubfileType[] = {
         {  1, N_("Full-resolution image data")                                  },
         {  2, N_("Reduced-resolution image data")                               },
         {  3, N_("A single page of a multi-page image")                         }
     };
 
     //! Compression, tag 0x0103
-    extern const TagDetails exifCompression[] = {
+    constexpr TagDetails exifCompression[] = {
         {     1, N_("Uncompressed")             },
         {     2, N_("CCITT RLE")                },
         {     3, N_("T4/Group 3 Fax")           },
@@ -295,7 +295,7 @@ namespace Exiv2 {
     };
 
     //! PhotometricInterpretation, tag 0x0106
-    extern const TagDetails exifPhotometricInterpretation[] = {
+    constexpr TagDetails exifPhotometricInterpretation[] = {
         {     0, N_("White Is Zero")      },
         {     1, N_("Black Is Zero")      },
         {     2, N_("RGB")                },
@@ -313,7 +313,7 @@ namespace Exiv2 {
     };
 
     //! Thresholding, tag 0x0107
-    extern const TagDetails exifThresholding[] = {
+    constexpr TagDetails exifThresholding[] = {
         { 1, N_("No dithering or halftoning")           },
         { 2, N_("Ordered dither or halftone technique") },
         { 3, N_("Randomized process")                   }
@@ -321,7 +321,7 @@ namespace Exiv2 {
 
 
     //! SampleFormat, tag 0x0153
-    extern const TagDetails exifSampleFormat[] = {
+    constexpr TagDetails exifSampleFormat[] = {
         { 1, N_("Unsigned integer data")                },
         { 2, N_("Two's complement signed integer data") },
         { 3, N_("IEEE floating point data")             },
@@ -330,13 +330,13 @@ namespace Exiv2 {
     };
 
     //! Indexed, tag 0x015a
-    extern const TagDetails exifIndexed[] = {
+    constexpr TagDetails exifIndexed[] = {
         { 0, N_("Not indexed") },
         { 1, N_("Indexed")     }
     };
 
     //! exifJpegLosslessPredictor, tag 0x0205
-    extern const TagDetails exifJpegLosslessPredictor[] = {
+    constexpr TagDetails exifJpegLosslessPredictor[] = {
         { 1, N_("A")           },
         { 2, N_("B")           },
         { 3, N_("C")           },
@@ -347,7 +347,7 @@ namespace Exiv2 {
     };
 
     //! Flash, Exif tag 0x9209
-    extern const TagDetails exifFlash[] = {
+    constexpr TagDetails exifFlash[] = {
         { 0x00, N_("No flash")                                                      },
         { 0x01, N_("Fired")                                                         },
         { 0x05, N_("Fired, return light not detected")                              },
@@ -378,7 +378,7 @@ namespace Exiv2 {
     };
 
     //! CFALayout, tag 0xc617
-    extern const TagDetails exifCfaLayout[] = {
+    constexpr TagDetails exifCfaLayout[] = {
         { 1, N_("Rectangular (or square) layout") },
         { 2, N_("Staggered layout A: even columns are offset down by 1/2 row")  },
         { 3, N_("Staggered layout B: even columns are offset up by 1/2 row")    },
@@ -1760,13 +1760,13 @@ namespace Exiv2 {
     }
 
     //! GPS latitude reference, tag 0x0001; also GPSDestLatitudeRef, tag 0x0013
-    extern const TagDetails exifGPSLatitudeRef[] = {
+    constexpr TagDetails exifGPSLatitudeRef[] = {
         { 78, N_("North") },
         { 83, N_("South") }
     };
 
     //! GPS longitude reference, tag 0x0003; also GPSDestLongitudeRef, tag 0x0015
-    extern const TagDetails exifGPSLongitudeRef[] = {
+    constexpr TagDetails exifGPSLongitudeRef[] = {
         { 69, N_("East") },
         { 87, N_("West") }
     };
@@ -2402,7 +2402,7 @@ namespace Exiv2 {
     }
 
     //! YCbCrPositioning, tag 0x0213
-    extern const TagDetails exifYCbCrPositioning[] = {
+    constexpr TagDetails exifYCbCrPositioning[] = {
         { 1, N_("Centered") },
         { 2, N_("Co-sited") }
     };
@@ -2473,7 +2473,7 @@ namespace Exiv2 {
     }
 
     //! ExposureProgram, tag 0x8822
-    extern const TagDetails exifExposureProgram[] = {
+    constexpr TagDetails exifExposureProgram[] = {
         { 0, N_("Not defined")       },
         { 1, N_("Manual")            },
         { 2, N_("Auto")              },
@@ -2588,7 +2588,7 @@ namespace Exiv2 {
     }
 
     //! MeteringMode, tag 0x9207
-    extern const TagDetails exifMeteringMode[] = {
+    constexpr TagDetails exifMeteringMode[] = {
         { 0,   N_("Unknown")                 },
         { 1,   N_("Average")                 },
         { 2,   N_("Center weighted average") },
@@ -2606,7 +2606,7 @@ namespace Exiv2 {
     }
 
     //! LightSource, tag 0x9208
-    extern const TagDetails exifLightSource[] = {
+    constexpr TagDetails exifLightSource[] = {
         {   0, N_("Unknown")                                 },
         {   1, N_("Daylight")                                },
         {   2, N_("Fluorescent")                             },
@@ -2667,7 +2667,7 @@ namespace Exiv2 {
     }
 
     //! ColorSpace, tag 0xa001
-    extern const TagDetails exifColorSpace[] = {
+    constexpr TagDetails exifColorSpace[] = {
         {      1, N_("sRGB")         },
         {      2, N_("Adobe RGB")    },    // Not defined to Exif 2.2 spec. But used by a lot of cameras.
         { 0xffff, N_("Uncalibrated") }
@@ -2679,7 +2679,7 @@ namespace Exiv2 {
     }
 
     //! SensingMethod, tag 0xa217
-    extern const TagDetails exifSensingMethod[] = {
+    constexpr TagDetails exifSensingMethod[] = {
         { 1, N_("Not defined")             },
         { 2, N_("One-chip color area")     },
         { 3, N_("Two-chip color area")     },
@@ -2695,7 +2695,7 @@ namespace Exiv2 {
     }
 
     //! FileSource, tag 0xa300
-    extern const TagDetails exifFileSource[] = {
+    constexpr TagDetails exifFileSource[] = {
         { 1, N_("Film scanner")            },   // Not defined to Exif 2.2 spec.
         { 2, N_("Reflexion print scanner") },   // but used by some scanner device softwares.
         { 3, N_("Digital still camera")    }
@@ -2707,7 +2707,7 @@ namespace Exiv2 {
     }
 
     //! SceneType, tag 0xa301
-    extern const TagDetails exifSceneType[] = {
+    constexpr TagDetails exifSceneType[] = {
         { 1, N_("Directly photographed") }
     };
 
@@ -2717,7 +2717,7 @@ namespace Exiv2 {
     }
 
     //! CustomRendered, tag 0xa401
-    extern const TagDetails exifCustomRendered[] = {
+    constexpr TagDetails exifCustomRendered[] = {
         { 0, N_("Normal process") },
         { 1, N_("Custom process") }
     };
@@ -2728,7 +2728,7 @@ namespace Exiv2 {
     }
 
     //! ExposureMode, tag 0xa402
-    extern const TagDetails exifExposureMode[] = {
+    constexpr TagDetails exifExposureMode[] = {
         { 0, N_("Auto")         },
         { 1, N_("Manual")       },
         { 2, N_("Auto bracket") }
@@ -2740,7 +2740,7 @@ namespace Exiv2 {
     }
 
     //! WhiteBalance, tag 0xa403
-    extern const TagDetails exifWhiteBalance[] = {
+    constexpr TagDetails exifWhiteBalance[] = {
         { 0, N_("Auto")   },
         { 1, N_("Manual") }
     };
@@ -2781,7 +2781,7 @@ namespace Exiv2 {
     }
 
     //! SceneCaptureType, tag 0xa406
-    extern const TagDetails exifSceneCaptureType[] = {
+    constexpr TagDetails exifSceneCaptureType[] = {
         { 0, N_("Standard")    },
         { 1, N_("Landscape")   },
         { 2, N_("Portrait")    },
@@ -2795,7 +2795,7 @@ namespace Exiv2 {
     }
 
     //! GainControl, tag 0xa407
-    extern const TagDetails exifGainControl[] = {
+    constexpr TagDetails exifGainControl[] = {
         { 0, N_("None")           },
         { 1, N_("Low gain up")    },
         { 2, N_("High gain up")   },
@@ -2809,7 +2809,7 @@ namespace Exiv2 {
     }
 
     //! Saturation, tag 0xa409
-    extern const TagDetails exifSaturation[] = {
+    constexpr TagDetails exifSaturation[] = {
         { 0, N_("Normal") },
         { 1, N_("Low")    },
         { 2, N_("High")   }
@@ -2821,7 +2821,7 @@ namespace Exiv2 {
     }
 
     //! SubjectDistanceRange, tag 0xa40c
-    extern const TagDetails exifSubjectDistanceRange[] = {
+    constexpr TagDetails exifSubjectDistanceRange[] = {
         { 0, N_("Unknown")      },
         { 1, N_("Macro")        },
         { 2, N_("Close view")   },
@@ -2835,7 +2835,7 @@ namespace Exiv2 {
     }
 
     //! GPS direction ref, tags 0x000e, 0x0010, 0x0017
-    extern const TagDetails exifGPSDirRef[] = {
+    constexpr TagDetails exifGPSDirRef[] = {
         { 'T', N_("True direction")     },
         { 'M', N_("Magnetic direction") }
     };
@@ -2846,7 +2846,7 @@ namespace Exiv2 {
     }
 
     //! Contrast, tag 0xa408 and Sharpness, tag 0xa40a
-    extern const TagDetails exifNormalSoftHard[] = {
+    constexpr TagDetails exifNormalSoftHard[] = {
         { 0, N_("Normal") },
         { 1, N_("Soft")   },
         { 2, N_("Hard")   }

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -18,7 +18,7 @@ namespace Exiv2 {
     const CryptFct notEncrypted = nullptr;
 
     //! Canon Camera Settings binary array - configuration
-    extern const ArrayCfg canonCsCfg = {
+    constexpr ArrayCfg canonCsCfg = {
         canonCsId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -29,12 +29,12 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Canon Camera Settings binary array - definition
-    extern const ArrayDef canonCsDef[] = {
+    constexpr ArrayDef canonCsDef[] = {
         { 46, ttUnsignedShort, 3 } // Exif.CanonCs.Lens
     };
 
     //! Canon Shot Info binary array - configuration
-    extern const ArrayCfg canonSiCfg = {
+    constexpr ArrayCfg canonSiCfg = {
         canonSiId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -46,7 +46,7 @@ namespace Exiv2 {
     };
 
     //! Canon Panorama binary array - configuration
-    extern const ArrayCfg canonPaCfg = {
+    constexpr ArrayCfg canonPaCfg = {
         canonPaId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -58,7 +58,7 @@ namespace Exiv2 {
     };
 
     //! Canon Custom Function binary array - configuration
-    extern const ArrayCfg canonCfCfg = {
+    constexpr ArrayCfg canonCfCfg = {
         canonCfId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -70,7 +70,7 @@ namespace Exiv2 {
     };
 
     //! Canon Picture Info binary array - configuration
-    extern const ArrayCfg canonPiCfg = {
+    constexpr ArrayCfg canonPiCfg = {
         canonPiId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -82,7 +82,7 @@ namespace Exiv2 {
     };
 
     //! Canon Time Info binary array - configuration
-    extern const ArrayCfg canonTiCfg = {
+    constexpr ArrayCfg canonTiCfg = {
         canonTiId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttSignedLong,     // Type for array entry and size element
@@ -94,7 +94,7 @@ namespace Exiv2 {
     };
 
     //! Canon File Info binary array - configuration
-    extern const ArrayCfg canonFiCfg = {
+    constexpr ArrayCfg canonFiCfg = {
         canonFiId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -105,12 +105,12 @@ namespace Exiv2 {
         { 0, ttSignedShort, 1 }
     };
     //! Canon File Info binary array - definition
-    extern const ArrayDef canonFiDef[] = {
+    constexpr ArrayDef canonFiDef[] = {
         { 2, ttUnsignedLong, 1 }
     };
 
     //! Canon Processing Info binary array - configuration
-    extern const ArrayCfg canonPrCfg = {
+    constexpr ArrayCfg canonPrCfg = {
         canonPrId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry and size element
@@ -122,7 +122,7 @@ namespace Exiv2 {
     };
 
     //! Nikon Vibration Reduction binary array - configuration
-    extern const ArrayCfg nikonVrCfg = {
+    constexpr ArrayCfg nikonVrCfg = {
         nikonVrId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -133,13 +133,13 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Vibration Reduction binary array - definition
-    extern const ArrayDef nikonVrDef[] = {
+    constexpr ArrayDef nikonVrDef[] = {
         { 0, ttUndefined,     4 }, // Version
         { 7, ttUnsignedByte,  1 }  // The array contains 8 bytes
     };
 
     //! Nikon Picture Control binary array - configuration
-    extern const ArrayCfg nikonPcCfg = {
+    constexpr ArrayCfg nikonPcCfg = {
         nikonPcId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -150,7 +150,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Picture Control binary array - definition
-    extern const ArrayDef nikonPcDef[] = {
+    constexpr ArrayDef nikonPcDef[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttAsciiString,  20 },
         { 24, ttAsciiString,  20 },
@@ -167,7 +167,7 @@ namespace Exiv2 {
     };
 
     //! Nikon World Time binary array - configuration
-    extern const ArrayCfg nikonWtCfg = {
+    constexpr ArrayCfg nikonWtCfg = {
         nikonWtId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -178,14 +178,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon World Time binary array - definition
-    extern const ArrayDef nikonWtDef[] = {
+    constexpr ArrayDef nikonWtDef[] = {
         { 0, ttSignedShort,   1 },
         { 2, ttUnsignedByte,  1 },
         { 3, ttUnsignedByte,  1 }
     };
 
     //! Nikon ISO info binary array - configuration
-    extern const ArrayCfg nikonIiCfg = {
+    constexpr ArrayCfg nikonIiCfg = {
         nikonIiId,        // Group for the elements
         bigEndian,        // Byte order
         ttUndefined,      // Type for array entry
@@ -196,7 +196,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon ISO info binary array - definition
-    extern const ArrayDef nikonIiDef[] = {
+    constexpr ArrayDef nikonIiDef[] = {
         {  0, ttUnsignedByte,  1 },
         {  4, ttUnsignedShort, 1 },
         {  6, ttUnsignedByte,  1 },
@@ -205,7 +205,7 @@ namespace Exiv2 {
     };
 
     //! Nikon Auto Focus binary array - configuration
-    extern const ArrayCfg nikonAfCfg = {
+    constexpr ArrayCfg nikonAfCfg = {
         nikonAfId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -216,14 +216,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Auto Focus binary array - definition
-    extern const ArrayDef nikonAfDef[] = {
+    constexpr ArrayDef nikonAfDef[] = {
         { 0, ttUnsignedByte,  1 },
         { 1, ttUnsignedByte,  1 },
         { 2, ttUnsignedShort, 1 } // The array contains 4 bytes
     };
 
     //! Nikon Auto Focus 21 binary array - configuration
-    extern const ArrayCfg nikonAf21Cfg = {
+    constexpr ArrayCfg nikonAf21Cfg = {
         nikonAf21Id,      // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -234,7 +234,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Auto Focus 21 binary array - definition
-    extern const ArrayDef nikonAf21Def[] = {
+    constexpr ArrayDef nikonAf21Def[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedByte,  1 }, // ContrastDetectAF
         {  5, ttUnsignedByte,  1 }, // AFAreaMode
@@ -250,7 +250,7 @@ namespace Exiv2 {
         { 28, ttUnsignedShort, 1 }, // ContrastDetectAFInFocus
     };
     //! Nikon Auto Focus 22 binary array - configuration
-    extern const ArrayCfg nikonAf22Cfg = {
+    constexpr ArrayCfg nikonAf22Cfg = {
         nikonAf22Id,      // Group for the elements
         invalidByteOrder, // Byte order
         ttUndefined,      // Type for array entry
@@ -261,7 +261,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Auto Focus 22 binary array - definition
-    extern const ArrayDef nikonAf22Def[] = {
+    constexpr ArrayDef nikonAf22Def[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedByte,  1 }, // ContrastDetectAF
         {  5, ttUnsignedByte,  1 }, // AFAreaMode
@@ -278,13 +278,13 @@ namespace Exiv2 {
 
     //! Nikon AF2 configuration and definitions
     //  https://github.com/Exiv2/exiv2/issues/646
-    extern const ArraySet nikonAf2Set[] = {
+    constexpr ArraySet nikonAf2Set[] = {
         { nikonAf21Cfg, nikonAf21Def, EXV_COUNTOF(nikonAf21Def) },
         { nikonAf22Cfg, nikonAf22Def, EXV_COUNTOF(nikonAf22Def) },
     };
 
     //! Nikon AF Fine Tune binary array - configuration
-    extern const ArrayCfg nikonAFTCfg = {
+    constexpr ArrayCfg nikonAFTCfg = {
         nikonAFTId,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -295,14 +295,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon AF Fine Tune binary array - definition
-    extern const ArrayDef nikonAFTDef[] = {
+    constexpr ArrayDef nikonAFTDef[] = {
         {  0, ttUnsignedByte,  1 }, // AF Fine Tune on/off
         {  1, ttUnsignedByte,  1 }, // AF Fine Tune index
         {  2, ttUnsignedByte,  1 }  // AF Fine Tune value
     };
 
     //! Nikon File Info binary array - configuration
-    extern const ArrayCfg nikonFiCfg = {
+    constexpr ArrayCfg nikonFiCfg = {
         nikonFiId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -313,14 +313,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon File Info binary array - definition
-    extern const ArrayDef nikonFiDef[] = {
+    constexpr ArrayDef nikonFiDef[] = {
         { 0, ttUndefined,     4 }, // Version
         { 6, ttUnsignedShort, 1 }, // Directory Number
         { 8, ttUnsignedShort, 1 }  // File Number
     };
 
     //! Nikon Multi Exposure binary array - configuration
-    extern const ArrayCfg nikonMeCfg = {
+    constexpr ArrayCfg nikonMeCfg = {
         nikonMeId,        // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -331,7 +331,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Multi Exposure binary array - definition
-    extern const ArrayDef nikonMeDef[] = {
+    constexpr ArrayDef nikonMeDef[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedLong,  1 }, // MultiExposureMode
         {  8, ttUnsignedLong,  1 }, // MultiExposureShots
@@ -339,7 +339,7 @@ namespace Exiv2 {
     };
 
     //! Nikon Flash Info binary array - configuration 1
-    extern const ArrayCfg nikonFl1Cfg = {
+    constexpr ArrayCfg nikonFl1Cfg = {
         nikonFl1Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -350,7 +350,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Flash Info binary array - definition 1
-    extern const ArrayDef nikonFl1Def[] = {
+    constexpr ArrayDef nikonFl1Def[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedByte,  1 }, // FlashSource
         {  6, ttUnsignedShort, 1 }, // ExternalFlashFirmware
@@ -363,7 +363,7 @@ namespace Exiv2 {
         { 16, ttUnsignedByte,  1 }  // FlashGroupBControlMode
     };
     //! Nikon Flash Info binary array - configuration 2
-    extern const ArrayCfg nikonFl2Cfg = {
+    constexpr ArrayCfg nikonFl2Cfg = {
         nikonFl2Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -374,7 +374,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Flash Info binary array - definition 2
-    extern const ArrayDef nikonFl2Def[] = {
+    constexpr ArrayDef nikonFl2Def[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedByte,  1 }, // FlashSource
         {  6, ttUnsignedShort, 1 }, // ExternalFlashFirmware
@@ -385,7 +385,7 @@ namespace Exiv2 {
         { 15, ttUnsignedByte,  1 }, // FlashGNDistance
     };
     //! Nikon Flash Info binary array - configuration 3
-    extern const ArrayCfg nikonFl3Cfg = {
+    constexpr ArrayCfg nikonFl3Cfg = {
         nikonFl3Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -396,7 +396,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Flash Info binary array - definition
-    extern const ArrayDef nikonFl3Def[] = {
+    constexpr ArrayDef nikonFl3Def[] = {
         {  0, ttUndefined,     4 }, // Version
         {  4, ttUnsignedByte,  1 }, // FlashSource
         {  6, ttUnsignedShort, 1 }, // ExternalFlashFirmware
@@ -408,14 +408,14 @@ namespace Exiv2 {
         { 16, ttUnsignedByte,  1 }, // FlashColorFilter
     };
     //! Nikon Lens Data configurations and definitions
-    extern const ArraySet nikonFlSet[] = {
+    constexpr ArraySet nikonFlSet[] = {
         { nikonFl1Cfg, nikonFl1Def, EXV_COUNTOF(nikonFl1Def) },
         { nikonFl2Cfg, nikonFl2Def, EXV_COUNTOF(nikonFl2Def) },
         { nikonFl3Cfg, nikonFl3Def, EXV_COUNTOF(nikonFl3Def) }
     };
 
     //! Nikon Shot Info binary array - configuration 1 (D80)
-    extern const ArrayCfg nikonSi1Cfg = {
+    constexpr ArrayCfg nikonSi1Cfg = {
         nikonSi1Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -426,13 +426,13 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Shot Info binary array - definition 1 (D80)
-    extern const ArrayDef nikonSi1Def[] = {
+    constexpr ArrayDef nikonSi1Def[] = {
         {    0, ttUndefined,    4 }, // Version
         {  586, ttUnsignedLong, 1 }, // ShutterCount
         { 1155, ttUnsignedByte, 1 }  // The array contains 1156 bytes
     };
     //! Nikon Shot Info binary array - configuration 2 (D40)
-    extern const ArrayCfg nikonSi2Cfg = {
+    constexpr ArrayCfg nikonSi2Cfg = {
         nikonSi2Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -443,14 +443,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Shot Info binary array - definition 2 (D40)
-    extern const ArrayDef nikonSi2Def[] = {
+    constexpr ArrayDef nikonSi2Def[] = {
         {    0, ttUndefined,    4 }, // Version
         {  582, ttUnsignedLong, 1 }, // ShutterCount
         {  738, ttUnsignedByte, 1 },
         { 1112, ttUnsignedByte, 1 }  // The array contains 1113 bytes
     };
     //! Nikon Shot Info binary array - configuration 3 (D300a)
-    extern const ArrayCfg nikonSi3Cfg = {
+    constexpr ArrayCfg nikonSi3Cfg = {
         nikonSi3Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -461,7 +461,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Shot Info binary array - definition 3 (D300a)
-    extern const ArrayDef nikonSi3Def[] = {
+    constexpr ArrayDef nikonSi3Def[] = {
         {    0, ttUndefined,     4 }, // Version
         {  604, ttUnsignedByte,  1 }, // ISO
         {  633, ttUnsignedLong,  1 }, // ShutterCount
@@ -469,7 +469,7 @@ namespace Exiv2 {
         {  814, ttUndefined,  4478 }  // The array contains 5291 bytes
     };
     //! Nikon Shot Info binary array - configuration 4 (D300b)
-    extern const ArrayCfg nikonSi4Cfg = {
+    constexpr ArrayCfg nikonSi4Cfg = {
         nikonSi4Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -480,14 +480,14 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Shot Info binary array - definition 4 (D300b)
-    extern const ArrayDef nikonSi4Def[] = {
+    constexpr ArrayDef nikonSi4Def[] = {
         {    0, ttUndefined,     4 }, // Version
         {  644, ttUnsignedLong,  1 }, // ShutterCount
         {  732, ttUnsignedShort, 1 }, // AFFineTuneAdj
         {  826, ttUndefined,  4478 }  // The array contains 5303 bytes
     };
     //! Nikon Shot Info binary array - configuration 5 (ver 02.xx)
-    extern const ArrayCfg nikonSi5Cfg = {
+    constexpr ArrayCfg nikonSi5Cfg = {
         nikonSi5Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -498,7 +498,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Shot Info binary array - definition 5 (ver 01.xx and ver 02.xx)
-    extern const ArrayDef nikonSi5Def[] = {
+    constexpr ArrayDef nikonSi5Def[] = {
         {    0, ttUndefined,     4 }, // Version
         {  106, ttUnsignedLong,  1 }, // ShutterCount1
         {  110, ttUnsignedLong,  1 }, // DeletedImageCount
@@ -510,7 +510,7 @@ namespace Exiv2 {
         {  630, ttUnsignedLong,  1 }  // ShutterCount
     };
     //! Nikon Shot Info binary array - configuration 6 (ver 01.xx)
-    extern const ArrayCfg nikonSi6Cfg = {
+    constexpr ArrayCfg nikonSi6Cfg = {
         nikonSi6Id,       // Group for the elements
         bigEndian,        // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -521,7 +521,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Lens Data configurations and definitions
-    extern const ArraySet nikonSiSet[] = {
+    constexpr ArraySet nikonSiSet[] = {
         { nikonSi1Cfg, nikonSi1Def, EXV_COUNTOF(nikonSi1Def) },
         { nikonSi2Cfg, nikonSi2Def, EXV_COUNTOF(nikonSi2Def) },
         { nikonSi3Cfg, nikonSi3Def, EXV_COUNTOF(nikonSi3Def) },
@@ -531,7 +531,7 @@ namespace Exiv2 {
     };
 
     //! Nikon Lens Data binary array - configuration 1
-    extern const ArrayCfg nikonLd1Cfg = {
+    constexpr ArrayCfg nikonLd1Cfg = {
         nikonLd1Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -542,7 +542,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Lens Data binary array - configuration 2
-    extern const ArrayCfg nikonLd2Cfg = {
+    constexpr ArrayCfg nikonLd2Cfg = {
         nikonLd2Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -553,7 +553,7 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Lens Data binary array - configuration 3
-    extern const ArrayCfg nikonLd3Cfg = {
+    constexpr ArrayCfg nikonLd3Cfg = {
         nikonLd3Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -564,18 +564,18 @@ namespace Exiv2 {
         { 0, ttUnsignedByte,  1 }
     };
     //! Nikon Lens Data binary array - definition
-    extern const ArrayDef nikonLdDef[] = {
+    constexpr ArrayDef nikonLdDef[] = {
         { 0, ttUndefined, 4 } // Version
     };
     //! Nikon Lens Data configurations and definitions
-    extern const ArraySet nikonLdSet[] = {
+    constexpr ArraySet nikonLdSet[] = {
         { nikonLd1Cfg, nikonLdDef, EXV_COUNTOF(nikonLdDef) },
         { nikonLd2Cfg, nikonLdDef, EXV_COUNTOF(nikonLdDef) },
         { nikonLd3Cfg, nikonLdDef, EXV_COUNTOF(nikonLdDef) }
     };
 
     //! Nikon Color Balance binary array - configuration 1
-    extern const ArrayCfg nikonCb1Cfg = {
+    constexpr ArrayCfg nikonCb1Cfg = {
         nikonCb1Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -586,7 +586,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - configuration 2
-    extern const ArrayCfg nikonCb2Cfg = {
+    constexpr ArrayCfg nikonCb2Cfg = {
         nikonCb2Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -597,7 +597,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - configuration 2a
-    extern const ArrayCfg nikonCb2aCfg = {
+    constexpr ArrayCfg nikonCb2aCfg = {
         nikonCb2aId,      // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -608,7 +608,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - configuration 2b
-    extern const ArrayCfg nikonCb2bCfg = {
+    constexpr ArrayCfg nikonCb2bCfg = {
         nikonCb2bId,      // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -619,7 +619,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - configuration 3
-    extern const ArrayCfg nikonCb3Cfg = {
+    constexpr ArrayCfg nikonCb3Cfg = {
         nikonCb3Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -630,7 +630,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - configuration 4
-    extern const ArrayCfg nikonCb4Cfg = {
+    constexpr ArrayCfg nikonCb4Cfg = {
         nikonCb4Id,       // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUndefined,      // Type for array entry
@@ -641,41 +641,41 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Nikon Color Balance binary array - definition 1 (D100)
-    extern const ArrayDef nikonCb1Def[] = {
+    constexpr ArrayDef nikonCb1Def[] = {
         {  0, ttUndefined,        4 }, // Version
         { 72, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance binary array - definition 2 (D2H)
-    extern const ArrayDef nikonCb2Def[] = {
+    constexpr ArrayDef nikonCb2Def[] = {
         {  0, ttUndefined,        4 }, // Version
         { 10, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance binary array - definition 2a (D50)
-    extern const ArrayDef nikonCb2aDef[] = {
+    constexpr ArrayDef nikonCb2aDef[] = {
         {  0, ttUndefined,        4 }, // Version
         { 18, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance binary array - definition 2b (D2X=0204,D2Hs=0206,D200=0207,D40=0208)
-    extern const ArrayDef nikonCb2bDef[] = {
+    constexpr ArrayDef nikonCb2bDef[] = {
         {  0, ttUndefined,        4 }, // Version
         {  4, ttUnsignedShort,  140 }, // Unknown
         {284, ttUnsignedShort,    3 }, // Unknown (encrypted)
         {290, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance binary array - definition 3 (D70)
-    extern const ArrayDef nikonCb3Def[] = {
+    constexpr ArrayDef nikonCb3Def[] = {
         {  0, ttUndefined,        4 }, // Version
         { 20, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance binary array - definition 4 (D3)
-    extern const ArrayDef nikonCb4Def[] = {
+    constexpr ArrayDef nikonCb4Def[] = {
         {  0, ttUndefined,        4 }, // Version
         {  4, ttUnsignedShort,  140 }, // Unknown
         {284, ttUnsignedShort,    5 }, // Unknown (encrypted)
         {294, ttUnsignedShort,    4 }  // Color balance levels
     };
     //! Nikon Color Balance configurations and definitions
-    extern const ArraySet nikonCbSet[] = {
+    constexpr ArraySet nikonCbSet[] = {
         { nikonCb1Cfg,  nikonCb1Def,  EXV_COUNTOF(nikonCb1Def)  },
         { nikonCb2Cfg,  nikonCb2Def,  EXV_COUNTOF(nikonCb2Def)  },
         { nikonCb2aCfg, nikonCb2aDef, EXV_COUNTOF(nikonCb2aDef) },
@@ -685,7 +685,7 @@ namespace Exiv2 {
     };
 
     //! Minolta Camera Settings (old) binary array - configuration
-    extern const ArrayCfg minoCsoCfg = {
+    constexpr ArrayCfg minoCsoCfg = {
         minoltaCsOldId,   // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -697,7 +697,7 @@ namespace Exiv2 {
     };
 
     //! Minolta Camera Settings (new) binary array - configuration
-    extern const ArrayCfg minoCsnCfg = {
+    constexpr ArrayCfg minoCsnCfg = {
         minoltaCsNewId,   // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -709,7 +709,7 @@ namespace Exiv2 {
     };
 
     //! Minolta 7D Camera Settings binary array - configuration
-    extern const ArrayCfg minoCs7Cfg = {
+    constexpr ArrayCfg minoCs7Cfg = {
         minoltaCs7DId,    // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -720,13 +720,13 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Minolta 7D Camera Settings binary array - definition
-    extern const ArrayDef minoCs7Def[] = {
+    constexpr ArrayDef minoCs7Def[] = {
         {  60, ttSignedShort, 1 }, // Exif.MinoltaCs7D.ExposureCompensation
         { 126, ttSignedShort, 1 }  // Exif.MinoltaCs7D.ColorTemperature
     };
 
     //! Minolta 5D Camera Settings binary array - configuration
-    extern const ArrayCfg minoCs5Cfg = {
+    constexpr ArrayCfg minoCs5Cfg = {
         minoltaCs5DId,    // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -737,7 +737,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Minolta 5D Camera Settings binary array - definition
-    extern const ArrayDef minoCs5Def[] = {
+    constexpr ArrayDef minoCs5Def[] = {
         { 146, ttSignedShort, 1 } // Exif.MinoltaCs5D.ColorTemperature
     };
 
@@ -747,7 +747,7 @@ namespace Exiv2 {
     //       setting in all four configurations.
 
     //! Sony1 Camera Settings binary array - configuration
-    extern const ArrayCfg sony1CsCfg = {
+    constexpr ArrayCfg sony1CsCfg = {
         sony1CsId,        // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -758,7 +758,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Sony1 Camera Settings 2 binary array - configuration
-    extern const ArrayCfg sony1Cs2Cfg = {
+    constexpr ArrayCfg sony1Cs2Cfg = {
         sony1Cs2Id,       // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -769,7 +769,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
 
-    extern const ArrayCfg sony2FpCfg = {
+    constexpr ArrayCfg sony2FpCfg = {
         sony2FpId,        // Group for the elements
         bigEndian,        // Big endian
         ttUnsignedByte,   // Type for array entry and size element
@@ -779,7 +779,7 @@ namespace Exiv2 {
         false,            // Don't concatenate gaps
         { 0, ttUnsignedByte, 1 }
     };
-    extern const ArrayDef sony2FpDef[] = {
+    constexpr ArrayDef sony2FpDef[] = {
         {  0x4, ttSignedByte  , 1 }, // Exif.Sony2Fp.AmbientTemperature
         { 0x16, ttUnsignedByte, 1 }, // Exif.Sony2Fp.FocusMode
         { 0x17, ttUnsignedByte, 1 }, // Exif.Sony2Fp.AFAreaMode
@@ -787,11 +787,11 @@ namespace Exiv2 {
     };
 
     //! Sony[12] Camera Settings binary array - definition
-    extern const ArrayDef sonyCsDef[] = {
+    constexpr ArrayDef sonyCsDef[] = {
         {  12, ttSignedShort,   1 }  // Exif.Sony[12]Cs.WhiteBalanceFineTune
     };
     //! Sony2 Camera Settings binary array - configuration
-    extern const ArrayCfg sony2CsCfg = {
+    constexpr ArrayCfg sony2CsCfg = {
         sony2CsId,        // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -802,7 +802,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Sony2 Camera Settings 2 binary array - configuration
-    extern const ArrayCfg sony2Cs2Cfg = {
+    constexpr ArrayCfg sony2Cs2Cfg = {
         sony2Cs2Id,       // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -813,22 +813,22 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Sony[12] Camera Settings 2 binary array - definition
-    extern const ArrayDef sonyCs2Def[] = {
+    constexpr ArrayDef sonyCs2Def[] = {
         {  44, ttUnsignedShort, 1 } // Exif.Sony[12]Cs2.FocusMode
     };
     //! Sony1 Camera Settings configurations and definitions
-    extern const ArraySet sony1CsSet[] = {
+    constexpr ArraySet sony1CsSet[] = {
         { sony1CsCfg,  sonyCsDef,  EXV_COUNTOF(sonyCsDef)  },
         { sony1Cs2Cfg, sonyCs2Def, EXV_COUNTOF(sonyCs2Def) }
     };
     //! Sony2 Camera Settings configurations and definitions
-    extern const ArraySet sony2CsSet[] = {
+    constexpr ArraySet sony2CsSet[] = {
         { sony2CsCfg,  sonyCsDef,  EXV_COUNTOF(sonyCsDef)  },
         { sony2Cs2Cfg, sonyCs2Def, EXV_COUNTOF(sonyCs2Def) }
     };
 
     //! Sony Minolta Camera Settings (old) binary array - configuration
-    extern const ArrayCfg sony1MCsoCfg = {
+    constexpr ArrayCfg sony1MCsoCfg = {
         sony1MltCsOldId,  // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -840,7 +840,7 @@ namespace Exiv2 {
     };
 
     //! Sony Minolta Camera Settings (new) binary array - configuration
-    extern const ArrayCfg sony1MCsnCfg = {
+    constexpr ArrayCfg sony1MCsnCfg = {
         sony1MltCsNewId,  // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -852,7 +852,7 @@ namespace Exiv2 {
     };
 
     //! Sony Minolta 7D Camera Settings binary array - configuration
-    extern const ArrayCfg sony1MCs7Cfg = {
+    constexpr ArrayCfg sony1MCs7Cfg = {
         sony1MltCs7DId,   // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -864,7 +864,7 @@ namespace Exiv2 {
     };
 
     //! Sony Minolta A100 Camera Settings binary array - configuration
-    extern const ArrayCfg sony1MCsA100Cfg = {
+    constexpr ArrayCfg sony1MCsA100Cfg = {
         sony1MltCsA100Id, // Group for the elements
         bigEndian,        // Big endian
         ttUndefined,      // Type for array entry and size element
@@ -875,14 +875,14 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Sony Minolta A100 Camera Settings binary array - definition
-    extern const ArrayDef sony1MCsA100Def[] = {
+    constexpr ArrayDef sony1MCsA100Def[] = {
         { 112, ttSignedShort, 1 }, // Exif.Sony1MltCsA100.WhiteBalanceFineTune
         { 116, ttSignedShort, 1 }, // Exif.Sony1MltCsA100.ColorCompensationFilter
         { 190, ttSignedShort, 1 }  // Exif.Sony1MltCsA100.ColorCompensationFilter2
     };
 
     //! Samsung PictureWizard binary array - configuration
-    extern const ArrayCfg samsungPwCfg = {
+    constexpr ArrayCfg samsungPwCfg = {
         samsungPwId,      // Group for the elements
         invalidByteOrder, // Use byte order from parent
         ttUnsignedShort,  // Type for array entry
@@ -893,7 +893,7 @@ namespace Exiv2 {
         { 0, ttUnsignedShort, 1 }
     };
     //! Samsung PictureWizard binary array - definition
-    extern const ArrayDef samsungPwDef[] = {
+    constexpr ArrayDef samsungPwDef[] = {
         {  0, ttUnsignedShort, 1 }, // Mode
         {  2, ttUnsignedShort, 1 }, // Color
         {  4, ttUnsignedShort, 1 }, // Saturation


### PR DESCRIPTION
Found with cppcoreguidelines-interfaces-global-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Went overboard and converted all extern const to constexpr.