### PR TITLE
cmake: Fix include_directories for exiv2lib target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 target_include_directories(exiv2lib PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/exiv2>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_include_directories(exiv2lib_int PUBLIC


### PR DESCRIPTION
The headers are installed to ${CMAKE_INSTALL_INCLUDEDIR} but the CMake config was hardcoded to include directory.

(cherry-picked from 306c8a6fd4ddd70e76043ab255734720829a57e8 (#1294))