### PR TITLE
Master - Use ctime and remove usage of EXV_HAVE_STDINT_H

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required( VERSION 3.5.0 )
 
 project(exiv2
     VERSION 0.27.99.0   # Fake version number to indicate that the next version will be 28.0
-    LANGUAGES CXX C
+    LANGUAGES CXX
 )
 
 include(cmake/mainSetup.cmake  REQUIRED)

--- a/src/timegm.h
+++ b/src/timegm.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <time.h>
+#include <ctime>
 
 #ifdef  __cplusplus	
 extern "C" {	

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -47,11 +47,6 @@ if (MSVC)
     target_compile_definitions(exiv2-xmp PRIVATE XML_STATIC)
 endif()
 
-check_include_file( "stdint.h"  EXV_HAVE_STDINT_H )
-if (EXV_HAVE_STDINT_H)
-    target_compile_definitions(exiv2-xmp PRIVATE EXV_HAVE_STDINT_H)
-endif()
-
 if (BUILD_SHARED_LIBS)
     set_property(TARGET exiv2-xmp PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/xmpsdk/include/MD5.h
+++ b/xmpsdk/include/MD5.h
@@ -25,18 +25,7 @@
 
 #include <sys/types.h>
 
-#ifdef _MSC_VER
-//   _MSC_VER   1600 == Visual Studio 2010
-# if _MSC_VER < 1600
-#  ifdef  EXV_HAVE_STDINT_H
-#   undef EXV_HAVE_STDINT_H
-#  endif
-# endif
-#endif
-
-#if defined(EXV_HAVE_STDINT_H) || defined(__MINGW32__) || defined(__MING64__) || defined(__APPLE__)
-# include <stdint.h>
-#endif
+# include <cstdint>
 
 /* MSVC doesn't provide C99 types, but it has MS specific variants */
 #ifdef _MSC_VER


### PR DESCRIPTION
In #1305 I replaced `ctime` by `time.h` with the aim of fixing the Fedora_MinGW CI job.

Thanks to @neheb comments I revisited the original issue and I found out that the problem was coming from compiling the C file `locatime.c` with the C compiler.

Thanks to this, I also noticed that we do not have anymore pure C files and I could do some other cleanups (maybe they can be also ported to `0.27-maintenance`). 

