### PR TITLE
clang-tidy: use explicit for single argument constructors

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -43,18 +43,18 @@ namespace Jzon
 		{
 			SetFormat(NoFormat);
 		}
-		FormatInterpreter(const Format &format)
-		{
-			SetFormat(format);
-		}
+        explicit FormatInterpreter(const Format &format)
+        {
+            SetFormat(format);
+        }
 
-		void SetFormat(const Format &format)
-		{
-			this->format = format;
-			indentationChar = (format.useTabs ? '\t' : ' ');
-			spacing = (format.spacing ? " " : "");
-			newline = (format.newline ? "\n" : spacing);
-		}
+        void SetFormat(const Format &format)
+        {
+            this->format = format;
+            indentationChar = (format.useTabs ? '\t' : ' ');
+            spacing = (format.spacing ? " " : "");
+            newline = (format.newline ? "\n" : spacing);
+        }
 
         EXV_WARN_UNUSED_RESULT std::string GetIndentation(unsigned int level) const
         {

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -146,11 +146,11 @@ namespace Exiv2
         class BigTiffImage: public Image
         {
             public:
-                BigTiffImage(BasicIo::UniquePtr io):
-                    Image(ImageType::bigtiff, mdExif, std::move(io)),
-                    header_(readHeader(Image::io())),
-                    dataSize_(0),
-                    doSwap_(false)
+                explicit BigTiffImage(BasicIo::UniquePtr io)
+                    : Image(ImageType::bigtiff, mdExif, std::move(io))
+                    , header_(readHeader(Image::io()))
+                    , dataSize_(0)
+                    , doSwap_(false)
                 {
                     assert(header_.isValid());
 


### PR DESCRIPTION
Found with google-explicit-constructor

Signed-off-by: Rosen Penev <rosenp@gmail.com>