### PR TITLE
clang-tidy: sort includes LLVM style

### DIFF
--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -2,11 +2,10 @@
 // addmoddel.cpp
 // Sample program showing how to add, modify and delete Exif metadata.
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -8,8 +8,8 @@
     #include <curl/curl.h>
 #endif
 
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 
 void httpcon(const std::string& url, bool useHttp1_0 = false) {
     Exiv2::Dictionary response;

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -2,11 +2,10 @@
 // convert-test.cpp
 // Conversion test driver - make sure you have a copy of the input file around!
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -3,11 +3,10 @@
 // Sample program using high-level metadata access functions
 
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 using EasyAccessFct = Exiv2::ExifData::const_iterator (*)(const Exiv2::ExifData&);
 

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -10,10 +10,9 @@
  */
 // *****************************************************************************
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iostream>
 
 // *****************************************************************************
 // Main

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -9,12 +9,11 @@
  */
 // *****************************************************************************
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
-#include <string>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 void write(const std::string& file, Exiv2::ExifData& ed);
 void print(const std::string& file);

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -2,11 +2,10 @@
 // exifdata.cpp
 // Sample program to format exif data in various external formats
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 #include <string>
 
 using format_t = std::map<std::string, int>;

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -2,11 +2,10 @@
 // exifprint.cpp
 // Sample program to print the Exif metadata of an image
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 // https://github.com/Exiv2/exiv2/issues/468
 #if defined(EXV_UNICODE_PATH) && defined(__MINGW__)

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -2,11 +2,10 @@
 // exifvalue.cpp
 // Sample program to print value of an exif key in an image
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 #include <string>
 
 int main(int argc, char* const argv[])

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -47,8 +47,8 @@ char*    realpath(const char* file,char* path);
 
 #if ! defined(_MSC_VER)
 #include <dirent.h>
-#include <unistd.h>
 #include <sys/param.h>
+#include <unistd.h>
 #define  stricmp strcasecmp
 #endif
 

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -29,9 +29,9 @@
 #ifdef EXV_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <iomanip>
+#include <iostream>
 
 #define Safe(x) (x?x:"unknown")
 const char* optstring = ":hVvqfbuktTFa:Y:O:D:r:p:P:d:e:i:c:m:M:l:S:g:K:n:Q:";

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -2,11 +2,10 @@
 // iptceasy.cpp
 // The quickest way to access, set or modify IPTC metadata.
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -2,11 +2,10 @@
 // iptcprint.cpp
 // Sample program to print the IPTC metadata of an image
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -9,11 +9,10 @@
  */
 // *****************************************************************************
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 using namespace Exiv2;
 

--- a/samples/key-test.cpp
+++ b/samples/key-test.cpp
@@ -9,11 +9,10 @@
  */
 // *****************************************************************************
 // included header files
+#include <cstring>
 #include <exiv2/exiv2.hpp>
-
 #include <iostream>
 #include <string>
-#include <cstring>
 
 using namespace Exiv2;
 

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -25,11 +25,10 @@
  */
 // *****************************************************************************
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <fstream>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <fstream>
+#include <iostream>
 
 // include local header files which are not part of libexiv2
 #include "getopt.hpp"

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -2,10 +2,9 @@
 // mmap-test.cpp
 // Simple mmap tests
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
 #include <cstring>
+#include <exiv2/exiv2.hpp>
+#include <iostream>
 
 using namespace Exiv2;
 

--- a/samples/path-test.cpp
+++ b/samples/path-test.cpp
@@ -2,9 +2,8 @@
 // path-test.cpp
 
 #include <exiv2/exiv2.hpp>
-
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -2,11 +2,10 @@
 // prevtest.cpp
 // Test access to preview images
 
-#include <exiv2/exiv2.hpp>
-
-#include <string>
-#include <iostream>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iostream>
+#include <string>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -4,11 +4,10 @@
 // It makes some modifications on the metadata of remote file, reads new metadata from that file
 // and reset the metadata back to the original status.
 
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -3,9 +3,8 @@
 // Test conversions from string to long, float and Rational types.
 
 #include <exiv2/exiv2.hpp>
-
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 const char* testcases[] = {
     // bool

--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -9,10 +9,9 @@
 // *****************************************************************************
 
 #include <exiv2/exiv2.hpp>
-
 #include <iostream>
-#include <string>
 #include <sstream>
+#include <string>
 
 using namespace Exiv2;
 

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -2,13 +2,12 @@
 // tiff-test.cpp
 // First and very simple TIFF write test.
 
-#include <exiv2/exiv2.hpp>
-#include <enforce.hpp>
-
-#include <string>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <enforce.hpp>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 using namespace Exiv2;
 

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -14,14 +14,13 @@
  */
 // *****************************************************************************
 // included header files
+#include <cassert>
 #include <exiv2/exiv2.hpp>
-
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
 #include <string>
 #include <utility>
-#include <cassert>
 
 // *****************************************************************************
 // local declarations

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -9,12 +9,11 @@
  */
 // *****************************************************************************
 // included header files
-#include <exiv2/exiv2.hpp>
-
-#include <iostream>
-#include <iomanip>
-#include <string>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 void write(const std::string& file, Exiv2::ExifData& ed);
 void print(const std::string& file);

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -3,10 +3,9 @@
 // Read an XMP packet from a file, parse it and print all (known) properties.
 
 #include <exiv2/exiv2.hpp>
-
-#include <string>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
+#include <string>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -3,10 +3,9 @@
 // Read an XMP packet from a file, parse and re-serialize it.
 
 #include <exiv2/exiv2.hpp>
-
-#include <string>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
+#include <string>
 
 int main(int argc, char* const argv[])
 try {

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -7,12 +7,11 @@
 //      g++ -o xmprint xmprint.cpp `pkg-config --cflags --libs exiv2`
 // ========================================================================
 
-#include <exiv2/exiv2.hpp>
-
-#include <string>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 int main(int argc, char** argv)
 {

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -2,14 +2,14 @@
 // xmpsample.cpp
 // Sample/test for high level XMP classes. See also addmoddel.cpp
 
-#include <exiv2/exiv2.hpp>
-#include "unused.h"
-
-#include <string>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
 #include <cmath>
+#include <exiv2/exiv2.hpp>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "unused.h"
 
 bool isEqual(float a, float b)
 {

--- a/src/MemIo.cpp
+++ b/src/MemIo.cpp
@@ -17,12 +17,12 @@
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <cassert>  /// \todo check usages of assert and try to cover the negative case with unit tests.
+#include <cstring>  // std::memcpy
+
 #include "basicio.hpp"
 #include "error.hpp"
 #include "futils.hpp"
-
-#include <cstring>  // std::memcpy
-#include <cassert>      /// \todo check usages of assert and try to cover the negative case with unit tests.
 
 namespace Exiv2
 {

--- a/src/RemoteIo.cpp
+++ b/src/RemoteIo.cpp
@@ -27,8 +27,8 @@
 #include <curl/curl.h>
 #endif
 
-#include <cstring>  // std::memcpy
 #include <cassert>      /// \todo check usages of assert and try to cover the negative case with unit tests.
+#include <cstring>      // std::memcpy
 #include <iostream>
 
 namespace Exiv2

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -24,18 +24,19 @@
 // included header files
 #include "actions.hpp"
 
-#include "config.h"
-#include "i18n.h"  // NLS support.
-
 #include <exiv2/easyaccess.hpp>
+#include <exiv2/error.hpp>
 #include <exiv2/exif.hpp>
 #include <exiv2/futils.hpp>
 #include <exiv2/types.hpp>
-#include <exiv2/error.hpp>
+
+#include "config.h"
+#include "i18n.h"  // NLS support.
 
 // + standard includes
 #include <sys/stat.h>   // for stat()
 #include <sys/types.h>  // for stat()
+
 #include <fstream>
 #ifdef EXV_HAVE_UNISTD_H
 #include <unistd.h>  // for stat()

--- a/src/bigtiffimage.cpp
+++ b/src/bigtiffimage.cpp
@@ -1,14 +1,14 @@
 #include "bigtiffimage.hpp"
 
-#include "safe_op.hpp"
-#include "exif.hpp"
-#include "error.hpp"
-#include "image_int.hpp"
-#include "enforce.hpp"
-
 #include <cassert>
-#include <limits>
 #include <iostream>
+#include <limits>
+
+#include "enforce.hpp"
+#include "error.hpp"
+#include "exif.hpp"
+#include "image_int.hpp"
+#include "safe_op.hpp"
 
 namespace Exiv2
 {

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -25,23 +25,24 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
-#include "makernote_int.hpp"
 #include "canonmn_int.hpp"
-#include "tags_int.hpp"
-#include "value.hpp"
+
 #include "exif.hpp"
 #include "i18n.h"                // NLS support.
+#include "makernote_int.hpp"
+#include "tags_int.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
-#include <ios>
 #include <algorithm>
 #include <cassert>
-#include <cstring>
 #include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <ios>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/casiomn_int.cpp
+++ b/src/casiomn_int.cpp
@@ -24,18 +24,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "casiomn_int.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "tags_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 #include <vector>
 
 // *****************************************************************************

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -26,15 +26,16 @@
  */
 // *****************************************************************************
 // included header files
+#include "convert.hpp"
+
 #include "config.h"
-#include "types.hpp"
 #include "error.hpp"
 #include "exif.hpp"
-#include "iptc.hpp"
-#include "xmp_exiv2.hpp"
 #include "futils.hpp"
-#include "convert.hpp"
+#include "iptc.hpp"
+#include "types.hpp"
 #include "unused.h"
+#include "xmp_exiv2.hpp"
 
 // + standard includes
 #include <cstdio>  // for snprintf (C99)

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -22,23 +22,23 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "cr2image.hpp"
-#include "tiffimage.hpp"
+
+#include "config.h"
 #include "cr2header_int.hpp"
-#include "tiffcomposite_int.hpp"
-#include "tiffimage_int.hpp"
-#include "image.hpp"
 #include "error.hpp"
 #include "futils.hpp"
 #include "i18n.h"                // NLS support.
+#include "image.hpp"
+#include "tiffcomposite_int.hpp"
+#include "tiffimage.hpp"
+#include "tiffimage_int.hpp"
 
 // + standard includes
-#include <iostream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
 
 // *****************************************************************************
 // class member definitions

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -25,26 +25,25 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "crwimage.hpp"
+
+#include "config.h"
 #include "crwimage_int.hpp"
 #include "error.hpp"
 #include "futils.hpp"
-#include "value.hpp"
 #include "tags.hpp"
 #include "tags_int.hpp"
+#include "value.hpp"
 
 // + standard includes
-#include <iostream>
-#include <iomanip>
-#include <stack>
+#include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <cmath>
-#include <cassert>
-
+#include <iomanip>
+#include <iostream>
+#include <stack>
 
 // *****************************************************************************
 // class member definitions

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -1,13 +1,14 @@
 #include "crwimage_int.hpp"
-#include "canonmn_int.hpp"
-#include "i18n.h"                // NLS support.
-#include "timegm.h"
-#include "unused.h"
-#include "error.hpp"
-#include "enforce.hpp"
 
 #include <cassert>
 #include <ctime>
+
+#include "canonmn_int.hpp"
+#include "enforce.hpp"
+#include "error.hpp"
+#include "i18n.h"                // NLS support.
+#include "timegm.h"
+#include "unused.h"
 
 // *****************************************************************************
 // local declarations

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -26,9 +26,9 @@
 #include "i18n.h"                // NLS support.
 
 // + standard includes
+#include <cassert>
 #include <iostream>
 #include <string>
-#include <cassert>
 
 // *****************************************************************************
 namespace {

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -25,21 +25,21 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "exif.hpp"
+
+#include <iostream>
+
+#include "basicio.hpp"
+#include "config.h"
+#include "error.hpp"
 #include "metadatum.hpp"
 #include "tags.hpp"
 #include "tags_int.hpp"
-#include "value.hpp"
-#include "types.hpp"
-#include "error.hpp"
-#include "basicio.hpp"
+#include "tiffcomposite_int.hpp"  // for Tag::root
 #include "tiffimage.hpp"
 #include "tiffimage_int.hpp"
-#include "tiffcomposite_int.hpp" // for Tag::root
-
-#include <iostream>
+#include "types.hpp"
+#include "value.hpp"
 
 // *****************************************************************************
 namespace {

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -27,11 +27,11 @@
 // *****************************************************************************
 
 // include local header files which are not part of libexiv2
-#include "actions.hpp"
-#include "params.hpp"
-#include "i18n.h"  // NLS support.
-
 #include <exiv2/futils.hpp>
+
+#include "actions.hpp"
+#include "i18n.h"  // NLS support.
+#include "params.hpp"
 
 int main(int argc, char* const argv[])
 {

--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -27,18 +27,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "fujimn_int.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "tags_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -19,22 +19,23 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "futils.hpp"
+
+#include "config.h"
 #include "enforce.hpp"
 
 // + standard includes
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <cstdio>
-#include <cerrno>
-#include <sstream>
-#include <cstring>
+#include <sys/types.h>
+
 #include <algorithm>
-#include <stdexcept>
-#include <set>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <fstream>
+#include <set>
+#include <sstream>
+#include <stdexcept>
 #ifdef   EXV_HAVE_UNISTD_H
 #include <unistd.h>                     // for stat()
 #endif

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -24,18 +24,18 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "gifimage.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
 
 // + standard includes
-#include <string>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -22,52 +22,50 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "image.hpp"
-#include "image_int.hpp"
+
+#include "config.h"
+#include "cr2image.hpp"
+#include "crwimage.hpp"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image_int.hpp"
+#include "jpgimage.hpp"
+#include "mrwimage.hpp"
 #include "safe_op.hpp"
 #include "slice.hpp"
 #include "unused.h"
-
-#include "cr2image.hpp"
-#include "crwimage.hpp"
-#include "jpgimage.hpp"
-#include "mrwimage.hpp"
 #ifdef EXIV2_ENABLE_PNG
 # include "pngimage.hpp"
 #endif
-#include "rafimage.hpp"
-#include "tiffimage.hpp"
-#include "tiffimage_int.hpp"
-#include "tiffcomposite_int.hpp"
-#include "tiffvisitor_int.hpp"
 #include "bigtiffimage.hpp"
-#include "webpimage.hpp"
-#include "orfimage.hpp"
-#include "gifimage.hpp"
-#include "psdimage.hpp"
-#include "tgaimage.hpp"
 #include "bmpimage.hpp"
+#include "gifimage.hpp"
 #include "jp2image.hpp"
 #include "nikonmn_int.hpp"
-
-#include "rw2image.hpp"
+#include "orfimage.hpp"
 #include "pgfimage.hpp"
+#include "psdimage.hpp"
+#include "rafimage.hpp"
+#include "rw2image.hpp"
+#include "tgaimage.hpp"
+#include "tiffcomposite_int.hpp"
+#include "tiffimage.hpp"
+#include "tiffimage_int.hpp"
+#include "tiffvisitor_int.hpp"
+#include "webpimage.hpp"
 #include "xmpsidecar.hpp"
 
 // + standard includes
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <cassert>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
-#include <cassert>
 #include <iostream>
 #include <limits>
-
-#include <sys/types.h>
-#include <sys/stat.h>
 #ifdef _MSC_VER
 # define S_ISREG(m)      (((m) & S_IFMT) == S_IFREG)
 #endif

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -21,9 +21,9 @@
 
 #include <cstdarg>
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 #include <vector>
-#include <cstdio>
 
 namespace Exiv2
 {

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -25,18 +25,19 @@
 // *****************************************************************************
 // included header files
 #include "iptc.hpp"
-#include "types.hpp"
-#include "error.hpp"
-#include "value.hpp"
+
 #include "datasets.hpp"
-#include "jpgimage.hpp"
+#include "error.hpp"
 #include "image_int.hpp"
+#include "jpgimage.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // + standard includes
-#include <iostream>
 #include <algorithm>
-#include <iterator>
 #include <fstream>      // write the temporary file
+#include <iostream>
+#include <iterator>
 
 // *****************************************************************************
 namespace {

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -21,25 +21,25 @@
 // *****************************************************************************
 
 // included header files
-#include "config.h"
-
 #include "jp2image.hpp"
-#include "tiffimage.hpp"
-#include "image.hpp"
-#include "image_int.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
 #include "error.hpp"
 #include "futils.hpp"
-#include "types.hpp"
+#include "image.hpp"
+#include "image_int.hpp"
 #include "safe_op.hpp"
+#include "tiffimage.hpp"
+#include "types.hpp"
 
 // + standard includes
 #include <array>
-#include <string>
-#include <cstring>
-#include <iostream>
 #include <cassert>
 #include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <string>
 
 // JPEG-2000 box types
 const uint32_t kJp2BoxTypeJp2Header   = 0x6a703268; // 'jp2h'

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -22,16 +22,16 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "jpgimage.hpp"
-#include "tiffimage.hpp"
-#include "image_int.hpp"
+
+#include "config.h"
+#include "enforce.hpp"
 #include "error.hpp"
 #include "futils.hpp"
 #include "helper_functions.hpp"
-#include "enforce.hpp"
+#include "image_int.hpp"
 #include "safe_op.hpp"
+#include "tiffimage.hpp"
 
 #ifdef WIN32
 #include <windows.h>
@@ -44,11 +44,11 @@
 #include "fff.h"
 
 // + standard includes
+#include <cassert>
 #include <cstdio>                               // for EOF
 #include <cstring>
-#include <cassert>
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 // *****************************************************************************
 // class member definitions

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -24,18 +24,18 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "makernote_int.hpp"
+
+#include "config.h"
 #include "ini.hpp"
 #include "tiffcomposite_int.hpp"
-#include "tiffvisitor_int.hpp"
 #include "tiffimage.hpp"
 #include "tiffimage_int.hpp"
+#include "tiffvisitor_int.hpp"
 
 // + standard includes
-#include <string>
 #include <cstring>
+#include <string>
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #ifndef __MINGW__
@@ -44,9 +44,9 @@
 #endif
 
 #if !defined(_MSC_VER) && !defined(__MINGW__)
-#include <unistd.h>
-#include <sys/types.h>
 #include <pwd.h>
+#include <sys/types.h>
+#include <unistd.h>
 #else
 #include <windows.h>
 #include <shlobj.h>

--- a/src/metadatum.cpp
+++ b/src/metadatum.cpp
@@ -29,9 +29,8 @@
 #include "metadatum.hpp"
 
 // + standard includes
-#include <iostream>
 #include <iomanip>
-
+#include <iostream>
 
 // *****************************************************************************
 // class member definitions

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -25,21 +25,21 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "mrwimage.hpp"
-#include "tiffimage.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
-#include "error.hpp"
+#include "config.h"
 #include "enforce.hpp"
+#include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
+#include "tiffimage.hpp"
 
 // + standard includes
-#include <string>
+#include <cassert>
 #include <cstring>
 #include <iostream>
-#include <cassert>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -30,14 +30,15 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "nikonmn_int.hpp"
-#include "value.hpp"
-#include "image.hpp"
-#include "tags_int.hpp"
-#include "makernote_int.hpp"
+
 #include "error.hpp"
 #include "i18n.h"                // NLS support.
+#include "image.hpp"
+#include "makernote_int.hpp"
+#include "tags_int.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // + standard includes
 #include <cassert>

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -29,20 +29,21 @@
 
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "olympusmn_int.hpp"
-#include "value.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "image.hpp"
-#include "tags_int.hpp"
 #include "makernote_int.hpp"
-#include "i18n.h"                // NLS support.
+#include "tags_int.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -25,23 +25,23 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "orfimage.hpp"
-#include "orfimage_int.hpp"
-#include "tiffimage.hpp"
-#include "tiffcomposite_int.hpp"
-#include "tiffimage_int.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
+#include "orfimage_int.hpp"
+#include "tiffcomposite_int.hpp"
+#include "tiffimage.hpp"
+#include "tiffimage_int.hpp"
 
 // + standard includes
-#include <string>
+#include <cassert>
 #include <cstring>
 #include <iostream>
-#include <cassert>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/panasonicmn_int.cpp
+++ b/src/panasonicmn_int.cpp
@@ -26,18 +26,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "panasonicmn_int.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "tags_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -22,14 +22,15 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "pentaxmn_int.hpp"
-#include "makernote_int.hpp"
-#include "value.hpp"
+
 #include "exif.hpp"
-#include "tags.hpp"
-#include "metadatum.hpp"
 #include "i18n.h"                // NLS support.
+#include "makernote_int.hpp"
+#include "metadatum.hpp"
+#include "tags.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // + standard includes
 #include <string>

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -25,22 +25,22 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "pgfimage.hpp"
-#include "image.hpp"
-#include "pngimage.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
 #include "enforce.hpp"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
+#include "pngimage.hpp"
 
 // + standard includes
+#include <cassert>
 #include <cstdio>                               // for EOF
-#include <string>
 #include <cstring>
 #include <iostream>
-#include <cassert>
+#include <string>
 
 // Signature from front of PGF file
 const unsigned char pgfSignature[3] = { 0x50, 0x47, 0x46 };

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -22,17 +22,17 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
+#include "pngimage.hpp"
 
 #include "basicio.hpp"
-#include "error.hpp"
+#include "config.h"
 #include "enforce.hpp"
+#include "error.hpp"
 #include "futils.hpp"
 #include "image.hpp"
 #include "image_int.hpp"
 #include "jpgimage.hpp"
 #include "pngchunk_int.hpp"
-#include "pngimage.hpp"
 #include "tiffimage.hpp"
 #include "types.hpp"
 

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -25,25 +25,24 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "psdimage.hpp"
-#include "jpgimage.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
+#include "enforce.hpp"
 #include "error.hpp"
 #include "futils.hpp"
-
+#include "image.hpp"
+#include "jpgimage.hpp"
 #include "safe_op.hpp"
-#include "enforce.hpp"
 
 // + standard includes
-#include <string>
-#include <cstring>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
 #include <memory>
+#include <string>
 
 // Todo: Consolidate with existing code in struct Photoshop (jpgimage.hpp):
 //       Extend this helper to a proper class with all required functionality,

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -25,23 +25,23 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "rafimage.hpp"
-#include "tiffimage.hpp"
-#include "image_int.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
+#include "enforce.hpp"
 #include "error.hpp"
 #include "futils.hpp"
-#include "enforce.hpp"
+#include "image.hpp"
+#include "image_int.hpp"
 #include "safe_op.hpp"
+#include "tiffimage.hpp"
 
 // + standard includes
-#include <string>
+#include <cassert>
 #include <cstring>
 #include <iostream>
-#include <cassert>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -25,16 +25,16 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "rw2image.hpp"
+
+#include "config.h"
+#include "error.hpp"
+#include "futils.hpp"
+#include "image.hpp"
+#include "preview.hpp"
 #include "rw2image_int.hpp"
 #include "tiffcomposite_int.hpp"
 #include "tiffimage_int.hpp"
-#include "image.hpp"
-#include "preview.hpp"
-#include "error.hpp"
-#include "futils.hpp"
 
 // + standard includes
 #ifdef EXIV2_DEBUG_MESSAGES

--- a/src/samsungmn_int.cpp
+++ b/src/samsungmn_int.cpp
@@ -24,18 +24,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "samsungmn_int.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "tags_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/sigmamn_int.cpp
+++ b/src/sigmamn_int.cpp
@@ -27,18 +27,19 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "sigmamn_int.hpp"
+
+#include "i18n.h"  // NLS support.
 #include "tags_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -24,20 +24,21 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
-#include "minoltamn_int.hpp"
 #include "sonymn_int.hpp"
+
+#include "i18n.h"  // NLS support.
+#include "minoltamn_int.hpp"
 #include "tags_int.hpp"
 #include "tiffcomposite_int.hpp"
+#include "types.hpp"
 #include "value.hpp"
-#include "i18n.h"                // NLS support.
 
 // + standard includes
-#include <string>
-#include <sstream>
-#include <iomanip>
 #include <cassert>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -26,18 +26,24 @@
  */
 // *****************************************************************************
 // included header files
-#include "types.hpp"
 #include "tags.hpp"
-#include "tags_int.hpp"
-#include "error.hpp"
-#include "futils.hpp"
-#include "value.hpp"
-#include "convert.hpp"
-#include "i18n.h"                // NLS support.
+
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
 
 #include "canonmn_int.hpp"
 #include "casiomn_int.hpp"
+#include "convert.hpp"
+#include "error.hpp"
 #include "fujimn_int.hpp"
+#include "futils.hpp"
+#include "i18n.h"  // NLS support.
 #include "minoltamn_int.hpp"
 #include "nikonmn_int.hpp"
 #include "olympusmn_int.hpp"
@@ -46,16 +52,9 @@
 #include "samsungmn_int.hpp"
 #include "sigmamn_int.hpp"
 #include "sonymn_int.hpp"
-
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <utility>
-#include <cstdlib>
-#include <cassert>
-#include <cmath>
-#include <cstring>
-
+#include "tags_int.hpp"
+#include "types.hpp"
+#include "value.hpp"
 
 // *****************************************************************************
 // class member definitions

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -24,18 +24,18 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "tgaimage.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
+#include "config.h"
 #include "error.hpp"
 #include "futils.hpp"
+#include "image.hpp"
 
 // + standard includes
-#include <string>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 // *****************************************************************************
 // class member definitions

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -24,22 +24,22 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
-#include "tiffimage_int.hpp"
 #include "tiffcomposite_int.hpp"
-#include "tiffvisitor_int.hpp"
-#include "makernote_int.hpp"
-#include "value.hpp"
-#include "error.hpp"
+
+#include "config.h"
 #include "enforce.hpp"
+#include "error.hpp"
+#include "makernote_int.hpp"
+#include "tiffimage_int.hpp"
+#include "tiffvisitor_int.hpp"
+#include "value.hpp"
 
 // + standard includes
-#include <string>
-#include <cstring>
-#include <iostream>
-#include <iomanip>
 #include <algorithm>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 // *****************************************************************************
 namespace {

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -22,29 +22,29 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "tiffimage.hpp"
-#include "tiffimage_int.hpp"
-#include "tiffcomposite_int.hpp"
-#include "tiffvisitor_int.hpp"
-#include "orfimage.hpp"
-#include "makernote_int.hpp"
-#include "nikonmn_int.hpp"
-#include "image.hpp"
-#include "image_int.hpp"
+
+#include "basicio.hpp"
+#include "config.h"
 #include "error.hpp"
 #include "futils.hpp"
-#include "types.hpp"
-#include "basicio.hpp"
 #include "i18n.h"                // NLS support.
+#include "image.hpp"
+#include "image_int.hpp"
+#include "makernote_int.hpp"
+#include "nikonmn_int.hpp"
+#include "orfimage.hpp"
+#include "tiffcomposite_int.hpp"
+#include "tiffimage_int.hpp"
+#include "tiffvisitor_int.hpp"
+#include "types.hpp"
 
 // + standard includes
-#include <string>
-#include <iostream>
-#include <iomanip>
 #include <cassert>
 #include <cstdarg>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 /* --------------------------------------------------------------------------
 

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1,10 +1,10 @@
 #include "tiffimage_int.hpp"
 
 #include "error.hpp"
+#include "i18n.h"  // NLS support.
 #include "makernote_int.hpp"
 #include "sonymn_int.hpp"
 #include "tiffvisitor_int.hpp"
-#include "i18n.h"                // NLS support.
 
 // Shortcuts for the newTiffBinaryArray templates.
 #define EXV_BINARY_ARRAY(arrayCfg, arrayDef) (newTiffBinaryArray0<&arrayCfg, EXV_COUNTOF(arrayDef), arrayDef>)

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -25,19 +25,18 @@
 // *****************************************************************************
 // included header files
 #include "config.h"
-
-#include "tiffcomposite_int.hpp" // Do not change the order of these 2 includes,
-#include "tiffvisitor_int.hpp"   // see bug #487
-#include "tiffimage_int.hpp"
-#include "makernote_int.hpp"
-#include "exif.hpp"
 #include "enforce.hpp"
-#include "iptc.hpp"
-#include "value.hpp"
+#include "exif.hpp"
+#include "i18n.h"  // NLS support.
 #include "image.hpp"
+#include "iptc.hpp"
 #include "jpgimage.hpp"
+#include "makernote_int.hpp"
 #include "sonymn_int.hpp"
-#include "i18n.h"             // NLS support.
+#include "tiffcomposite_int.hpp"  // Do not change the order of these 2 includes,
+#include "tiffimage_int.hpp"
+#include "tiffvisitor_int.hpp"   // see bug #487
+#include "value.hpp"
 
 // + standard includes
 #include <cassert>

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -27,10 +27,11 @@
 // *****************************************************************************
 // included header files
 #include "value.hpp"
-#include "types.hpp"
+
+#include "convert.hpp"
 #include "enforce.hpp"
 #include "error.hpp"
-#include "convert.hpp"
+#include "types.hpp"
 #include "unused.h"
 
 // + standard includes

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -25,10 +25,10 @@
 #include <curl/curl.h>
 #endif
 
-#include "http.hpp"
-#include "version.hpp"
-#include "makernote_int.hpp"
 #include "futils.hpp"
+#include "http.hpp"
+#include "makernote_int.hpp"
+#include "version.hpp"
 
 // Adobe XMP Toolkit
 #ifdef EXV_HAVE_XMP_TOOLKIT
@@ -43,8 +43,8 @@
 #include <string>
 
 #if ! defined(WIN32) && ! defined(__CYGWIN__) && ! defined(__MINGW__)
-#include <unistd.h>
 #include <sys/types.h>
+#include <unistd.h>
 #endif
 
 std::string Exiv2::versionString()

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -27,29 +27,29 @@
 
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "webpimage.hpp"
-#include "image_int.hpp"
-#include "enforce.hpp"
-#include "futils.hpp"
-#include "basicio.hpp"
-#include "tags.hpp"
-#include "tags_int.hpp"
-#include "types.hpp"
-#include "tiffimage.hpp"
-#include "tiffimage_int.hpp"
-#include "convert.hpp"
-#include "safe_op.hpp"
 
+#include <cassert>
 #include <cmath>
-#include <iomanip>
-#include <string>
+#include <cstdio>
 #include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <cassert>
-#include <cstdio>
+#include <string>
+
+#include "basicio.hpp"
+#include "config.h"
+#include "convert.hpp"
+#include "enforce.hpp"
+#include "futils.hpp"
+#include "image_int.hpp"
+#include "safe_op.hpp"
+#include "tags.hpp"
+#include "tags_int.hpp"
+#include "tiffimage.hpp"
+#include "tiffimage_int.hpp"
+#include "types.hpp"
 
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -24,16 +24,16 @@
  */
 // *****************************************************************************
 // included header files
-#include "xmp_exiv2.hpp"
-#include "types.hpp"
 #include "error.hpp"
-#include "value.hpp"
 #include "properties.hpp"
+#include "types.hpp"
+#include "value.hpp"
+#include "xmp_exiv2.hpp"
 
 // + standard includes
-#include <iostream>
 #include <algorithm>
 #include <cassert>
+#include <iostream>
 #include <string>
 
 // Adobe XMP Toolkit

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -25,20 +25,20 @@
  */
 // *****************************************************************************
 // included header files
-#include "config.h"
-
 #include "xmpsidecar.hpp"
-#include "image.hpp"
+
 #include "basicio.hpp"
-#include "error.hpp"
-#include "xmp_exiv2.hpp"
-#include "futils.hpp"
+#include "config.h"
 #include "convert.hpp"
+#include "error.hpp"
+#include "futils.hpp"
+#include "image.hpp"
+#include "xmp_exiv2.hpp"
 
 // + standard includes
-#include <string>
-#include <iostream>
 #include <cassert>
+#include <iostream>
+#include <string>
 
 // *****************************************************************************
 namespace {


### PR DESCRIPTION
Found with llvm-include-order

Signed-off-by: Rosen Penev <rosenp@gmail.com>