### PR TITLE
Second effort to unexpose winsock2.h from include <exiv2/exiv2.hpp>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(exiv2          # use TWEAK to categorize the build
     LANGUAGES CXX
 )
 include(cmake/mainSetup.cmake  REQUIRED)
+add_compile_options(-DEXIV2_BUILDING_EXIV2)
 
 # options and their default values
 option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"                    ON  )

--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -92,6 +92,13 @@ typedef int pid_t;
 # endif
 #endif
 //////////////////////////////////////
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)
+#ifdef EXIV2_BUILDING_EXIV2
+#define __USE_W32_SOCKETS
+#include <winsock2.h>
+#endif
+#endif
+
 
 // https://softwareengineering.stackexchange.com/questions/291141/how-to-handle-design-changes-for-auto-ptr-deprecation-in-c11
 #if __cplusplus >= 201103L

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -40,11 +40,6 @@
 
 ////////////////////////////////////////
 // platform specific code
-#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)
-#define __USE_W32_SOCKETS
-#include <winsock2.h>
-#endif
-
 #if defined(WIN32) || defined(_MSC_VER) || defined(__MINGW__)
 #include <string.h>
 #include <io.h>


### PR DESCRIPTION
Using EXIV2_BUILDING_EXIV2 mechanism.