### PR TITLE
0.27 winsock2 changes (0.27->master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(exiv2          # use TWEAK to categorize the build
     LANGUAGES CXX
 )
 include(cmake/mainSetup.cmake  REQUIRED)
-add_compile_options(-DEXIV2_BUILDING_EXIV2)
 
 # options and their default values
 option( BUILD_SHARED_LIBS             "Build exiv2lib as a shared library"                    ON  )

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -139,7 +139,7 @@ if(MSVC)
 
     # Object Level Parallelism
     add_compile_options(/MP)
-    add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
+    add_definitions(-DNOMINMAX)	# This definition is not only needed for Exiv2 but also for xmpsdk
     
     # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
     if (MSVC_VERSION GREATER_EQUAL "1910") # VS2017 and up

--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -92,12 +92,6 @@ typedef int pid_t;
 # endif
 #endif
 //////////////////////////////////////
-#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)
-#ifdef EXIV2_BUILDING_EXIV2
-#define __USE_W32_SOCKETS
-#include <winsock2.h>
-#endif
-#endif
 
 
 // https://softwareengineering.stackexchange.com/questions/291141/how-to-handle-design-changes-for-auto-ptr-deprecation-in-c11

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,7 +192,9 @@ if (EXIV2_ENABLE_WEBREADY)
 endif()
 
 if (WIN32)
-    target_compile_definitions(exiv2lib PRIVATE PSAPI_VERSION=1) # to be compatible with <= WinVista (#905)
+    target_compile_definitions(exiv2lib PRIVATE PSAPI_VERSION=1)    # to be compatible with <= WinVista (#905)
+    # Since windows.h is included in some headers, we need to propagate this definition
+    target_compile_definitions(exiv2lib PUBLIC WIN32_LEAN_AND_MEAN) 
 endif()
 
 if (NOT MSVC)

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -40,6 +40,11 @@
 
 ////////////////////////////////////////
 // platform specific code
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)	
+#define __USE_W32_SOCKETS
+#include <winsock2.h>
+#endif
+
 #if defined(WIN32) || defined(_MSC_VER) || defined(__MINGW__)
 #include <string.h>
 #include <io.h>

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -18,7 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
 
-// included header files
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)	
+#define __USE_W32_SOCKETS
+#include <winsock2.h>
+#endif
+
 #include "config.h"
 #include "datasets.hpp"
 #include "http.hpp"
@@ -40,10 +44,6 @@
 
 ////////////////////////////////////////
 // platform specific code
-#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW__)	
-#define __USE_W32_SOCKETS
-#include <winsock2.h>
-#endif
 
 #if defined(WIN32) || defined(_MSC_VER) || defined(__MINGW__)
 #include <string.h>


### PR DESCRIPTION
I have analysed the situation described in #1335 and I think the solution is easier than I thought.

In https://bitbucket.org/agriggio/art/issues/128/msys2-compiling-errors-with-windows-10-and#comment-58935959 @clanmills commented the following:

> I can’t change that in the codebase because I made the change for a solid reason: https://github.com/Exiv2/exiv2/pull/1222 to deal with C++11 which wasn’t supported by 0.27.2.

However, that change was not needed for the C++11 topic and we can just move the winsock2 inclusion to the top of `http.cpp` (As the agriggio developpers mentioned in the previous link). 

I also did a small modification to the CMake code to define the `WIN32_LEAN_AND_MEAN` definition in a different way. Now we use `target_compile_definitions(exiv2lib PUBLIC)` so that the definition is included in consumer projects if consuming Exiv2 with CMake. In case we would not have a inclusion of windows.h in our public headers, this would not be needed. However, the file `include/exiv2/rwlock.hpp` is including it.