### PR TITLE
Do not install target exiv2-xmp. It is a implementation detail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ install:
     - set PATH=C:\projects\deps\ninja;%PATH%
     - ninja --version
     - python -m pip install --upgrade pip
-    - pip3.exe install conan==1.24.1
+    - pip3.exe install conan==1.30.2
     - pip3.exe install lxml
     - cd %APPVEYOR_BUILD_FOLDER%
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,14 +14,14 @@ if [[ "$(uname -s)" == 'Linux' ]]; then
     sudo pip install virtualenv
     virtualenv conan
     source conan/bin/activate
-    pip install conan==1.22.0
+    pip install conan==1.30.2
     pip install codecov
     pip install lxml
 else
     sudo pip3 install virtualenv
     virtualenv conan
     source conan/bin/activate
-    pip3 install conan==1.22.0
+    pip3 install conan==1.30.2
     pip3 install codecov
     pip3 install lxml
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,7 +144,10 @@ set_target_properties( exiv2lib_int PROPERTIES
 )
 
 target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
-target_include_directories(exiv2lib PRIVATE ${ZLIB_INCLUDE_DIR})
+target_include_directories(exiv2lib PRIVATE 
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
+    ${ZLIB_INCLUDE_DIR}
+)
 
 if (EXIV2_ENABLE_XMP)
     target_link_libraries(exiv2lib PRIVATE exiv2-xmp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,7 +211,7 @@ else()
 endif()
 
 if( EXIV2_ENABLE_PNG )
-    target_link_libraries( exiv2lib PRIVATE ${ZLIB_LIBRARIES} )
+    target_link_libraries( exiv2lib PRIVATE $<BUILD_INTERFACE:${ZLIB_LIBRARIES}>)
 endif()
 
 if( EXIV2_ENABLE_NLS )

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -28,13 +28,12 @@ add_library(exiv2-xmp STATIC
 
 target_link_libraries(exiv2-xmp
     PRIVATE 
-        ${EXPAT_LIBRARY}
+        $<BUILD_INTERFACE:${EXPAT_LIBRARY}>
 )
 
 target_include_directories(exiv2-xmp
-    PUBLIC 
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
     PRIVATE 
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
         ${EXPAT_INCLUDE_DIR}
 )
 
@@ -50,8 +49,9 @@ if (BUILD_SHARED_LIBS)
     set_property(TARGET exiv2-xmp PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-# 1119  Install libxmp.a for use by third party applications (Thanks, Emmanuel)
-install(TARGETS exiv2-xmp EXPORT exiv2Config
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+# The private dependencies of a static library still need to be exported because they are needed to properly link the consumers of the static library.
+install(TARGETS exiv2-xmp EXPORT exiv2Config	
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}	
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}	
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
This PR should fix #1363. 

At the moment, the CMake configuration file generated during the installation (`share/cmake/exiv2Config.cmake`) is containing information about **exiv2-xmp** which is an implementation detail which should not be made public to consumers of Exiv2. It also contains information about the STATIC dependencies of exiv2-xmp (such as libexpat) which contain absolute paths.

When generating the exiv2 package, consumers do not need to know about exiv2-xmp or expat.

With this change, the CMake configuration file will not contain anymore absolute paths. 