### PR TITLE
027 - Add more ubuntu distros to Travis CI and fix cmake variable passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,38 @@ matrix:
       env:
         - BUILD_TYPE="Debug"
 
+    - name: "Ubuntu 18.04 - gcc (Release)"
+      os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="Release"
+
+    - name: "Ubuntu 18.04 - gcc (Debug)"
+      os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="Debug"
+
+    - name: "Ubuntu 20.04 - gcc (Release)"
+      os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="Release"
+
+    - name: "Ubuntu 20.04 - gcc (Debug)"
+      os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env:
+        - BUILD_TYPE="Debug"
+
     - name: "Ubuntu 16.04 - gcc-5.4 with coverage"
       os: linux
       dist: xenial

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -2,12 +2,21 @@
 set -e # Enables cheking of return values from each command
 set -x # Prints every command
 
+# This file is only used from Travis CI, where the only Linux distro used is Ubuntu
+
 python --version
 python3 --version
 
 if [[ "$(uname -s)" == 'Linux' ]]; then
     sudo apt-get update
-    sudo apt-get install cmake zlib1g-dev libssh-dev python-pip libxml2-utils
+
+    if [[ "$(lsb_release -cs)" == 'focal' ]]; then
+        # In Ubuntu 20.04 python-pip does not exist. Furthermore we need to have the alias python for python3
+        sudo apt-get install cmake zlib1g-dev libssh-dev python3-pip python-is-python3 libxml2-utils
+    else
+        sudo apt-get install cmake zlib1g-dev libssh-dev python-pip libxml2-utils
+    fi
+
     if [ -n "$WITH_VALGRIND" ]; then
         sudo apt-get install valgrind
     fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,21 +8,21 @@ source conan/bin/activate
 if [[ "$(uname -s)" == 'Linux' ]]; then
     if [ "$CC" == "clang" ]; then
         # clang + Ubuntu don't like to run with UBSAN, but ASAN works
-        export CMAKE_OPTIONS="$CMAKE_OPTIONS"
+        export CMAKE_OPTIONS="$COMMON_CMAKE_OPTIONS"
     elif [ -n "$WITH_VALGRIND" ]; then
         export EXIV2_VALGRIND="valgrind --quiet"
     else
-        export CMAKE_OPTIONS="$CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=OFF"
+        export CMAKE_OPTIONS="$COMMON_CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=OFF"
     fi
 else
-    export CMAKE_OPTIONS="$CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=OFF"
+    export CMAKE_OPTIONS="$COMMON_CMAKE_OPTIONS -DEXIV2_TEAM_USE_SANITIZERS=OFF"
 fi
-CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_CXX_FLAGS=-Wno-deprecated"
+CMAKE_OPTIONS="$COMMON_CMAKE_OPTIONS -DCMAKE_CXX_FLAGS=-Wno-deprecated -DCMAKE_CXX_STANDARD=98 -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
 
 mkdir build
 cd    build
 conan install .. -o webready=True --build missing
-cmake ${CMAKE_OPTIONS} -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_INSTALL_PREFIX=install ..
+cmake ${CMAKE_OPTIONS} ..
 make  -j
 make  tests
 make  install

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -79,7 +79,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    memcpy(dest, src, size);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
My motivation here is to add more Ubuntu versions to Travis CI, so that we know that exiv2 builds without problems in more recent version of Ubuntu.

As you can see in the [TravisCI documentation](https://docs.travis-ci.com/user/reference/linux/), Xenial (16.04) was the default version which we were using. Support for 18.04 and 20.04 has been added here.

Furthermore, I noticed that the variable `COMMON_CMAKE_OPTIONS` that we were defining at `.travis.yml` was not used in `ci/run.sh`. The build mode (Debug or Release) was not passed either. I fixed those issues and I checked out that now the variables are properly passed to the CI jobs.

The final change was in `src/ini.cpp`. Gcc 9.3 was reporting this error at the `strncpy` function:

```
In file included from /usr/include/string.h:495,
                 from /home/travis/build/Exiv2/exiv2/src/ini.cpp:33:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘int Exiv2::ini_parse_stream(Exiv2::ini_reader, void*, Exiv2::ini_handler, void*)’ at /home/travis/build/Exiv2/exiv2/src/ini.cpp:82:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: error: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 50 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘int Exiv2::ini_parse_stream(Exiv2::ini_reader, void*, Exiv2::ini_handler, void*)’ at /home/travis/build/Exiv2/exiv2/src/ini.cpp:82:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: error: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ output may be truncated copying 50 bytes from a string of length 199 [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
```

By replacing the `strncpy` with `memcpy` I got rid of the warning. 