### PR TITLE
clang-tidy: fix ending namespace comments

### DIFF
--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -84,11 +84,11 @@ namespace {
     std::string getExifModel(Exiv2::Internal::TiffComponent* const pRoot);
     //! Nikon en/decryption function
     void ncrypt(Exiv2::byte* pData, size_t size, uint32_t count, uint32_t serial);
-}
+    } // namespace
 
-// *****************************************************************************
-// class member definitions
-namespace Exiv2 {
+    // *****************************************************************************
+    // class member definitions
+    namespace Exiv2 {
     namespace Internal {
 
         std::string getExiv2ConfigPath()

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -45,11 +45,11 @@
 namespace {
     //! Add \em tobe - \em curr 0x00 filler bytes if necessary
     uint32_t fillGap(Exiv2::Internal::IoWrapper& ioWrapper, uint32_t curr, uint32_t tobe);
-}
+    } // namespace
 
-// *****************************************************************************
-// class member definitions
-namespace Exiv2 {
+    // *****************************************************************************
+    // class member definitions
+    namespace Exiv2 {
     namespace Internal {
 
     bool TiffMappingInfo::operator==(const TiffMappingInfo::Key& key) const

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -51,16 +51,7 @@
 #include <cassert>
 #include <cstdio>
 
-// *****************************************************************************
-// class member definitions
 namespace Exiv2 {
-    namespace Internal {
-
-    }}                                      // namespace Internal, Exiv2
-
-namespace Exiv2 {
-    using namespace Exiv2::Internal;
-
     WebPImage::WebPImage(BasicIo::UniquePtr io)
     : Image(ImageType::webp, mdNone, std::move(io))
     {

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -45,11 +45,10 @@ namespace {
     const char* xmlHeader = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n";
     const long xmlHdrCnt = static_cast<long>(std::strlen(xmlHeader));  // without the trailing 0-character
     const char* xmlFooter = "<?xpacket end=\"w\"?>";
-}
+    } // namespace
 
-// class member definitions
-namespace Exiv2 {
-
+    // class member definitions
+    namespace Exiv2 {
 
     XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, bool create)
         : Image(ImageType::xmp, mdXmp, std::move(io))


### PR DESCRIPTION
Found with llvm-namespace-comment

Signed-off-by: Rosen Penev <rosenp@gmail.com>