### PR TITLE
Add support for Sony lens aberration correction parameters (0.27 only).

### DIFF
--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -802,6 +802,18 @@ namespace Exiv2 {
         TagInfo(0x4749, "RatingPercent", N_("Windows Rating Percent"),
                 N_("Rating tag used by Windows, value in percent"),
                 ifd0Id, otherTags, unsignedShort, -1, printValue), // Windows Tag
+        TagInfo(0x7032, "VignettingCorrParams",
+                N_("Vignetting Correction Params"),
+                N_("Sony vignetting correction parameters"),
+                ifd0Id, otherTags, signedShort, 17, printValue),  // Sony Tag
+        TagInfo(0x7035, "ChromaticAberrationCorrParams",
+                N_("Chromatic Aberration Correction Params"),
+                N_("Sony chromatic aberration correction parameters"),
+                ifd0Id, otherTags, signedShort, 33, printValue),  // Sony Tag
+        TagInfo(0x7037, "DistortionCorrParams",
+                N_("Distortion Correction Params"),
+                N_("Sony distortion correction parameters"),
+                ifd0Id, otherTags, signedShort, 17, printValue),  // Sony Tag
         TagInfo(0x800d, "ImageID", N_("Image ID"),
                 N_("ImageID is the full pathname of the original, high-resolution image, "
                    "or any other identifying string that uniquely identifies the original "


### PR DESCRIPTION
This PR adds support for extracting the lens aberration correction parameters which recent Sony cameras embed into RAW files. Tag details were obtained from exiftool.

A test file can be found:

https://discuss.pixls.us/uploads/short-url/gIfiQgbaX9PdFDKKjOUMHrqzwcg.ARW

where the correct output from exiftool is:
```
Vignetting Corr Params          : 16 0 64 128 256 448 704 960 1280 1792 2432 3392 4864 6656 8640 10752 12864
Chromatic Aberration Corr Params: 32 896 896 896 896 896 896 896 896 768 768 896 768 768 768 640 640 640 512 512 384 384 384 384 512 512 384 384 384 256 256 384 256
Distortion Corr Params          : 16 13 -2 -29 -65 -113 -171 -241 -313 -394 -473 -557 -636 -713 -780 -841 -884
```

and this patch gives:
```
Exif.SubImage1.VignettingCorrParams          SShort     17  16 0 64 128 256 448 704 960 1280 1792 2432 3392 4864 6656 8640 10752 12864
Exif.SubImage1.ChromaticAberrationCorrParams SShort     33  32 896 896 896 896 896 896 896 896 768 768 896 768 768 768 640 640 640 512 512 384 384 384 384 512 512 384 384 384 256 256 384 256
Exif.SubImage1.DistortionCorrParams          SShort     17  16 13 -2 -29 -65 -113 -171 -241 -313 -394 -473 -557 -636 -713 -780 -841 -884
```