### PR TITLE
Use a.rfind(b, 0) == 0 instead of a.find(b) == 0 to reduce processing…

### DIFF
--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -275,7 +275,7 @@ namespace Exiv2 {
         , { "-"         ,pStdin    , false }
         };
         for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-            if ( path.find(prots[i].name) == 0 )
+            if ( path.rfind(prots[i].name, 0) == 0 )
                 // URL's require data.  Stdin == "-" and no further data
                 if ( prots[i].isUrl ? path.size() > prots[i].name.size() : path.size() == prots[i].name.size() )
                     result = prots[i].prot;
@@ -300,7 +300,7 @@ namespace Exiv2 {
         , { L"-"         ,pStdin    , false }
         };
         for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-            if ( path.find(prots[i].name) == 0 )
+            if ( path.rfind(prots[i].name, 0) == 0 )
                 // URL's require data.  Stdin == "-" and no further data
                 if ( prots[i].isUrl ? path.size() > prots[i].name.size() : path.size() == prots[i].name.size() )
                     result = prots[i].prot;

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -665,7 +665,7 @@ namespace Exiv2 {
                     //       2 | 0xe1 APP1  |     911 | Exif..MM.*.......%.........#....
                     //     915 | 0xe1 APP1  |     870 | http://ns.adobe.com/xap/1.0/.<x:
                     //    1787 | 0xe1 APP1  |   65460 | http://ns.adobe.com/xmp/extensio
-                    if (option == kpsXMP && signature.find("http://ns.adobe.com/x") == 0) {
+                    if (option == kpsXMP && signature.rfind("http://ns.adobe.com/x", 0) == 0) {
                         // extract XMP
                         if (size > 0) {
                             io_->seek(-bufRead, BasicIo::cur);

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1316,7 +1316,7 @@ namespace Exiv2 {
                                                     ;
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.find("PENTAX K-3")==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 168 && lensInfo->toLong(2) == 144 ) index = 7;
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 168 && lensInfo->toLong(2) == 144 ) index = 7;
             }
 
             if ( index > 0 )  {
@@ -1344,14 +1344,14 @@ namespace Exiv2 {
                                                     ;
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.find("PENTAX K-3")==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 131 && lensInfo->toLong(2) == 128 )
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 131 && lensInfo->toLong(2) == 128 )
                     index = 6;
             }
             if ( value.count() == 2 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.find("PENTAX K100D")==0 && lensInfo->count() == 44 )
+                if ( model.rfind("PENTAX K100D", 0)==0 && lensInfo->count() == 44 )
                     index = 6;
-                if ( model.find("PENTAX *ist DL")==0 && lensInfo->count() == 36 )
+                if ( model.rfind("PENTAX *ist DL", 0)==0 && lensInfo->count() == 36 )
                     index = 6;
             }
 


### PR DESCRIPTION
… time when checking that a starts wit b, #1459