### PR TITLE
Fixing exiv2-test.sh message when test/tmp is empty.

### DIFF
--- a/test/exiv2-test.sh
+++ b/test/exiv2-test.sh
@@ -65,7 +65,7 @@ fi
         20060127_225027.exv \
         20110626_213900.exv"
 
-    for i in $images; do copyTestFile $i; done
+    for i in $images; do copyTestFile $i; done ; copyTestFile 20110626_213900.psd
     echo "Exiv2 test directory -----------------------------------------------------"
     cd "$testdir"
 


### PR DESCRIPTION
The first time your run the test suite on a "clean" machine, you get warnings and messages from exiv2-test.sh.  When you re-run it's OK because the missing file (20110626_213900.psd) has been copied to the test/tmp directory by another test.  This is very ugly.  It's harmless.  And now it's fixed!