### PR TITLE
fix_1473_LocationShown

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -986,7 +986,7 @@ namespace Exiv2 {
         { "RegItemId",               N_("Registry Entry-Item Identifier"),  "Text",                       xmpText, xmpExternal, N_("A unique identifier created by a registry and applied by the creator of the digital image. This value shall not be changed after being applied. This identifier is linked to a corresponding Registry Organisation Identifier.") },
         { "RegOrgId",                N_("Registry Entry-Organisation Identifier"), "Text",                xmpText, xmpExternal, N_("An identifier for the registry which issued the corresponding Registry Image Id.") },
         { "IptcLastEdited",          N_("IPTC Fields Last Edited"),         "Date",                       xmpText, xmpExternal, N_("The date and optionally time when any of the IPTC photo metadata fields has been last edited.") },
-        { "LocationShown",           N_("Location shown"),                  "bag LocationDetails",        xmpBag,  xmpExternal, N_("A location shown in the image.") },
+        { "LocationShown",           N_("Location Shown"),                  "bag LocationDetails",        xmpBag,  xmpExternal, N_("A location shown in the image.") },
         { "LocationCreated",         N_("Location Created"),                "bag LocationDetails",        xmpBag,  xmpExternal, N_("The location the photo was taken.") },
         { "City",                    N_("Location-City"),                   "Text",                       xmpText, xmpExternal, N_("Name of the city of a location.") },
         { "CountryCode",             N_("Location-Country ISO-Code"),       "Text",                       xmpText, xmpExternal, N_("The ISO code of a country of a location.") },

--- a/tests/bugfixes/github/test_issue_1473.py
+++ b/tests/bugfixes/github/test_issue_1473.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, CopyTmpFiles, path
+@CopyTmpFiles("$data_path/Stonehenge.exv")
+
+class test_issue_1473(metaclass=CaseMeta):
+    url       = "https://github.com/Exiv2/exiv2/issues/1473"
+    filename  = path("$tmp_path/Stonehenge.exv")
+    commands  = [ "$exiv2 -g shown/i                              $filename" 
+                , "$exiv2 -M\"set Xmp.iptc.LocationShown Lost\" $filename"
+                , "$exiv2 -g shown/i                              $filename"
+                ]
+    stdout   =  ["","","""Xmp.iptc.LocationShown                       XmpText     4  Lost
+"""]
+    stderr = [""]*len(commands)
+    retval = [ 1,0,0]


### PR DESCRIPTION
Fix #1473

The web-pages will be updated when Exiv2 v0.27.4 ships on 2021-05.22.  The first pre-release is scheduled for 2021-03-31 and will be published on https://pre-release.exiv2.org

I'm not sure that my test is valid as LocationShown should be an XmpBag.  This is an obscure corner of the mysterious world of Metadata.  This matter deserves no more more time.