### PR TITLE
fix_1508_enableBMMF_effort2

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ int main(int argc, const char* argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#if EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF(true);
 #endif
     ...
@@ -608,7 +608,7 @@ The exiv2 command-line program and sample applications call the following at the
 ```cpp
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#if EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF(true);
 #endif
 ```

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -132,7 +132,7 @@ int main(int argc,const char** argv)
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -171,7 +171,7 @@ int main(int argc,const char* argv[])
 {
 	Exiv2::XmpParser::initialize();
 	::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -46,7 +46,7 @@ int _tmain(int argc, _tchar* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -287,7 +287,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -783,7 +783,7 @@ int main(int argc,const char* argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** const argv)
 {
 	Exiv2::XmpParser::initialize();
 	::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/httptest.cpp
+++ b/samples/httptest.cpp
@@ -39,7 +39,7 @@ int main(int argc,const char** argv)
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/ini-test.cpp
+++ b/samples/ini-test.cpp
@@ -34,7 +34,7 @@ int main()
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/key-test.cpp
+++ b/samples/key-test.cpp
@@ -29,7 +29,7 @@ int main()
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
     try {
         Exiv2::XmpParser::initialize();
         ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
         Exiv2::enableBMFF();
 #endif
 

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/mt-test.cpp
+++ b/samples/mt-test.cpp
@@ -82,7 +82,7 @@ int main(int argc,const char* argv[])
 {
 	Exiv2::XmpParser::initialize();
 	::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/path-test.cpp
+++ b/samples/path-test.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -59,7 +59,7 @@ int main()
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/tiffaddpath-test.cpp
+++ b/samples/tiffaddpath-test.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/toexv.cpp
+++ b/samples/toexv.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/werror-test.cpp
+++ b/samples/werror-test.cpp
@@ -29,7 +29,7 @@ int main()
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[])
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
 {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -39,7 +39,7 @@ int main()
 try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXIV2_ENABLE_BMFF
+#ifdef EXV_ENABLE_BMFF
     Exiv2::enableBMFF();
 #endif
 


### PR DESCRIPTION
Thanks for pointing this out @kmilos.  Total proof of the stupidity of have symbols deliberated wrongly spelt in the code.  This is a trap for dyslexic engineers like me.  I have opened #1514 to fix this properly for v1.00.