### PR TITLE
fix_enableBMFF_v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option( EXIV2_ENABLE_WIN_UNICODE      "Use Unicode paths (wstring) on Windows"  
 option( EXIV2_ENABLE_WEBREADY         "Build webready support into library"                   OFF )
 option( EXIV2_ENABLE_CURL             "USE Libcurl for HttpIo (WEBREADY)"                     OFF )
 option( EXIV2_ENABLE_SSH              "USE Libssh for SshIo (WEBREADY)"                       OFF )
-option( EXIV2_ENABLE_BMFF             "Build with BMFF support"                               OFF )
+option( EXIV2_ENABLE_BMFF             "Build with BMFF support"                               ON  )
 
 option( EXIV2_BUILD_SAMPLES           "Build sample applications"                             ON  )
 option( EXIV2_BUILD_EXIV2_COMMAND     "Build exiv2 command-line executable"                   ON  )

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ option( EXIV2_ENABLE_XMP           "Build with XMP metadata support"         ON 
 option( EXIV2_ENABLE_EXTERNAL_XMP  "Use external version of XMP"            OFF )
 option( EXIV2_ENABLE_PNG           "Build with png support (requires libz)"  ON )
 ...
-option( EXIV2_ENABLE_BMFF          "Build with BMFF support"                OFF )
+option( EXIV2_ENABLE_BMFF          "Build with BMFF support"                 ON )
 577 rmills@rmillsmm:~/gnu/github/exiv2/exiv2 $
 ```
 
@@ -786,7 +786,7 @@ Access to the bmff code is guarded in two ways.  Firstly, you have to build the 
 EXIV2API bool enableBMFF(bool enable);
 ```
 
-The return value from `enableBMFF()` reports the current status of bmff support before calling this function.
+The return value from `enableBMFF()` is true if the library has been build with bmff support (cmake option -DEXIV2_ANABLE_BMFF=On).
 
 Applications may wish to provide a preference setting to enable bmff support and thereby place the responsibility for the use of this code with the user of the application.
 

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -32,7 +32,11 @@
 namespace Exiv2
 {
     EXIV2API bool enableBMFF(bool enable = true);
+}
 
+#ifdef EXV_ENABLE_BMFF
+namespace Exiv2
+{
     struct Iloc
     {
         Iloc(uint32_t ID = 0, uint32_t start = 0, uint32_t length = 0) : ID_(ID), start_(start), length_(length){};
@@ -168,3 +172,4 @@ namespace Exiv2
     //! Check if the file iIo is a BMFF image.
     EXIV2API bool isBmffType(BasicIo& iIo, bool advance);
 }  // namespace Exiv2
+#endif // EXV_ENABLE_BMFF

--- a/include/exiv2/exiv2.hpp
+++ b/include/exiv2/exiv2.hpp
@@ -45,9 +45,7 @@
 #include "exiv2/mrwimage.hpp"
 #include "exiv2/orfimage.hpp"
 #include "exiv2/pgfimage.hpp"
-#ifdef EXV_ENABLE_BMFF
 #include "bmffimage.hpp"
-#endif
 
 #ifdef EXV_HAVE_LIBZ
 #include "exiv2/pngimage.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,11 +118,9 @@ if( EXIV2_ENABLE_VIDEO )
     )
 endif()
 
-if( EXIV2_ENABLE_BMFF )
-    target_sources(exiv2lib PRIVATE
-        bmffimage.cpp           ../include/exiv2/bmffimage.hpp
-    )
-endif()
+target_sources(exiv2lib PRIVATE
+    bmffimage.cpp           ../include/exiv2/bmffimage.hpp
+)
 
 # Other library target properties
 # ---------------------------------------------------------

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -84,18 +84,15 @@ struct BmffBoxHeader
 
 // *****************************************************************************
 // class member definitions
+#ifdef EXV_ENABLE_BMFF
 namespace Exiv2
 {
-    static bool enabled = false;
-
-#ifdef EXV_ENABLE_BMFF
+    static bool   enabled = false;
     EXIV2API bool enableBMFF(bool enable)
     {
-        bool   result = enabled;
-        enabled       = enable ;
-        return result ;
+        enabled = enable ;
+        return true ;
     }
-#endif                   // EXV_ENABLE_BMFF
 
     std::string Iloc::toString() const
     {
@@ -629,3 +626,13 @@ namespace Exiv2
         return matched;
     }
 }  // namespace Exiv2
+#else  // ifdef EXV_ENABLE_BMFF
+namespace Exiv2
+{
+    EXIV2API bool enableBMFF(bool)
+    {
+        return false ;
+    }
+}
+#endif
+


### PR DESCRIPTION
In a team discussion on Element following RC2, we agreed that in Exiv2 v1.00, we would:

1.  Build the function Exiv2::enableBMFF(bool) into the library (even when -DEXIV2_ENABLE_BMFF=False)
2.  The bool returned by Exiv2::enableBMFF(bool) would indicate if the library was built with bmff support.
3.  The default for -DEXIV2_ENABLE_BMFF=On
4.  The documentation would be appropriated updated.

Built with cmake .. -DEXIV2_ENABLE_BMFF=On

```bash
517 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $ nm -g --demangle lib/libexiv2.dylib | grep enableBMFF
0000000000163c60 T Exiv2::enableBMFF(bool)
518 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $ make version_test | grep bmff

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
enable_bmff          1
519 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $
```

Built with cmake .. -DEXIV2_ENABLE_BMFF=Off

```bash
528 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $ nm -g --demangle lib/libexiv2.dylib | grep enableBMFF
00000000001632a0 T Exiv2::enableBMFF(bool)
529 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $ make version_test | grep bmff

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
enable_bmff          0
530 rmills@rmillsmm-local:~/gnu/github/exiv2/main/build $ 
```
