### PR TITLE
xmpsdk: don't use register

### DIFF
--- a/xmpsdk/src/MD5.cpp
+++ b/xmpsdk/src/MD5.cpp
@@ -153,7 +153,7 @@ MD5Final(md5byte digest[16], struct MD5_CTX *ctx)
 void
 MD5Transform(UWORD32 buf[4], UWORD32 const in[16])
 {
-	register UWORD32 a, b, c, d;
+	UWORD32 a, b, c, d;
 
 	a = buf[0];
 	b = buf[1];


### PR DESCRIPTION
register is gone with C++17.

Signed-off-by: Rosen Penev <rosenp@gmail.com>