### PR TITLE
fix_enableBMFF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,7 @@ env:
 
 matrix:
   include:
-    - name: "Ubuntu 16.04 - gcc-5.4 (Release)"
-      os: linux
-      dist: xenial
-      sudo: required
-      compiler: gcc
-      env:
-        - BUILD_TYPE="Release"
-
-    - name: "Ubuntu 16.04 - gcc-5.4 (Debug)"
-      os: linux
-      dist: xenial
-      sudo: required
-      compiler: gcc
-      env:
-        - BUILD_TYPE="Debug"
-
-    - name: "Ubuntu 18.04 - gcc (Release)"
+    - name: "Ubuntu 18.04 - gcc-7.5 (Release)"
       os: linux
       dist: bionic
       sudo: required
@@ -34,7 +18,7 @@ matrix:
       env:
         - BUILD_TYPE="Release"
 
-    - name: "Ubuntu 18.04 - gcc (Debug)"
+    - name: "Ubuntu 18.04 - gcc-7.5 (Debug)"
       os: linux
       dist: bionic
       sudo: required
@@ -42,7 +26,7 @@ matrix:
       env:
         - BUILD_TYPE="Debug"
 
-    - name: "Ubuntu 20.04 - gcc (Release)"
+    - name: "Ubuntu 20.04 - gcc-9.3 (Release)"
       os: linux
       dist: focal
       sudo: required
@@ -50,7 +34,7 @@ matrix:
       env:
         - BUILD_TYPE="Release"
 
-    - name: "Ubuntu 20.04 - gcc (Debug)"
+    - name: "Ubuntu 20.04 - gcc-9.3 (Debug)"
       os: linux
       dist: focal
       sudo: required
@@ -58,55 +42,62 @@ matrix:
       env:
         - BUILD_TYPE="Debug"
 
-    - name: "Ubuntu 16.04 - gcc-5.4 with coverage"
+    - name: "Ubuntu 20.04 - clang-7 (Release)"
       os: linux
-      dist: xenial
+      dist: focal
+      sudo: required
+      compiler: clang
+      env:
+        - BUILD_TYPE="Release"
+
+    - name: "Ubuntu 20.04 - clang-7 (Debug)"
+      os: linux
+      dist: focal
+      sudo: required
+      compiler: clang
+      env:
+        - BUILD_TYPE="Debug"
+
+    - name: "Ubuntu 20.04 - gcc-9.3 (Debug+Coverage)"
+      os: linux
+      dist: focal
       sudo: required
       compiler: gcc
       env:
+        - BUILD_TYPE="Debug"
         - WITH_COVERAGE=1
-        - BUILD_TYPE="Release"
 
-    - name: "Ubuntu 16.04 - gcc-5.4 with Valgrind"
+    - name: "Ubuntu 20.04 - gcc-9.3 (Release+Valgrind)"
       os: linux
-      dist: xenial
+      dist: focal
       sudo: required
       compiler: gcc
       env:
+        - BUILD_TYPE="Release"
         - WITH_VALGRIND=1
-        - BUILD_TYPE="Release"
 
-    - name: "Ubuntu 16.04 - gcc-5.4 with sanitizers"
+    - name: "Ubuntu 20.04 - gcc-9.3 (Release+Sanitizers)"
       os: linux
-      dist: xenial
+      dist: focal
       sudo: required
       compiler: gcc
       env:
+        - BUILD_TYPE="Release"
         - WITH_SANITIZERS=1
-        - BUILD_TYPE="Release"
 
-    - name: "Ubuntu 16.04 - CLANG 7.0 (Release)"
-      os: linux
-      dist: xenial
-      sudo: required
-      compiler: clang
-      env:
-        - BUILD_TYPE="Release"
-
-    - name: "Ubuntu 16.04 - CLANG 7.0 (Debug)"
-      os: linux
-      dist: xenial
-      sudo: required
-      compiler: clang
-      env:
-        - BUILD_TYPE="Debug"
-
-    - name: "macOS 10.14 - XCode 11.3"
+    - name: "macOS 10.14 - XCode 11.3 (Release)"
       os: osx
       osx_image: xcode11.3
       compiler: clang
       env:
         - BUILD_TYPE="Release"
+
+    - name: "macOS 10.14 - XCode 11.3 (Debug)"
+      os: osx
+      osx_image: xcode11.3
+      compiler: clang
+      env:
+        - BUILD_TYPE="Debug"
 
 install: ./ci/install.sh
 script:  ./ci/run.sh

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ option( EXIV2_ENABLE_XMP           "Build with XMP metadata support"         ON 
 option( EXIV2_ENABLE_EXTERNAL_XMP  "Use external version of XMP"            OFF )
 option( EXIV2_ENABLE_PNG           "Build with png support (requires libz)"  ON )
 ...
-option( EXIV2_ENABLE_BMFF          "Build with BMFF support"                OFF )
+option( EXIV2_ENABLE_BMFF          "Build with BMFF support"                 OFF)
 577 rmills@rmillsmm:~/gnu/github/exiv2/exiv2 $
 ```
 
@@ -148,6 +148,9 @@ Options are defined on the CMake command-line:
 ```bash
 $ cmake -DBUILD_SHARED_LIBS=On -DEXIV2_ENABLE_NLS=Off
 ```
+
+It is planned to set the default -DEXIV2\_ENABLE\_BMFF=On for Exiv2 v1.00.  BMFF support is disabled by default in v0.27.4.
+
 
 [TOC](#TOC)
 <div id="2-4">
@@ -786,7 +789,7 @@ Access to the bmff code is guarded in two ways.  Firstly, you have to build the 
 EXIV2API bool enableBMFF(bool enable);
 ```
 
-The return value from `enableBMFF()` reports the current status of bmff support before calling this function.
+The return value from `enableBMFF()` is true if the library has been build with bmff support (cmake option -DEXIV2_ANABLE_BMFF=On).
 
 Applications may wish to provide a preference setting to enable bmff support and thereby place the responsibility for the use of this code with the user of the application.
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,24 +4,17 @@ set -x # Prints every command
 
 # This file is only used from Travis CI, where the only Linux distro used is Ubuntu
 
-python --version
 python3 --version
 
 if [[ "$(uname -s)" == 'Linux' ]]; then
     sudo apt-get update
 
-    sudo apt-get install cmake
-    if [[ "$(lsb_release -cs)" == 'focal' ]]; then
-        # In Ubuntu 20.04 python-pip does not exist. Furthermore we need to have the alias python for python3
-        sudo apt-get install zlib1g-dev libssh-dev python3-pip python-is-python3 libxml2-utils
-    else
-        sudo apt-get install zlib1g-dev libssh-dev python-pip libxml2-utils
-    fi
-
+    sudo apt-get install cmake zlib1g-dev libssh-dev python3-pip libxml2-utils
+    
     if [ -n "$WITH_VALGRIND" ]; then
         sudo apt-get install valgrind
     fi
-    sudo pip install virtualenv
+    sudo pip3 install virtualenv
     virtualenv conan
     source conan/bin/activate
     pip install conan==1.30.2

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -32,7 +32,11 @@
 namespace Exiv2
 {
     EXIV2API bool enableBMFF(bool enable = true);
+}
 
+#ifdef EXV_ENABLE_BMFF
+namespace Exiv2
+{
     struct Iloc
     {
         Iloc(uint32_t ID = 0, uint32_t start = 0, uint32_t length = 0) : ID_(ID), start_(start), length_(length){};
@@ -168,3 +172,4 @@ namespace Exiv2
     //! Check if the file iIo is a BMFF image.
     EXIV2API bool isBmffType(BasicIo& iIo, bool advance);
 }  // namespace Exiv2
+#endif // EXV_ENABLE_BMFF

--- a/include/exiv2/exiv2.hpp
+++ b/include/exiv2/exiv2.hpp
@@ -45,9 +45,7 @@
 #include "exiv2/mrwimage.hpp"
 #include "exiv2/orfimage.hpp"
 #include "exiv2/pgfimage.hpp"
-#ifdef EXV_ENABLE_BMFF
 #include "bmffimage.hpp"
-#endif
 
 #ifdef EXV_HAVE_LIBZ
 #include "exiv2/pngimage.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,11 +118,9 @@ if( EXIV2_ENABLE_VIDEO )
     )
 endif()
 
-if( EXIV2_ENABLE_BMFF )
-    target_sources(exiv2lib PRIVATE
-        bmffimage.cpp           ../include/exiv2/bmffimage.hpp
-    )
-endif()
+target_sources(exiv2lib PRIVATE
+    bmffimage.cpp           ../include/exiv2/bmffimage.hpp
+)
 
 # Other library target properties
 # ---------------------------------------------------------

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -84,18 +84,15 @@ struct BmffBoxHeader
 
 // *****************************************************************************
 // class member definitions
+#ifdef EXV_ENABLE_BMFF
 namespace Exiv2
 {
-    static bool enabled = false;
-
-#ifdef EXV_ENABLE_BMFF
+    static bool   enabled = false;
     EXIV2API bool enableBMFF(bool enable)
     {
-        bool   result = enabled;
-        enabled       = enable ;
-        return result ;
+        enabled = enable ;
+        return true ;
     }
-#endif                   // EXV_ENABLE_BMFF
 
     std::string Iloc::toString() const
     {
@@ -629,3 +626,13 @@ namespace Exiv2
         return matched;
     }
 }  // namespace Exiv2
+#else  // ifdef EXV_ENABLE_BMFF
+namespace Exiv2
+{
+    EXIV2API bool enableBMFF(bool)
+    {
+        return false ;
+    }
+}
+#endif
+


### PR DESCRIPTION
We agreed on Element/ChatServer that if we made a release Exiv2 v0.27.4 RC3, we would include the API Exiv2::enableBMFF() in the library, even when EXV_ENABLE_BMFF is not set.