### PR TITLE
Clean wdeprecated-copy warnings and others

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -61,6 +61,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
         endif()
 
         add_compile_options(-Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W)
+        add_compile_options(-Wno-error=format-nonliteral)
 
         # This seems to be causing issues in the Fedora_MinGW GitLab job
         #add_compile_options(-fasynchronous-unwind-tables)

--- a/cmake/compilerFlagsExiv2.cmake
+++ b/cmake/compilerFlagsExiv2.cmake
@@ -5,9 +5,9 @@ include(CheckCXXCompilerFlag)
 if (COMPILER_IS_GCC OR COMPILER_IS_CLANG) # MINGW, Linux, APPLE, CYGWIN
     if ( EXIV2_TEAM_WARNINGS_AS_ERRORS )
         add_compile_options(-Werror)
-        check_cxx_compiler_flag(-Wno-error=deprecated-copy DEPRECATED_COPY)
+        check_cxx_compiler_flag(-Wdeprecated-copy DEPRECATED_COPY)
         if ( DEPRECATED_COPY) 
-            add_compile_options(-Wno-error=deprecated-copy)
+            add_compile_options(-Wdeprecated-copy)
         endif ()
     endif ()
 

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -49,7 +49,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Destructor
-        virtual ~Key();
+        virtual ~Key() = default;
         //@}
 
         //! @name Accessors

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -58,7 +58,7 @@ namespace Exiv2 {
         //! Constructor, taking a type id to initialize the base class with
         explicit Value(TypeId typeId);
         //! Virtual destructor.
-        virtual ~Value();
+        virtual ~Value() = default;
         //@}
         //! @name Manipulators
         //@{
@@ -231,7 +231,7 @@ namespace Exiv2 {
           @brief Assignment operator. Protected so that it can only be used
                  by subclasses but not directly.
          */
-        Value& operator=(const Value& rhs);
+        Value& operator=(const Value& rhs) = default;
         // DATA
         mutable bool ok_;                //!< Indicates the status of the previous to<Type> conversion
 
@@ -696,7 +696,7 @@ namespace Exiv2 {
           @brief Assignment operator. Protected so that it can only be used
                  by subclasses but not directly.
          */
-        XmpValue& operator=(const XmpValue& rhs);
+        XmpValue& operator=(const XmpValue& rhs) = default;
 
     private:
         // DATA
@@ -1320,7 +1320,7 @@ namespace Exiv2 {
         virtual ValueType<T>* clone_() const;
 
         // DATA
-        //! Pointer to the buffer, 0 if none has been allocated
+        //! Pointer to the buffer, nullptr if none has been allocated
         byte* pDataArea_;
         //! The current size of the buffer
         long sizeDataArea_;
@@ -1495,33 +1495,33 @@ namespace Exiv2 {
 
     template<typename T>
     ValueType<T>::ValueType()
-        : Value(getType<T>()), pDataArea_(0), sizeDataArea_(0)
+        : Value(getType<T>()), pDataArea_(nullptr), sizeDataArea_(0)
     {
     }
 
     template<typename T>
     ValueType<T>::ValueType(TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
     }
 
     template<typename T>
     ValueType<T>::ValueType(const byte* buf, long len, ByteOrder byteOrder, TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
         read(buf, len, byteOrder);
     }
 
     template<typename T>
     ValueType<T>::ValueType(const T& val, TypeId typeId)
-        : Value(typeId), pDataArea_(0), sizeDataArea_(0)
+        : Value(typeId), pDataArea_(nullptr), sizeDataArea_(0)
     {
         value_.push_back(val);
     }
 
     template<typename T>
     ValueType<T>::ValueType(const ValueType<T>& rhs)
-        : Value(rhs)
+        : Value(rhs.typeId())
         , value_(rhs.value_)
         , pDataArea_(nullptr)
         , sizeDataArea_(0)

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -184,14 +184,6 @@ public:
     { }
 
     virtual ~Position() {}
-//  copy constructor
-    Position(const Position& o) :
-        time_(o.time_)
-      , lon_(o.lon_)
-      , lat_(o.lat_)
-      , ele_(o.ele_)
-      , delta_(o.delta_)
-    {}
 
 //  instance methods
     bool good()                 { return time_ || lon_ || lat_ || ele_ ; }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,7 +133,7 @@ set_target_properties( exiv2lib_int PROPERTIES
 )
 
 target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
-target_include_directories(exiv2lib PRIVATE 
+target_include_directories(exiv2lib SYSTEM PRIVATE 
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
     ${ZLIB_INCLUDE_DIR}
 )

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -344,13 +344,13 @@ namespace Action {
             std::cout << _("None");
         }
         else {
-            Exiv2::DataBuf buf = exifThumb.copy();
-            if (buf.size_ == 0) {
+            auto dataBuf = exifThumb.copy();
+            if (dataBuf.size_ == 0) {
                 std::cout << _("None");
             }
             else {
                 std::cout << exifThumb.mimeType() << ", "
-                          << buf.size_ << " " << _("Bytes");
+                          << dataBuf.size_ << " " << _("Bytes");
             }
         }
         std::cout << std::endl;

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -189,7 +189,7 @@ namespace Exiv2
     long BmffImage::boxHandler(std::ostream& out /* = std::cout*/ , Exiv2::PrintStructureOption option /* = kpsNone */,int depth /* =0 */)
     {
         long result  = (long)io_->size();
-        long address = io_->tell();
+        long address = (long)io_->tell();
         // never visit a box twice!
         if ( depth == 0 ) visits_.clear();
         if (visits_.find(address) != visits_.end() || visits_.size() > visits_max_) {

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -189,7 +189,7 @@ namespace Exiv2
     long BmffImage::boxHandler(std::ostream& out /* = std::cout*/ , Exiv2::PrintStructureOption option /* = kpsNone */,int depth /* =0 */)
     {
         long result  = (long)io_->size();
-        long address = (long)io_->tell();
+        long address = io_->tell();
         // never visit a box twice!
         if ( depth == 0 ) visits_.clear();
         if (visits_.find(address) != visits_.end() || visits_.size() > visits_max_) {
@@ -299,7 +299,7 @@ namespace Exiv2
                     bLF = false;
                 }
                 io_->seek(skip, BasicIo::cur);
-                while ((long)io_->tell() < (long)(address + box.length)) {
+                while (io_->tell() < (address + box.length)) {
                     io_->seek(boxHandler(out,option,depth + 1), BasicIo::beg);
                 }
                 // post-process meta box to recover Exif and XMP
@@ -372,9 +372,9 @@ namespace Exiv2
 
             case TAG_ispe: {
                 skip += 4;
-                int width = (int)getLong(data.pData_ + skip, endian_);
+                int width = getLong(data.pData_ + skip, endian_);
                 skip += 4;
-                int height = (int)getLong(data.pData_ + skip, endian_);
+                int height = getLong(data.pData_ + skip, endian_);
                 skip += 4;
                 if ( bTrace ) {
                     out << "pixelWidth_, pixelHeight_ = " << Internal::stringFormat("%d, %d", width, height);
@@ -417,7 +417,7 @@ namespace Exiv2
                     bLF = false;
                 }
                 if (name == "cano") {
-                    while ((long)io_->tell() < (long)(address + box.length)) {
+                    while (io_->tell() < (address + box.length)) {
                         io_->seek(boxHandler(out,option,depth + 1), BasicIo::beg);
                     }
                 } else if ( name == "xmp" ) {
@@ -449,7 +449,7 @@ namespace Exiv2
         if ( bLF&& bTrace) out << std::endl;
 
         // return address of next box
-        result = static_cast<long>(address + box.length);
+        result = (address + box.length);
 
         return result;
     }

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2730,7 +2730,7 @@ namespace Exiv2 {
         ExifData::const_iterator pos = metadata->findKey(key);
         if (pos != metadata->end() && pos->value().count() >= 3 && pos->value().typeId() == unsignedShort) {
             float fu = pos->value().toFloat(2);
-            if (fu != 0.0) {
+            if (fu != 0.0f) {
                 float fl = value.toFloat(1) / fu;
                 std::ostringstream oss;
                 oss.copyfmt(os);
@@ -2845,8 +2845,7 @@ namespace Exiv2 {
     }
 
     //! convertFocalLength to a human readable string
-    void convertFocalLength(LensTypeAndFocalLengthAndMaxAperture& ltfl,
-                            double divisor)
+    void convertFocalLength(LensTypeAndFocalLengthAndMaxAperture& ltfl, float divisor)
     {
         std::ostringstream oss;
         oss << std::fixed << std::setprecision(0);
@@ -2870,8 +2869,9 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0) return os << value;
-        convertFocalLength(ltfl, 1.0);
+        if (ltfl.focalLengthMax_ == 0.0f)
+            return os << value;
+        convertFocalLength(ltfl, 1.0f);
 
         ExifKey key("Exif.CanonCs.MaxAperture");
         ExifData::const_iterator pos = metadata->findKey(key);
@@ -2907,8 +2907,9 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0) return os << value;
-        convertFocalLength(ltfl, 1.0);
+        if (ltfl.focalLengthMax_ == 0.0f)
+            return os << value;
+        convertFocalLength(ltfl, 1.0f);
 
         if (ltfl.focalLength_.empty()) return os << value;
 
@@ -2929,14 +2930,15 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0) return os << value;
-        convertFocalLength(ltfl, 1.0); // just lens
+        if (ltfl.focalLengthMax_ == 0.0f)
+            return os << value;
+        convertFocalLength(ltfl, 1.0f);  // just lens
         const TagDetails* td = find(canonCsLensType, ltfl);
         if (!td) {
-            convertFocalLength(ltfl, 1.4); // lens + 1.4x TC
+            convertFocalLength(ltfl, 1.4f); // lens + 1.4x TC
             td = find(canonCsLensType, ltfl);
             if (!td) {
-                convertFocalLength(ltfl, 2.0); // lens + 2x TC
+                convertFocalLength(ltfl, 2.0f); // lens + 2x TC
                 td = find(canonCsLensType, ltfl);
                 if (!td) return os << value;
             }
@@ -2983,7 +2985,8 @@ namespace Exiv2 {
         }
 
         float fu = value.toFloat(2);
-        if (fu == 0.0) return os << value;
+        if (fu == 0.0f)
+            return os << value;
         float len1 = value.toLong(0) / fu;
         float len2 = value.toLong(1) / fu;
         std::ostringstream oss;
@@ -3006,7 +3009,7 @@ namespace Exiv2 {
         std::ios::fmtflags f( os.flags() );
         if (   value.typeId() == unsignedShort
             && value.count() > 0) {
-            os << exp(canonEv(value.toLong()) / 32 * log(2.0)) * 100.0;
+            os << std::exp(canonEv(value.toLong()) / 32 * std::log(2.0f)) * 100.0f;
         }
         os.flags(f);
         return os;
@@ -3020,7 +3023,7 @@ namespace Exiv2 {
         if (   value.typeId() == unsignedShort
             && value.count() > 0) {
             // Ported from Exiftool by Will Stokes
-            os << exp(canonEv(value.toLong()) * log(2.0)) * 100.0 / 32.0;
+            os << std::exp(canonEv(value.toLong()) * std::log(2.0f)) * 100.0f / 32.0f;
         }
         os.flags(f);
         return os;

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -598,7 +598,9 @@ namespace Exiv2 {
     }
 
     IptcKey::IptcKey(const IptcKey& rhs)
-        : Key(rhs), tag_(rhs.tag_), record_(rhs.record_), key_(rhs.key_)
+        : tag_(rhs.tag_)
+        , record_(rhs.record_)
+        , key_(rhs.key_)
     {
     }
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -63,22 +63,22 @@ namespace {
 
     /*!
       @brief Parse the oparg string into a bitmap of common targets.
-      @param optarg Option arguments
+      @param optArg Option arguments
       @param action Action being processed
       @return A bitmap of common targets or -1 in case of a parse error
      */
-    int parseCommonTargets(const std::string& optarg,
+    int parseCommonTargets(const std::string& optArg,
                            const std::string& action);
 
     /*!
       @brief Parse numbers separated by commas into container
       @param previewNumbers Container for the numbers
-      @param optarg Option arguments
-      @param j Starting index into optarg
+      @param optArg Option arguments
+      @param j Starting index into optArg
       @return Number of characters processed
      */
     int parsePreviewNumbers(Params::PreviewNumbers& previewNumbers,
-                            const std::string& optarg,
+                            const std::string& optArg,
                             int j);
 
     /*!
@@ -370,7 +370,7 @@ void Params::help(std::ostream& os) const
        << _("   -S .suf Use suffix .suf for source files for insert command.\n\n");
 } // Params::help
 
-int Params::option(int opt, const std::string& optarg, int optopt)
+int Params::option(int opt, const std::string& optArg, int optOpt)
 {
     int rc = 0;
     switch (opt) {
@@ -378,41 +378,41 @@ int Params::option(int opt, const std::string& optarg, int optopt)
     case 'V': version_ = true; break;
     case 'v': verbose_ = true; break;
     case 'q': Exiv2::LogMsg::setLevel(Exiv2::LogMsg::mute); break;
-    case 'Q': rc = setLogLevel(optarg); break;
+    case 'Q': rc = setLogLevel(optArg); break;
     case 'k': preserve_ = true; break;
     case 'b': binary_ = true; break;
     case 'u': unknown_ = false; break;
     case 'f': force_ = true; fileExistsPolicy_ = overwritePolicy; break;
     case 'F': force_ = true; fileExistsPolicy_ = renamePolicy; break;
-    case 'g': rc = evalGrep(optarg); break;
-    case 'K': rc = evalKey(optarg); printMode_ = pmList; break;
-    case 'n': charset_ = optarg; break;
-    case 'r': rc = evalRename(opt, optarg); break;
-    case 't': rc = evalRename(opt, optarg); break;
-    case 'T': rc = evalRename(opt, optarg); break;
-    case 'a': rc = evalAdjust(optarg); break;
-    case 'Y': rc = evalYodAdjust(yodYear, optarg); break;
-    case 'O': rc = evalYodAdjust(yodMonth, optarg); break;
-    case 'D': rc = evalYodAdjust(yodDay, optarg); break;
-    case 'p': rc = evalPrint(optarg); break;
-    case 'P': rc = evalPrintFlags(optarg); break;
-    case 'd': rc = evalDelete(optarg); break;
-    case 'e': rc = evalExtract(optarg); break;
-    case 'C': rc = evalExtract(optarg); break;
-    case 'i': rc = evalInsert(optarg); break;
-    case 'c': rc = evalModify(opt, optarg); break;
-    case 'm': rc = evalModify(opt, optarg); break;
-    case 'M': rc = evalModify(opt, optarg); break;
-    case 'l': directory_ = optarg; break;
-    case 'S': suffix_ = optarg; break;
+    case 'g': rc = evalGrep(optArg); break;
+    case 'K': rc = evalKey(optArg); printMode_ = pmList; break;
+    case 'n': charset_ = optArg; break;
+    case 'r': rc = evalRename(opt, optArg); break;
+    case 't': rc = evalRename(opt, optArg); break;
+    case 'T': rc = evalRename(opt, optArg); break;
+    case 'a': rc = evalAdjust(optArg); break;
+    case 'Y': rc = evalYodAdjust(yodYear, optArg); break;
+    case 'O': rc = evalYodAdjust(yodMonth, optArg); break;
+    case 'D': rc = evalYodAdjust(yodDay, optArg); break;
+    case 'p': rc = evalPrint(optArg); break;
+    case 'P': rc = evalPrintFlags(optArg); break;
+    case 'd': rc = evalDelete(optArg); break;
+    case 'e': rc = evalExtract(optArg); break;
+    case 'C': rc = evalExtract(optArg); break;
+    case 'i': rc = evalInsert(optArg); break;
+    case 'c': rc = evalModify(opt, optArg); break;
+    case 'm': rc = evalModify(opt, optArg); break;
+    case 'M': rc = evalModify(opt, optArg); break;
+    case 'l': directory_ = optArg; break;
+    case 'S': suffix_ = optArg; break;
     case ':':
-        std::cerr << progname() << ": " << _("Option") << " -" << static_cast<char>(optopt)
+        std::cerr << progname() << ": " << _("Option") << " -" << static_cast<char>(optOpt)
                    << " " << _("requires an argument\n");
         rc = 1;
         break;
     case '?':
         std::cerr << progname() << ": " << _("Unrecognized option") << " -"
-                  << static_cast<char>(optopt) << "\n";
+                  << static_cast<char>(optOpt) << "\n";
         rc = 1;
         break;
     default:
@@ -425,10 +425,10 @@ int Params::option(int opt, const std::string& optarg, int optopt)
     return rc;
 } // Params::option
 
-int Params::setLogLevel(const std::string& optarg)
+int Params::setLogLevel(const std::string& optArg)
 {
     int rc = 0;
-    const char logLevel = tolower(optarg[0]);
+    const char logLevel = tolower(optArg[0]);
     switch (logLevel) {
     case 'd': Exiv2::LogMsg::setLevel(Exiv2::LogMsg::debug); break;
     case 'i': Exiv2::LogMsg::setLevel(Exiv2::LogMsg::info); break;
@@ -437,7 +437,7 @@ int Params::setLogLevel(const std::string& optarg)
     case 'm': Exiv2::LogMsg::setLevel(Exiv2::LogMsg::mute); break;
     default:
         std::cerr << progname() << ": " << _("Option") << " -Q: "
-                  << _("Invalid argument") << " \"" << optarg << "\"\n";
+                  << _("Invalid argument") << " \"" << optArg << "\"\n";
         rc = 1;
         break;
     }
@@ -453,12 +453,12 @@ static inline bool ends_with(std::string const & value, std::string const & endi
     return bResult ;
 }
 
-int Params::evalGrep( const std::string& optarg)
+int Params::evalGrep( const std::string& optArg)
 {
     int result=0;
     std::string pattern;
     std::string ignoreCase("/i");
-    bool bIgnoreCase = ends_with(optarg,ignoreCase,pattern);
+    bool bIgnoreCase = ends_with(optArg,ignoreCase,pattern);
 #if defined(EXV_HAVE_REGEX_H)
     // try to compile a reg-exp from the input argument and store it in the vector
     const size_t i = greps_.size();
@@ -473,7 +473,7 @@ int Params::evalGrep( const std::string& optarg)
         regerror (errcode, pRegex, buffer, length);
         std::cerr << progname()
               << ": " << _("Option") << " -g: "
-              << _("Invalid regexp") << " \"" << optarg << "\": " << buffer << "\n";
+              << _("Invalid regexp") << " \"" << optArg << "\": " << buffer << "\n";
 
         // free the memory and drop the regexp
         delete[] buffer;
@@ -487,14 +487,14 @@ int Params::evalGrep( const std::string& optarg)
     return result;
 } // Params::evalGrep
 
-int Params::evalKey( const std::string& optarg)
+int Params::evalKey( const std::string& optArg)
 {
     int result=0;
-    keys_.push_back(optarg);
+    keys_.push_back(optArg);
     return result;
 } // Params::evalKey
 
-int Params::evalRename(int opt, const std::string& optarg)
+int Params::evalRename(int opt, const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -502,7 +502,7 @@ int Params::evalRename(int opt, const std::string& optarg)
         action_ = Action::rename;
         switch (opt) {
         case 'r':
-            format_ = optarg;
+            format_ = optArg;
             formatSet_ = true;
             break;
         case 't': timestamp_ = true; break;
@@ -512,10 +512,10 @@ int Params::evalRename(int opt, const std::string& optarg)
     case Action::rename:
         if (opt == 'r' && (formatSet_ || timestampOnly_)) {
             std::cerr << progname()
-                      << ": " << _("Ignoring surplus option") << " -r \"" << optarg << "\"\n";
+                      << ": " << _("Ignoring surplus option") << " -r \"" << optArg << "\"\n";
         }
         else {
-            format_ = optarg;
+            format_ = optArg;
             formatSet_ = true;
         }
         break;
@@ -529,7 +529,7 @@ int Params::evalRename(int opt, const std::string& optarg)
     return rc;
 } // Params::evalRename
 
-int Params::evalAdjust(const std::string& optarg)
+int Params::evalAdjust(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -537,14 +537,14 @@ int Params::evalAdjust(const std::string& optarg)
     case Action::adjust:
         if (adjust_) {
             std::cerr << progname()
-                      << ": " << _("Ignoring surplus option -a")  << " " << optarg << "\n";
+                      << ": " << _("Ignoring surplus option -a")  << " " << optArg << "\n";
             break;
         }
         action_ = Action::adjust;
-        adjust_ = parseTime(optarg, adjustment_);
+        adjust_ = parseTime(optArg, adjustment_);
         if (!adjust_) {
             std::cerr << progname() << ": " << _("Error parsing -a option argument") << " `"
-                      << optarg << "'\n";
+                      << optArg << "'\n";
             rc = 1;
         }
         break;
@@ -557,7 +557,7 @@ int Params::evalAdjust(const std::string& optarg)
     return rc;
 } // Params::evalAdjust
 
-int Params::evalYodAdjust(const Yod& yod, const std::string& optarg)
+int Params::evalYodAdjust(const Yod& yod, const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -566,15 +566,15 @@ int Params::evalYodAdjust(const Yod& yod, const std::string& optarg)
         if (yodAdjust_[yod].flag_) {
             std::cerr << progname()
                       << ": " << _("Ignoring surplus option") << " "
-                      << yodAdjust_[yod].option_ << " " << optarg << "\n";
+                      << yodAdjust_[yod].option_ << " " << optArg << "\n";
             break;
         }
         action_ = Action::adjust;
         yodAdjust_[yod].flag_ = true;
-        if (!Util::strtol(optarg.c_str(), yodAdjust_[yod].adjustment_)) {
+        if (!Util::strtol(optArg.c_str(), yodAdjust_[yod].adjustment_)) {
             std::cerr << progname() << ": " << _("Error parsing") << " "
                       << yodAdjust_[yod].option_ << " "
-                      << _("option argument") << " `" << optarg << "'\n";
+                      << _("option argument") << " `" << optArg << "'\n";
             rc = 1;
         }
         break;
@@ -589,12 +589,12 @@ int Params::evalYodAdjust(const Yod& yod, const std::string& optarg)
     return rc;
 } // Params::evalYodAdjust
 
-int Params::evalPrint(const std::string& optarg)
+int Params::evalPrint(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
         case Action::none:
-            switch (optarg[0]) {
+            switch (optArg[0]) {
                 case 's':
                     action_ = Action::print;
                     printMode_ = pmSummary;
@@ -635,7 +635,7 @@ int Params::evalPrint(const std::string& optarg)
                 case 'R':
                 #ifdef NDEBUG
                     std::cerr << progname() << ": " << _("Action not available in Release mode")
-                              << ": '" << optarg << "'\n";
+                              << ": '" << optArg << "'\n";
                     rc = 1;
                 #else
                     action_ = Action::print;
@@ -651,13 +651,13 @@ int Params::evalPrint(const std::string& optarg)
                     printMode_ = pmXMP;
                     break;
                 default:
-                    std::cerr << progname() << ": " << _("Unrecognized print mode") << " `" << optarg << "'\n";
+                    std::cerr << progname() << ": " << _("Unrecognized print mode") << " `" << optArg << "'\n";
                     rc = 1;
                     break;
             }
             break;
         case Action::print:
-            std::cerr << progname() << ": " << _("Ignoring surplus option -p") << optarg << "\n";
+            std::cerr << progname() << ": " << _("Ignoring surplus option -p") << optArg << "\n";
             break;
         default:
             std::cerr << progname() << ": " << _("Option -p is not compatible with a previous option\n");
@@ -667,15 +667,15 @@ int Params::evalPrint(const std::string& optarg)
     return rc;
 }  // Params::evalPrint
 
-int Params::evalPrintFlags(const std::string& optarg)
+int Params::evalPrintFlags(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
     case Action::none:
         action_ = Action::print;
         printMode_ = pmList;
-        for (std::size_t i = 0; i < optarg.length(); ++i) {
-            switch (optarg[i]) {
+        for (std::size_t i = 0; i < optArg.length(); ++i) {
+            switch (optArg[i]) {
             case 'E': printTags_  |= Exiv2::mdExif; break;
             case 'I': printTags_  |= Exiv2::mdIptc; break;
             case 'X': printTags_  |= Exiv2::mdXmp;  break;
@@ -693,7 +693,7 @@ int Params::evalPrintFlags(const std::string& optarg)
             case 'V': printItems_ |= prSet|prValue;break;
             default:
                 std::cerr << progname() << ": " << _("Unrecognized print item") << " `"
-                          << optarg[i] << "'\n";
+                          << optArg[i] << "'\n";
                 rc = 1;
                 break;
             }
@@ -701,7 +701,7 @@ int Params::evalPrintFlags(const std::string& optarg)
         break;
     case Action::print:
         std::cerr << progname() << ": "
-                  << _("Ignoring surplus option -P") << optarg << "\n";
+                  << _("Ignoring surplus option -P") << optArg << "\n";
         break;
     default:
         std::cerr << progname() << ": "
@@ -712,7 +712,7 @@ int Params::evalPrintFlags(const std::string& optarg)
     return rc;
 } // Params::evalPrintFlags
 
-int Params::evalDelete(const std::string& optarg)
+int Params::evalDelete(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -721,7 +721,7 @@ int Params::evalDelete(const std::string& optarg)
         target_ = 0;
         // fallthrough
     case Action::erase:
-        rc = parseCommonTargets(optarg, "erase");
+        rc = parseCommonTargets(optArg, "erase");
         if (rc > 0) {
             target_ |= rc;
             rc = 0;
@@ -739,7 +739,7 @@ int Params::evalDelete(const std::string& optarg)
     return rc;
 } // Params::evalDelete
 
-int Params::evalExtract(const std::string& optarg)
+int Params::evalExtract(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -749,7 +749,7 @@ int Params::evalExtract(const std::string& optarg)
         target_ = 0;
         // fallthrough
     case Action::extract:
-        rc = parseCommonTargets(optarg, "extract");
+        rc = parseCommonTargets(optArg, "extract");
         if (rc > 0) {
             target_ |= rc;
             rc = 0;
@@ -767,7 +767,7 @@ int Params::evalExtract(const std::string& optarg)
     return rc;
 } // Params::evalExtract
 
-int Params::evalInsert(const std::string& optarg)
+int Params::evalInsert(const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -777,7 +777,7 @@ int Params::evalInsert(const std::string& optarg)
         target_ = 0;
         // fallthrough
     case Action::insert:
-        rc = parseCommonTargets(optarg, "insert");
+        rc = parseCommonTargets(optArg, "insert");
         if (rc > 0) {
             target_ |= rc;
             rc = 0;
@@ -795,7 +795,7 @@ int Params::evalInsert(const std::string& optarg)
     return rc;
 } // Params::evalInsert
 
-int Params::evalModify(int opt, const std::string& optarg)
+int Params::evalModify(int opt, const std::string& optArg)
 {
     int rc = 0;
     switch (action_) {
@@ -805,9 +805,9 @@ int Params::evalModify(int opt, const std::string& optarg)
     case Action::modify:
     case Action::extract:
     case Action::insert:
-        if (opt == 'c') jpegComment_ = parseEscapes(optarg);
-        if (opt == 'm') cmdFiles_.push_back(optarg);  // parse the files later
-        if (opt == 'M') cmdLines_.push_back(optarg);  // parse the commands later
+        if (opt == 'c') jpegComment_ = parseEscapes(optArg);
+        if (opt == 'm') cmdFiles_.push_back(optArg);  // parse the files later
+        if (opt == 'M') cmdLines_.push_back(optArg);  // parse the commands later
         break;
     default:
         std::cerr << progname() << ": "
@@ -1177,14 +1177,14 @@ namespace {
                   << action << " " << _("target") << " `"  << argc << "'\n";
     }
 
-    int parseCommonTargets(const std::string& optarg, const std::string& action)
+    int parseCommonTargets(const std::string& optArg, const std::string& action)
     {
         int rc = 0;
         int target = 0;
         int all = Params::ctExif | Params::ctIptc | Params::ctComment | Params::ctXmp;
         int extra = Params::ctXmpSidecar | Params::ctExif | Params::ctIptc | Params::ctXmp;
-        for (size_t i = 0; rc == 0 && i < optarg.size(); ++i) {
-            switch (optarg[i]) {
+        for (size_t i = 0; rc == 0 && i < optArg.size(); ++i) {
+            switch (optArg[i]) {
                 case 'e':
                     target |= Params::ctExif;
                     break;
@@ -1222,16 +1222,16 @@ namespace {
 
                 case 'p': {
                     if (strcmp(action.c_str(), "extract") == 0) {
-                        i += (size_t)parsePreviewNumbers(Params::instance().previewNumbers_, optarg, (int)i + 1);
+                        i += (size_t)parsePreviewNumbers(Params::instance().previewNumbers_, optArg, (int)i + 1);
                         target |= Params::ctPreview;
                         break;
                     }
-                    printUnrecognizedArgument(optarg[i], action);
+                    printUnrecognizedArgument(optArg[i], action);
                     rc = -1;
                     break;
                 }
                 default:
-                    printUnrecognizedArgument(optarg[i], action);
+                    printUnrecognizedArgument(optArg[i], action);
                     rc = -1;
                     break;
             }
@@ -1240,14 +1240,14 @@ namespace {
     }
 
     int parsePreviewNumbers(Params::PreviewNumbers& previewNumbers,
-                            const std::string& optarg,
+                            const std::string& optArg,
                             int j)
     {
         size_t k = j;
-        for (size_t i = j; i < optarg.size(); ++i) {
+        for (size_t i = j; i < optArg.size(); ++i) {
             std::ostringstream os;
-            for (k = i; k < optarg.size() && isdigit(optarg[k]); ++k) {
-                os << optarg[k];
+            for (k = i; k < optArg.size() && isdigit(optArg[k]); ++k) {
+                os << optArg[k];
             }
             if (k > i) {
                 bool ok = false;
@@ -1261,7 +1261,7 @@ namespace {
                 }
                 i = k;
             }
-            if (!(k < optarg.size() && optarg[i] == ',')) break;
+            if (!(k < optArg.size() && optArg[i] == ',')) break;
         }
         int ret = static_cast<int>(k - j);
         if (ret == 0) {

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -137,8 +137,7 @@ static int forgive(int n,int& err)
     return n ;
 }
 
-static int error(std::string& errors, const char* msg, const char* x = NULL, const char* y = NULL, int z = 0);
-static int error(std::string& errors, const char* msg, const char* x, const char* y, int z)
+static int error(std::string& errors, const char* msg, const char* x = NULL, const char* y = NULL, int z = 0)
 {
     static const size_t buffer_size = 512;
     char buffer[buffer_size];
@@ -253,8 +252,9 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 
     ////////////////////////////////////
     // open the socket
-    int     sockfd = (int) socket(AF_INET , SOCK_STREAM,IPPROTO_TCP) ;
-    if (    sockfd < 0 ) return error(errors, "unable to create socket\n",NULL,NULL,0) ;
+    int     sockfd = socket(AF_INET , SOCK_STREAM,IPPROTO_TCP) ;
+    if (sockfd < 0)
+        return error(errors, "unable to create socket\n", NULL, NULL, 0);
 
     // connect the socket to the server
     int     server  = -1 ;
@@ -273,8 +273,9 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
     if (serv_addr.sin_addr.s_addr == (unsigned long)INADDR_NONE)
     {
         struct hostent* host = gethostbyname(servername_p);
-        if ( !host )  return error(errors, "no such host", servername_p);
-        memcpy(&serv_addr.sin_addr,host->h_addr,sizeof(serv_addr.sin_addr));
+        if (!host)
+            return error(errors, "no such host", servername_p);
+        memcpy(&serv_addr.sin_addr, host->h_addr, sizeof(serv_addr.sin_addr));
     }
 
     makeNonBlocking(sockfd) ;
@@ -283,7 +284,8 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
     // and connect
     server = connect(sockfd, (const struct sockaddr *) &serv_addr, serv_len) ;
     if ( server == SOCKET_ERROR && WSAGetLastError() != WSAEWOULDBLOCK )
-        return error(errors,"error - unable to connect to server = %s port = %s wsa_error = %d",servername_p,port_p,WSAGetLastError());
+        return error(errors, "error - unable to connect to server = %s port = %s wsa_error = %d", servername_p, port_p,
+                     WSAGetLastError());
 
     char   buffer[32*1024+1];
     size_t buff_l= sizeof buffer - 1 ;
@@ -303,7 +305,8 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
     }
 
     if ( sleep_ < 0 )
-        return error(errors,"error - timeout connecting to server = %s port = %s wsa_error = %d",servername,port,WSAGetLastError());
+        return error(errors, "error - timeout connecting to server = %s port = %s wsa_error = %d", servername, port,
+                     WSAGetLastError());
 
     int    end   = 0         ; // write position in buffer
     bool   bSearching = true ; // looking for headers in the response
@@ -398,7 +401,8 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
         //  we finished OK without finding headers, flush the buffer
             flushBuffer(buffer,0,end,file) ;
         } else {
-            return error(errors,"error - no response from server = %s port = %s wsa_error = %d",servername,port,WSAGetLastError());
+            return error(errors, "error - no response from server = %s port = %s wsa_error = %d", servername, port,
+                         WSAGetLastError());
         }
     }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -449,7 +449,7 @@ namespace Exiv2 {
                     if ( option == kpsRecursive && (tag == 0x8769 /* ExifTag */ || tag == 0x014a/*SubIFDs*/  || type == tiffIfd) ) {
                         for ( size_t k = 0 ; k < count ; k++ ) {
                             size_t   restore = io.tell();
-                            uint32_t offset = byteSwap4(buf,k*size,bSwap);
+                            offset = byteSwap4(buf,k*size,bSwap);
                             printIFDStructure(io,out,option,offset,bSwap,c,depth);
                             io.seek(restore,BasicIo::beg);
                         }
@@ -479,11 +479,11 @@ namespace Exiv2 {
                         bytes[jump]=0               ;
                         if ( ::strcmp("Nikon",chars) == 0 ) {
                             // tag is an embedded tiff
-                            byte* bytes=new byte[count-jump] ;  // allocate memory
-                            io.read(bytes,count-jump)        ;  // read
-                            MemIo memIo(bytes,count-jump)    ;  // create a file
+                            byte* bytes2=new byte[count-jump] ;  // allocate memory
+                            io.read(bytes2,count-jump)        ;  // read
+                            MemIo memIo(bytes2,count-jump)    ;  // create a file
                             printTiffStructure(memIo,out,option,depth);
-                            delete[] bytes                   ;  // free
+                            delete[] bytes2                   ;  // free
                         } else {
                             // tag is an IFD
                             io.seek(0,BasicIo::beg);  // position

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -61,10 +61,10 @@ namespace Exiv2
         {
             std::stringstream hexOutput;
 
-            unsigned long tl = ((size / 16) * 16);
-            unsigned long tl_offset = (size - tl);
+            unsigned long tl = (unsigned long)((size / 16) * 16);
+            unsigned long tl_offset = (unsigned long)(size - tl);
 
-            for (unsigned long loop = 0; loop < size; loop++) {
+            for (unsigned long loop = 0; loop < (unsigned long)size; loop++) {
                 if (data[loop] < 16) {
                     hexOutput << "0";
                 }

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -61,10 +61,10 @@ namespace Exiv2
         {
             std::stringstream hexOutput;
 
-            unsigned long tl = (unsigned long)((size / 16) * 16);
-            unsigned long tl_offset = (unsigned long)(size - tl);
+            unsigned long tl = ((size / 16) * 16);
+            unsigned long tl_offset = (size - tl);
 
-            for (unsigned long loop = 0; loop < (unsigned long)size; loop++) {
+            for (unsigned long loop = 0; loop < size; loop++) {
                 if (data[loop] < 16) {
                     hexOutput << "0";
                 }

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -81,7 +81,7 @@ namespace Exiv2 {
     template <typename T>
     struct binaryToStringHelper
     {
-        explicit binaryToStringHelper(const Slice<T> buf) throw() : buf_(buf)
+        explicit binaryToStringHelper(const Slice<T> myBuf) throw() : buf_(myBuf)
         {
         }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -501,7 +501,7 @@ static void boxes_check(size_t b,size_t m)
                 enforce(box.length <= io_->size()-io_->tell() , Exiv2::kerCorruptedMetadata);
 
                 if (bPrint) {
-                    out << Internal::stringFormat("%8ld | %8ld | ", (size_t)(position - sizeof(box)),
+                    out << Internal::stringFormat("%8ld | %8ld | ", position - sizeof(box),
                                                   (size_t)box.length)
                         << toAscii(box.type) << "      | ";
                     bLF = true;

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -277,7 +277,7 @@ namespace Exiv2 {
         long pos = sizeFront;
         while (0 == Photoshop::locateIptcIrb(pPsData + pos, sizePsData - pos,
                                              &record, &sizeHdr, &sizeIptc)) {
-            const long newPos = record - pPsData;
+            const long newPos = static_cast<long>(record - pPsData);
             // Copy data up to the IPTC IRB
             if (newPos > pos) {
                 append(psBlob, pPsData + pos, newPos - pos);

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -126,7 +126,7 @@ namespace Exiv2 {
         const byte* pEnd = pPsData + sizePsData;
         int ret = 0;
         while (pCur < pEnd
-               && 0 == (ret = Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
+               && 0 == (ret = Photoshop::locateIptcIrb(pCur, pEnd - pCur,
                                                        &record, &sizeHdr, &sizeIptc))) {
             pCur = record + sizeHdr + sizeIptc + (sizeIptc & 1);
         }
@@ -277,7 +277,7 @@ namespace Exiv2 {
         long pos = sizeFront;
         while (0 == Photoshop::locateIptcIrb(pPsData + pos, sizePsData - pos,
                                              &record, &sizeHdr, &sizeIptc)) {
-            const long newPos = static_cast<long>(record - pPsData);
+            const long newPos = record - pPsData;
             // Copy data up to the IPTC IRB
             if (newPos > pos) {
                 append(psBlob, pPsData + pos, newPos - pos);
@@ -539,7 +539,7 @@ namespace Exiv2 {
             const byte* pCur = &psBlob[0];
             const byte* pEnd = pCur + psBlob.size();
             while (   pCur < pEnd
-                   && 0 == Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
+                   && 0 == Photoshop::locateIptcIrb(pCur, pEnd - pCur,
                                                     &record, &sizeHdr, &sizeIptc)) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Found IPTC IRB, size = " << sizeIptc << "\n";
@@ -1160,13 +1160,13 @@ namespace Exiv2 {
                     tmpBuf[1] = app2_;
 
                     int chunk_size = 256 * 256 - 40;  // leave bytes for marker, header and padding
-                    int size = (int)iccProfile_.size_;
-                    int chunks = 1 + (size - 1) / chunk_size;
+                    int sizeProfile = (int)iccProfile_.size_;
+                    int chunks = 1 + (sizeProfile - 1) / chunk_size;
                     if (iccProfile_.size_ > 256 * chunk_size)
                         throw Error(kerTooLargeJpegSegment, "IccProfile");
                     for (int chunk = 0; chunk < chunks; chunk++) {
-                        int bytes = size > chunk_size ? chunk_size : size;  // bytes to write
-                        size -= bytes;
+                        int bytes = sizeProfile > chunk_size ? chunk_size : sizeProfile;  // bytes to write
+                        sizeProfile -= bytes;
 
                         // write JPEG marker (2 bytes)
                         if (outIo.write(tmpBuf, 2) != 2)
@@ -1200,11 +1200,11 @@ namespace Exiv2 {
                     const byte* chunkEnd = chunkStart + newPsData.size_;
                     while (chunkStart < chunkEnd) {
                         // Determine size of next chunk
-                        long chunkSize = static_cast<long>(chunkEnd - chunkStart);
+                        long chunkSize = chunkEnd - chunkStart;
                         if (chunkSize > maxChunkSize) {
                             chunkSize = maxChunkSize;
                             // Don't break at a valid IRB boundary
-                            const long writtenSize = static_cast<long>(chunkStart - newPsData.pData_);
+                            const long writtenSize = chunkStart - newPsData.pData_;
                             if (Photoshop::valid(newPsData.pData_, writtenSize + chunkSize)) {
                                 // Since an IRB has minimum size 12,
                                 // (chunkSize - 8) can't be also a IRB boundary

--- a/src/metadatum.cpp
+++ b/src/metadatum.cpp
@@ -30,10 +30,6 @@
 // class member definitions
 namespace Exiv2 {
 
-    Key::~Key()
-    {
-    }
-
     Key::UniquePtr Key::clone() const
     {
         return UniquePtr(clone_());

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -2840,7 +2840,7 @@ fmountlens[] = {
         std::ostringstream oss;
         oss.copyfmt(os);
         char sign = value.toLong() < 0 ? '-' : '+';
-        long h    = long(std::abs( (int) (value.toFloat()/60.0)  ))%24;
+        long h    = long(std::abs( (int) (value.toFloat()/60.0f)  ))%24;
         long min  = long(std::abs( (int) (value.toFloat()-h*60)  ))%60;
         os << std::fixed << "UTC " << sign << std::setw(2) << std::setfill('0') << h << ":"
            << std::setw(2) << std::setfill('0') << min;

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1183,7 +1183,8 @@ namespace Exiv2 {
             return os << "(" << value << ")";
         }
         float f = value.toFloat();
-        if (f == 0.0 || f == 1.0) return os << _("None");
+        if (f == 0.0f || f == 1.0f)
+            return os << _("None");
         std::ostringstream oss;
         oss.copyfmt(os);
         os << std::fixed << std::setprecision(1) << f << "x";

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1117,7 +1117,7 @@ namespace Exiv2 {
                << " EV";
         } else {
             os << std::setprecision(2)
-               << static_cast<float>(l0) - 9.5
+               << static_cast<float>(l0) - 9.5f
                << " EV";
         }
 

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -312,7 +312,7 @@ namespace Exiv2 {
                 const byte* pCur = psData.pData_;
                 while (   pCur < pEnd
                        && 0 == Photoshop::locateIptcIrb(pCur,
-                                                        static_cast<long>(pEnd - pCur),
+                                                        pEnd - pCur,
                                                         &record,
                                                         &sizeHdr,
                                                         &sizeIptc)) {
@@ -459,7 +459,7 @@ namespace Exiv2 {
 
         do {
             arr.alloc(uncompressedLen);
-            zlibResult = uncompress((Bytef*)arr.pData_,
+            zlibResult = uncompress(arr.pData_,
                                     &uncompressedLen,
                                     compressedText,
                                     compressedTextSize);
@@ -490,14 +490,14 @@ namespace Exiv2 {
 
     std::string PngChunk::zlibCompress(const std::string& text)
     {
-        uLongf compressedLen = static_cast<uLongf>(text.size() * 2); // just a starting point
+        uLongf compressedLen = (text.size() * 2); // just a starting point
         int zlibResult;
 
         DataBuf arr;
         do {
             arr.alloc(compressedLen);
-            zlibResult = compress2((Bytef*)arr.pData_, &compressedLen,
-                                   (const Bytef*)text.data(), static_cast<uLong>(text.size()),
+            zlibResult = compress2(arr.pData_, &compressedLen,
+                                   (const Bytef*)text.data(), text.size(),
                                    Z_BEST_COMPRESSION);
 
             switch (zlibResult) {
@@ -692,7 +692,7 @@ namespace Exiv2 {
 
         // Copy profile, skipping white space and column 1 "=" signs
 
-        unsigned char *dp = (unsigned char*)info.pData_; // decode pointer
+        unsigned char *dp = info.pData_; // decode pointer
         unsigned int nibbles = length * 2;
 
         for (long i = 0; i < (long) nibbles; i++)

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -102,13 +102,13 @@ namespace Exiv2 {
 
         do {
             result.alloc(uncompressedLen);
-            zlibResult = uncompress((Bytef*)result.pData_,&uncompressedLen,bytes,length);
+            zlibResult = uncompress(result.pData_,&uncompressedLen,bytes,length);
             // if result buffer is large than necessary, redo to fit perfectly.
             if (zlibResult == Z_OK && (long) uncompressedLen < result.size_ ) {
                 result.free();
 
                 result.alloc(uncompressedLen);
-                zlibResult = uncompress((Bytef*)result.pData_,&uncompressedLen,bytes,length);
+                zlibResult = uncompress(result.pData_,&uncompressedLen,bytes,length);
             }
             if (zlibResult == Z_BUF_ERROR) {
                 // the uncompressed buffer needs to be larger
@@ -130,7 +130,7 @@ namespace Exiv2 {
 
         do {
             result.alloc(compressedLen);
-            zlibResult = compress((Bytef*)result.pData_,&compressedLen,bytes,length);
+            zlibResult = compress(result.pData_,&compressedLen,bytes,length);
             if (zlibResult == Z_BUF_ERROR) {
                 // the compressedArray needs to be larger
                 result.free();
@@ -138,7 +138,7 @@ namespace Exiv2 {
             } else {
                 result.free();
                 result.alloc(compressedLen);
-                zlibResult = compress((Bytef*)result.pData_,&compressedLen,bytes,length);
+                zlibResult = compress(result.pData_,&compressedLen,bytes,length);
             }
         } while (zlibResult == Z_BUF_ERROR);
 
@@ -655,9 +655,9 @@ namespace Exiv2 {
 
                         // calculate CRC
                         uLong   tmp = crc32(0L, Z_NULL, 0);
-                        tmp         = crc32(tmp, (const Bytef*)type, 4);
+                        tmp         = crc32(tmp, type, 4);
                         tmp         = crc32(tmp, (const Bytef*)profileName_.data(), nameLength);
-                        tmp         = crc32(tmp, (const Bytef*)nullComp, 2);
+                        tmp         = crc32(tmp, nullComp, 2);
                         tmp         = crc32(tmp, (const Bytef*)compressed.pData_,compressed.size_);
                         byte    crc[4];
                         ul2Data(crc, tmp, bigEndian);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2736,7 +2736,8 @@ namespace Exiv2 {
     {
     }
 
-    XmpKey::XmpKey(const XmpKey& rhs) : Key(rhs), p_(new Impl(*rhs.p_))
+    XmpKey::XmpKey(const XmpKey& rhs)
+        : p_(new Impl(*rhs.p_))
     {
     }
 

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -345,7 +345,7 @@ namespace Exiv2 {
     }
 
     ExifKey::ExifKey(const ExifKey& rhs)
-        : Key(rhs), p_(new Impl(*rhs.p_))
+        : p_(new Impl(*rhs.p_))
     {
     }
 

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -1267,7 +1267,7 @@ namespace Exiv2 {
             break;
         case ttUnsignedLong:
         case ttSignedLong:
-            rc = l2Data(buf, static_cast<int32_t>(offset), byteOrder);
+            rc = l2Data(buf, offset, byteOrder);
             break;
         default:
             throw Error(kerUnsupportedDataAreaOffsetType);

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -397,7 +397,7 @@ namespace Exiv2 {
             std::string::size_type idx = xmpPacket.find_first_of('<');
             if (idx != std::string::npos && idx > 0) {
 #ifndef SUPPRESS_WARNINGS
-                EXV_WARNING << "Removing " << idx
+                EXV_WARNING << "Removing " << static_cast<unsigned long>(idx)
                             << " characters from the beginning of the XMP packet\n";
 #endif
                 xmpPacket = xmpPacket.substr(idx);

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -397,7 +397,7 @@ namespace Exiv2 {
             std::string::size_type idx = xmpPacket.find_first_of('<');
             if (idx != std::string::npos && idx > 0) {
 #ifndef SUPPRESS_WARNINGS
-                EXV_WARNING << "Removing " << static_cast<unsigned long>(idx)
+                EXV_WARNING << "Removing " << idx
                             << " characters from the beginning of the XMP packet\n";
 #endif
                 xmpPacket = xmpPacket.substr(idx);
@@ -804,7 +804,7 @@ namespace Exiv2 {
     {
         assert(object != 0);
 
-        ExifData::iterator pos = exifData_.findKey(ExifKey("Exif.MakerNote.ByteOrder"));
+        auto pos = exifData_.findKey(ExifKey("Exif.MakerNote.ByteOrder"));
         if (pos != exifData_.end()) {
             // Set Makernote byte order
             ByteOrder bo = stringToByteOrder(pos->toString());
@@ -820,7 +820,7 @@ namespace Exiv2 {
                 "Exif.MakerNote.Offset",
             };
             for (unsigned int i = 0; i < EXV_COUNTOF(synthesizedTags); ++i) {
-                ExifData::iterator pos = exifData_.findKey(ExifKey(synthesizedTags[i]));
+                pos = exifData_.findKey(ExifKey(synthesizedTags[i]));
                 if (pos != exifData_.end()) exifData_.erase(pos);
             }
         }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -78,18 +78,6 @@ namespace Exiv2 {
     {
     }
 
-    Value::~Value()
-    {
-    }
-
-    Value& Value::operator=(const Value& rhs)
-    {
-        if (this == &rhs) return *this;
-        type_ = rhs.type_;
-        ok_ = rhs.ok_;
-        return *this;
-    }
-
     Value::UniquePtr Value::create(TypeId typeId)
     {
         UniquePtr value;
@@ -188,7 +176,8 @@ namespace Exiv2 {
         return DataBuf(0, 0);
     }
 
-    DataValue::DataValue(TypeId typeId) : Value(typeId)
+    DataValue::DataValue(TypeId typeId)
+        : Value(typeId)
     {
     }
 
@@ -609,14 +598,6 @@ namespace Exiv2 {
           xmpArrayType_(xaNone),
           xmpStruct_(xsNone)
     {
-    }
-
-    XmpValue& XmpValue::operator=(const XmpValue& rhs)
-    {
-        if (this == &rhs) return *this;
-        xmpArrayType_ = rhs.xmpArrayType_;
-        xmpStruct_ = rhs.xmpStruct_;
-        return *this;
     }
 
     void XmpValue::setXmpArrayType(XmpArrayType xmpArrayType)

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -221,9 +221,7 @@ namespace Exiv2 {
     long DataValue::copy(byte* buf, ByteOrder /*byteOrder*/) const
     {
         // byteOrder not needed
-        return static_cast<long>(
-            std::copy(value_.begin(), value_.end(), buf) - buf
-            );
+        return std::copy(value_.begin(), value_.end(), buf) - buf;
     }
 
     long DataValue::size() const
@@ -1057,7 +1055,7 @@ namespace Exiv2 {
         tms.tm_mday = date_.day;
         tms.tm_mon = date_.month - 1;
         tms.tm_year = date_.year - 1900;
-        long l = static_cast<long>(std::mktime(&tms));
+        auto l = std::mktime(&tms);
         ok_ = (l != -1);
         return l;
     }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -223,7 +223,7 @@ static Exiv2::StringVector getLoadedLibraries()
     while ( std::getline(maps,string) ) {
         std::size_t pos = string.find_last_of(' ');
         if ( pos != std::string::npos ) {
-            std::string path = string.substr(pos+1);
+            path = string.substr(pos+1);
             pushPath(path,libs,paths);
         }
     }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -614,7 +614,7 @@ namespace Exiv2 {
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF)) {
                 readOrThrow(*io_, payload.pData_, payload.size_, Exiv2::kerCorruptedMetadata);
 
-                byte  size_buff[2];
+                byte  size_buff2[2];
                 // 4 meaningful bytes + 2 padding bytes
                 byte  exifLongHeader[]   = { 0xFF, 0x01, 0xFF, 0xE1, 0x00, 0x00 };
                 byte  exifShortHeader[]  = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
@@ -653,27 +653,27 @@ namespace Exiv2 {
                     offset += 12;
                 }
 
-                const long size = payload.size_ + offset;
-                rawExifData = (byte*)malloc(size);
+                const long sizePayload = payload.size_ + offset;
+                rawExifData = (byte*)malloc(sizePayload);
 
                 if (s_header) {
-                    us2Data(size_buff, (uint16_t) (size - 6), bigEndian);
+                    us2Data(size_buff2, (uint16_t) (sizePayload - 6), bigEndian);
                     memcpy(rawExifData, (char*)&exifLongHeader, 4);
-                    memcpy(rawExifData + 4, (char*)&size_buff, 2);
+                    memcpy(rawExifData + 4, (char*)&size_buff2, 2);
                 }
 
                 if (be_header || le_header) {
-                    us2Data(size_buff, (uint16_t) (size - 6), bigEndian);
+                    us2Data(size_buff2, (uint16_t) (sizePayload - 6), bigEndian);
                     memcpy(rawExifData, (char*)&exifLongHeader, 4);
-                    memcpy(rawExifData + 4, (char*)&size_buff, 2);
+                    memcpy(rawExifData + 4, (char*)&size_buff2, 2);
                     memcpy(rawExifData + 6, (char*)&exifShortHeader, 6);
                 }
 
                 memcpy(rawExifData + offset, payload.pData_, payload.size_);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-                std::cout << "Display Hex Dump [size:" << (unsigned long)size << "]" << std::endl;
-                std::cout << Internal::binaryToHex(rawExifData, size);
+                std::cout << "Display Hex Dump [size:" << (unsigned long)sizePayload << "]" << std::endl;
+                std::cout << Internal::binaryToHex(rawExifData, sizePayload);
 #endif
 
                 if (pos != -1) {

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -597,7 +597,7 @@ namespace Exiv2 {
             return 2;
         }
 
-        SXMPMeta meta(xmpPacket.data(), static_cast<XMP_StringLen>(xmpPacket.size()));
+        SXMPMeta meta(xmpPacket.data(), xmpPacket.size());
         SXMPIterator iter(meta);
         std::string schemaNs, propPath, propValue;
         XMP_OptionBits opt;

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -48,7 +48,7 @@ if (exiv2lib_COMPILE_DEFINITIONS)
     target_compile_definitions(unit_tests PRIVATE ${exiv2lib_COMPILE_DEFINITIONS})
 endif ()
 
-target_include_directories(unit_tests
+target_include_directories(unit_tests SYSTEM
     PRIVATE
         ${exiv2lib_INCLUDE_DIRECTORIES}
 )

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -65,7 +65,7 @@ TEST(Rational, floatToRationalCast)
     for (size_t i = 0; i < sizeof(floats) / sizeof(*floats); ++i) {
         const Rational r = floatToRationalCast(floats[i]);
         const float fraction = static_cast<float>(r.first) / static_cast<float>(r.second);
-        ASSERT_TRUE(fabs((floats[i] - fraction) / floats[i]) < 0.01f);
+        ASSERT_TRUE(std::fabs((floats[i] - fraction) / floats[i]) < 0.01f);
     }
 
     const Rational plus_inf = floatToRationalCast(std::numeric_limits<float>::infinity());

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -31,9 +31,9 @@ target_link_libraries(exiv2-xmp
         $<BUILD_INTERFACE:${EXPAT_LIBRARY}>
 )
 
-target_include_directories(exiv2-xmp
+target_include_directories(exiv2-xmp SYSTEM
     PRIVATE 
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
+        ${PROJECT_SOURCE_DIR}/xmpsdk/include
         ${EXPAT_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
The main objective of this PR was to clean the warnings reported by `-Wdeprecated-copy` which were not treated as errors temporarily after enabling C++11 on `main`.

This PR cleans all these warnings and others reported when using the option `EXIV2_TEAM_EXTRA_WARNINGS` on CMake. The compiler output should be much cleaner now. 