### PR TITLE
Use auto for iterators

### DIFF
--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -1,7 +1,3 @@
-| Travis        | AppVeyor      | GitLab| Codecov| Repology| Chat |
-|:-------------:|:-------------:|:-----:|:------:|:-------:|:----:|
-| [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=main)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al/branch/main?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp/branch/main) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/main/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/main) | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/main/graph/badge.svg)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
-
 ![Exiv2](exiv2.png)
 
 # Building Exiv2 and dependencies with conan

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-| Travis        | AppVeyor      | GitLab| Codecov| Repology| Chat |
-|:-------------:|:-------------:|:-----:|:------:|:-------:|:----:|
-| [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=main)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al/branch/main?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp/branch/main) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/main/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/main) | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/main/graph/badge.svg)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
+|                            Travis                            |                           AppVeyor                           |                            GitLab                            |                           Codecov                            |                           Repology                           |                             Chat                             |
+| :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
+| [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=main)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/main/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/main) | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/master/graph/badge.svg?token=O9G7Iswx26)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
 
 <div id="1">
 # Welcome to Exiv2
-
 Exiv2 is a C++ library and a command-line utility to read,
 write, delete and modify Exif, IPTC, XMP and ICC image metadata.
 

--- a/cmake/printSummary.cmake
+++ b/cmake/printSummary.cmake
@@ -69,9 +69,3 @@ OptionOutput( "Building unit tests:                " EXIV2_BUILD_UNIT_TESTS     
 OptionOutput( "Building doc:                       " EXIV2_BUILD_DOC                 )
 OptionOutput( "Building with coverage flags:       " BUILD_WITH_COVERAGE             )
 OptionOutput( "Using ccache:                       " BUILD_WITH_CCACHE               )
-
-message( STATUS "------------------------------------------------------------------" )
-
-message(STATUS " WARNING: Deprecated features: EPS, Video, Ssh")
-
-message( STATUS "------------------------------------------------------------------" )

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -362,50 +362,6 @@ namespace Exiv2 {
       @brief typedef for string:string map
      */
     typedef std::map<std::string,std::string>                 Dictionary;
-    /*!
-      @brief typedef for Dictionary*
-     */
-    typedef Dictionary*                                       Dictionary_p;
-
-    /*!
-      @brief typedef for string set (unique strings)
-     */
-    typedef std::set<std::string>                             StringSet;
-    /*!
-      @brief typedef for StringSet*
-     */
-    typedef StringSet*                                        StringSet_p;
-    /*!
-      @brief Class to provide a StringSet iterator
-     */
-    typedef std::set<std::string>::const_iterator             StringSet_i;
-
-    /*!
-      @brief typedef for string vector
-     */
-    typedef std::vector<std::string>                          StringVector;
-    /*!
-      @brief typedef for StringVector pointer
-     */
-    typedef StringVector*                                     StringVector_p;
-    /*!
-      @brief Class to provide a StringVector iterator
-     */
-    typedef StringVector::const_iterator                      StringVector_i;
-
-    /*!
-      @brief typedef for uint32_t vector
-     */
-    typedef std::vector<uint32_t>                             Uint32Vector  ;
-    /*!
-      @brief typedef for Uint32Vector pointer
-     */
-    typedef Uint32Vector*                                     Uint32Vector_p;
-    /*!
-      @brief typedef for Uint32Vector iterator
-     */
-    typedef Uint32Vector::const_iterator                      Uint32Vector_i;
-
 
 // *****************************************************************************
 // free functions

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -366,10 +366,6 @@ namespace Exiv2 {
       @brief typedef for Dictionary*
      */
     typedef Dictionary*                                       Dictionary_p;
-    /*!
-      @brief typedef for Dictionary iterator
-     */
-    typedef Dictionary::const_iterator                        Dictionary_i;
 
     /*!
       @brief typedef for string set (unique strings)

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -143,7 +143,7 @@ namespace Jzon
 
 	Node::Type Node::DetermineType(const std::string &json)
 	{
-		std::string::const_iterator jsonIt = json.begin();
+        auto jsonIt = json.begin();
 
 		while (jsonIt != json.end() && IsWhitespace(*jsonIt))
 			++jsonIt;
@@ -433,10 +433,8 @@ namespace Jzon
 	{
 		std::string escaped;
 
-		for (std::string::const_iterator it = value.begin(); it != value.end(); ++it)
+        for (const auto& c: value)
 		{
-			const char &c = (*it);
-
 			const char *&a = getEscaped(c);
 			if (a[0] != '\0')
 			{
@@ -455,7 +453,7 @@ namespace Jzon
 	{
 		std::string unescaped;
 
-		for (std::string::const_iterator it = value.begin(); it != value.end(); ++it)
+        for (auto it = value.cbegin(); it != value.cend(); ++it)
 		{
 			const char &c = (*it);
 			char c2 = '\0';
@@ -484,7 +482,7 @@ namespace Jzon
 	}
 	Object::Object(const Object &other) : Node()
 	{
-		for (ChildList::const_iterator it = other.children.begin(); it != other.children.end(); ++it)
+        for (auto it = other.children.cbegin(); it != other.children.cend(); ++it)
 		{
 			const std::string &name = (*it).first;
 			Node &value = *(*it).second;
@@ -496,7 +494,7 @@ namespace Jzon
 	{
 		const Object &object = other.AsObject();
 
-		for (ChildList::const_iterator it = object.children.begin(); it != object.children.end(); ++it)
+        for (auto it = object.children.cbegin(); it != object.children.cend(); ++it)
 		{
 			const std::string &name = (*it).first;
 			Node &value = *(*it).second;
@@ -524,7 +522,7 @@ namespace Jzon
 	}
 	void Object::Remove(const std::string &name)
 	{
-		for (ChildList::iterator it = children.begin(); it != children.end(); ++it)
+        for (auto it = children.cbegin(); it != children.cend(); ++it)
 		{
 			if ((*it).first == name)
 			{
@@ -534,9 +532,10 @@ namespace Jzon
 			}
 		}
 	}
+
 	void Object::Clear()
 	{
-		for (ChildList::iterator it = children.begin(); it != children.end(); ++it)
+        for (auto it = children.begin(); it != children.end(); ++it)
 		{
 			delete (*it).second;
 			(*it).second = NULL;
@@ -551,6 +550,7 @@ namespace Jzon
 		else
 			return Object::iterator(NULL);
 	}
+
 	Object::const_iterator Object::begin() const
 	{
 		if (!children.empty())
@@ -558,6 +558,7 @@ namespace Jzon
 		else
 			return Object::const_iterator(NULL);
 	}
+
 	Object::iterator Object::end()
 	{
 		if (!children.empty())
@@ -610,26 +611,27 @@ namespace Jzon
 	Array::Array() : Node()
 	{
 	}
+
 	Array::Array(const Array &other) : Node()
 	{
-		for (ChildList::const_iterator it = other.children.begin(); it != other.children.end(); ++it)
+        for (auto it = other.children.cbegin(); it != other.children.cend(); ++it)
 		{
 			const Node &value = *(*it);
-
 			children.push_back(value.GetCopy());
 		}
-	}
+    }
+
 	Array::Array(const Node &other) : Node()
 	{
 		const Array &array = other.AsArray();
 
-		for (ChildList::const_iterator it = array.children.begin(); it != array.children.end(); ++it)
+        for (auto it = array.children.cbegin(); it != array.children.cend(); ++it)
 		{
 			const Node &value = *(*it);
-
 			children.push_back(value.GetCopy());
 		}
 	}
+
 	Array::~Array()
 	{
 		Clear();

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -91,7 +91,7 @@ try {
 
     // Alternatively, we can use findKey()
     key = Exiv2::ExifKey("Exif.Image.PrimaryChromaticities");
-    Exiv2::ExifData::iterator pos = exifData.findKey(key);
+    auto pos = exifData.findKey(key);
     if (pos == exifData.end()) throw Exiv2::Error(Exiv2::kerErrorMessage, "Key not found");
     // Get a pointer to a copy of the value
     v = pos->getValue();

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -88,7 +88,7 @@ try {
     Exiv2::ExifData& ed = image->exifData();
 
     for (unsigned int i = 0; i < EXV_COUNTOF(easyAccess); ++i) {
-        Exiv2::ExifData::const_iterator pos = easyAccess[i].findFct_(ed);
+        auto pos = easyAccess[i].findFct_(ed);
         std::cout << std::setw(21) << std::left << easyAccess[i].label_;
         if (pos != ed.end()) {
             std::cout << " (" << std::setw(35) << pos->key() << ") : "

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -130,8 +130,8 @@ void print(const std::string& file)
     image->readMetadata();
 
     Exiv2::ExifData &ed = image->exifData();
-    Exiv2::ExifData::const_iterator end = ed.end();
-    for (Exiv2::ExifData::const_iterator i = ed.begin(); i != end; ++i) {
+    auto end = ed.end();
+    for (auto i = ed.begin(); i != end; ++i) {
         std::cout << std::setw(45) << std::setfill(' ') << std::left
                   << i->key() << " "
                   << "0x" << std::setw(4) << std::setfill('0') << std::right

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -44,14 +44,14 @@ void syntax(const char* argv[],format_t& formats)
 size_t formatInit(Exiv2::ExifData& exifData)
 {
 	size_t result = 0;
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != exifData.end() ; ++i) {
+	for (auto i = exifData.begin(); i != exifData.end() ; ++i) {
 		result ++ ;
 	}
 	return result ;
 }
 
 ///////////////////////////////////////////////////////////////////////
-std::string escapeCSV(Exiv2::ExifData::const_iterator it,bool bValue)
+std::string escapeCSV(Exiv2::ExifData::const_iterator  it,bool bValue)
 {
 	std::string   result ;
 
@@ -73,13 +73,13 @@ std::string formatCSV(Exiv2::ExifData& exifData)
 	size_t length = formatInit(exifData);
 	std::ostringstream result;
 
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); count++ < length; ++i) {
+	for (auto i = exifData.begin(); count++ < length; ++i) {
 		result << escapeCSV(i,false) << (count != length ? ", " : "" ) ;
 	}
 	result << std::endl;
 
 	count = 0;
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); count++ < length ; ++i) {
+	for (auto i = exifData.begin(); count++ < length ; ++i) {
 		result << escapeCSV(i,true) << (count != length ? ", " : "" ) ;
 	}
 	return result.str();
@@ -93,7 +93,7 @@ std::string formatWolf(Exiv2::ExifData& exifData)
 	std::ostringstream result;
 
 	result << "{ " << std::endl;
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); count++ < length ; ++i) {
+	for (auto i = exifData.begin(); count++ < length ; ++i) {
 		result << "  " << i->key()  << " -> " << i->value()  << (count != length ? "," : "" ) << std::endl ;
 	}
 	result << "}";
@@ -101,7 +101,7 @@ std::string formatWolf(Exiv2::ExifData& exifData)
 }
 
 ///////////////////////////////////////////////////////////////////////
-std::string escapeJSON(Exiv2::ExifData::const_iterator it,bool bValue=true)
+std::string escapeJSON(Exiv2::ExifData::const_iterator  it,bool bValue=true)
 {
 	std::string   result ;
 
@@ -125,7 +125,7 @@ std::string formatJSON(Exiv2::ExifData& exifData)
 	std::ostringstream result;
 
 	result << "{" << std::endl ;
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); count++ < length ; ++i) {
+	for (auto i = exifData.begin(); count++ < length ; ++i) {
 		result << "  " << escapeJSON(i,false)  << ":" << escapeJSON(i,true) << ( count != length ? "," : "" ) << std::endl ;
 	}
 	result << "}";
@@ -133,7 +133,7 @@ std::string formatJSON(Exiv2::ExifData& exifData)
 }
 
 ///////////////////////////////////////////////////////////////////////
-std::string escapeXML(Exiv2::ExifData::const_iterator it,bool bValue=true)
+std::string escapeXML(Exiv2::ExifData::const_iterator  it,bool bValue=true)
 {
 	std::string   result ;
 
@@ -157,7 +157,7 @@ std::string formatXML(Exiv2::ExifData& exifData)
 	std::ostringstream result;
 
 	result << "<exif>" << std::endl;
-	for (Exiv2::ExifData::const_iterator i = exifData.begin(); count++ < length ; ++i) {
+	for (auto i = exifData.begin(); count++ < length ; ++i) {
 		std::string key   = escapeXML(i,false);
 		std::string value = escapeXML(i,true);
 		result << "  <" << key << ">" << value << "<" << key << "/>" << std::endl ;

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -98,8 +98,8 @@ try {
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
 
-    Exiv2::ExifData::const_iterator end = exifData.end();
-    for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != end; ++i) {
+    auto end = exifData.end();
+    for (auto i = exifData.begin(); i != end; ++i) {
         const char* tn = i->typeName();
         std::cout << std::setw(44) << std::setfill(' ') << std::left
                   << i->key() << " "

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -63,7 +63,7 @@ struct Token {
 typedef std::vector<Token>    Tokens;
 
 // "XMP.xmp.MP.RegionInfo/MPRI:Regions[1]/MPReg:Rectangle"
-bool getToken(std::string& in,Token& token,Exiv2::StringSet* pNS=NULL)
+bool getToken(std::string& in,Token& token, std::set<std::string>* pNS=NULL)
 {
     bool result = false;
     bool ns     = false;
@@ -118,7 +118,7 @@ Jzon::Node& recursivelyBuildTree(Jzon::Node& root,Tokens& tokens,size_t k)
 }
 
 // build the json tree for this key.  return location and discover the name
-Jzon::Node& objectForKey(const std::string& Key,Jzon::Object& root,std::string& name,Exiv2::StringSet* pNS=NULL)
+Jzon::Node& objectForKey(const std::string& Key,Jzon::Object& root,std::string& name,std::set<std::string>* pNS=NULL)
 {
     // Parse the key
     Tokens      tokens ;
@@ -339,8 +339,8 @@ int main(int argc, char* const argv[])
             Exiv2::XmpData  &xmpData  = image->xmpData();
             if ( !xmpData.empty() ) {
                 // get the xmpData and recursively parse into a Jzon Object
-                Exiv2::StringSet     namespaces;
-                for (Exiv2::XmpData::const_iterator i = xmpData.begin(); i != xmpData.end(); ++i) {
+                std::set<std::string> namespaces;
+                for (auto i = xmpData.begin(); i != xmpData.end(); ++i) {
                     std::string name   ;
                     Jzon::Node& object = objectForKey(i->key(),root,name,&namespaces);
                     push(object,name,i);
@@ -352,7 +352,7 @@ int main(int argc, char* const argv[])
 
                 // create and populate a Jzon::Object for the namespaces
                 Jzon::Object    xmlns;
-                for ( Exiv2::StringSet_i it = namespaces.begin() ; it != namespaces.end() ; it++ ) {
+                for ( auto it = namespaces.begin() ; it != namespaces.end() ; it++ ) {
                     std::string ns  = *it       ;
                     std::string uri = nsDict[ns];
                     xmlns.Add(ns,uri);

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -317,7 +317,7 @@ int main(int argc, char* const argv[])
 
         if ( option == 'a' || option == 'e' ) {
             Exiv2::ExifData &exifData = image->exifData();
-            for ( Exiv2::ExifData::const_iterator i = exifData.begin(); i != exifData.end() ; ++i ) {
+            for ( auto i = exifData.begin(); i != exifData.end() ; ++i ) {
                 std::string name   ;
                 Jzon::Node& object = objectForKey(i->key(),root,name);
                 push(object,name,i);

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -49,8 +49,8 @@ try {
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
 
-    Exiv2::IptcData::iterator end = iptcData.end();
-    for (Exiv2::IptcData::iterator md = iptcData.begin(); md != end; ++md) {
+    auto end = iptcData.end();
+    for (auto md = iptcData.begin(); md != end; ++md) {
         std::cout << std::setw(44) << std::setfill(' ') << std::left
                   << md->key() << " "
                   << "0x" << std::setw(4) << std::setfill('0') << std::right

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* const argv[])
         }
 
         Exiv2::ExifKey key("Exif.Minolta.ThumbnailOffset");
-        Exiv2::ExifData::const_iterator format = exifData.findKey(key);
+        auto format = exifData.findKey(key);
 
         if (format != exifData.end()) {
             Exiv2::DataBuf buf = format->dataArea();

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -79,8 +79,8 @@ try {
         error += ": No Exif data found in the file";
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    Exiv2::ExifData::const_iterator end = exifReadData.end();
-    for (Exiv2::ExifData::const_iterator i = exifReadData.begin(); i != end; ++i) {
+    auto end = exifReadData.end();
+    for (auto i = exifReadData.begin(); i != end; ++i) {
         const char* tn = i->typeName();
         std::cout << std::setw(44) << std::setfill(' ') << std::left
                   << i->key() << " "
@@ -102,7 +102,7 @@ try {
     exifReadData["Exif.Image.Software"]     = "Exiv2.org";                 // AsciiValue
     exifReadData["Exif.Image.Copyright"]    = "Exiv2.org";                 // AsciiValue
     key = Exiv2::ExifKey("Exif.Image.Make");
-    Exiv2::ExifData::iterator pos = exifReadData.findKey(key);
+    auto pos = exifReadData.findKey(key);
     if (pos == exifReadData.end()) throw Exiv2::Error(Exiv2::kerErrorMessage, "Exif.Image.Make not found");
     exifReadData.erase(pos);
     key = Exiv2::ExifKey("Exif.Image.DateTime");

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -115,8 +115,8 @@ void print(const ExifData& exifData)
         std::string error("No Exif data found in the file");
         throw Exiv2::Error(kerErrorMessage, error);
     }
-    Exiv2::ExifData::const_iterator end = exifData.end();
-    for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != end; ++i) {
+    auto end = exifData.end();
+    for (auto i = exifData.begin(); i != end; ++i) {
         std::cout << std::setw(44) << std::setfill(' ') << std::left
                   << i->key() << " "
                   << "0x" << std::setw(4) << std::setfill('0') << std::right

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -179,7 +179,7 @@ void testCase(const std::string& file1,
 
     Exiv2::ExifData &ed1 = image1->exifData();
     std::cerr << "---> Modifying Exif data\n";
-    Exiv2::ExifData::iterator pos = ed1.findKey(ek);
+    auto pos = ed1.findKey(ek);
     if (pos == ed1.end()) {
         throw Error(kerErrorMessage, "Metadatum with key = " + ek.key() + " not found");
     }
@@ -209,7 +209,7 @@ void testCase(const std::string& file1,
 
 void exifPrint(const ExifData& exifData)
 {
-    ExifData::const_iterator i = exifData.begin();
+    auto i = exifData.begin();
     for (; i != exifData.end(); ++i) {
         std::cout << std::setw(44) << std::setfill(' ') << std::left
                   << i->key() << " "

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -233,8 +233,8 @@ void print(const std::string& file)
     image->readMetadata();
 
     Exiv2::ExifData &ed = image->exifData();
-    Exiv2::ExifData::const_iterator end = ed.end();
-    for (Exiv2::ExifData::const_iterator i = ed.begin(); i != end; ++i) {
+    auto end = ed.end();
+    for (auto i = ed.begin(); i != end; ++i) {
         std::cout << std::setw(45) << std::setfill(' ') << std::left
                   << i->key() << " "
                   << "0x" << std::setw(4) << std::setfill('0') << std::right

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -127,7 +127,7 @@ try {
     assert(getv8.ok());
 
     // Deleting an XMP property
-    Exiv2::XmpData::iterator pos = xmpData.findKey(Exiv2::XmpKey("Xmp.dc.eight"));
+    auto pos = xmpData.findKey(Exiv2::XmpKey("Xmp.dc.eight"));
     if (pos == xmpData.end()) throw Exiv2::Error(Exiv2::kerErrorMessage, "Key not found");
     xmpData.erase(pos);
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -184,8 +184,7 @@ namespace Action {
     void TaskFactory::cleanup()
     {
         if (instance_ != 0) {
-            Registry::iterator e = registry_.end();
-            for (Registry::iterator i = registry_.begin(); i != e; ++i) {
+            for (auto i = registry_.begin(); i != registry_.end(); ++i) {
                 delete i->second;
             }
             delete instance_;
@@ -195,7 +194,7 @@ namespace Action {
 
     void TaskFactory::registerTask(TaskType type, Task::UniquePtr task)
     {
-        Registry::iterator i = registry_.find(type);
+        auto i = registry_.find(type);
         if (i != registry_.end()) {
             delete i->second;
         }
@@ -218,7 +217,7 @@ namespace Action {
 
     Task::UniquePtr TaskFactory::create(TaskType type)
     {
-        Registry::const_iterator i = registry_.find(type);
+        auto i = registry_.find(type);
         if (i != registry_.end() && i->second != 0) {
             Task* t = i->second;
             return t->clone();
@@ -399,7 +398,7 @@ namespace Action {
             printLabel(label);
         }
         Exiv2::ExifKey ek(key);
-        Exiv2::ExifData::const_iterator md = exifData.findKey(ek);
+        auto md = exifData.findKey(ek);
         if (md != exifData.end()) {
             md->write(std::cout, &exifData);
             rc = 1;
@@ -417,7 +416,7 @@ namespace Action {
         if (!label.empty()) {
             printLabel(label);
         }
-        Exiv2::ExifData::const_iterator md = easyAccessFct(exifData);
+        auto md = easyAccessFct(exifData);
         if (md != exifData.end()) {
             md->write(std::cout, &exifData);
             rc = 1;
@@ -460,8 +459,7 @@ namespace Action {
         bool noExif = false;
         if (Params::instance().printTags_ & Exiv2::mdExif) {
             const Exiv2::ExifData& exifData = image->exifData();
-            for (Exiv2::ExifData::const_iterator md = exifData.begin();
-                 md != exifData.end(); ++md) {
+            for (auto md = exifData.begin(); md != exifData.end(); ++md) {
                 ret |= printMetadatum(*md, image);
             }
             if (exifData.empty()) noExif = true;
@@ -470,8 +468,7 @@ namespace Action {
         bool noIptc = false;
         if (Params::instance().printTags_ & Exiv2::mdIptc) {
             const Exiv2::IptcData& iptcData = image->iptcData();
-            for (Exiv2::IptcData::const_iterator md = iptcData.begin();
-                 md != iptcData.end(); ++md) {
+            for (auto md = iptcData.begin(); md != iptcData.end(); ++md) {
                 ret |= printMetadatum(*md, image);
             }
             if (iptcData.empty()) noIptc = true;
@@ -480,8 +477,7 @@ namespace Action {
         bool noXmp = false;
         if (Params::instance().printTags_ & Exiv2::mdXmp) {
             const Exiv2::XmpData& xmpData = image->xmpData();
-            for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-                 md != xmpData.end(); ++md) {
+            for (auto md = xmpData.begin(); md != xmpData.end(); ++md) {
                 ret |= printMetadatum(*md, image);
             }
             if (xmpData.empty()) noXmp = true;
@@ -504,8 +500,7 @@ namespace Action {
     bool Print::grepTag(const std::string& key)
     {
         bool result=Params::instance().greps_.empty();
-        for (Params::Greps::const_iterator g = Params::instance().greps_.begin();
-                !result && g != Params::instance().greps_.end(); ++g)
+        for (auto g = Params::instance().greps_.begin(); !result && g != Params::instance().greps_.end(); ++g)
         {
 #if defined(EXV_HAVE_REGEX_H)
             result = regexec( &(*g), key.c_str(), 0, NULL, 0) == 0 ;
@@ -526,8 +521,7 @@ namespace Action {
     bool Print::keyTag(const std::string& key)
     {
         bool result=Params::instance().keys_.empty();
-        for (Params::Keys::const_iterator k = Params::instance().keys_.begin();
-                !result && k != Params::instance().keys_.end(); ++k)
+        for (auto k = Params::instance().keys_.begin(); !result && k != Params::instance().keys_.end(); ++k)
         {
             result = key.compare(*k) == 0;
         }
@@ -685,7 +679,7 @@ namespace Action {
         int cnt = 0;
         Exiv2::PreviewManager pm(*image);
         Exiv2::PreviewPropertiesList list = pm.getPreviewProperties();
-        for (Exiv2::PreviewPropertiesList::const_iterator pos = list.begin(); pos != list.end(); ++pos) {
+        for (auto pos = list.begin(); pos != list.end(); ++pos) {
             if (manyFiles) {
                 std::cout << std::setfill(' ') << std::left << std::setw(20)
                           << path_ << "  ";
@@ -736,7 +730,7 @@ namespace Action {
             return -3;
         }
         Exiv2::ExifKey key("Exif.Photo.DateTimeOriginal");
-        Exiv2::ExifData::iterator md = exifData.findKey(key);
+        auto md = exifData.findKey(key);
         if (md == exifData.end()) {
             key = Exiv2::ExifKey("Exif.Image.DateTime");
             md = exifData.findKey(key);
@@ -1030,7 +1024,7 @@ namespace Action {
         Exiv2::PreviewPropertiesList pvList = pvMgr.getPreviewProperties();
 
         const Params::PreviewNumbers& numbers = Params::instance().previewNumbers_;
-        for (Params::PreviewNumbers::const_iterator n = numbers.begin(); n != numbers.end(); ++n) {
+        for (auto n = numbers.begin(); n != numbers.end(); ++n) {
             if (*n == 0) {
                 // Write all previews
                 for (int num = 0; num < static_cast<int>(pvList.size()); ++num) {
@@ -1349,8 +1343,8 @@ namespace Action {
 
         // loop through command table and apply each command
         ModifyCmds& modifyCmds = Params::instance().modifyCmds_;
-        ModifyCmds::const_iterator i = modifyCmds.begin();
-        ModifyCmds::const_iterator end = modifyCmds.end();
+        auto i = modifyCmds.cbegin();
+        auto end = modifyCmds.cend();
         int rc = 0;
         int ret = 0;
         for (; i != end; ++i) {
@@ -1426,22 +1420,19 @@ namespace Action {
         Exiv2::XmpData&  xmpData  = pImage->xmpData();
         Exiv2::Metadatum* metadatum = 0;
         if (modifyCmd.metadataId_ == exif) {
-            Exiv2::ExifData::iterator pos =
-                exifData.findKey(Exiv2::ExifKey(modifyCmd.key_));
+            auto pos = exifData.findKey(Exiv2::ExifKey(modifyCmd.key_));
             if (pos != exifData.end()) {
                 metadatum = &(*pos);
             }
         }
         if (modifyCmd.metadataId_ == iptc) {
-            Exiv2::IptcData::iterator pos =
-                iptcData.findKey(Exiv2::IptcKey(modifyCmd.key_));
+            auto pos = iptcData.findKey(Exiv2::IptcKey(modifyCmd.key_));
             if (pos != iptcData.end()) {
                 metadatum = &(*pos);
             }
         }
         if (modifyCmd.metadataId_ == xmp) {
-            Exiv2::XmpData::iterator pos =
-                xmpData.findKey(Exiv2::XmpKey(modifyCmd.key_));
+            auto pos = xmpData.findKey(Exiv2::XmpKey(modifyCmd.key_));
             if (pos != xmpData.end()) {
                 metadatum = &(*pos);
             }
@@ -1597,7 +1588,7 @@ namespace Action {
                                const std::string& path) const
     {
         Exiv2::ExifKey ek(key);
-        Exiv2::ExifData::iterator md = exifData.findKey(ek);
+        auto md = exifData.findKey(ek);
         if (md == exifData.end()) {
             // Key not found. That's ok, we do nothing.
             return 0;
@@ -1700,7 +1691,7 @@ namespace Action {
                       << ": " << _("No Exif data found in the file\n");
             return -3;
         }
-        Exiv2::ExifData::const_iterator md = Exiv2::isoSpeed(exifData);
+        auto md = Exiv2::isoSpeed(exifData);
         if (md != exifData.end()) {
             if (strcmp(md->key().c_str(), "Exif.Photo.ISOSpeedRatings") == 0) {
                 if (Params::instance().verbose_) {
@@ -1763,7 +1754,7 @@ namespace Action {
                       << ": " << _("No Exif data found in the file\n");
             return -3;
         }
-        Exiv2::ExifData::iterator pos = exifData.findKey(Exiv2::ExifKey("Exif.Photo.UserComment"));
+        auto pos = exifData.findKey(Exiv2::ExifKey("Exif.Photo.UserComment"));
         if (pos == exifData.end()) {
             if (Params::instance().verbose_) {
                 std::cout << _("No Exif user comment found") << "\n";
@@ -2013,8 +2004,8 @@ namespace {
                           << " " << _("to") << " " << target << std::endl;
             }
             if ( preserve ) {
-                Exiv2::ExifData::const_iterator end = sourceImage->exifData().end();
-                for (Exiv2::ExifData::const_iterator i = sourceImage->exifData().begin(); i != end; ++i) {
+                auto end = sourceImage->exifData().end();
+                for (auto i = sourceImage->exifData().begin(); i != end; ++i) {
                     targetImage->exifData()[i->key()] = i->value();
                 }
             } else {

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -2100,7 +2100,7 @@ namespace Exiv2 {
             throw Error(kerFileOpenFailed, "http",Exiv2::Internal::stringFormat("%d",serverCode), hostInfo_.Path);
         }
 
-        Exiv2::Dictionary_i lengthIter = response.find("Content-Length");
+        auto lengthIter = response.find("Content-Length");
         return (lengthIter == response.end()) ? -1 : atol((lengthIter->second).c_str());
     }
 

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -299,7 +299,7 @@ namespace Exiv2
                     bLF = false;
                 }
                 io_->seek(skip, BasicIo::cur);
-                while (io_->tell() < (address + box.length)) {
+                while (io_->tell() < static_cast<long>((address + box.length))) {
                     io_->seek(boxHandler(out,option,depth + 1), BasicIo::beg);
                 }
                 // post-process meta box to recover Exif and XMP
@@ -417,7 +417,7 @@ namespace Exiv2
                     bLF = false;
                 }
                 if (name == "cano") {
-                    while (io_->tell() < (address + box.length)) {
+                    while (io_->tell() < static_cast<long>(address + box.length)) {
                         io_->seek(boxHandler(out,option,depth + 1), BasicIo::beg);
                     }
                 } else if ( name == "xmp" ) {

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -158,7 +158,7 @@ namespace Exiv2
 
     int BmffImage::pixelWidth() const
     {
-        ExifData::const_iterator imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
+        auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             return imageWidth->toLong();
         }
@@ -167,7 +167,7 @@ namespace Exiv2
 
     int BmffImage::pixelHeight() const
     {
-        ExifData::const_iterator imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
+        auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             return imageHeight->toLong();
         }

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2686,7 +2686,7 @@ namespace Exiv2 {
             return os;
         }
 
-        ExifData::const_iterator pos = metadata->findKey(ExifKey("Exif.Image.Model"));
+        auto pos = metadata->findKey(ExifKey("Exif.Image.Model"));
         if (pos == metadata->end())
             return os << "(" << value << ")";
 
@@ -2727,7 +2727,7 @@ namespace Exiv2 {
         }
 
         ExifKey key("Exif.CanonCs.Lens");
-        ExifData::const_iterator pos = metadata->findKey(key);
+        auto pos = metadata->findKey(key);
         if (pos != metadata->end() && pos->value().count() >= 3 && pos->value().typeId() == unsignedShort) {
             float fu = pos->value().toFloat(2);
             if (fu != 0.0f) {
@@ -2792,9 +2792,9 @@ namespace Exiv2 {
     {
         try {
             // 1140
-            const ExifData::const_iterator itModel = metadata->findKey(ExifKey("Exif.Image.Model"));
-            const ExifData::const_iterator itLens  = metadata->findKey(ExifKey("Exif.CanonCs.Lens"));
-            const ExifData::const_iterator itApert = metadata->findKey(ExifKey("Exif.CanonCs.MaxAperture"));
+            const auto itModel = metadata->findKey(ExifKey("Exif.Image.Model"));
+            const auto itLens  = metadata->findKey(ExifKey("Exif.CanonCs.Lens"));
+            const auto itApert = metadata->findKey(ExifKey("Exif.CanonCs.MaxAperture"));
 
             if( itModel != metadata->end() && itModel->value().toString() == "Canon EOS 30D"
             &&  itLens  != metadata->end() && itLens->value().toString() == "24 24 1"
@@ -2828,7 +2828,7 @@ namespace Exiv2 {
                                 const ExifData* metadata)
     {
         ExifKey key("Exif.CanonCs.Lens");
-        ExifData::const_iterator pos = metadata->findKey(key);
+        auto pos = metadata->findKey(key);
         ltfl.focalLengthMin_ = 0.0f;
         ltfl.focalLengthMax_ = 0.0f;
         if (pos != metadata->end()) {
@@ -2874,7 +2874,7 @@ namespace Exiv2 {
         convertFocalLength(ltfl, 1.0f);
 
         ExifKey key("Exif.CanonCs.MaxAperture");
-        ExifData::const_iterator pos = metadata->findKey(key);
+        auto pos = metadata->findKey(key);
         if (   pos != metadata->end()
             && pos->value().count() == 1
             && pos->value().typeId() == unsignedShort) {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -480,7 +480,7 @@ namespace Exiv2 {
 
     bool Converter::prepareExifTarget(const char* to, bool force)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(to));
+        auto pos = exifData_->findKey(ExifKey(to));
         if (pos == exifData_->end()) return true;
         if (!overwrite_ && !force) return false;
         exifData_->erase(pos);
@@ -489,7 +489,7 @@ namespace Exiv2 {
 
     bool Converter::prepareIptcTarget(const char* to, bool force)
     {
-        Exiv2::IptcData::iterator pos = iptcData_->findKey(IptcKey(to));
+        auto pos = iptcData_->findKey(IptcKey(to));
         if (pos == iptcData_->end()) return true;
         if (!overwrite_ && !force) return false;
         while ((pos = iptcData_->findKey(IptcKey(to))) != iptcData_->end()) {
@@ -500,7 +500,7 @@ namespace Exiv2 {
 
     bool Converter::prepareXmpTarget(const char* to, bool force)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(to));
+        auto pos = xmpData_->findKey(XmpKey(to));
         if (pos == xmpData_->end()) return true;
         if (!overwrite_ && !force) return false;
         xmpData_->erase(pos);
@@ -509,7 +509,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifValue(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         std::string value = pos->toString();
         if (!pos->value().ok()) {
@@ -525,7 +525,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifComment(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         const CommentValue* cv = dynamic_cast<const CommentValue*>(&pos->value());
@@ -542,7 +542,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifArray(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         for (int i = 0; i < pos->count(); ++i) {
@@ -560,7 +560,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifDate(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         int year, month, day, hour, min, sec;
@@ -629,7 +629,7 @@ namespace Exiv2 {
             buf[1] = '.'; // some locales use ','
             subsec = buf + 1;
 
-            Exiv2::ExifData::iterator datePos = exifData_->findKey(ExifKey("Exif.GPSInfo.GPSDateStamp"));
+            auto datePos = exifData_->findKey(ExifKey("Exif.GPSInfo.GPSDateStamp"));
             if (datePos == exifData_->end()) {
                 datePos = exifData_->findKey(ExifKey("Exif.Photo.DateTimeOriginal"));
             }
@@ -664,7 +664,7 @@ namespace Exiv2 {
         }
 
         if (subsecTag) {
-            ExifData::iterator subsec_pos = exifData_->findKey(ExifKey(subsecTag));
+            auto subsec_pos = exifData_->findKey(ExifKey(subsecTag));
             if (   subsec_pos != exifData_->end()
                 && subsec_pos->typeId() == asciiString) {
                 std::string ss = subsec_pos->toString();
@@ -688,7 +688,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifVersion(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         std::ostringstream value;
@@ -701,7 +701,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifGPSVersion(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         std::ostringstream value;
@@ -715,7 +715,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifFlash(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end() || pos->count() == 0) return;
         if (!prepareXmpTarget(to)) return;
         int value = pos->toLong();
@@ -737,7 +737,7 @@ namespace Exiv2 {
 
     void Converter::cnvExifGPSCoord(const char* from, const char* to)
     {
-        Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
+        auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         if (pos->count() != 3) {
@@ -746,7 +746,7 @@ namespace Exiv2 {
 #endif
             return;
         }
-        Exiv2::ExifData::iterator refPos = exifData_->findKey(ExifKey(std::string(from) + "Ref"));
+        auto refPos = exifData_->findKey(ExifKey(std::string(from) + "Ref"));
         if (refPos == exifData_->end()) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to convert " << from << " to " << to << "\n";
@@ -781,7 +781,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpValue(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
         std::string value;
@@ -803,7 +803,7 @@ namespace Exiv2 {
     void Converter::cnvXmpComment(const char* from, const char* to)
     {
         if (!prepareExifTarget(to)) return;
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         std::string value;
         if (!getTextValue(value, pos)) {
@@ -820,7 +820,7 @@ namespace Exiv2 {
     void Converter::cnvXmpArray(const char* from, const char* to)
     {
         if (!prepareExifTarget(to)) return;
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         std::ostringstream array;
         for (int i = 0; i < pos->count(); ++i) {
@@ -840,7 +840,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpDate(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
 #ifdef EXV_HAVE_XMP_TOOLKIT
@@ -938,7 +938,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpVersion(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
         std::string value = pos->toString();
@@ -961,7 +961,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpGPSVersion(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
         std::string value = pos->toString();
@@ -982,7 +982,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpFlash(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:Fired"));
+        auto pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:Fired"));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
         unsigned short value = 0;
@@ -1043,7 +1043,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpGPSCoord(const char* from, const char* to)
     {
-        Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareExifTarget(to)) return;
         std::string value = pos->toString();
@@ -1107,7 +1107,7 @@ namespace Exiv2 {
 
     void Converter::cnvIptcValue(const char* from, const char* to)
     {
-        Exiv2::IptcData::iterator pos = iptcData_->findKey(IptcKey(from));
+        auto pos = iptcData_->findKey(IptcKey(from));
         if (pos == iptcData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         while (pos != iptcData_->end()) {
@@ -1133,7 +1133,7 @@ namespace Exiv2 {
 
     void Converter::cnvXmpValueToIptc(const char* from, const char* to)
     {
-        XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
+        auto pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         if (!prepareIptcTarget(to)) return;
 
@@ -1188,7 +1188,7 @@ namespace Exiv2 {
 
                 if (!res.str().empty()) res << ',';
                 res << key.tag();
-                Exiv2::ExifData::iterator pos = exifData_->findKey(key);
+                auto pos = exifData_->findKey(key);
                 if (pos == exifData_->end()) continue;
                 DataBuf data(pos->size());
                 pos->copy(data.pData_, littleEndian /* FIXME ? */);
@@ -1221,8 +1221,8 @@ namespace Exiv2 {
 
     void Converter::syncExifWithXmp()
     {
-        Exiv2::XmpData::iterator td = xmpData_->findKey(XmpKey("Xmp.tiff.NativeDigest"));
-        Exiv2::XmpData::iterator ed = xmpData_->findKey(XmpKey("Xmp.exif.NativeDigest"));
+        auto td = xmpData_->findKey(XmpKey("Xmp.tiff.NativeDigest"));
+        auto ed = xmpData_->findKey(XmpKey("Xmp.exif.NativeDigest"));
         if (td != xmpData_->end() && ed != xmpData_->end()) {
             if (td->value().toString() == computeExifDigest(true) &&
                 ed->value().toString() == computeExifDigest(false)) {

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -58,7 +58,7 @@ namespace Exiv2 {
 
     int Cr2Image::pixelWidth() const
     {
-        ExifData::const_iterator imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
+        auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             return imageWidth->toLong();
         }
@@ -67,7 +67,7 @@ namespace Exiv2 {
 
     int Cr2Image::pixelHeight() const
     {
-        ExifData::const_iterator imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
+        auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             return imageHeight->toLong();
         }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -64,7 +64,7 @@ namespace Exiv2 {
 
     int CrwImage::pixelWidth() const
     {
-        Exiv2::ExifData::const_iterator widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
+        auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
             return widthIter->toLong();
         }
@@ -73,7 +73,7 @@ namespace Exiv2 {
 
     int CrwImage::pixelHeight() const
     {
-        Exiv2::ExifData::const_iterator heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
+        auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
             return heightIter->toLong();
         }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -1040,7 +1040,7 @@ namespace Exiv2 {
 
         // Determine the source Exif metadatum
         ExifKey ek(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
-        ExifData::const_iterator ed = image.exifData().findKey(ek);
+        auto ed = image.exifData().findKey(ek);
 
         // Set the new value or remove the entry
         if (ed != image.exifData().end()) {
@@ -1091,9 +1091,9 @@ namespace Exiv2 {
 
         const ExifKey k1("Exif.Image.Make");
         const ExifKey k2("Exif.Image.Model");
-        const ExifData::const_iterator ed1 = image.exifData().findKey(k1);
-        const ExifData::const_iterator ed2 = image.exifData().findKey(k2);
-        const ExifData::const_iterator edEnd = image.exifData().end();
+        const auto ed1 = image.exifData().findKey(k1);
+        const auto ed2 = image.exifData().findKey(k2);
+        const auto edEnd = image.exifData().end();
 
         long size = 0;
         if (ed1 != edEnd) size += ed1->size();
@@ -1148,7 +1148,7 @@ namespace Exiv2 {
 
         time_t t = 0;
         const ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
-        const ExifData::const_iterator ed = image.exifData().findKey(key);
+        const auto ed = image.exifData().findKey(key);
         if (ed != image.exifData().end()) {
             struct tm tm;
             std::memset(&tm, 0x0, sizeof(tm));
@@ -1178,10 +1178,10 @@ namespace Exiv2 {
         const ExifKey kY("Exif.Photo.PixelYDimension");
         const ExifKey kO("Exif.Image.Orientation");
         const ExifData &exivData = image.exifData();
-        const ExifData::const_iterator edX = exivData.findKey(kX);
-        const ExifData::const_iterator edY = exivData.findKey(kY);
-        const ExifData::const_iterator edO = exivData.findKey(kO);
-        const ExifData::const_iterator edEnd = exivData.end();
+        const auto edX = exivData.findKey(kX);
+        const auto edY = exivData.findKey(kY);
+        const auto edO = exivData.findKey(kO);
+        const auto edEnd = exivData.end();
 
         CiffComponent* cc = pHead->findComponent(pCrwMapping->crwTagId_,
                                                  pCrwMapping->crwDir_);
@@ -1241,9 +1241,9 @@ namespace Exiv2 {
         std::memset(buf.pData_, 0x0, buf.size_);
 
         uint16_t len = 0;
-        const ExifData::const_iterator b = exifData.begin();
-        const ExifData::const_iterator e = exifData.end();
-        for (ExifData::const_iterator i = b; i != e; ++i) {
+        const auto b = exifData.begin();
+        const auto e = exifData.end();
+        for (auto i = b; i != e; ++i) {
             if (i->ifdId() != ifdId) continue;
             const uint16_t s = i->tag()*2 + static_cast<uint16_t>(i->size());
             assert(s <= size);

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -688,7 +688,7 @@ namespace Exiv2 {
             "Exif.Canon.AFPointsUnusable",
         };
         for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfd0Tags); ++i) {
-            ExifData::iterator pos = ed.findKey(ExifKey(filteredIfd0Tags[i]));
+            auto pos = ed.findKey(ExifKey(filteredIfd0Tags[i]));
             if (pos != ed.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Warning: Exif tag " << pos->key() << " not encoded\n";
@@ -815,7 +815,7 @@ namespace Exiv2 {
         }
 
         // Delete unknown tags larger than 4kB and known tags larger than 20kB.
-        for (ExifData::iterator tag_iter = ed.begin(); tag_iter != ed.end(); ) {
+        for (auto tag_iter = ed.begin(); tag_iter != ed.end(); ) {
             if ( (tag_iter->size() > 4096 && tag_iter->tagName().substr(0, 2) == "0x") ||
                   tag_iter->size() > 20480) {
 #ifndef SUPPRESS_WARNINGS
@@ -864,7 +864,7 @@ namespace {
     {
         Thumbnail::UniquePtr thumbnail;
         const Exiv2::ExifKey k1("Exif.Thumbnail.Compression");
-        Exiv2::ExifData::const_iterator pos = exifData.findKey(k1);
+        auto pos = exifData.findKey(k1);
         if (pos != exifData.end()) {
             if (pos->count() == 0) return thumbnail;
             long compression = pos->toLong();
@@ -906,7 +906,7 @@ namespace {
     {
         Exiv2::ExifData thumb;
         // Copy all Thumbnail (IFD1) tags from exifData to Image (IFD0) tags in thumb
-        for (Exiv2::ExifData::const_iterator i = exifData.begin(); i != exifData.end(); ++i) {
+        for (auto i = exifData.begin(); i != exifData.end(); ++i) {
             if (i->groupName() == "Thumbnail") {
                 std::string key = "Exif.Image." + i->tagName();
                 thumb.add(Exiv2::ExifKey(key), &i->value());
@@ -940,7 +940,7 @@ namespace {
     Exiv2::DataBuf JpegThumbnail::copy(const Exiv2::ExifData& exifData) const
     {
         Exiv2::ExifKey key("Exif.Thumbnail.JPEGInterchangeFormat");
-        Exiv2::ExifData::const_iterator format = exifData.findKey(key);
+        auto format = exifData.findKey(key);
         if (format == exifData.end()) return Exiv2::DataBuf();
         return format->dataArea();
     }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -252,7 +252,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 
     ////////////////////////////////////
     // open the socket
-    int     sockfd = socket(AF_INET , SOCK_STREAM,IPPROTO_TCP) ;
+    int sockfd = static_cast<int>(socket(AF_INET , SOCK_STREAM,IPPROTO_TCP));
     if (sockfd < 0)
         return error(errors, "unable to create socket\n", NULL, NULL, 0);
 

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -126,7 +126,7 @@ namespace Exiv2 {
         const byte* pEnd = pPsData + sizePsData;
         int ret = 0;
         while (pCur < pEnd
-               && 0 == (ret = Photoshop::locateIptcIrb(pCur, pEnd - pCur,
+               && 0 == (ret = Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
                                                        &record, &sizeHdr, &sizeIptc))) {
             pCur = record + sizeHdr + sizeIptc + (sizeIptc & 1);
         }
@@ -539,7 +539,7 @@ namespace Exiv2 {
             const byte* pCur = &psBlob[0];
             const byte* pEnd = pCur + psBlob.size();
             while (   pCur < pEnd
-                   && 0 == Photoshop::locateIptcIrb(pCur, pEnd - pCur,
+                   && 0 == Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
                                                     &record, &sizeHdr, &sizeIptc)) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Found IPTC IRB, size = " << sizeIptc << "\n";
@@ -1200,11 +1200,11 @@ namespace Exiv2 {
                     const byte* chunkEnd = chunkStart + newPsData.size_;
                     while (chunkStart < chunkEnd) {
                         // Determine size of next chunk
-                        long chunkSize = chunkEnd - chunkStart;
+                        long chunkSize = static_cast<long>(chunkEnd - chunkStart);
                         if (chunkSize > maxChunkSize) {
                             chunkSize = maxChunkSize;
                             // Don't break at a valid IRB boundary
-                            const long writtenSize = chunkStart - newPsData.pData_;
+                            const long writtenSize = static_cast<long>(chunkStart - newPsData.pData_);
                             if (Photoshop::valid(newPsData.pData_, writtenSize + chunkSize)) {
                                 // Since an IRB has minimum size 12,
                                 // (chunkSize - 8) can't be also a IRB boundary

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -583,7 +583,7 @@ namespace Exiv2 {
         }
 
         bool bPrint = option == kpsBasic || option == kpsRecursive;
-        Exiv2::Uint32Vector iptcDataSegs;
+        std::vector<uint32_t> iptcDataSegs;
 
         if (bPrint || option == kpsXMP || option == kpsIccProfile || option == kpsIptcErase) {
             // nmonic for markers
@@ -850,7 +850,7 @@ namespace Exiv2 {
             uint64_t* pos = new uint64_t[count + 2];
             pos[0] = 0;
             // copy the data that is not iptc
-            Uint32Vector_i it = iptcDataSegs.begin();
+            auto it = iptcDataSegs.begin();
             for (uint64_t i = 0; i < count; i++) {
                 bool bOdd = (i % 2) != 0;
                 bool bEven = !bOdd;

--- a/src/minoltamn_int.cpp
+++ b/src/minoltamn_int.cpp
@@ -2163,7 +2163,7 @@ namespace Exiv2 {
             std::string maxAperture = getKeyString("Exif.Photo.MaxApertureValue" ,metadata);
 
             std::string F1_8        = "434/256" ;
-            Exiv2::StringSet maxApertures;
+            std::set<std::string> maxApertures;
                              maxApertures.insert( "926/256") ; // F3.5
                              maxApertures.insert("1024/256") ; // F4
                              maxApertures.insert("1110/256") ; // F4.5

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -51,7 +51,7 @@ namespace Exiv2 {
 
     int MrwImage::pixelWidth() const
     {
-        ExifData::const_iterator imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
+        auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             return imageWidth->toLong();
         }
@@ -60,7 +60,7 @@ namespace Exiv2 {
 
     int MrwImage::pixelHeight() const
     {
-        ExifData::const_iterator imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
+        auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             return imageHeight->toLong();
         }

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1726,7 +1726,7 @@ namespace Exiv2 {
 
         bool dModel = false;
         if (metadata) {
-            ExifData::const_iterator pos = metadata->findKey(ExifKey("Exif.Image.Model"));
+            auto pos = metadata->findKey(ExifKey("Exif.Image.Model"));
             if (pos != metadata->end() && pos->count() != 0) {
                 std::string model = pos->toString();
                 if (model.find("NIKON D") != std::string::npos) {
@@ -1758,7 +1758,7 @@ namespace Exiv2 {
         bool d70 = false;
         if (metadata) {
             ExifKey key("Exif.Image.Model");
-            ExifData::const_iterator pos = metadata->findKey(key);
+            auto pos = metadata->findKey(key);
             if (pos != metadata->end() && pos->count() != 0) {
                 std::string model = pos->toString();
                 if (model.find("D70") != std::string::npos) {
@@ -2641,14 +2641,14 @@ fmountlens[] = {
         const std::string pre = std::string("Exif.") + group + std::string(".");
         for (unsigned int i = 0; i < 7; ++i) {
             ExifKey key(pre + std::string(tags[i]));
-            ExifData::const_iterator md = metadata->findKey(key);
+            auto md = metadata->findKey(key);
             if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
                 return os << value;
             }
             raw[i] = static_cast<byte>(md->toLong());
         }
 
-        ExifData::const_iterator md = metadata->findKey(ExifKey("Exif.Nikon3.LensType"));
+        auto md = metadata->findKey(ExifKey("Exif.Nikon3.LensType"));
         if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
             return os << value;
         }

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1667,7 +1667,7 @@ value, const ExifData* metadata)
         bool E3_E30model = false;
 
         if (metadata != NULL) {
-            ExifData::const_iterator pos = metadata->findKey(ExifKey("Exif.Image.Model"));
+            auto pos = metadata->findKey(ExifKey("Exif.Image.Model"));
             if (pos != metadata->end() && pos->count() != 0) {
                 std::string model = pos->toString();
                 if (model.find("E-3 ") != std::string::npos ||

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -56,7 +56,7 @@ namespace Exiv2 {
 
     int OrfImage::pixelWidth() const
     {
-        ExifData::const_iterator imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
+        auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             return imageWidth->toLong();
         }
@@ -65,7 +65,7 @@ namespace Exiv2 {
 
     int OrfImage::pixelHeight() const
     {
-        ExifData::const_iterator imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
+        auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             return imageHeight->toLong();
         }

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1160,12 +1160,12 @@ namespace Exiv2 {
     {
         if ( ! metadata ) return os << "undefined" ;
 
-        ExifData::const_iterator dateIt = metadata->findKey(
+        auto dateIt = metadata->findKey(
                 ExifKey("Exif.PentaxDng.Date"));
         if (dateIt == metadata->end()) {
             dateIt = metadata->findKey(ExifKey("Exif.Pentax.Date"));
         }
-        ExifData::const_iterator timeIt = metadata->findKey(
+        auto timeIt = metadata->findKey(
                 ExifKey("Exif.PentaxDng.Time"));
         if (timeIt == metadata->end()) {
             timeIt = metadata->findKey(ExifKey("Exif.Pentax.Time"));
@@ -1249,7 +1249,7 @@ namespace Exiv2 {
             unsigned long index  = 0;
 
             // http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Pentax.html#LensData
-            const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
+            const auto lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
                                                     ? metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo"))
                                                     : metadata->findKey(ExifKey("Exif.Pentax.LensInfo"))
                                                     ;
@@ -1307,7 +1307,7 @@ namespace Exiv2 {
         try {
             unsigned long index  = 0;
 
-            const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
+            const auto lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
                                                     ? metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo"))
                                                     : metadata->findKey(ExifKey("Exif.Pentax.LensInfo"))
                                                     ;
@@ -1335,7 +1335,7 @@ namespace Exiv2 {
         try {
             unsigned long index  = 0;
 
-            const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
+            const auto lensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo")) != metadata->end()
                                                     ? metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo"))
                                                     : metadata->findKey(ExifKey("Exif.Pentax.LensInfo"))
                                                     ;

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -312,7 +312,7 @@ namespace Exiv2 {
                 const byte* pCur = psData.pData_;
                 while (   pCur < pEnd
                        && 0 == Photoshop::locateIptcIrb(pCur,
-                                                        pEnd - pCur,
+                                                        static_cast<long>(pEnd - pCur),
                                                         &record,
                                                         &sizeHdr,
                                                         &sizeIptc)) {
@@ -490,14 +490,14 @@ namespace Exiv2 {
 
     std::string PngChunk::zlibCompress(const std::string& text)
     {
-        uLongf compressedLen = (text.size() * 2); // just a starting point
+        uLongf compressedLen = static_cast<uLongf>(text.size() * 2); // just a starting point
         int zlibResult;
 
         DataBuf arr;
         do {
             arr.alloc(compressedLen);
             zlibResult = compress2(arr.pData_, &compressedLen,
-                                   (const Bytef*)text.data(), text.size(),
+                                   (const Bytef*)text.data(), static_cast<uLong>(text.size()),
                                    Z_BEST_COMPRESSION);
 
             switch (zlibResult) {

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -521,7 +521,7 @@ namespace {
     {
         offset_ = 0;
         const ExifData &exifData = image_.exifData();
-        ExifData::const_iterator pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
+        auto pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
         if (pos != exifData.end() && pos->count() > 0) {
             offset_ = pos->toLong();
         }
@@ -613,7 +613,7 @@ namespace {
         : Loader(id, image),
           dataKey_(param_[parIdx].dataKey_)
     {
-        ExifData::const_iterator pos = image_.exifData().findKey(dataKey_);
+        auto pos = image_.exifData().findKey(dataKey_);
         if (pos != image_.exifData().end()) {
             size_ = pos->sizeDataArea(); // indirect data
             if (size_ == 0 && pos->typeId() == undefined)
@@ -645,7 +645,7 @@ namespace {
     {
         if (!valid()) return DataBuf();
 
-        ExifData::const_iterator pos = image_.exifData().findKey(dataKey_);
+        auto pos = image_.exifData().findKey(dataKey_);
         if (pos != image_.exifData().end()) {
             DataBuf buf = pos->dataArea(); // indirect data
 
@@ -760,7 +760,7 @@ namespace {
         ExifData preview;
 
         // copy tags
-        for (ExifData::const_iterator pos = exifData.begin(); pos != exifData.end(); ++pos) {
+        for (auto pos = exifData.begin(); pos != exifData.end(); ++pos) {
             if (pos->groupName() == group_) {
                 /*
                    Write only the necessary TIFF image tags

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
 
     int RafImage::pixelWidth() const
     {
-        Exiv2::ExifData::const_iterator widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
+        auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
             return widthIter->toLong();
         }
@@ -62,7 +62,7 @@ namespace Exiv2 {
 
     int RafImage::pixelHeight() const
     {
-        Exiv2::ExifData::const_iterator heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
+        auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
             return heightIter->toLong();
         }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
 
     int Rw2Image::pixelWidth() const
     {
-        ExifData::const_iterator imageWidth =
+        auto imageWidth =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             return imageWidth->toLong();
@@ -63,7 +63,7 @@ namespace Exiv2 {
 
     int Rw2Image::pixelHeight() const
     {
-        ExifData::const_iterator imageHeight =
+        auto imageHeight =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorHeight"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             return imageHeight->toLong();
@@ -150,9 +150,9 @@ namespace Exiv2 {
         ExifData& prevData = image->exifData();
         if (!prevData.empty()) {
             // Filter duplicate tags
-            for (ExifData::const_iterator pos = exifData_.begin(); pos != exifData_.end(); ++pos) {
+            for (auto pos = exifData_.begin(); pos != exifData_.end(); ++pos) {
                 if (pos->ifdId() == panaRawId) continue;
-                ExifData::iterator dup = prevData.findKey(ExifKey(pos->key()));
+                auto dup = prevData.findKey(ExifKey(pos->key()));
                 if (dup != prevData.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cerr << "Filtering duplicate tag " << pos->key()
@@ -195,7 +195,7 @@ namespace Exiv2 {
             "Exif.Image.YCbCrPositioning"
         };
         for (unsigned int i = 0; i < EXV_COUNTOF(filteredTags); ++i) {
-            ExifData::iterator pos = prevData.findKey(ExifKey(filteredTags[i]));
+            auto pos = prevData.findKey(ExifKey(filteredTags[i]));
             if (pos != prevData.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Exif tag " << pos->key() << " removed\n";
@@ -205,7 +205,7 @@ namespace Exiv2 {
         }
 
         // Add the remaining tags
-        for (ExifData::const_iterator pos = prevData.begin(); pos != prevData.end(); ++pos) {
+        for (auto pos = prevData.begin(); pos != prevData.end(); ++pos) {
             exifData_.add(*pos);
         }
 

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -94,7 +94,7 @@ namespace Exiv2 {
 
         mimeType_ = std::string("image/tiff");
         std::string key = "Exif." + primaryGroup() + ".Compression";
-        ExifData::const_iterator md = exifData_.findKey(ExifKey(key));
+        auto md = exifData_.findKey(ExifKey(key));
         if (md != exifData_.end() && md->count() > 0) {
             const MimeTypeList* i = find(mimeTypeList, static_cast<int>(md->toLong()));
             if (i) mimeType_ = std::string(i->mimeType_);
@@ -121,7 +121,7 @@ namespace Exiv2 {
         // Find the group of the primary image, default to "Image"
         primaryGroup_ = std::string("Image");
         for (unsigned int i = 0; i < EXV_COUNTOF(keys); ++i) {
-            ExifData::const_iterator md = exifData_.findKey(ExifKey(keys[i]));
+            auto md = exifData_.findKey(ExifKey(keys[i]));
             // Is it the primary image?
             if (md != exifData_.end() && md->count() > 0 && md->toLong() == 0) {
                 // Sometimes there is a JPEG primary image; that's not our first choice
@@ -138,7 +138,7 @@ namespace Exiv2 {
         if (pixelWidth_ != 0) return pixelWidth_;
 
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageWidth"));
-        ExifData::const_iterator imageWidth = exifData_.findKey(key);
+        auto imageWidth = exifData_.findKey(key);
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
             pixelWidth_ = static_cast<int>(imageWidth->toLong());
         }
@@ -150,7 +150,7 @@ namespace Exiv2 {
         if (pixelHeight_ != 0) return pixelHeight_;
 
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageLength"));
-        ExifData::const_iterator imageHeight = exifData_.findKey(key);
+        auto imageHeight = exifData_.findKey(key);
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
             pixelHeight_ = imageHeight->toLong();
         }
@@ -190,7 +190,7 @@ namespace Exiv2 {
 
         // read profile from the metadata
         Exiv2::ExifKey            key("Exif.Image.InterColorProfile");
-        Exiv2::ExifData::iterator pos   = exifData_.findKey(key);
+        auto pos   = exifData_.findKey(key);
         if ( pos != exifData_.end() ) {
             long size = pos->count() * pos->typeSize();
             if (size == 0) {
@@ -229,7 +229,7 @@ namespace Exiv2 {
 
         // fixup ICC profile
         Exiv2::ExifKey            key("Exif.Image.InterColorProfile");
-        Exiv2::ExifData::iterator pos   = exifData_.findKey(key);
+        auto pos   = exifData_.findKey(key);
         bool                      found = pos != exifData_.end();
         if ( iccProfileDefined() ) {
             Exiv2::DataValue value(iccProfile_.pData_,iccProfile_.size_);

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -606,7 +606,7 @@ namespace Exiv2 {
 
         // Find camera make
         ExifKey key("Exif.Image.Make");
-        ExifData::const_iterator pos = exifData_.findKey(key);
+        auto pos = exifData_.findKey(key);
         if (pos != exifData_.end()) {
             make_ = pos->toString();
         }
@@ -632,7 +632,7 @@ namespace Exiv2 {
         // not exist, create a new IPTCNAA Exif tag.
         bool del = false;
         ExifKey iptcNaaKey("Exif.Image.IPTCNAA");
-        ExifData::iterator pos = exifData_.findKey(iptcNaaKey);
+        auto pos = exifData_.findKey(iptcNaaKey);
         if (pos != exifData_.end()) {
             iptcNaaKey.setIdx(pos->idx());
             exifData_.erase(pos);
@@ -682,7 +682,7 @@ namespace Exiv2 {
 #ifdef EXV_HAVE_XMP_TOOLKIT
         ExifKey xmpKey("Exif.Image.XMLPacket");
         // Remove any existing XMP Exif tag
-        ExifData::iterator pos = exifData_.findKey(xmpKey);
+        auto pos = exifData_.findKey(xmpKey);
         if (pos != exifData_.end()) {
             xmpKey.setIdx(pos->idx());
             exifData_.erase(pos);
@@ -795,7 +795,7 @@ namespace Exiv2 {
         else if (del_) {
             // The makernote is made up of decoded tags, delete binary tag
             ExifKey key(object->tag(), groupName(object->group()));
-            ExifData::iterator pos = exifData_.findKey(key);
+            auto pos = exifData_.findKey(key);
             if (pos != exifData_.end()) exifData_.erase(pos);
         }
     }
@@ -894,7 +894,7 @@ namespace Exiv2 {
     {
         assert(object != 0);
 
-        ExifData::iterator pos = exifData_.end();
+        auto pos = exifData_.end();
         const Exifdatum* ed = datum;
         if (ed == 0) {
             // Non-intrusive writing: find matching tag
@@ -904,7 +904,7 @@ namespace Exiv2 {
                 ed = &(*pos);
                 if (object->idx() != pos->idx()) {
                     // Try to find exact match (in case of duplicate tags)
-                    ExifData::iterator pos2 =
+                    auto pos2 =
                         std::find_if(exifData_.begin(), exifData_.end(),
                                      FindExifdatum2(object->group(), object->idx()));
                     if (pos2 != exifData_.end() && pos2->key() == key.key()) {
@@ -1015,7 +1015,7 @@ namespace Exiv2 {
 #endif
             // Set pseudo strips (without a data pointer) from the size tag
             ExifKey key(object->szTag(), groupName(object->szGroup()));
-            ExifData::const_iterator pos = exifData_.findKey(key);
+            auto pos = exifData_.findKey(key);
             const byte* zero = 0;
             if (pos == exifData_.end()) {
 #ifndef SUPPRESS_WARNINGS
@@ -1150,8 +1150,8 @@ namespace Exiv2 {
         // iterate over all remaining entries.
         del_ = false;
 
-        ExifData::const_iterator posBo = exifData_.end();
-        for (ExifData::const_iterator i = exifData_.begin();
+        auto posBo = exifData_.end();
+        for (auto i = exifData_.begin();
              i != exifData_.end(); ++i) {
 
             IfdId group = groupId(i->groupName());

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -221,7 +221,7 @@ namespace Exiv2 {
     long DataValue::copy(byte* buf, ByteOrder /*byteOrder*/) const
     {
         // byteOrder not needed
-        return std::copy(value_.begin(), value_.end(), buf) - buf;
+        return static_cast<long>(std::copy(value_.begin(), value_.end(), buf) - buf);
     }
 
     long DataValue::size() const
@@ -1055,7 +1055,7 @@ namespace Exiv2 {
         tms.tm_mday = date_.day;
         tms.tm_mon = date_.month - 1;
         tms.tm_year = date_.year - 1900;
-        auto l = std::mktime(&tms);
+        long l = static_cast<long>(std::mktime(&tms));
         ok_ = (l != -1);
         return l;
     }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -557,9 +557,9 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
 
     Exiv2::Dictionary ns;
     Exiv2::XmpProperties::registeredNamespaces(ns);
-    for ( Exiv2::Dictionary_i it = ns.begin(); it != ns.end() ; ++it ) {
-        std::string xmlns = (*it).first;
-        std::string uri   = (*it).second;
+    for ( auto it = ns.begin(); it != ns.end() ; ++it ) {
+        std::string xmlns = it->first;
+        std::string uri   = it->second;
         output(os,keys,name,xmlns+":"+uri);
     }
 #endif

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -150,7 +150,7 @@ static void output(std::ostream& os,const exv_grep_keys_t& greps,const char* nam
     output(os,greps,name,stringStream.str());
 }
 
-static bool pushPath(std::string& path,Exiv2::StringVector& libs,Exiv2::StringSet& paths)
+static bool pushPath(std::string& path,std::vector<std::string>& libs,std::set<std::string>& paths)
 {
     bool result = Exiv2::fileExists(path,true) && paths.find(path) == paths.end() && path != "/" ;
     if ( result ) {
@@ -160,10 +160,10 @@ static bool pushPath(std::string& path,Exiv2::StringVector& libs,Exiv2::StringSe
     return result ;
 }
 
-static Exiv2::StringVector getLoadedLibraries()
+static std::vector<std::string> getLoadedLibraries()
 {
-    Exiv2::StringVector libs ;
-    Exiv2::StringSet    paths;
+    std::vector<std::string> libs ;
+    std::set<std::string> paths;
     std::string         path ;
 
 #if defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW__)
@@ -476,7 +476,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     use_curl=1;
 #endif
 
-    Exiv2::StringVector libs =getLoadedLibraries();
+    std::vector<std::string> libs =getLoadedLibraries();
 
     output(os,keys,"exiv2",Exiv2::versionString());
     output(os,keys,"platform"       , platform   );
@@ -507,7 +507,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     output(os,keys,"curl"          , use_curl);
     if ( libs.begin() != libs.end() ) {
         output(os,keys,"executable" ,*libs.begin());
-        for ( Exiv2::StringVector_i lib = libs.begin()+1 ; lib != libs.end() ; ++lib )
+        for ( auto lib = libs.begin()+1 ; lib != libs.end() ; ++lib )
             output(os,keys,"library",*lib);
     }
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -392,7 +392,7 @@ namespace Exiv2 {
         // The side effects are avoided by the two-step approach
         // https://github.com/Exiv2/exiv2/issues/560
         std::string         key(pos->key());
-        Exiv2::StringVector keys;
+        std::vector<std::string> keys;
         while ( pos != xmpMetadata_.end() ) {
             if ( pos->key().find(key)==0 ) {
                 keys.push_back(pos->key());
@@ -402,8 +402,8 @@ namespace Exiv2 {
             }
         }
         // now erase the family!
-        for ( Exiv2::StringVector_i it = keys.begin() ; it != keys.end() ; it++ ) {
-            erase(findKey(Exiv2::XmpKey(*it)));
+        for (const auto& key: keys) {
+            erase(findKey(Exiv2::XmpKey(key)));
         }
     }
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -597,7 +597,7 @@ namespace Exiv2 {
             return 2;
         }
 
-        SXMPMeta meta(xmpPacket.data(), xmpPacket.size());
+        SXMPMeta meta(xmpPacket.data(), static_cast<XMP_StringLen>(xmpPacket.size()));
         SXMPIterator iter(meta);
         std::string schemaNs, propPath, propValue;
         XMP_OptionBits opt;

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -153,7 +153,7 @@ namespace Exiv2 {
             }
 
             // #1112 - restore dates if they lost their TZ info
-            for ( Exiv2::Dictionary_i it = dates_.begin() ; it != dates_.end() ; ++it ) {
+            for ( auto it = dates_.begin() ; it != dates_.end() ; ++it ) {
                 std::string   sKey = it->first;
                 Exiv2::XmpKey key(sKey);
                 if ( xmpData_.findKey(key) != xmpData_.end() ) {


### PR DESCRIPTION
In this PR I am introducing the usage of `auto` for accessing the STL iterators. This is one of my favuorite usages of àuto` because of 2 reasons:

1. You type less code.
2. You avoid many mistakes in the usage of iterators (like corverting implicitly the types of the iterators to something else by mistake).

I also noticed that in #1569 some of the links were not correct, so I am fixing that here too.