### PR TITLE
Update bmffimage.hpp include order and path

### DIFF
--- a/include/exiv2/exiv2.hpp
+++ b/include/exiv2/exiv2.hpp
@@ -25,6 +25,7 @@
 #include "exiv2/config.h"
 #include "exiv2/datasets.hpp"
 #include "exiv2/basicio.hpp"
+#include "exiv2/bmffimage.hpp"
 #include "exiv2/bmpimage.hpp"
 #include "exiv2/convert.hpp"
 #include "exiv2/cr2image.hpp"
@@ -45,7 +46,6 @@
 #include "exiv2/mrwimage.hpp"
 #include "exiv2/orfimage.hpp"
 #include "exiv2/pgfimage.hpp"
-#include "bmffimage.hpp"
 
 #ifdef EXV_HAVE_LIBZ
 #include "exiv2/pngimage.hpp"


### PR DESCRIPTION
No need to treat it differently since https://github.com/Exiv2/exiv2/commit/206a2c495c2e30ef760e0f6e83d05bf3c452810f

Should be back-ported to 0.27 if there is RC3 coming?