### PR TITLE
Fix infinite loop caused by subBox with zero size.

### DIFF
--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -670,6 +670,7 @@ static void boxes_check(size_t b,size_t m)
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Jp2Image::encodeJp2Header subbox: "<< toAscii(subBox.type) << " length = " << subBox.length << std::endl;
 #endif
+                enforce(subBox.length > 0, Exiv2::kerCorruptedMetadata);
                 enforce(subBox.length <= length - count, Exiv2::kerCorruptedMetadata);
                 count        += subBox.length;
                 newBox.type   = subBox.type;


### PR DESCRIPTION
A sub-box with zero size causes an infinite loop in `Jp2Image::encodeJp2Header`.