### PR TITLE
clang-tidy: use braced init list

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -205,13 +205,13 @@ namespace Exiv2 {
     Slice<byte*> makeSlice(DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return Slice<byte*>(buf.pData_, begin, end);
+        return {buf.pData_, begin, end};
     }
 
     Slice<const byte*> makeSlice(const DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return Slice<const byte*>(buf.pData_, begin, end);
+        return {buf.pData_, begin, end};
     }
 
     std::ostream& operator<<(std::ostream& os, const Rational& r)
@@ -673,13 +673,15 @@ namespace Exiv2 {
         if (ok) return ret;
 
         long l = stringTo<long>(s, ok);
-        if (ok) return Rational(l, 1);
+        if (ok)
+            return {l, 1};
 
         float f = stringTo<float>(s, ok);
         if (ok) return floatToRationalCast(f);
 
         bool b = stringTo<bool>(s, ok);
-        if (ok) return b ? Rational(1, 1) : Rational(0, 1);
+        if (ok)
+            return {b ? 1 : 0, 1};
 
         // everything failed, return from stringTo<Rational> is probably the best fit
         return ret;
@@ -692,7 +694,7 @@ namespace Exiv2 {
 #else
         if (!std::isfinite(f)) {
 #endif
-            return Rational(f > 0 ? 1 : -1, 0);
+            return {f > 0 ? 1 : -1, 0};
         }
         // Beware: primitive conversion algorithm
         int32_t den = 1000000;
@@ -710,7 +712,7 @@ namespace Exiv2 {
         const int32_t nom = static_cast<int32_t>(f * den + rnd);
         const int32_t g = gcd(nom, den);
 
-        return Rational(nom / g, den / g);
+        return {nom / g, den / g};
     }
 
 }                                       // namespace Exiv2

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -267,7 +267,7 @@ namespace Exiv2 {
     Rational DataValue::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n], 1);
+        return {value_[n], 1};
     }
 
     StringValueBase::StringValueBase(TypeId typeId)
@@ -351,7 +351,7 @@ namespace Exiv2 {
     Rational StringValueBase::toRational(long n) const
     {
         ok_ = true;
-        return Rational(value_[n], 1);
+        return {value_[n], 1};
     }
 
     StringValue::StringValue()
@@ -930,7 +930,7 @@ namespace Exiv2 {
     Rational LangAltValue::toRational(long /*n*/) const
     {
         ok_ = false;
-        return Rational(0, 0);
+        return {0, 0};
     }
 
     LangAltValue* LangAltValue::clone_() const
@@ -1067,7 +1067,7 @@ namespace Exiv2 {
 
     Rational DateValue::toRational(long n) const
     {
-        return Rational(toLong(n), 1);
+        return {toLong(n), 1};
     }
 
     TimeValue::TimeValue()
@@ -1251,7 +1251,7 @@ namespace Exiv2 {
 
     Rational TimeValue::toRational(long n) const
     {
-        return Rational(toLong(n), 1);
+        return {toLong(n), 1};
     }
 
 }                                       // namespace Exiv2


### PR DESCRIPTION
Found with modernize-return-braced-init-list

Signed-off-by: Rosen Penev <rosenp@gmail.com>