### PR TITLE
clang-tidy: range for loop conversions

### DIFF
--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -87,9 +87,9 @@ try {
     image->readMetadata();
     Exiv2::ExifData& ed = image->exifData();
 
-    for (unsigned int i = 0; i < EXV_COUNTOF(easyAccess); ++i) {
-        auto pos = easyAccess[i].findFct_(ed);
-        std::cout << std::setw(21) << std::left << easyAccess[i].label_;
+    for (auto&& ea : easyAccess) {
+        auto pos = ea.findFct_(ed);
+        std::cout << std::setw(21) << std::left << ea.label_;
         if (pos != ed.end()) {
             std::cout << " (" << std::setw(35) << pos->key() << ") : "
                       << pos->print(&ed) << "\n";

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -35,19 +35,15 @@ void syntax(const char* argv[],format_t& formats)
 	std::cout << "Usage: " << argv[0] << " file format" << std::endl;
 	int count = 0;
 	std::cout << "formats: ";
-	for ( format_i i = formats.begin() ; i != formats.end() ; i++ ) {
-		std::cout << ( count++ ? " | " : "") << i->first ;
-	}
-	std::cout << std::endl;
+    for (auto&& format : formats) {
+        std::cout << (count++ ? " | " : "") << format.first;
+    }
+    std::cout << std::endl;
 }
 
 size_t formatInit(Exiv2::ExifData& exifData)
 {
-	size_t result = 0;
-	for (auto i = exifData.begin(); i != exifData.end() ; ++i) {
-		result ++ ;
-	}
-	return result ;
+    return std::distance(exifData.begin(), exifData.end());
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -59,12 +55,13 @@ std::string escapeCSV(Exiv2::ExifData::const_iterator  it,bool bValue)
 	if ( bValue ) os << it->value() ; else os << it->key() ;
 
 	std::string s = os.str();
-	for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-		if ( s[i] == ',' ) result += '\\';
-		result += s[i];
-	}
+    for (auto&& c : s) {
+        if (c == ',')
+            result += '\\';
+        result += c;
+    }
 
-	return result ;
+    return result;
 }
 
 std::string formatCSV(Exiv2::ExifData& exifData)
@@ -109,13 +106,14 @@ std::string escapeJSON(Exiv2::ExifData::const_iterator  it,bool bValue=true)
 	if ( bValue ) os << it->value() ; else os << it->key() ;
 
 	std::string s = os.str();
-	for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-		if ( s[i] == '"' ) result += "\\\"";
-		result += s[i];
-	}
+    for (auto&& c : s) {
+        if (c == '"')
+            result += "\\\"";
+        result += c;
+    }
 
-	std::string q = "\"";
-	return q + result + q ;
+    std::string q = "\"";
+    return q + result + q;
 }
 
 std::string formatJSON(Exiv2::ExifData& exifData)
@@ -141,13 +139,15 @@ std::string escapeXML(Exiv2::ExifData::const_iterator  it,bool bValue=true)
 	if ( bValue ) os << it->value() ; else os << it->key() ;
 
 	std::string s = os.str();
-	for ( size_t i = 0 ;i < s.length() ; i ++ ) {
-		if ( s[i] == '<' ) result += "&lg;";
-		if ( s[i] == '>' ) result += "&gt;";
-		result += s[i];
-	}
+    for (auto&& c : s) {
+        if (c == '<')
+            result += "&lg;";
+        if (c == '>')
+            result += "&gt;";
+        result += c;
+    }
 
-	return result ;
+    return result;
 }
 
 std::string formatXML(Exiv2::ExifData& exifData)

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -907,8 +907,7 @@ int main(int argc,const char* argv[])
             }
         }
 */
-        for ( size_t p = 0 ; p < gFiles.size() ; p++ ) {
-            std::string path  = gFiles[p] ;
+        for (auto&& path : gFiles) {
             std::string stamp ;
             try {
                 time_t t       = readImageTime(path,&stamp) ;

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -45,17 +45,13 @@ try {
 
     Exiv2::PreviewManager loader(*image);
     Exiv2::PreviewPropertiesList list = loader.getPreviewProperties();
-    for (Exiv2::PreviewPropertiesList::iterator pos = list.begin(); pos != list.end(); pos++) {
-        std::cout << pos->mimeType_
-                  << " preview, type " << pos->id_ << ", "
-                  << pos->size_ << " bytes, "
-                  << pos->width_ << 'x' << pos->height_ << " pixels"
+    for (auto&& pos : list) {
+        std::cout << pos.mimeType_ << " preview, type " << pos.id_ << ", " << pos.size_ << " bytes, " << pos.width_
+                  << 'x' << pos.height_ << " pixels"
                   << "\n";
 
-        Exiv2::PreviewImage preview = loader.getPreviewImage(*pos);
-        preview.writeFile(filename + "_"
-                          + Exiv2::toString(pos->width_) + "x"
-                          + Exiv2::toString(pos->height_));
+        Exiv2::PreviewImage preview = loader.getPreviewImage(pos);
+        preview.writeFile(filename + "_" + Exiv2::toString(pos.width_) + "x" + Exiv2::toString(pos.height_));
     }
 
     // Cleanup

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -72,28 +72,37 @@ int main()
 
     std::cout << std::endl;
 
-    for (unsigned int i = 0; i < EXV_COUNTOF(testcases); ++i) try {
-        std::string s(testcases[i]);
-        std::cout << std::setw(12) << std::left << s;
-        bool ok;
+    for (auto&& testcase : testcases) {
+        try {
+            std::string s(testcase);
+            std::cout << std::setw(12) << std::left << s;
+            bool ok;
 
-        long l = Exiv2::parseLong(s, ok);
-        std::cout << std::setw(12) << std::left;
-        if (ok) std::cout << l; else std::cout << "nok";
+            long l = Exiv2::parseLong(s, ok);
+            std::cout << std::setw(12) << std::left;
+            if (ok)
+                std::cout << l;
+            else
+                std::cout << "nok";
 
-        float f = Exiv2::parseFloat(s, ok);
-        std::cout << std::setw(12) << std::left;
-        if (ok) std::cout << f; else std::cout << "nok";
+            float f = Exiv2::parseFloat(s, ok);
+            std::cout << std::setw(12) << std::left;
+            if (ok)
+                std::cout << f;
+            else
+                std::cout << "nok";
 
-        Exiv2::Rational r = Exiv2::parseRational(s, ok);
-        if (ok) std::cout << r.first << "/" << r.second;
-        else std::cout << "nok";
+            Exiv2::Rational r = Exiv2::parseRational(s, ok);
+            if (ok)
+                std::cout << r.first << "/" << r.second;
+            else
+                std::cout << "nok";
 
-        std::cout << std::endl;
-    }
-    catch (Exiv2::AnyError& e) {
-        std::cout << "Caught Exiv2 exception '" << e << "'\n";
-        return -1;
+            std::cout << std::endl;
+        } catch (Exiv2::AnyError& e) {
+            std::cout << "Caught Exiv2 exception '" << e << "'\n";
+            return -1;
+        }
     }
 
     return 0;

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -51,18 +51,10 @@ try {
         error += ": No XMP properties found in the XMP packet";
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->toString()
-                  << std::endl;
+    for (auto&& md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.toString() << std::endl;
     }
     Exiv2::XmpParser::terminate();
     return 0;

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -53,18 +53,10 @@ try {
         error += ": No XMP properties found in the XMP packet";
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
     }
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->toString()
-                  << std::endl;
+    for (auto&& md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.toString() << std::endl;
     }
     filename += "-new";
     std::cerr << "-----> Encoding XMP data to write to " << filename << " <-----\n";

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -65,19 +65,10 @@ int main(int argc, char** argv)
         throw Exiv2::Error(Exiv2::kerErrorMessage, error);
       }
 
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-         md != xmpData.end(); ++md) 
-      {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->toString()
-                  << std::endl;
+      for (auto&& md : xmpData) {
+          std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                    << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                    << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.toString() << std::endl;
       }
 
     Exiv2::XmpParser::terminate();

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -214,18 +214,10 @@ try {
 
     // -------------------------------------------------------------------------
     // Output XMP properties
-    for (Exiv2::XmpData::const_iterator md = xmpData.begin();
-        md != xmpData.end(); ++md) {
-        std::cout << std::setfill(' ') << std::left
-                  << std::setw(44)
-                  << md->key() << " "
-                  << std::setw(9) << std::setfill(' ') << std::left
-                  << md->typeName() << " "
-                  << std::dec << std::setw(3)
-                  << std::setfill(' ') << std::right
-                  << md->count() << "  "
-                  << std::dec << md->value()
-                  << std::endl;
+    for (auto &&md : xmpData) {
+        std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
+                  << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
+                  << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.value() << std::endl;
     }
 
     // -------------------------------------------------------------------------

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -184,8 +184,8 @@ namespace Action {
     void TaskFactory::cleanup()
     {
         if (instance_ != 0) {
-            for (auto i = registry_.begin(); i != registry_.end(); ++i) {
-                delete i->second;
+            for (auto&& i : registry_) {
+                delete i.second;
             }
             delete instance_;
             instance_ = 0;
@@ -459,8 +459,8 @@ namespace Action {
         bool noExif = false;
         if (Params::instance().printTags_ & Exiv2::mdExif) {
             const Exiv2::ExifData& exifData = image->exifData();
-            for (auto md = exifData.begin(); md != exifData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (auto&& md : exifData) {
+                ret |= printMetadatum(md, image);
             }
             if (exifData.empty()) noExif = true;
         }
@@ -468,8 +468,8 @@ namespace Action {
         bool noIptc = false;
         if (Params::instance().printTags_ & Exiv2::mdIptc) {
             const Exiv2::IptcData& iptcData = image->iptcData();
-            for (auto md = iptcData.begin(); md != iptcData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (auto&& md : iptcData) {
+                ret |= printMetadatum(md, image);
             }
             if (iptcData.empty()) noIptc = true;
         }
@@ -477,8 +477,8 @@ namespace Action {
         bool noXmp = false;
         if (Params::instance().printTags_ & Exiv2::mdXmp) {
             const Exiv2::XmpData& xmpData = image->xmpData();
-            for (auto md = xmpData.begin(); md != xmpData.end(); ++md) {
-                ret |= printMetadatum(*md, image);
+            for (auto&& md : xmpData) {
+                ret |= printMetadatum(md, image);
             }
             if (xmpData.empty()) noXmp = true;
         }
@@ -679,18 +679,16 @@ namespace Action {
         int cnt = 0;
         Exiv2::PreviewManager pm(*image);
         Exiv2::PreviewPropertiesList list = pm.getPreviewProperties();
-        for (auto pos = list.begin(); pos != list.end(); ++pos) {
+        for (auto&& pos : list) {
             if (manyFiles) {
                 std::cout << std::setfill(' ') << std::left << std::setw(20)
                           << path_ << "  ";
             }
-            std::cout << _("Preview") << " " << ++cnt << ": "
-                      << pos->mimeType_ << ", ";
-            if (pos->width_ != 0 && pos->height_ != 0) {
-                std::cout << pos->width_ << "x" << pos->height_ << " "
-                          << _("pixels") << ", ";
+            std::cout << _("Preview") << " " << ++cnt << ": " << pos.mimeType_ << ", ";
+            if (pos.width_ != 0 && pos.height_ != 0) {
+                std::cout << pos.width_ << "x" << pos.height_ << " " << _("pixels") << ", ";
             }
-            std::cout << pos->size_ << " " << _("bytes") << "\n";
+            std::cout << pos.size_ << " " << _("bytes") << "\n";
         }
         return 0;
     } // Print::printPreviewList
@@ -1024,20 +1022,19 @@ namespace Action {
         Exiv2::PreviewPropertiesList pvList = pvMgr.getPreviewProperties();
 
         const Params::PreviewNumbers& numbers = Params::instance().previewNumbers_;
-        for (auto n = numbers.begin(); n != numbers.end(); ++n) {
-            if (*n == 0) {
+        for (auto&& number : numbers) {
+            if (number == 0) {
                 // Write all previews
                 for (int num = 0; num < static_cast<int>(pvList.size()); ++num) {
                     writePreviewFile(pvMgr.getPreviewImage(pvList[num]), num + 1);
                 }
                 break;
             }
-            if (*n > static_cast<int>(pvList.size())) {
-                std::cerr << path_ << ": " << _("Image does not have preview")
-                          << " " << *n << "\n";
+            if (number > static_cast<int>(pvList.size())) {
+                std::cerr << path_ << ": " << _("Image does not have preview") << " " << number << "\n";
                 continue;
             }
-            writePreviewFile(pvMgr.getPreviewImage(pvList[*n - 1]), *n);
+            writePreviewFile(pvMgr.getPreviewImage(pvList[number - 1]), number);
         }
         return 0;
     } // Extract::writePreviews

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -453,8 +453,7 @@ namespace Exiv2 {
 
     void Converter::cnvToXmp()
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
+        for (auto&& c : conversion_) {
             if (   (c.metadataId_ == mdExif && exifData_)
                 || (c.metadataId_ == mdIptc && iptcData_)) {
                 EXV_CALL_MEMBER_FN(*this, c.key1ToKey2_)(c.key1_, c.key2_);
@@ -464,8 +463,7 @@ namespace Exiv2 {
 
     void Converter::cnvFromXmp()
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
+        for (auto&& c : conversion_) {
             if (   (c.metadataId_ == mdExif && exifData_)
                 || (c.metadataId_ == mdIptc && iptcData_)) {
                 EXV_CALL_MEMBER_FN(*this, c.key2ToKey1_)(c.key2_, c.key1_);
@@ -972,9 +970,7 @@ namespace Exiv2 {
             return;
         }
 
-        for (unsigned i = 0; i < value.length(); ++i) {
-            if (value[i] == '.') value[i] = ' ';
-        }
+        std::replace(value.begin(), value.end(), '.', ' ');
         (*exifData_)[to] = value;
         if (erase_) xmpData_->erase(pos);
 
@@ -1179,8 +1175,7 @@ namespace Exiv2 {
         unsigned char digest[16];
 
         MD5Init ( &context );
-        for (unsigned int i = 0; i < EXV_COUNTOF(conversion_); ++i) {
-            const Conversion& c = conversion_[i];
+        for (auto&& c : conversion_) {
             if (c.metadataId_ == mdExif) {
                 Exiv2::ExifKey key(c.key1_);
                 if (tiff && key.groupName() != "Image") continue;
@@ -1198,8 +1193,8 @@ namespace Exiv2 {
         MD5Final(digest, &context);
         res << ';';
         res << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
-        for (int i = 0; i < 16; ++i) {
-            res << static_cast<int>(digest[i]);
+        for (auto&& i : digest) {
+            res << static_cast<int>(i);
         }
         return res.str();
     }
@@ -1270,8 +1265,8 @@ namespace Exiv2 {
         MD5Update(&context, data.pData_, data.size_);
         MD5Final(digest, &context);
         res << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
-        for (int i = 0; i < 16; ++i) {
-            res << static_cast<int>(digest[i]);
+        for (auto&& i : digest) {
+            res << static_cast<int>(i);
         }
         return res.str();
 #else

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -173,14 +173,11 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto&& filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -574,9 +574,7 @@ namespace Exiv2 {
 
     void IptcDataSets::dataSetList(std::ostream& os)
     {
-        const int count = sizeof(records_)/sizeof(records_[0]);
-        for (int i=0; i < count; ++i) {
-            const DataSet *record = records_[i];
+        for (auto&& record : records_) {
             for (int j=0; record != 0 && record[j].number_ != 0xffff; ++j) {
                 os << record[j] << "\n";
             }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -687,8 +687,8 @@ namespace Exiv2 {
             "Exif.Canon.AFPointsSelected",
             "Exif.Canon.AFPointsUnusable",
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfd0Tags); ++i) {
-            auto pos = ed.findKey(ExifKey(filteredIfd0Tags[i]));
+        for (auto&& filteredIfd0Tag : filteredIfd0Tags) {
+            auto pos = ed.findKey(ExifKey(filteredIfd0Tag));
             if (pos != ed.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Warning: Exif tag " << pos->key() << " not encoded\n";
@@ -713,11 +713,11 @@ namespace Exiv2 {
             ifd2Id,
             ifd3Id
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto&& filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            eraseIfd(ed, filteredIfds[i]);
+            eraseIfd(ed, filteredIfd);
         }
 
         // IPTC and XMP are stored elsewhere, not in the Exif APP1 segment.
@@ -779,22 +779,22 @@ namespace Exiv2 {
         };
         bool delTags = false;
         ExifData::iterator pos;
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredPvTags); ++i) {
-            switch (filteredPvTags[i].ptt_) {
-            case pttLen:
-                delTags = false;
-                pos = ed.findKey(ExifKey(filteredPvTags[i].key_));
-                if (pos != ed.end() && sumToLong(*pos) > 32768) {
-                    delTags = true;
+        for (auto&& filteredPvTag : filteredPvTags) {
+            switch (filteredPvTag.ptt_) {
+                case pttLen:
+                    delTags = false;
+                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
+                    if (pos != ed.end() && sumToLong(*pos) > 32768) {
+                        delTags = true;
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Exif tag " << pos->key() << " not encoded\n";
 #endif
                     ed.erase(pos);
-                }
+                    }
                 break;
             case pttTag:
                 if (delTags) {
-                    pos = ed.findKey(ExifKey(filteredPvTags[i].key_));
+                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
                     if (pos != ed.end()) {
 #ifndef SUPPRESS_WARNINGS
                         EXV_WARNING << "Exif tag " << pos->key() << " not encoded\n";
@@ -806,9 +806,9 @@ namespace Exiv2 {
             case pttIfd:
                 if (delTags) {
 #ifndef SUPPRESS_WARNINGS
-                    EXV_WARNING << "Exif IFD " << filteredPvTags[i].key_ << " not encoded\n";
+                    EXV_WARNING << "Exif IFD " << filteredPvTag.key_ << " not encoded\n";
 #endif
-                    eraseIfd(ed, Internal::groupId(filteredPvTags[i].key_));
+                    eraseIfd(ed, Internal::groupId(filteredPvTag.key_));
                 }
                 break;
             }
@@ -906,10 +906,10 @@ namespace {
     {
         Exiv2::ExifData thumb;
         // Copy all Thumbnail (IFD1) tags from exifData to Image (IFD0) tags in thumb
-        for (auto i = exifData.begin(); i != exifData.end(); ++i) {
-            if (i->groupName() == "Thumbnail") {
-                std::string key = "Exif.Image." + i->tagName();
-                thumb.add(Exiv2::ExifKey(key), &i->value());
+        for (auto&& i : exifData) {
+            if (i.groupName() == "Thumbnail") {
+                std::string key = "Exif.Image." + i.tagName();
+                thumb.add(Exiv2::ExifKey(key), &i.value());
             }
         }
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -158,13 +158,13 @@ int main(int argc, char* const argv[])
         int n = 1;
         int s = static_cast<int>(params.files_.size());
         int w = s > 9 ? s > 99 ? 3 : 2 : 1;
-        for (Params::Files::const_iterator i = params.files_.begin(); i != params.files_.end(); ++i) {
+        for (auto&& file : params.files_) {
             if (params.verbose_) {
-                std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << s << ": " << *i
+                std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << s << ": " << file
                           << std::endl;
             }
             task->setBinary(params.binary_);
-            int ret = task->run(*i);
+            int ret = task->run(file);
             if (rc == 0)
                 rc = ret;
         }
@@ -202,8 +202,8 @@ Params& Params::instance()
 
 Params::~Params() {
 #if defined(EXV_HAVE_REGEX_H)
-    for (size_t i=0; i<instance().greps_.size(); ++i) {
-        regfree(&instance().greps_.at(i));
+    for (auto&& grep : instance().greps_) {
+        regfree(&grep);
     }
 #endif
 }
@@ -674,28 +674,57 @@ int Params::evalPrintFlags(const std::string& optArg)
     case Action::none:
         action_ = Action::print;
         printMode_ = pmList;
-        for (std::size_t i = 0; i < optArg.length(); ++i) {
-            switch (optArg[i]) {
-            case 'E': printTags_  |= Exiv2::mdExif; break;
-            case 'I': printTags_  |= Exiv2::mdIptc; break;
-            case 'X': printTags_  |= Exiv2::mdXmp;  break;
-            case 'x': printItems_ |= prTag;   break;
-            case 'g': printItems_ |= prGroup; break;
-            case 'k': printItems_ |= prKey;   break;
-            case 'l': printItems_ |= prLabel; break;
-            case 'n': printItems_ |= prName;  break;
-            case 'y': printItems_ |= prType;  break;
-            case 'c': printItems_ |= prCount; break;
-            case 's': printItems_ |= prSize;  break;
-            case 'v': printItems_ |= prValue; break;
-            case 't': printItems_ |= prTrans; break;
-            case 'h': printItems_ |= prHex;   break;
-            case 'V': printItems_ |= prSet|prValue;break;
-            default:
-                std::cerr << progname() << ": " << _("Unrecognized print item") << " `"
-                          << optArg[i] << "'\n";
-                rc = 1;
-                break;
+        for (auto&& i : optArg) {
+            switch (i) {
+                case 'E':
+                    printTags_ |= Exiv2::mdExif;
+                    break;
+                case 'I':
+                    printTags_ |= Exiv2::mdIptc;
+                    break;
+                case 'X':
+                    printTags_ |= Exiv2::mdXmp;
+                    break;
+                case 'x':
+                    printItems_ |= prTag;
+                    break;
+                case 'g':
+                    printItems_ |= prGroup;
+                    break;
+                case 'k':
+                    printItems_ |= prKey;
+                    break;
+                case 'l':
+                    printItems_ |= prLabel;
+                    break;
+                case 'n':
+                    printItems_ |= prName;
+                    break;
+                case 'y':
+                    printItems_ |= prType;
+                    break;
+                case 'c':
+                    printItems_ |= prCount;
+                    break;
+                case 's':
+                    printItems_ |= prSize;
+                    break;
+                case 'v':
+                    printItems_ |= prValue;
+                    break;
+                case 't':
+                    printItems_ |= prTrans;
+                    break;
+                case 'h':
+                    printItems_ |= prHex;
+                    break;
+                case 'V':
+                    printItems_ |= prSet | prValue;
+                    break;
+                default:
+                    std::cerr << progname() << ": " << _("Unrecognized print item") << " `" << i << "'\n";
+                    rc = 1;
+                    break;
             }
         }
         break;
@@ -1269,10 +1298,8 @@ namespace {
         }
 #ifdef DEBUG
         std::cout << "\nThe set now contains: ";
-        for (Params::PreviewNumbers::const_iterator i = previewNumbers.begin();
-             i != previewNumbers.end();
-             ++i) {
-            std::cout << *i << ", ";
+        for (auto&& number : previewNumbers) {
+            std::cout << number << ", ";
         }
         std::cout << std::endl;
 #endif
@@ -1282,15 +1309,12 @@ namespace {
     bool parseCmdFiles(ModifyCmds& modifyCmds,
                        const Params::CmdFiles& cmdFiles)
     {
-        Params::CmdFiles::const_iterator end = cmdFiles.end();
-        Params::CmdFiles::const_iterator filename = cmdFiles.begin();
-        for ( ; filename != end; ++filename) {
+        for (auto&& filename : cmdFiles) {
             try {
-                std::ifstream file(filename->c_str());
-                bool bStdin = filename->compare("-")== 0;
+                std::ifstream file(filename.c_str());
+                bool bStdin = filename.compare("-") == 0;
                 if (!file && !bStdin) {
-                    std::cerr << *filename << ": "
-                              << _("Failed to open command file for reading\n");
+                    std::cerr << filename << ": " << _("Failed to open command file for reading\n");
                     return false;
                 }
                 int num = 0;
@@ -1303,7 +1327,7 @@ namespace {
                 }
             }
             catch (const Exiv2::AnyError& error) {
-                std::cerr << *filename << ", " << _("line") << " " << error << "\n";
+                std::cerr << filename << ", " << _("line") << " " << error << "\n";
                 return false;
             }
         }
@@ -1315,11 +1339,9 @@ namespace {
     {
         try {
             int num = 0;
-            Params::CmdLines::const_iterator end = cmdLines.end();
-            Params::CmdLines::const_iterator line = cmdLines.begin();
-            for ( ; line != end; ++line) {
+            for (auto&& line : cmdLines) {
                 ModifyCmd modifyCmd;
-                if (parseLine(modifyCmd, *line, ++num)) {
+                if (parseLine(modifyCmd, line, ++num)) {
                     modifyCmds.push_back(modifyCmd);
                 }
             }

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -233,11 +233,15 @@ namespace Exiv2 {
         , { "data://"   ,pDataUri  , true  }
         , { "-"         ,pStdin    , false }
         };
-        for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-            if ( path.rfind(prots[i].name, 0) == 0 )
+        for (auto&& prot : prots) {
+            if (result != pFile)
+                break;
+
+            if (path.rfind(prot.name, 0) == 0)
                 // URL's require data.  Stdin == "-" and no further data
-                if ( prots[i].isUrl ? path.size() > prots[i].name.size() : path.size() == prots[i].name.size() )
-                    result = prots[i].prot;
+                if (prot.isUrl ? path.size() > prot.name.size() : path.size() == prot.name.size())
+                    result = prot.prot;
+        }
 
         return result;
     } // fileProtocol
@@ -257,11 +261,15 @@ namespace Exiv2 {
         , { L"data://"   ,pDataUri  , true  }
         , { L"-"         ,pStdin    , false }
         };
-        for ( size_t i = 0 ; result == pFile && i < sizeof(prots)/sizeof(prots[0]) ; i ++ )
-            if ( path.rfind(prots[i].name, 0) == 0 )
+        for (auto&& prot : prots) {
+            if (result != pFile)
+                break;
+
+            if (path.rfind(prot.name, 0) == 0)
                 // URL's require data.  Stdin == "-" and no further data
-                if ( prots[i].isUrl ? path.size() > prots[i].name.size() : path.size() == prots[i].name.size() )
-                    result = prots[i].prot;
+                if (prot.isUrl ? path.size() > prot.name.size() : path.size() == prot.name.size())
+                    result = prot.prot;
+        }
 
         return result;
     } // fileProtocol

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -107,10 +107,6 @@ static const char* httpTemplate =
 "\r\n"
 ;
 
-#ifndef lengthof
-#define lengthof(x) (sizeof(x)/sizeof((x)[0]))
-#endif
-
 #define white(c) ((c == ' ') || (c == '\t'))
 
 #define FINISH          -999
@@ -325,11 +321,13 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
             if ( bSearching ) {
 
                 // search for the body
-                for ( size_t b = 0 ; bSearching && b < lengthof(blankLines) ; b++ ) {
-                    const char* blankLinePos = strstr(buffer,blankLines[b]);
+                for (auto&& line : blankLines) {
+                    if (!bSearching)
+                        break;
+                    const char* blankLinePos = strstr(buffer, line);
                     if ( blankLinePos ) {
                         bSearching = false ;
-                        body   = blankLinePos - buffer + strlen(blankLines[b]);
+                        body = blankLinePos - buffer + strlen(line);
                         const char* firstSpace = strchr(buffer,' ');
                         if (firstSpace) {
                             status = atoi(firstSpace);

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -387,9 +387,7 @@ namespace Exiv2 {
             std::string value = pos->toString();
             if (pos->value().ok()) {
                 int seqCount = 0;
-                std::string::iterator i;
-                for (i = value.begin(); i != value.end(); ++i) {
-                    char c = *i;
+                for (auto&& c : value) {
                     if (seqCount) {
                         if ((c & 0xc0) != 0x80) {
                             utf8 = false;

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -109,9 +109,10 @@ namespace Exiv2 {
                           long        sizePsData)
     {
         if (sizePsData < 4) return false;
-        for (size_t i = 0; i < (sizeof irbId_) / (sizeof *irbId_); i++) {
-            assert(strlen(irbId_[i]) == 4);
-            if (memcmp(pPsData, irbId_[i], 4) == 0) return true;
+        for (auto&& i : irbId_) {
+            assert(strlen(i) == 4);
+            if (memcmp(pPsData, i, 4) == 0)
+                return true;
         }
         return false;
     }
@@ -836,8 +837,8 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "iptc data blocks: " << iptcDataSegs.size() << std::endl;
             uint32_t toggle = 0;
-            for (Uint32Vector_i i = iptcDataSegs.begin(); i != iptcDataSegs.end(); i++) {
-                std::cout << *i;
+            for (auto&& iptc : iptcDataSegs) {
+                std::cout << iptc;
                 if (toggle++ % 2)
                     std::cout << std::endl;
                 else

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1250,8 +1250,8 @@ namespace Exiv2 {
         const char* models[] = { "SLT-A58", "SLT-A99", "ILCE-3000", "ILCE-3500", "NEX-3N", "NEX-5R", "NEX-5T", "NEX-6", "VG30E", "VG900",
             "DSC-RX100", "DSC-RX1", "DSC-RX1R", "DSC-HX300", "DSC-HX50V", "DSC-TX30", "DSC-WX60", "DSC-WX200", "DSC-WX300" };
         std::set<std::string> s2010eModels;
-        for (size_t i = 0; i < EXV_COUNTOF(models); i++) {
-            s2010eModels.insert(models[i]);
+        for (auto&& model : models) {
+            s2010eModels.insert(model);
         }
         std::string model = getExifModel(pRoot);
         int idx = -1;

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -179,14 +179,11 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto&& filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -35,6 +35,7 @@
 #include "types.hpp"
 
 // + standard includes
+#include <array>
 #include <string>
 #include <iterator>
 #include <cstring>
@@ -148,11 +149,10 @@ namespace Exiv2 {
     static bool tEXtToDataBuf(const byte* bytes,long length,DataBuf& result)
     {
         static const char* hexdigits = "0123456789ABCDEF";
-        static int         value   [256] ;
-        static bool        bFirst = true ;
+        static std::array<int, 256> value;
+        static bool bFirst = true;
         if ( bFirst ) {
-            for ( int i = 0 ; i < 256 ; i++ )
-                value[i] = 0;
+            value = {};
             for ( int i = 0 ; i < 16 ; i++ ) {
                 value[tolower(hexdigits[i])]=i+1;
                 value[toupper(hexdigits[i])]=i+1;

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -21,6 +21,7 @@
 // included header files
 #include "config.h"
 
+#include <array>
 #include <climits>
 #include <string>
 
@@ -760,8 +761,8 @@ namespace {
         ExifData preview;
 
         // copy tags
-        for (auto pos = exifData.begin(); pos != exifData.end(); ++pos) {
-            if (pos->groupName() == group_) {
+        for (auto &&pos : exifData) {
+            if (pos.groupName() == group_) {
                 /*
                    Write only the necessary TIFF image tags
                    tags that especially could cause problems are:
@@ -769,9 +770,9 @@ namespace {
                    "Orientation" - this tag typically appears only in the "Image" group. Deleting it ensures
                                    consistent result for all previews, including JPEG
                 */
-                uint16_t tag = pos->tag();
+                uint16_t tag = pos.tag();
                 if (tag != 0x00fe && tag != 0x00ff && Internal::isTiffImageTag(tag, Internal::ifd0Id)) {
-                    preview.add(ExifKey(tag, "Image"), &pos->value());
+                    preview.add(ExifKey(tag, "Image"), &pos.value());
                 }
             }
         }
@@ -891,8 +892,8 @@ namespace {
     {
         // create decoding table
         byte invalid = 16;
-        byte decodeHexTable[256];
-        for (long i = 0; i < 256; i++) decodeHexTable[i] = invalid;
+        std::array<byte, 256> decodeHexTable;
+        decodeHexTable.fill(invalid);
         for (byte i = 0; i < 10; i++) decodeHexTable[static_cast<byte>('0') + i] = i;
         for (byte i = 0; i < 6; i++) decodeHexTable[static_cast<byte>('A') + i] = i + 10;
         for (byte i = 0; i < 6; i++) decodeHexTable[static_cast<byte>('a') + i] = i + 10;
@@ -929,9 +930,8 @@ namespace {
 
         // create decoding table
         unsigned long invalid = 64;
-        unsigned long decodeBase64Table[256] = {};
-        for (unsigned long i = 0; i < 256; i++)
-            decodeBase64Table[i] = invalid;
+        std::array<unsigned long, 256> decodeBase64Table;
+        decodeBase64Table.fill(invalid);
         for (unsigned long i = 0; i < 64; i++)
             decodeBase64Table[(unsigned char)encodeBase64Table[i]] = i;
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2487,9 +2487,9 @@ namespace Exiv2 {
 
     const XmpNsInfo* XmpProperties::lookupNsRegistryUnsafe(const XmpNsInfo::Prefix& prefix)
     {
-        for (NsRegistry::const_iterator i = nsRegistry_.begin();
-             i != nsRegistry_.end(); ++i) {
-            if (i->second == prefix) return &(i->second);
+        for (auto&& ns : nsRegistry_) {
+            if (ns.second == prefix)
+                return &(ns.second);
         }
         return 0;
     }
@@ -2657,8 +2657,8 @@ namespace Exiv2 {
 
     void XmpProperties::registeredNamespaces(Exiv2::Dictionary& nsDict)
     {
-        for (unsigned int i = 0; i < EXV_COUNTOF(xmpNsInfo); ++i) {
-             Exiv2::XmpParser::registerNs(xmpNsInfo[i].ns_,xmpNsInfo[i].prefix_);
+        for (auto&& i : xmpNsInfo) {
+            Exiv2::XmpParser::registerNs(i.ns_, i.prefix_);
         }
         Exiv2::XmpParser::registeredNamespaces(nsDict);
     }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -150,9 +150,10 @@ namespace Exiv2 {
         ExifData& prevData = image->exifData();
         if (!prevData.empty()) {
             // Filter duplicate tags
-            for (auto pos = exifData_.begin(); pos != exifData_.end(); ++pos) {
-                if (pos->ifdId() == panaRawId) continue;
-                auto dup = prevData.findKey(ExifKey(pos->key()));
+            for (auto&& pos : exifData_) {
+                if (pos.ifdId() == panaRawId)
+                    continue;
+                auto dup = prevData.findKey(ExifKey(pos.key()));
                 if (dup != prevData.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cerr << "Filtering duplicate tag " << pos->key()
@@ -194,8 +195,8 @@ namespace Exiv2 {
             "Exif.Image.PrintImageMatching",
             "Exif.Image.YCbCrPositioning"
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredTags); ++i) {
-            auto pos = prevData.findKey(ExifKey(filteredTags[i]));
+        for (auto&& filteredTag : filteredTags) {
+            auto pos = prevData.findKey(ExifKey(filteredTag));
             if (pos != prevData.end()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Exif tag " << pos->key() << " removed\n";
@@ -205,8 +206,8 @@ namespace Exiv2 {
         }
 
         // Add the remaining tags
-        for (auto pos = prevData.begin(); pos != prevData.end(); ++pos) {
-            exifData_.add(*pos);
+        for (auto&& pos : prevData) {
+            exifData_.add(pos);
         }
 
     } // Rw2Image::readMetadata

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -3236,10 +3236,8 @@ namespace Exiv2 {
         if (stringValue[19] == 'Z') {
             stringValue = stringValue.substr(0, 19);
         }
-        for (unsigned int i = 0; i < stringValue.length(); ++i) {
-            if (stringValue[i] == 'T') stringValue[i] = ' ';
-            if (stringValue[i] == '-') stringValue[i] = ':';
-        }
+        std::replace(stringValue.begin(), stringValue.end(), 'T', ' ');
+        std::replace(stringValue.begin(), stringValue.end(), '-', ':');
 
         return os << stringValue;
     }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -120,8 +120,8 @@ namespace Exiv2 {
         };
         // Find the group of the primary image, default to "Image"
         primaryGroup_ = std::string("Image");
-        for (unsigned int i = 0; i < EXV_COUNTOF(keys); ++i) {
-            auto md = exifData_.findKey(ExifKey(keys[i]));
+        for (auto&& i : keys) {
+            auto md = exifData_.findKey(ExifKey(i));
             // Is it the primary image?
             if (md != exifData_.end() && md->count() > 0 && md->toLong() == 0) {
                 // Sometimes there is a JPEG primary image; that's not our first choice
@@ -289,14 +289,11 @@ namespace Exiv2 {
         static const IfdId filteredIfds[] = {
             panaRawId
         };
-        for (unsigned int i = 0; i < EXV_COUNTOF(filteredIfds); ++i) {
+        for (auto&& filteredIfd : filteredIfds) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Warning: Exif IFD " << filteredIfds[i] << " not encoded\n";
 #endif
-            ed.erase(std::remove_if(ed.begin(),
-                                    ed.end(),
-                                    FindExifdatum(filteredIfds[i])),
-                     ed.end());
+            ed.erase(std::remove_if(ed.begin(), ed.end(), FindExifdatum(filteredIfd)), ed.end());
         }
 
         std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1870,8 +1870,8 @@ namespace Exiv2 {
             subImage9Id
         };
 
-        for (unsigned int i = 0; i < EXV_COUNTOF(imageGroups); ++i) {
-            TiffFinder finder(0x00fe, imageGroups[i]);
+        for (auto&& imageGroup : imageGroups) {
+            TiffFinder finder(0x00fe, imageGroup);
             pSourceDir->accept(finder);
             TiffEntryBase* te = dynamic_cast<TiffEntryBase*>(finder.result());
             const Value* pV = te != NULL ? te->pValue() : NULL;
@@ -2137,10 +2137,10 @@ namespace Exiv2 {
 
     void OffsetWriter::writeOffsets(BasicIo& io) const
     {
-        for (OffsetList::const_iterator it = offsetList_.begin(); it != offsetList_.end(); ++it) {
-            io.seek(it->second.origin_, BasicIo::beg);
+        for (auto&& it : offsetList_) {
+            io.seek(it.second.origin_, BasicIo::beg);
             byte buf[4] = { 0, 0, 0, 0 };
-            l2Data(buf, it->second.target_, it->second.byteOrder_);
+            l2Data(buf, it.second.target_, it.second.byteOrder_);
             io.write(buf, 4);
         }
     }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -80,9 +80,7 @@ namespace Exiv2 {
 
     TiffVisitor::TiffVisitor()
     {
-        for (int i = 0; i < events_; ++i) {
-            go_[i] = true;
-        }
+        go_.fill(true);
     }
 
     TiffVisitor::~TiffVisitor()

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -27,6 +27,7 @@
 #include "types.hpp"
 
 // + standard includes
+#include <array>
 #include <memory>
 #include <iostream>
 #include <iomanip>
@@ -75,7 +76,7 @@ namespace Exiv2 {
 
     private:
         static const int events_ = 2;  //!< The number of stop/go flags.
-        bool go_[events_];             //!< Array of stop/go flags. See setGo().
+        std::array<bool, events_> go_; //!< Array of stop/go flags. See setGo().
 
     public:
         //! @name Creators

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -557,9 +557,9 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
 
     Exiv2::Dictionary ns;
     Exiv2::XmpProperties::registeredNamespaces(ns);
-    for ( auto it = ns.begin(); it != ns.end() ; ++it ) {
-        std::string xmlns = it->first;
-        std::string uri   = it->second;
+    for (auto&& n : ns) {
+        std::string xmlns = n.first;
+        std::string uri = n.second;
         output(os,keys,name,xmlns+":"+uri);
     }
 #endif

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -402,7 +402,7 @@ namespace Exiv2 {
             }
         }
         // now erase the family!
-        for (const auto& k: keys) {
+        for (auto&& k : keys) {
             erase(findKey(Exiv2::XmpKey(k)));
         }
     }
@@ -746,69 +746,64 @@ namespace Exiv2 {
             return 2;
         }
         // Register custom namespaces with XMP-SDK
-        for (XmpProperties::NsRegistry::iterator i = XmpProperties::nsRegistry_.begin();
-             i != XmpProperties::nsRegistry_.end(); ++i) {
+        for (auto&& i : XmpProperties::nsRegistry_) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << "Registering " << i->second.prefix_ << " : " << i->first << "\n";
 #endif
-            registerNs(i->first, i->second.prefix_);
+            registerNs(i.first, i.second.prefix_);
         }
         SXMPMeta meta;
-        for (XmpData::const_iterator i = xmpData.begin(); i != xmpData.end(); ++i) {
-            const std::string ns = XmpProperties::ns(i->groupName());
+        for (auto&& i : xmpData) {
+            const std::string ns = XmpProperties::ns(i.groupName());
             XMP_OptionBits options = 0;
 
-            if (i->typeId() == langAlt) {
-
+            if (i.typeId() == langAlt) {
                 // Encode Lang Alt property
-                const LangAltValue* la = dynamic_cast<const LangAltValue*>(&i->value());
-                if (la == 0) throw Error(kerEncodeLangAltPropertyFailed, i->key());
+                const LangAltValue* la = dynamic_cast<const LangAltValue*>(&i.value());
+                if (la == 0)
+                    throw Error(kerEncodeLangAltPropertyFailed, i.key());
 
                 int idx = 1;
-                for ( LangAltValue::ValueType::const_iterator k = la->value_.begin()
-                    ; k != la->value_.end()
-                    ; ++k
-                ) {
-                    if ( k->second.size() ) { // remove lang specs with no value
-                        printNode(ns, i->tagName(), k->second, 0);
-                        meta.AppendArrayItem(ns.c_str(), i->tagName().c_str(), kXMP_PropArrayIsAlternate, k->second.c_str());
-                        const std::string item = i->tagName() + "[" + toString(idx++) + "]";
-                        meta.SetQualifier(ns.c_str(), item.c_str(), kXMP_NS_XML, "lang", k->first.c_str());
+                for (auto&& k : la->value_) {
+                    if (k.second.size()) {  // remove lang specs with no value
+                        printNode(ns, i.tagName(), k.second, 0);
+                        meta.AppendArrayItem(ns.c_str(), i.tagName().c_str(), kXMP_PropArrayIsAlternate,
+                                             k.second.c_str());
+                        const std::string item = i.tagName() + "[" + toString(idx++) + "]";
+                        meta.SetQualifier(ns.c_str(), item.c_str(), kXMP_NS_XML, "lang", k.first.c_str());
                     }
                 }
                 continue;
             }
 
             // Todo: Xmpdatum should have an XmpValue, not a Value
-            const XmpValue* val = dynamic_cast<const XmpValue*>(&i->value());
-            if (val == 0) throw Error(kerInvalidKeyXmpValue, i->key(), i->typeName());
+            const XmpValue* val = dynamic_cast<const XmpValue*>(&i.value());
+            if (val == 0)
+                throw Error(kerInvalidKeyXmpValue, i.key(), i.typeName());
             options =   xmpArrayOptionBits(val->xmpArrayType())
                       | xmpArrayOptionBits(val->xmpStruct());
-            if (   i->typeId() == xmpBag
-                || i->typeId() == xmpSeq
-                || i->typeId() == xmpAlt) {
-                printNode(ns, i->tagName(), "", options);
-                meta.SetProperty(ns.c_str(), i->tagName().c_str(), 0, options);
-                for (int idx = 0; idx < i->count(); ++idx) {
-                    const std::string item = i->tagName() + "[" + toString(idx + 1) + "]";
-                    printNode(ns, item, i->toString(idx), 0);
-                    meta.SetProperty(ns.c_str(), item.c_str(), i->toString(idx).c_str());
+            if (i.typeId() == xmpBag || i.typeId() == xmpSeq || i.typeId() == xmpAlt) {
+                printNode(ns, i.tagName(), "", options);
+                meta.SetProperty(ns.c_str(), i.tagName().c_str(), 0, options);
+                for (int idx = 0; idx < i.count(); ++idx) {
+                    const std::string item = i.tagName() + "[" + toString(idx + 1) + "]";
+                    printNode(ns, item, i.toString(idx), 0);
+                    meta.SetProperty(ns.c_str(), item.c_str(), i.toString(idx).c_str());
                 }
                 continue;
             }
-            if (i->typeId() == xmpText) {
-                if (i->count() == 0) {
-                    printNode(ns, i->tagName(), "", options);
-                    meta.SetProperty(ns.c_str(), i->tagName().c_str(), 0, options);
-                }
-                else {
-                    printNode(ns, i->tagName(), i->toString(0), options);
-                    meta.SetProperty(ns.c_str(), i->tagName().c_str(), i->toString(0).c_str(), options);
+            if (i.typeId() == xmpText) {
+                if (i.count() == 0) {
+                    printNode(ns, i.tagName(), "", options);
+                    meta.SetProperty(ns.c_str(), i.tagName().c_str(), 0, options);
+                } else {
+                    printNode(ns, i.tagName(), i.toString(0), options);
+                    meta.SetProperty(ns.c_str(), i.tagName().c_str(), i.toString(0).c_str(), options);
                 }
                 continue;
             }
             // Don't let any Xmpdatum go by unnoticed
-            throw Error(kerUnhandledXmpdatum, i->tagName(), i->typeName());
+            throw Error(kerUnhandledXmpdatum, i.tagName(), i.typeName());
         }
         std::string tmpPacket;
         meta.SerializeToBuffer(&tmpPacket, xmpFormatOptionBits(static_cast<XmpFormatFlags>(formatFlags)), padding); // throws

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -99,10 +99,10 @@ namespace Exiv2 {
         }
 
         // #1112 - store dates to deal with loss of TZ information during conversions
-        for (Exiv2::XmpData::const_iterator it = xmpData_.begin(); it != xmpData_.end(); ++it) {
-            std::string  key(it->key());
+        for (auto&& it : xmpData_) {
+            std::string key(it.key());
             if ( key.find("Date") != std::string::npos ) {
-                std::string value(it->value().toString());
+                std::string value(it.value().toString());
                 dates_[key] = value;
             }
         }
@@ -112,13 +112,11 @@ namespace Exiv2 {
     } // XmpSidecar::readMetadata
 
     // lower case string
-    static std::string toLowerCase(std::string a)
+    static std::string toLowerCase(const std::string& a)
     {
-        for(size_t i=0 ; i < a.length() ; i++)
-        {
-            a[i]=tolower(a[i]);
-        }
-        return a;
+        std::string b = a;
+        std::transform(a.begin(), a.end(), b.begin(), ::tolower);
+        return b;
     }
 
     static bool matchi(const std::string key,const char* substr)
@@ -137,9 +135,9 @@ namespace Exiv2 {
         if (writeXmpFromPacket() == false) {
             // #589 copy XMP tags
             Exiv2::XmpData  copy   ;
-            for (Exiv2::XmpData::const_iterator it = xmpData_.begin(); it != xmpData_.end(); ++it) {
-                if ( !matchi(it->key(),"exif") && !matchi(it->key(),"iptc") ) {
-                    copy[it->key()] = it->value();
+            for (auto&& it : xmpData_) {
+                if (!matchi(it.key(), "exif") && !matchi(it.key(), "iptc")) {
+                    copy[it.key()] = it.value();
                 }
             }
 
@@ -148,16 +146,16 @@ namespace Exiv2 {
             copyIptcToXmp(iptcData_, xmpData_);
 
             // #589 - restore tags which were modified by the convertors
-            for (Exiv2::XmpData::const_iterator it = copy.begin(); it != copy.end(); ++it) {
-                xmpData_[it->key()] = it->value() ;
+            for (auto&& it : copy) {
+                xmpData_[it.key()] = it.value();
             }
 
             // #1112 - restore dates if they lost their TZ info
-            for ( auto it = dates_.begin() ; it != dates_.end() ; ++it ) {
-                std::string   sKey = it->first;
+            for (auto&& date : dates_) {
+                std::string sKey = date.first;
                 Exiv2::XmpKey key(sKey);
                 if ( xmpData_.findKey(key) != xmpData_.end() ) {
-                    std::string value_orig(it->second);
+                    std::string value_orig(date.second);
                     std::string value_now(xmpData_[sKey].value().toString());
                     // std::cout << key << " -> " << value_now << " => " << value_orig << std::endl;
                     if ( value_orig.find(value_now.substr(0,10)) != std::string::npos ) {


### PR DESCRIPTION
Found with modernize-loop-convert

Ran through git clang-format.

Also removed several questionable loops and replaced with simpler
algorithms.

Signed-off-by: Rosen Penev <rosenp@gmail.com>