### PR TITLE
fix archlinux ci build

### DIFF
--- a/.github/workflows/linux_distribution_check.yml
+++ b/.github/workflows/linux_distribution_check.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # arch suffering this issue: https://github.com/abseil/abseil-cpp/issues/709
         # centos:8 had linking issues with gtest
-        container_image: ["fedora:latest", "debian:9", "archlinux/base", "ubuntu:20.04", "centos:8", "opensuse/tumbleweed", "alpine:3.13"]
+        container_image: ["fedora:latest", "debian:9", "archlinux:base", "ubuntu:20.04", "centos:8", "opensuse/tumbleweed", "alpine:3.13"]
         compiler: [g++, clang++]
         build_type: [Release, Debug]
         shared_libraries: [ON, OFF]


### PR DESCRIPTION
@piponazo whenever you have a free minute, could you have a look at this?   

I know that `archlinux/base` worked for you in the beginning, but it seems to not work anymore.   
I'm not sure what exactly changed, but I tried just switching to the official base image, and that works :tada: 