### PR TITLE
READMEs: Add whitespace around atx-style headers

### DIFF
--- a/README-CONAN.md
+++ b/README-CONAN.md
@@ -44,6 +44,7 @@ The build procedures for those platforms are discussed here: See [README.md](REA
 # 1 Step by Step Guide
 
 <name id="1-1"></a>
+
 ##### 1.1) </a>Install conan:
 
 ```bash
@@ -59,6 +60,7 @@ $ pip install conan --upgrade
 ```
 
 <name id="1-2"></a>
+
 ##### 1.2) Test conan installation
 
 ```bash
@@ -67,6 +69,7 @@ Conan version 1.23.0
 ```
 
 <name id="1-3"></a>
+
 ##### 1.3) Create a build directory<name id="1-3"></a>
 
 Create a build directory and run the conan commands:
@@ -98,6 +101,7 @@ os_build=Windows
 _Profiles for Visual Studio are discussed in detail here: [Visual Studio Notes](#2-2)__
 
 <name id="1-4"></a>
+
 ##### 1.4) Build dependencies, create build environment, build and test</a>
 
 
@@ -112,9 +116,11 @@ _Profiles for Visual Studio are discussed in detail here: [Visual Studio Notes](
 
 [TOC](#TOC)
 <name id="2"></a>
+
 ## 2) Platform Notes
 
 <name id="2-1"></a>
+
 ### 2.1) Linux Notes
 
 ##### Default Profile
@@ -165,6 +171,7 @@ algorithms when bringing the Exiv2 dependencies with conan, this might indicate 
 
 [TOC](#TOC)
 <name id="2-2"></a>
+
 ### 2.2) Visual Studio Notes
 
 We recommend that you install python as discussed here:  [https://github.com/Exiv2/exiv2/pull/1403#issuecomment-731836146](https://github.com/Exiv2/exiv2/pull/1403#issuecomment-731836146)
@@ -293,6 +300,7 @@ $ cmake --build .  --config Release
 ## 3 Conan Architecture
 
 <name id="3-1">
+
 ##### 3.1) conanfile.py
 
 In the root level of the **Exiv2** repository, the file `conanfile.py` defines C/C++ dependencies with the syntax: `Library/version@user/channel`
@@ -305,6 +313,7 @@ self.requires('self.requires('zlib/1.2.11@conan/stable')')
 
 [TOC](#TOC)
 <name id="3-2">
+
 ##### 3.2) Conan _**Recipes**_
 
 Conan searches remote servers for a _**recipe**_ to build a dependency.
@@ -354,6 +363,7 @@ Existing packages for recipe zlib/1.2.11@conan/stable:
 
 [TOC](#TOC)
 <name id="3-3">
+
 ##### 3.3) Conan server search path
 
 Conan searches remote servers for a _**recipe**_ to build the dependency.  You can list them with the command:
@@ -370,6 +380,7 @@ $ conan remote add conan-piponazo https://api.bintray.com/conan/piponazo/piponaz
 
 [TOC](#TOC)
 <name id="3-4">
+
 ##### 3.4) Configuring conan on your machine
 
 Conan stores its configuration and local builds in the directory ~/.conan (%HOMEPATH%\\.conan on Windows).
@@ -383,6 +394,7 @@ $HOME/.conan/data       Dependencies are built/stored in this directory
 
 [TOC](#TOC)
 <name id="3-5">
+
 ##### 3.5) Running `conan install` for the first time
 
 The first time you run `$ conan install`, it will auto-detect your configuration and store a default profile in the file
@@ -507,6 +519,7 @@ Indicating that the packages were found in the local cache.
 
 [TOC](#TOC)
 <name id="4">
+
 ## 4 Building Exiv2 with Adobe XMPsdk 2016
 
 With Exiv2 v0.27, you can build Exiv2 with Adobe XMPsdk 2016 on Linux/GCC, Mac/clang and Visual Studio 2017.
@@ -517,6 +530,7 @@ library can be used by the application and Exiv2.  The Adobe XMPsdk can be built
 To build Exiv2 with Adobe XMPsdk 2016, perform steps 1.1, 1.2 and 1.3 described above, then perform the following:
 
 <name id="4-1">
+
 ##### 4.1) Add a remote directory to conan's recipe search path
 
 By default, conan knows about several public conan repositories. Exiv2 requires
@@ -527,6 +541,7 @@ $ conan remote add conan-piponazo https://api.bintray.com/conan/piponazo/piponaz
 ```
 
 <name id="4-2">
+
 ##### 4.2) Build dependencies and install conan artefacts in your build directory
 
 ```bash
@@ -534,6 +549,7 @@ $ conan install .. --options xmp=True --build missing
 ```
 
 <name id="4-3">
+
 ##### 4.3) Execute cmake to generate build files for your environment:
 
 You must tell CMake to link Adobe's library:
@@ -548,6 +564,7 @@ $ cmake .. -DEXIV2_ENABLE_EXTERNAL_XMP=On -G Xcode
 ```
 
 <name id="4-4">
+
 ##### 4.4) Build Exiv2 and link Adobe XMPsdk library
 
 ```bash
@@ -556,6 +573,7 @@ $ cmake --build . --config Release
 
 [TOC](#TOC)
 <name id="5">
+
 ## 5 Webready Support
 
 Exiv2 can perform I/O using internet protocols such as http, https and ftp.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 | [![Build Status](https://travis-ci.org/Exiv2/exiv2.svg?branch=main)](https://travis-ci.org/Exiv2/exiv2) | [![Build status](https://ci.appveyor.com/api/projects/status/d6vxf2n0cp3v88al?svg=true)](https://ci.appveyor.com/project/piponazo/exiv2-wutfp) | [![pipeline status](https://gitlab.com/D4N/exiv2/badges/main/pipeline.svg)](https://gitlab.com/D4N/exiv2/commits/main) | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/master/graph/badge.svg?token=O9G7Iswx26)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
 
 <div id="1">
+
 # Welcome to Exiv2
 Exiv2 is a C++ library and a command-line utility to read,
 write, delete and modify Exif, IPTC, XMP and ICC image metadata.
@@ -15,6 +16,7 @@ write, delete and modify Exif, IPTC, XMP and ICC image metadata.
 The file ReadMe.txt in a build bundle describes how to install the library on the platform.  ReadMe.txt also documents how to compile and link code on the platform.
 
 <div id="TOC">
+
 ### TABLE  OF  CONTENTS
 ![Exiv2](exiv2.png)
 
@@ -58,11 +60,13 @@ The file ReadMe.txt in a build bundle describes how to install the library on th
 
 [TOC](#TOC)
 <div id="2">
+
 ## 2 Building, Installing, Using and Uninstalling Exiv2
 
 You need [CMake](https://cmake.org/download/) to configure the Exiv2 project and the GCC or Clang compiler and associated tool chain.
 
 <div id="2-1">
+
 ### 2.1 Build, Install, Use Exiv2 on a UNIX-like system
 
 ```bash
@@ -107,6 +111,7 @@ These commands will remove the exiv2 executables, library, header files and man 
 
 [TOC](#TOC)
 <div id="2-2">
+
 ### 2.2 Build and Install Exiv2 with Visual Studio
 
 We recommend that you use conan to download the Exiv2 external dependencies on Windows.  On other platforms (maxOS, Ubuntu and others), you should use the platform package manger.  These are discussed: [Platform Notes](#5) The options to configure and compile the project using Visual Studio are similar to UNIX like systems.
@@ -121,6 +126,7 @@ This will create and copy the exiv2 build artefacts to C:\Program Files (x86)\ex
 
 [TOC](#TOC)
 <div id="2-3">
+
 ### 2.3 Build options
 
 There are two groups of CMake options.  There are many options defined by CMake.  Here are some particularly useful options:
@@ -150,6 +156,7 @@ $ cmake -DBUILD_SHARED_LIBS=On -DEXIV2_ENABLE_NLS=Off
 
 [TOC](#TOC)
 <div id="2-4">
+
 ### 2.4 Dependencies
 
 The following Exiv2 features require external libraries:
@@ -188,6 +195,7 @@ If you wish to use libiconv with Visual Studio you will have to build libiconv a
 
 [TOC](#TOC)
 <div id="2-5">
+
 ### 2.5 Building and linking your code with Exiv2
 
 There are detailed platform notes about compiling and linking in `releasenotes/{platform}/ReadMe.txt`
@@ -214,6 +222,7 @@ $ g++ -std=c++98 myprog.cpp -o myprog -I/usr/local/include -L/usr/local/lib -lex
 
 [TOC](#TOC)
 <div id="2-6">
+
 ### 2.6 Consuming Exiv2 with CMake
 
 When exiv2 is installed, the files required to consume Exiv2 are installed in `${CMAKE_INSTALL_PREFIX}/lib/cmake/exiv2`
@@ -244,6 +253,7 @@ $
 
 [TOC](#TOC)
 <div id="2-7">
+
 ### 2.7 Using pkg-config to compile and link your code with Exiv2
 
 When exiv2 is installed, the file exiv2.pc used by pkg-config is installed in `${CMAKE_INSTALL_PREFIX}/lib/pkgconfig`  You will need to set the following in your environment:
@@ -268,6 +278,7 @@ g++ -std=c++98 myprogram.cpp -o myprogram $(pkg-config exiv2 --libs --cflags)
 
 [TOC](#TOC)
 <div id="2-8">
+
 ### 2.8 Localisation
 
 Localisation is supported on a UNIX-like platform:  Linux, macOS, Cygwin and MinGW/msys2.  Localisation is not supported for Visual Studio builds.
@@ -357,6 +368,7 @@ $
 
 [TOC](#TOC)
 <div id="2-9">
+
 ### 2.9 Building Exiv2 Documentation
 
 Building documentation requires installing special tools.  You will probably prefer to
@@ -378,6 +390,7 @@ To build the documentation, you must install the following products:
 
 [TOC](#TOC)
 <div id="2-10">
+
 ### 2.10 Building Exiv2 Packages
 
 To enable the building of Exiv2 packages, use the CMake option `-DEXIV2_TEAM_PACKAGING=On`.
@@ -419,6 +432,7 @@ You may prefer to run `$ cmake --build . --config Release --target package_sourc
 
 [TOC](#TOC)
 <div id="2-11">
+
 ### 2.11 Debugging Exiv2
 
 1) Generating and installing a debug library
@@ -513,6 +527,7 @@ The following are some of the valid targets for this Makefile:
 
 [TOC](#TOC)
 <div id="2-12">
+
 ### 2.12 Building Exiv2 with **clang** and other build chains
 
 1) On Linux
@@ -545,6 +560,7 @@ I have been unable to get clang to work on any of those platforms.
 
 [TOC](#TOC)
 <div id="2-13">
+
 ### 2.13 Building Exiv2 with ccache
 
 To speed up compilation, the utility ccache can be installed to cache the output of the compiler.  This greatly speeds up the build when you frequently built code that has not been modified.
@@ -571,6 +587,7 @@ Due to the way in which ccache is installed in Fedora (and other Linux distros),
 
 [TOC](#TOC)
 <div id="2-14">
+
 ### 2.14 Thread Safety
 
 Exiv2 heavily relies on standard C++ containers. Static or global variables are used read-only, with the exception of the XMP namespace registration function (see below). Thus Exiv2 is thread safe in the same sense as C++ containers:
@@ -598,6 +615,7 @@ The use of the _**thread unsafe function**_ Exiv2::enableBMFF(true) is discussed
 
 [TOC](#TOC)
 <div id="2-15">
+
 ### 2.15 Library Initialisation and Cleanup
 
 As discussed in the section on Thread Safety, Exiv2 classes for Exif and IPTC metadata are fully reentrant and require no initialisation or cleanup.
@@ -616,19 +634,20 @@ The exiv2 command-line program and sample applications call the following at the
 
 [TOC](#TOC)
 <div id="2-16">
+
 ### 2.16 Cross Platform Build and Test on Linux for MinGW
 
 You can cross compile Exiv2 on Linux for MinGW.  We have used the following method on **Fedora** and believe this is also possible on Ubuntu and other distros.  Detailed instructions are provided here for **Fedora**.
 
 ### Cross Build and Test On Fedora
 
-####1 Install the cross platform build tools
+#### 1 Install the cross platform build tools
 
 ```bash
 $ sudo dnf install mingw64-gcc-c++ mingw64-filesystem mingw64-expat mingw64-zlib cmake make
 ```
 
-####2 Install Dependancies
+#### 2 Install Dependancies
 
 You will need to install x86_64 libraries to support the options you wish to use.  By default, you will need libz and expat.  Your `dnf` command above has installed them for you.  If you wish to use features such as `webready` you should install openssl and libcurl as follows:
 
@@ -643,7 +662,7 @@ Installing:
 ...
 ```
 
-####3 Get the code and build
+#### 3 Get the code and build
 
 ```bash
 $ git clone://github.com/exiv2/exiv2 --branch 0.27-maintenance exiv2
@@ -664,7 +683,7 @@ $ mingw64-cmake .. -DEXIV2_TEAM_EXTRA_WARNINGS=On \
 The options available for cross-compiling are the same as provided for all builds.  See: [Build Options](#2-3)
 
 
-####4 Copy "system dlls" in the bin directory
+#### 4 Copy "system dlls" in the bin directory
 
 These DLLs are required to execute the cross-platform build in the bin from Windows
 
@@ -674,7 +693,7 @@ for i in libexpat-1.dll libgcc_s_seh-1.dll libstdc++-6.dll libwinpthread-1.dll z
 done
 ```
 
-####5 Executing exiv2 in wine
+#### 5 Executing exiv2 in wine
 
 You may wish to use wine to execute exiv2 from the command prompt.  To do this:
 
@@ -694,7 +713,7 @@ Z:\Home\gnu\github\exiv2\0.27-maintenance\build_mingw_fedora>
 
 If you have not installed wine, Fedora will offer to install it for you.
 
-####6 Running the test suite
+#### 6 Running the test suite
 
 On a default wine installation, you are in the MSDOS/cmd.exe prompt.  You cannot execute the exiv2 test suite in this environment as you require python3 and MSYS/bash to run the suite.
 
@@ -723,6 +742,7 @@ You will find that 3 tests fail at the end of the test suite.  It is safe to ign
 
 [TOC](#TOC)
 <div id="2-17">
+
 ### 2.17 Building with C++11 and other compilers
 
 Exiv2 uses the default compiler for your system.  Exiv2 v0.27 was written to the C++ 1998 standard and uses `auto_ptr`.  The C++11 and C++14 compilers will issue deprecation warnings about auto\_ptr.  As _auto\_ptr support has been removed from C++17, you cannot build Exiv2 v0.27 with C++17 or later compilers._  Exiv2 v1.0 and later do not use `auto_ptr` and will build with all modern C++ Standard Compilers.
@@ -744,6 +764,7 @@ The option -DCMAKE\_CXX\_FLAGS=-Wno-deprecated suppresses warnings from C++11 co
 
 [TOC](#TOC)
 <div id="2-18">
+
 ### 2.18 Static and Shared Libraries
 
 You can build either static or shared libraries.  Both can be linked with either static or shared run-time libraries.  You specify the shared/static with the option `-BUILD_SHARED_LIBS=On|Off` You specify the run-time with the option `-DEXIV2_ENABLE_DYNAMIC_RUNTIME=On|Off`.  The default for both options default is On.  So you build shared and use the shared libraries which are `.dll` on Windows (msvc, Cygwin and MinGW/msys), `.dylib` on macOS and `.so` on Linux and UNIX.  
@@ -774,6 +795,7 @@ This is discussed: [https://github.com/Exiv2/exiv2/issues/1230](https://github.c
 
 [TOC](#TOC)
 <div id="2-19">
+
 ### 2.19 Support for bmff files (CR3, HEIF, HEIC, and AVIF)
 
 **Attention is drawn to the possibility that bmff support may be the subject of patent rights. _Exiv2 shall not be held responsible for identifying any or all such patent rights.  Exiv2 shall not be held responsible for the legal consequences of the use of this code_.**
@@ -790,12 +812,14 @@ Applications may wish to provide a preference setting to enable bmff support and
 
 [TOC](#TOC)
 <div id="3">
+
 ## 3 License and Support
 
 All project resources are accessible from the project website.
     https://github.com/Exiv2/exiv2
 
 <div id="3-1">
+
 ### 3.1 License
 
 Copyright (C) 2004-2021 Exiv2 authors.
@@ -818,12 +842,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 [TOC](#TOC)
 <div id="3-2">
+
 ### 3.2 Support
 
 For new bug reports, feature requests and support:  Please open an issue in Github.  [https://github.com/exiv2/exiv2](https://github.com/exiv2/exiv2)
 
 [TOC](#TOC)
 <div id="4">
+
 ## 4 Running the test suite
 
 #### Different kinds of tests:
@@ -859,6 +885,7 @@ The Variable EXIV2\_PORT or EXIV2\_HTTP can be set to None to skip http tests.  
 
 [TOC](#TOC)
 <div id="4-1">
+
 ### 4.1 Running tests on a UNIX-like system
 
 You can run tests directly from the build:
@@ -893,6 +920,7 @@ $
 
 [TOC](#TOC)
 <div id="4-2">
+
 ### 4.2 Running tests on Visual Studio builds from cmd.exe
 
 **Caution:** _The python3 interpreter must be on the PATH, build for DOS, and called python3.exe.  I copied the python.exe program:
@@ -938,6 +966,7 @@ set VERBOSE=
 
 [TOC](#TOC)
 <div id="4-3">
+
 ### 4.3 Unit tests
 
 The code for the unit tests is in `<exiv2dir>/unitTests`.  To include unit tests in the build, use the *cmake* option `-DEXIV2_BUILD_UNIT_TESTS=On`.
@@ -957,6 +986,7 @@ $ popd
 
 [TOC](#TOC)
 <div id="4-4">
+
 ### 4.4 Python tests
 
 You can run the python tests from the build directory:
@@ -997,6 +1027,7 @@ $ make python_tests 2>&1 | grep FAIL
 
 [TOC](#TOC)
 <div id="4-5">
+
 ### 4.5 Test Summary
 
 | *Tests*      | Unix Style Platforms _(bash)_      | Visual Studio _(cmd.exe)_             |
@@ -1012,11 +1043,13 @@ The name **bash_tests** is historical.  They are implemented in python.
 
 [TOC](#TOC)
 <div id="5">
+
 ## 5 Platform Notes
 
 There are many ways to set up and configure your platform.  The following notes are provided as a guide.
 
 <div id="5-1">
+
 ### 5.1 Linux
 
 Update your system and install the build tools and dependencies (zlib, expat, gtest and others)
@@ -1042,6 +1075,7 @@ $ make
 
 [TOC](#TOC)
 <div id="5-2">
+
 ### 5.2 macOS
 
 You will need to install Xcode and the Xcode command-line tools to build on macOS.
@@ -1052,6 +1086,7 @@ I recommend that you build and install CMake from source.
 
 [TOC](#TOC)
 <div id="5-3">
+
 ### 5.3 MinGW/msys2
 
 Please note that the platform MinGW/msys2 32 is obsolete and superceded by MinGW/msys2 64.
@@ -1115,6 +1150,7 @@ $
 
 [TOC](#TOC)
 <div id="5-4">
+
 ### 5.4 Cygwin/64
 
 Please note that the platform Cygwin/32 is obsolete and superceded by Cygwin/64.
@@ -1144,6 +1180,7 @@ endlocal
 
 [TOC](#TOC)
 <div id="5-5">
+
 ### 5.5 Visual Studio
 
 We recommend that you use Conan to build Exiv2 using Visual Studio. Exiv2 v0.27 can be built with Visual Studio versions 2008 and later.  We actively support and build with Visual Studio 2015, 2017 and 2019.
@@ -1163,6 +1200,7 @@ The python3 interpreter must be on your PATH.
 
 [TOC](#TOC)
 <div id="5-6">
+
 ### 5.6 Unix
 
 Exiv2 can be built on many Unix and Linux distros.  With v0.27.2, we are starting to actively support the Unix Distributions NetBSD and FreeBSD.  For v0.27.3, I have added support for Solaris 11.4


### PR DESCRIPTION
The extra whitespace is necessary for GitHub to render the headers correctly.