### PR TITLE
clang-tidy: use = default

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -91,22 +91,17 @@ namespace Jzon
 		return ((c >= '0' && c <= '9') || c == '.' || c == '-');
 	}
 
-	Node::Node()
-	{
-	}
-	Node::~Node()
-	{
-	}
+    Node::Node() = default;
+    Node::~Node() = default;
 
-	Object &Node::AsObject()
-	{
-		if (IsObject())
-			return static_cast<Object&>(*this);
-		else
-			throw TypeException();
-	}
-	const Object &Node::AsObject() const
-	{
+    Object &Node::AsObject()
+    {
+        if (IsObject())
+            return static_cast<Object&>(*this);
+        throw TypeException();
+    }
+    const Object &Node::AsObject() const
+    {
 		if (IsObject())
 			return static_cast<const Object&>(*this);
 		else
@@ -201,16 +196,14 @@ namespace Jzon
 	{
 		Set(value);
 	}
-	Value::~Value()
-	{
-	}
+    Value::~Value() = default;
 
-	Node::Type Value::GetType() const
-	{
-		return T_VALUE;
-	}
-	Value::ValueType Value::GetValueType() const
-	{
+    Node::Type Value::GetType() const
+    {
+        return T_VALUE;
+    }
+    Value::ValueType Value::GetValueType() const
+    {
 		return type;
 	}
 
@@ -721,18 +714,16 @@ namespace Jzon
 	FileWriter::FileWriter(const std::string &filename) : filename(filename)
 	{
 	}
-	FileWriter::~FileWriter()
-	{
-	}
+    FileWriter::~FileWriter() = default;
 
-	void FileWriter::WriteFile(const std::string &filename, const Node &root, const Format &format)
-	{
-		FileWriter writer(filename);
-		writer.Write(root, format);
-	}
+    void FileWriter::WriteFile(const std::string &filename, const Node &root, const Format &format)
+    {
+        FileWriter writer(filename);
+        writer.Write(root, format);
+    }
 
-	void FileWriter::Write(const Node &root, const Format &format)
-	{
+    void FileWriter::Write(const Node &root, const Format &format)
+    {
 		Writer writer(root, format);
 		writer.Write();
 
@@ -749,18 +740,16 @@ namespace Jzon
 			error = "Failed to load file";
 		}
 	}
-	FileReader::~FileReader()
-	{
-	}
+    FileReader::~FileReader() = default;
 
-	bool FileReader::ReadFile(const std::string &filename, Node &node)
-	{
-		FileReader reader(filename);
-		return reader.Read(node);
-	}
+    bool FileReader::ReadFile(const std::string &filename, Node &node)
+    {
+        FileReader reader(filename);
+        return reader.Read(node);
+    }
 
-	bool FileReader::Read(Node &node)
-	{
+    bool FileReader::Read(Node &node)
+    {
 		if (!error.empty())
 			return false;
 
@@ -894,17 +883,15 @@ namespace Jzon
 	{
 		SetJson(json);
 	}
-	Parser::~Parser()
-	{
-	}
+    Parser::~Parser() = default;
 
-	void Parser::SetJson(const std::string &json)
-	{
-		this->json = json;
-		jsonSize   = json.size();
-	}
-	bool Parser::Parse()
-	{
+    void Parser::SetJson(const std::string &json)
+    {
+        this->json = json;
+        jsonSize   = json.size();
+    }
+    bool Parser::Parse()
+    {
 		cursor = 0;
 
 		tokenize();

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -115,7 +115,7 @@ public:
         ascii       = false;
     }
 
-    virtual ~Options() {} ;
+    virtual ~Options() = default;
 } ;
 
 enum
@@ -183,9 +183,9 @@ public:
       , delta_(0)
     { }
 
-    virtual ~Position() {}
+    virtual ~Position() = default;
 
-//  instance methods
+    //  instance methods
     bool good()                 { return time_ || lon_ || lat_ || ele_ ; }
     std::string getTimeString() { if ( times_.empty() ) times_ = getExifTime(time_) ;  return times_; }
     time_t      getTime()       { return time_ ; }
@@ -302,9 +302,9 @@ public:
       , lon(0.0)
       , options_(options)
     {}
-    virtual ~UserData() {}
+    virtual ~UserData() = default;
 
-//  public data members
+    //  public data members
     int         indent;
     size_t      count ;
     Position    now ;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -162,10 +162,7 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Action {
-
-    Task::~Task()
-    {
-    }
+    Task::~Task() = default;
 
     Task::UniquePtr Task::clone() const
     {
@@ -226,9 +223,7 @@ namespace Action {
         return nullptr;
     } // TaskFactory::create
 
-    Print::~Print()
-    {
-    }
+    Print::~Print() = default;
 
     int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::string& path,bool binary)
     {
@@ -704,9 +699,7 @@ namespace Action {
         return new Print(*this);
     }
 
-    Rename::~Rename()
-    {
-    }
+    Rename::~Rename() = default;
 
     int Rename::run(const std::string& path)
     {
@@ -792,9 +785,7 @@ namespace Action {
         return new Rename(*this);
     }
 
-    Erase::~Erase()
-    {
-    }
+    Erase::~Erase() = default;
 
     int Erase::run(const std::string& path)
     try {
@@ -918,9 +909,7 @@ namespace Action {
         return new Erase(*this);
     }
 
-    Extract::~Extract()
-    {
-    }
+    Extract::~Extract() = default;
 
     int Extract::run(const std::string& path)
     {
@@ -1109,9 +1098,7 @@ namespace Action {
         return new Extract(*this);
     }
 
-    Insert::~Insert()
-    {
-    }
+    Insert::~Insert() = default;
 
     int Insert::run(const std::string& path)
     try {
@@ -1291,9 +1278,7 @@ namespace Action {
         return new Insert(*this);
     }
 
-    Modify::~Modify()
-    {
-    }
+    Modify::~Modify() = default;
 
     int Modify::run(const std::string& path)
     {
@@ -1525,9 +1510,7 @@ namespace Action {
         return new Modify(*this);
     }
 
-    Adjust::~Adjust()
-    {
-    }
+    Adjust::~Adjust() = default;
 
     int Adjust::run(const std::string& path)
     try {
@@ -1665,9 +1648,7 @@ namespace Action {
         return 0;
     } // Adjust::adjustDateTime
 
-    FixIso::~FixIso()
-    {
-    }
+    FixIso::~FixIso() = default;
 
     int FixIso::run(const std::string& path)
     {
@@ -1728,9 +1709,7 @@ namespace Action {
         return new FixIso(*this);
     }
 
-    FixCom::~FixCom()
-    {
-    }
+    FixCom::~FixCom() = default;
 
     int FixCom::run(const std::string& path)
     {

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -77,9 +77,7 @@ typedef short nlink_t;
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-    BasicIo::~BasicIo()
-    {
-    }
+    BasicIo::~BasicIo() = default;
 
     //! Internal Pimpl structure of class FileIo.
     class FileIo::Impl {

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -11,9 +11,7 @@ namespace Exiv2 {
     {
     }
 
-    Cr2Header::~Cr2Header()
-    {
-    }
+    Cr2Header::~Cr2Header() = default;
 
     bool Cr2Header::read(const byte* pData, uint32_t size)
     {

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -186,9 +186,7 @@ namespace Exiv2 {
         if (isAllocated_) delete[] pData_;
     }
 
-    CiffEntry::~CiffEntry()
-    {
-    }
+    CiffEntry::~CiffEntry() = default;
 
     CiffDirectory::~CiffDirectory()
     {

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -602,9 +602,7 @@ namespace Exiv2 {
     {
     }
 
-    IptcKey::~IptcKey()
-    {
-    }
+    IptcKey::~IptcKey() = default;
 
     IptcKey& IptcKey::operator=(const IptcKey& rhs)
     {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -215,14 +215,9 @@ namespace Exiv2 {
 
     }
 
-    AnyError::AnyError(const AnyError &o): std::exception(o)
-    {
+    AnyError::AnyError(const AnyError& o) = default;
 
-    }
-
-    AnyError::~AnyError() throw()
-    {
-    }
+    AnyError::~AnyError() throw() = default;
 
     template<>
     void EXIV2API BasicError<char>::setMsg()

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -85,7 +85,7 @@ namespace {
         //! @name Creators
         //@{
         //! Virtual destructor
-        virtual ~Thumbnail() {}
+        virtual ~Thumbnail() = default;
         //@}
 
         //! Factory function to create a thumbnail for the Exif metadata provided.
@@ -205,9 +205,7 @@ namespace Exiv2 {
         if (pValue) value_ = pValue->clone();
     }
 
-    Exifdatum::~Exifdatum()
-    {
-    }
+    Exifdatum::~Exifdatum() = default;
 
     Exifdatum::Exifdatum(const Exifdatum& rhs)
         : Metadatum(rhs)

--- a/src/getopt.cpp
+++ b/src/getopt.cpp
@@ -113,9 +113,7 @@ namespace Util {
     {
     }
 
-    Getopt::~Getopt()
-    {
-    }
+    Getopt::~Getopt() = default;
 
     int Getopt::getopt(int argc, char* const argv[], const std::string& optstring)
     {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -157,9 +157,7 @@ namespace Exiv2 {
     {
     }
 
-    Image::~Image()
-    {
-    }
+    Image::~Image() = default;
 
     void Image::printStructure(std::ostream&, PrintStructureOption,int /*depth*/)
     {

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -94,9 +94,7 @@ namespace Exiv2 {
         if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
     }
 
-    Iptcdatum::~Iptcdatum()
-    {
-    }
+    Iptcdatum::~Iptcdatum() = default;
 
     long Iptcdatum::copy(byte* buf, ByteOrder byteOrder) const
     {

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -204,9 +204,7 @@ namespace Exiv2 {
         return tc;
     } // TiffMnCreator::create
 
-    MnHeader::~MnHeader()
-    {
-    }
+    MnHeader::~MnHeader() = default;
 
     void MnHeader::setByteOrder(ByteOrder /*byteOrder*/)
     {
@@ -241,9 +239,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    OlympusMnHeader::~OlympusMnHeader()
-    {
-    }
+    OlympusMnHeader::~OlympusMnHeader() = default;
 
     uint32_t OlympusMnHeader::size() const
     {
@@ -290,9 +286,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    Olympus2MnHeader::~Olympus2MnHeader()
-    {
-    }
+    Olympus2MnHeader::~Olympus2MnHeader() = default;
 
     uint32_t Olympus2MnHeader::size() const
     {
@@ -345,9 +339,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), byteOrder_);
     }
 
-    FujiMnHeader::~FujiMnHeader()
-    {
-    }
+    FujiMnHeader::~FujiMnHeader() = default;
 
     uint32_t FujiMnHeader::size() const
     {
@@ -407,9 +399,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    Nikon2MnHeader::~Nikon2MnHeader()
-    {
-    }
+    Nikon2MnHeader::~Nikon2MnHeader() = default;
 
     uint32_t Nikon2MnHeader::size() const
     {
@@ -458,9 +448,7 @@ namespace Exiv2 {
         start_ = sizeOfSignature();
     }
 
-    Nikon3MnHeader::~Nikon3MnHeader()
-    {
-    }
+    Nikon3MnHeader::~Nikon3MnHeader() = default;
 
     uint32_t Nikon3MnHeader::size() const
     {
@@ -530,9 +518,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    PanasonicMnHeader::~PanasonicMnHeader()
-    {
-    }
+    PanasonicMnHeader::~PanasonicMnHeader() = default;
 
     uint32_t PanasonicMnHeader::size() const
     {
@@ -577,9 +563,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    PentaxDngMnHeader::~PentaxDngMnHeader()
-    {
-    }
+    PentaxDngMnHeader::~PentaxDngMnHeader() = default;
 
     uint32_t PentaxDngMnHeader::size() const
     {
@@ -631,9 +615,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    PentaxMnHeader::~PentaxMnHeader()
-    {
-    }
+    PentaxMnHeader::~PentaxMnHeader() = default;
 
     uint32_t PentaxMnHeader::size() const
     {
@@ -712,9 +694,7 @@ namespace Exiv2 {
         read(signature1_, sizeOfSignature(), invalidByteOrder);
     }
 
-    SigmaMnHeader::~SigmaMnHeader()
-    {
-    }
+    SigmaMnHeader::~SigmaMnHeader() = default;
 
     uint32_t SigmaMnHeader::size() const
     {
@@ -760,9 +740,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder);
     }
 
-    SonyMnHeader::~SonyMnHeader()
-    {
-    }
+    SonyMnHeader::~SonyMnHeader() = default;
 
     uint32_t SonyMnHeader::size() const
     {
@@ -808,9 +786,7 @@ namespace Exiv2 {
         read(signature_, sizeOfSignature(), invalidByteOrder );
     }
 
-    Casio2MnHeader::~Casio2MnHeader()
-    {
-    }
+    Casio2MnHeader::~Casio2MnHeader() = default;
 
     uint32_t Casio2MnHeader::size() const
     {

--- a/src/metadatum.cpp
+++ b/src/metadatum.cpp
@@ -35,27 +35,15 @@ namespace Exiv2 {
         return UniquePtr(clone_());
     }
 
-    Key& Key::operator=(const Key& /*rhs*/)
-    {
-        return *this;
-    }
+    Key& Key::operator=(const Key& /*rhs*/) = default;
 
-    Metadatum::Metadatum()
-    {
-    }
+    Metadatum::Metadatum() = default;
 
-    Metadatum::Metadatum(const Metadatum& /*rhs*/)
-    {
-    }
+    Metadatum::Metadatum(const Metadatum& /*rhs*/) = default;
 
-    Metadatum::~Metadatum()
-    {
-    }
+    Metadatum::~Metadatum() = default;
 
-    Metadatum& Metadatum::operator=(const Metadatum& /*rhs*/)
-    {
-        return *this;
-    }
+    Metadatum& Metadatum::operator=(const Metadatum& /*rhs*/) = default;
 
     std::string Metadatum::print(const ExifData* pMetadata) const
     {

--- a/src/orfimage_int.cpp
+++ b/src/orfimage_int.cpp
@@ -29,9 +29,7 @@ namespace Exiv2 {
     {
     }
 
-    OrfHeader::~OrfHeader()
-    {
-    }
+    OrfHeader::~OrfHeader() = default;
 
     bool OrfHeader::read(const byte* pData, uint32_t size)
     {

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -86,7 +86,7 @@ namespace {
     class Loader {
     public:
         //! Virtual destructor.
-        virtual ~Loader() {}
+        virtual ~Loader() = default;
 
         //! Loader auto pointer
         typedef std::unique_ptr<Loader> UniquePtr;

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2686,9 +2686,7 @@ namespace Exiv2 {
     //! @brief Internal Pimpl structure with private members and data of class XmpKey.
     struct XmpKey::Impl
     {
-        Impl()
-        {
-        }                                                              //!< Default constructor
+        Impl() = default;                                              //!< Default constructor
         Impl(const std::string& prefix, const std::string& property);  //!< Constructor
 
         /*!
@@ -2729,9 +2727,7 @@ namespace Exiv2 {
     {
     }
 
-    XmpKey::~XmpKey()
-    {
-    }
+    XmpKey::~XmpKey() = default;
 
     XmpKey::XmpKey(const XmpKey& rhs)
         : p_(new Impl(*rhs.p_))

--- a/src/rw2image_int.cpp
+++ b/src/rw2image_int.cpp
@@ -28,9 +28,7 @@ namespace Exiv2 {
     {
     }
 
-    Rw2Header::~Rw2Header()
-    {
-    }
+    Rw2Header::~Rw2Header() = default;
 
     DataBuf Rw2Header::write() const
     {

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -349,7 +349,7 @@ namespace Exiv2 {
     {
     }
 
-    ExifKey::~ExifKey() {}
+    ExifKey::~ExifKey() = default;
 
     ExifKey& ExifKey::operator=(const ExifKey& rhs)
     {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -172,9 +172,7 @@ namespace Exiv2 {
         elDef_.count_ = 0;
     }
 
-    TiffComponent::~TiffComponent()
-    {
-    }
+    TiffComponent::~TiffComponent() = default;
 
     TiffDirectory::~TiffDirectory()
     {
@@ -199,25 +197,15 @@ namespace Exiv2 {
         delete pValue_;
     }
 
-    TiffEntry::~TiffEntry()
-    {
-    }
+    TiffEntry::~TiffEntry() = default;
 
-    TiffDataEntryBase::~TiffDataEntryBase()
-    {
-    }
+    TiffDataEntryBase::~TiffDataEntryBase() = default;
 
-    TiffDataEntry::~TiffDataEntry()
-    {
-    }
+    TiffDataEntry::~TiffDataEntry() = default;
 
-    TiffImageEntry::~TiffImageEntry()
-    {
-    }
+    TiffImageEntry::~TiffImageEntry() = default;
 
-    TiffSizeEntry::~TiffSizeEntry()
-    {
-    }
+    TiffSizeEntry::~TiffSizeEntry() = default;
 
     TiffMnEntry::~TiffMnEntry()
     {
@@ -236,9 +224,7 @@ namespace Exiv2 {
         }
     }
 
-    TiffBinaryElement::~TiffBinaryElement()
-    {
-    }
+    TiffBinaryElement::~TiffBinaryElement() = default;
 
     TiffEntryBase::TiffEntryBase(const TiffEntryBase& rhs)
         : TiffComponent(rhs),

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1893,9 +1893,7 @@ namespace Exiv2 {
     {
     }
 
-    TiffHeaderBase::~TiffHeaderBase()
-    {
-    }
+    TiffHeaderBase::~TiffHeaderBase() = default;
 
     bool TiffHeaderBase::read(const byte* pData, uint32_t size)
     {
@@ -2082,9 +2080,7 @@ namespace Exiv2 {
     {
     }
 
-    TiffHeader::~TiffHeader()
-    {
-    }
+    TiffHeader::~TiffHeader() = default;
 
     bool TiffHeader::isImageTag(      uint16_t       tag,
                                       IfdId          group,

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -83,9 +83,7 @@ namespace Exiv2 {
         go_.fill(true);
     }
 
-    TiffVisitor::~TiffVisitor()
-    {
-    }
+    TiffVisitor::~TiffVisitor() = default;
 
     void TiffVisitor::setGo(GoEvent event, bool go)
     {
@@ -123,9 +121,7 @@ namespace Exiv2 {
         setGo(geTraverse, true);
     }
 
-    TiffFinder::~TiffFinder()
-    {
-    }
+    TiffFinder::~TiffFinder() = default;
 
     void TiffFinder::findObject(TiffComponent* object)
     {
@@ -199,9 +195,7 @@ namespace Exiv2 {
         assert(pPrimaryGroups_ != 0);
     }
 
-    TiffCopier::~TiffCopier()
-    {
-    }
+    TiffCopier::~TiffCopier() = default;
 
     void TiffCopier::copyObject(TiffComponent* object)
     {
@@ -302,9 +296,7 @@ namespace Exiv2 {
         }
     }
 
-    TiffDecoder::~TiffDecoder()
-    {
-    }
+    TiffDecoder::~TiffDecoder() = default;
 
     void TiffDecoder::visitEntry(TiffEntry* object)
     {
@@ -618,9 +610,7 @@ namespace Exiv2 {
         }
     }
 
-    TiffEncoder::~TiffEncoder()
-    {
-    }
+    TiffEncoder::~TiffEncoder() = default;
 
     void TiffEncoder::encodeIptc()
     {
@@ -1224,9 +1214,7 @@ namespace Exiv2 {
 
     } // TiffReader::TiffReader
 
-    TiffReader::~TiffReader()
-    {
-    }
+    TiffReader::~TiffReader() = default;
 
     void TiffReader::setOrigState()
     {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -188,9 +188,7 @@ namespace Exiv2 {
         read(buf, len, byteOrder);
     }
 
-    DataValue::~DataValue()
-    {
-    }
+    DataValue::~DataValue() = default;
 
     long DataValue::count() const
     {
@@ -282,13 +280,10 @@ namespace Exiv2 {
     }
 
     StringValueBase::StringValueBase(const StringValueBase& rhs)
-        : Value(rhs), value_(rhs.value_)
-    {
-    }
 
-    StringValueBase::~StringValueBase()
-    {
-    }
+        = default;
+
+    StringValueBase::~StringValueBase() = default;
 
     StringValueBase& StringValueBase::operator=(const StringValueBase& rhs)
     {
@@ -364,9 +359,7 @@ namespace Exiv2 {
     {
     }
 
-    StringValue::~StringValue()
-    {
-    }
+    StringValue::~StringValue() = default;
 
     StringValue* StringValue::clone_() const
     {
@@ -383,9 +376,7 @@ namespace Exiv2 {
     {
     }
 
-    AsciiValue::~AsciiValue()
-    {
-    }
+    AsciiValue::~AsciiValue() = default;
 
     int AsciiValue::read(const std::string& buf)
     {
@@ -466,9 +457,7 @@ namespace Exiv2 {
         read(comment);
     }
 
-    CommentValue::~CommentValue()
-    {
-    }
+    CommentValue::~CommentValue() = default;
 
     int CommentValue::read(const std::string& comment)
     {
@@ -951,9 +940,7 @@ namespace Exiv2 {
         date_.day = day;
     }
 
-    DateValue::~DateValue()
-    {
-    }
+    DateValue::~DateValue() = default;
 
     int DateValue::read(const byte* buf, long len, ByteOrder /*byteOrder*/)
     {
@@ -1087,9 +1074,7 @@ namespace Exiv2 {
         time_.tzMinute = tzMinute;
     }
 
-    TimeValue::~TimeValue()
-    {
-    }
+    TimeValue::~TimeValue() = default;
 
     int TimeValue::read(const byte* buf, long len, ByteOrder /*byteOrder*/)
     {

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -167,9 +167,7 @@ namespace Exiv2 {
         return *this;
     }
 
-    Xmpdatum::~Xmpdatum()
-    {
-    }
+    Xmpdatum::~Xmpdatum() = default;
 
     std::string Xmpdatum::key() const
     {


### PR DESCRIPTION
Found with modernize-use-equals-default

Ran through git clang-format

Signed-off-by: Rosen Penev <rosenp@gmail.com>