### PR TITLE
clang-tidy: simplify boolean expressions

### DIFF
--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -147,7 +147,7 @@ int Params::getopt(int argc, char* const argv[])
 {
     int rc = Util::Getopt::getopt(argc, argv, optstring_);
     // Further consistency checks
-    if (help_==false) {
+    if (!help_) {
         if (rc==0 && read_.empty() ) {
             std::cerr << progname() << ": Read and write files must be specified\n";
             rc = 1;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -928,7 +928,7 @@ namespace Action {
             path_ = path;
             int rc = 0;
 
-            bool bStdout = Params::instance().target_ & Params::ctStdInOut ? true : false;
+            bool bStdout = (Params::instance().target_ & Params::ctStdInOut) != 0;
             if (bStdout) {
                 _setmode(_fileno(stdout), _O_BINARY);
             }
@@ -1116,7 +1116,7 @@ namespace Action {
     int Insert::run(const std::string& path)
     try {
         // -i{tgt}-  reading from stdin?
-        bool          bStdin = (Params::instance().target_ & Params::ctStdInOut)?true:false;
+        bool bStdin = (Params::instance().target_ & Params::ctStdInOut) != 0;
 
         if (!Exiv2::fileExists(path, true)) {
             std::cerr << path

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1699,7 +1699,7 @@ namespace Exiv2 {
     {
         close(); // reset the IO position
         bigBlock_ = NULL;
-        if (p_->isMalloced_ == false) {
+        if (!p_->isMalloced_) {
             long length = p_->getFileLength();
             if (length < 0) { // unable to get the length of remote file, get the whole file content.
                 std::string data;

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -204,8 +204,7 @@ namespace Exiv2 {
               || ('M' == tmpBuf[0] && 'M' == tmpBuf[1]))) {
             result = false;
         }
-        if (   true == result
-            && std::memcmp(tmpBuf + 6, CiffHeader::signature(), 8) != 0) {
+        if (result && std::memcmp(tmpBuf + 6, CiffHeader::signature(), 8) != 0) {
             result = false;
         }
         if (!advance || !result) iIo.seek(-14, BasicIo::cur);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -229,7 +229,7 @@ namespace Exiv2 {
             char c[4];
         } e = { 0x01000000 };
 
-        return e.c[0]?true:false;
+        return e.c[0] != 0;
     }
     bool Image::isLittleEndianPlatform() { return !isBigEndianPlatform(); }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -180,7 +180,7 @@ namespace Exiv2
             char c[4];
         } e = { 0x01000000 };
 
-        return e.c[0]?true:false;
+        return e.c[0] != 0;
     }
 
     static std::string toAscii(long n)
@@ -874,8 +874,7 @@ static void boxes_check(size_t b,size_t m)
                         }
                     }
 
-                    if (writeXmpFromPacket() == false)
-                    {
+                    if (!writeXmpFromPacket()) {
                         if (XmpParser::encode(xmpPacket_, xmpData_) > 1)
                         {
 #ifndef SUPPRESS_WARNINGS

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -1059,9 +1059,9 @@ namespace Exiv2 {
         }
         if (exifData_.count() > 0)
             ++search;
-        if (writeXmpFromPacket() == false && xmpData_.count() > 0)
+        if (!writeXmpFromPacket() && xmpData_.count() > 0)
             ++search;
-        if (writeXmpFromPacket() == true && xmpPacket_.size() > 0)
+        if (writeXmpFromPacket() && xmpPacket_.size() > 0)
             ++search;
         if (foundCompletePsData || iptcData_.count() > 0)
             ++search;
@@ -1125,7 +1125,7 @@ namespace Exiv2 {
                         --search;
                     }
                 }
-                if (writeXmpFromPacket() == false) {
+                if (!writeXmpFromPacket()) {
                     if (XmpParser::encode(xmpPacket_, xmpData_,
                                           XmpParser::useCompactFormat | XmpParser::omitAllFormatting) > 1) {
 #ifndef SUPPRESS_WARNINGS

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -262,11 +262,8 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
         std::memcpy(header_.pData_, pData, header_.size_);
-        if (   static_cast<uint32_t>(header_.size_) < sizeOfSignature()
-            || 0 != memcmp(header_.pData_, signature_, 6)) {
-            return false;
-        }
-        return true;
+        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
+                 0 != memcmp(header_.pData_, signature_, 6));
     } // OlympusMnHeader::read
 
     uint32_t OlympusMnHeader::write(IoWrapper& ioWrapper,
@@ -316,11 +313,8 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
         std::memcpy(header_.pData_, pData, header_.size_);
-        if (   static_cast<uint32_t>(header_.size_) < sizeOfSignature()
-            || 0 != memcmp(header_.pData_, signature_, 10)) {
-            return false;
-        }
-        return true;
+        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
+                 0 != memcmp(header_.pData_, signature_, 10));
     } // Olympus2MnHeader::read
 
     uint32_t Olympus2MnHeader::write(IoWrapper& ioWrapper,
@@ -379,11 +373,8 @@ namespace Exiv2 {
         // Read offset to the IFD relative to the start of the makernote
         // from the header. Note that we ignore the byteOrder argument
         start_ = getULong(header_.pData_ + 8, byteOrder_);
-        if (   static_cast<uint32_t>(header_.size_) < sizeOfSignature()
-            || 0 != memcmp(header_.pData_, signature_, 8)) {
-            return false;
-        }
-        return true;
+        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
+                 0 != memcmp(header_.pData_, signature_, 8));
     } // FujiMnHeader::read
 
     uint32_t FujiMnHeader::write(IoWrapper& ioWrapper,
@@ -603,11 +594,8 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
         std::memcpy(header_.pData_, pData, header_.size_);
-        if (   static_cast<uint32_t>(header_.size_) < sizeOfSignature()
-            || 0 != memcmp(header_.pData_, signature_, 7)) {
-            return false;
-        }
-        return true;
+        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
+                 0 != memcmp(header_.pData_, signature_, 7));
     } // PentaxDngMnHeader::read
 
     uint32_t PentaxDngMnHeader::write(IoWrapper& ioWrapper,
@@ -652,11 +640,8 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
         std::memcpy(header_.pData_, pData, header_.size_);
-        if (   static_cast<uint32_t>(header_.size_) < sizeOfSignature()
-            || 0 != memcmp(header_.pData_, signature_, 3)) {
-            return false;
-        }
-        return true;
+        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
+                 0 != memcmp(header_.pData_, signature_, 3));
     } // PentaxMnHeader::read
 
     uint32_t PentaxMnHeader::write(IoWrapper& ioWrapper,

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -678,7 +678,7 @@ namespace Exiv2 {
                     }
                 }
 
-                if (writeXmpFromPacket() == false) {
+                if (!writeXmpFromPacket()) {
                     if (XmpParser::encode(xmpPacket_, xmpData_) > 1) {
 #ifndef SUPPRESS_WARNINGS
                         EXV_ERROR << "Failed to encode XMP metadata.\n";

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -461,22 +461,22 @@ namespace Exiv2 {
             uint32_t curOffset = io_->tell();
 
             // Write IPTC_NAA resource block
-            if ((resourceId == kPhotoshopResourceID_IPTC_NAA  ||
-                 resourceId >  kPhotoshopResourceID_IPTC_NAA) && iptcDone == false) {
+            if ((resourceId == kPhotoshopResourceID_IPTC_NAA || resourceId > kPhotoshopResourceID_IPTC_NAA) &&
+                !iptcDone) {
                 newResLength += writeIptcData(iptcData_, outIo);
                 iptcDone = true;
             }
 
             // Write ExifInfo resource block
-            else if ((resourceId == kPhotoshopResourceID_ExifInfo  ||
-                      resourceId >  kPhotoshopResourceID_ExifInfo) && exifDone == false) {
+            else if ((resourceId == kPhotoshopResourceID_ExifInfo || resourceId > kPhotoshopResourceID_ExifInfo) &&
+                     !exifDone) {
                 newResLength += writeExifData(exifData_, outIo);
                 exifDone = true;
             }
 
             // Write XMPpacket resource block
-            else if ((resourceId == kPhotoshopResourceID_XMPPacket  ||
-                      resourceId >  kPhotoshopResourceID_XMPPacket) && xmpDone == false) {
+            else if ((resourceId == kPhotoshopResourceID_XMPPacket || resourceId > kPhotoshopResourceID_XMPPacket) &&
+                     !xmpDone) {
                 newResLength += writeXmpData(xmpData_, outIo);
                 xmpDone = true;
             }
@@ -525,19 +525,19 @@ namespace Exiv2 {
         }
 
         // Append IPTC_NAA resource block, if not yet written
-        if (iptcDone == false) {
+        if (!iptcDone) {
             newResLength += writeIptcData(iptcData_, outIo);
             iptcDone = true;
         }
 
         // Append ExifInfo resource block, if not yet written
-        if (exifDone == false) {
+        if (!exifDone) {
             newResLength += writeExifData(exifData_, outIo);
             exifDone = true;
         }
 
         // Append XmpPacket resource block, if not yet written
-        if (xmpDone == false) {
+        if (!xmpDone) {
             newResLength += writeXmpData(xmpData_, outIo);
             xmpDone = true;
         }
@@ -646,7 +646,7 @@ namespace Exiv2 {
         std::cerr << "writeXmpFromPacket(): " << writeXmpFromPacket() << "\n";
 #endif
 //        writeXmpFromPacket(true);
-        if (writeXmpFromPacket() == false) {
+        if (!writeXmpFromPacket()) {
             if (XmpParser::encode(xmpPacket, xmpData) > 1) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_ERROR << "Failed to encode XMP metadata.\n";

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -715,8 +715,7 @@ namespace Exiv2 {
 
     bool TiffEncoder::dirty() const
     {
-        if (dirty_ || exifData_.count() > 0) return true;
-        return false;
+        return dirty_ || exifData_.count() > 0;
     }
 
     void TiffEncoder::visitEntry(TiffEntry* object)
@@ -879,10 +878,7 @@ namespace Exiv2 {
 
     bool TiffEncoder::isImageTag(uint16_t tag, IfdId group) const
     {
-        if (!isNewImage_ && pHeader_->isImageTag(tag, group, pPrimaryGroups_)) {
-            return true;
-        }
-        return false;
+        return !isNewImage_ && pHeader_->isImageTag(tag, group, pPrimaryGroups_);
     }
 
     void TiffEncoder::encodeTiffComponent(

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -131,8 +131,7 @@ namespace Exiv2 {
         }
         IoCloser closer(*io_);
 
-
-        if (writeXmpFromPacket() == false) {
+        if (!writeXmpFromPacket()) {
             // #589 copy XMP tags
             Exiv2::XmpData  copy   ;
             for (auto&& it : xmpData_) {


### PR DESCRIPTION
Found with readability-simplify-boolean-expr

Signed-off-by: Rosen Penev <rosenp@gmail.com>