### PR TITLE
clang-tidy: don't check for NULL with delete

### DIFF
--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* const argv[])
                     output.putb(io->getb()) ;
                 }
             }
-            if ( bytes ) delete [] bytes;
+            delete[] bytes;
             output.close();
         }
 

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1684,7 +1684,7 @@ namespace Exiv2 {
     }
 
     RemoteIo::Impl::~Impl() {
-        if (blocksMap_) delete[] blocksMap_;
+        delete[] blocksMap_;
     }
 
     RemoteIo::~RemoteIo()


### PR DESCRIPTION
Found with readability-delete-null-pointer

Signed-off-by: Rosen Penev <rosenp@gmail.com>