### PR TITLE
clang-tidy: remove pointless static

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1911,16 +1911,16 @@ namespace {
   #endif
  #else
   #if defined(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP)
-    static pthread_mutex_t cs =  PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-   #else
-    static pthread_mutex_t cs =  PTHREAD_MUTEX_INITIALIZER;
-  #endif
- #endif
+    pthread_mutex_t cs = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#else
+    pthread_mutex_t cs = PTHREAD_MUTEX_INITIALIZER;
+#endif
+#endif
 #endif
 
-    static std::string temporaryPath()
-    {
-        static int  count = 0 ;
+ std::string temporaryPath()
+ {
+     static int count = 0;
 
 #if defined(_MSC_VER) || defined(__MINGW__)
         EnterCriticalSection(&cs);
@@ -1948,7 +1948,7 @@ namespace {
 #endif
 
         return result;
-    }
+ }
 
     int metacopy(const std::string& source,
                  const std::string& tgt,

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -50,12 +50,12 @@
 namespace {
 
     //! List of all command identifiers and corresponding strings
-    static const CmdIdAndString cmdIdAndString[] = {
+    const CmdIdAndString cmdIdAndString[] = {
         { add, "add" },
         { set, "set" },
         { del, "del" },
         { reg, "reg" },
-        { invalidCmdId, "invalidCmd" }          // End of list marker
+        { invalidCmdId, "invalidCmd" },          // End of list marker
     };
 
     // Return a command Id for a command string

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -922,7 +922,7 @@ namespace {
         return dest;
     }
 
-    static const char encodeBase64Table[64 + 1] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const char encodeBase64Table[64 + 1] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
     DataBuf decodeBase64(const std::string& src)
     {


### PR DESCRIPTION
Found with readability-static-definition-in-anonymous-namespace

Signed-off-by: Rosen Penev <rosenp@gmail.com>