### PR TITLE
clang-tidy: use default member init

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -172,17 +172,9 @@ public:
       , lon_(lon)
       , lat_(lat)
       , ele_(ele)
-      , delta_(0)
     {}
 
-    Position():
-        time_(0)
-      , lon_(0.0)
-      , lat_(0.0)
-      , ele_(0.0)
-      , delta_(0)
-    { }
-
+    Position() = default;
     virtual ~Position() = default;
 
     //  instance methods
@@ -200,14 +192,14 @@ public:
 
 //  data
 private:
-    time_t      time_;
-    double      lon_ ;
-    double      lat_ ;
-    double      ele_ ;
+    time_t time_{0};
+    double lon_{0.0};
+    double lat_{0.0};
+    double ele_{0.0};
     std::string times_;
-    int         delta_;
+    int delta_{0};
 
-// public static data
+    // public static data
 public:
     static int    adjust_  ;
     static int    tz_      ;

--- a/samples/metacopy.hpp
+++ b/samples/metacopy.hpp
@@ -23,15 +23,15 @@
 class Params : public Util::Getopt {
 private:
     std::string optstring_;
-    bool first_;
+    bool first_{true};
 
 public:
-    bool help_;                    //!< Help option flag.
-    bool iptc_;                    //!< Iptc option flag.
-    bool exif_;                    //!< Exif option flag.
-    bool comment_;                 //!< JPEG comment option flag.
-    bool xmp_;                     //!< XMP option flag.
-    bool preserve_;                //!< Preserve existing metadata option flag.
+    bool help_{false};             //!< Help option flag.
+    bool iptc_{false};             //!< Iptc option flag.
+    bool exif_{false};             //!< Exif option flag.
+    bool comment_{false};          //!< JPEG comment option flag.
+    bool xmp_{false};              //!< XMP option flag.
+    bool preserve_{false};         //!< Preserve existing metadata option flag.
     std::string read_;             //!< Source file
     std::string write_;            //!< Destination file
 
@@ -39,15 +39,9 @@ public:
     /*!
       @brief Default constructor. Note that optstring_ is initialized here.
      */
-    Params() : optstring_(":iecxaph"),
-               first_(true),
-               help_(false),
-               iptc_(false),
-               exif_(false),
-               comment_(false),
-               xmp_(false),
-               preserve_(false)
-        {}
+    Params() : optstring_(":iecxaph")
+    {
+    }
 
     /*!
       @brief Call Getopt::getopt() with optstring, to initiate command line

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -76,7 +76,7 @@ namespace {
     class Timestamp {
     public:
         //! C'tor
-        Timestamp() : actime_(0), modtime_(0) {}
+        Timestamp() = default;
         //! Read the timestamp of a file
         int read(const std::string& path);
         //! Read the timestamp from a broken-down time in buffer \em tm.
@@ -85,8 +85,8 @@ namespace {
         int touch(const std::string& path);
 
     private:
-        time_t actime_;
-        time_t modtime_;
+        time_t actime_{0};
+        time_t modtime_{0};
     };
 
     /*!

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -116,10 +116,10 @@ namespace Exiv2 {
         // TYPES
         //! Simple struct stat wrapper for internal use
         struct StructStat {
-            StructStat() : st_mode(0), st_size(0), st_nlink(0) {}
-            mode_t  st_mode;            //!< Permissions
-            off_t   st_size;            //!< Size
-            nlink_t st_nlink;           //!< Number of hard links (broken on Windows, see winNumberOfLinks())
+            StructStat() = default;
+            mode_t st_mode{0};    //!< Permissions
+            off_t st_size{0};     //!< Size
+            nlink_t st_nlink{0};  //!< Number of hard links (broken on Windows, see winNumberOfLinks())
         };
 // #endif
         // METHODS
@@ -1044,16 +1044,16 @@ namespace Exiv2 {
     //! Internal Pimpl structure of class MemIo.
     class MemIo::Impl {
     public:
-        Impl();                            //!< Default constructor
+        Impl() = default;                  //!< Default constructor
         Impl(const byte* data, long size); //!< Constructor 2
 
         // DATA
-        byte* data_;                       //!< Pointer to the start of the memory area
-        long idx_;                         //!< Index into the memory area
-        long size_;                        //!< Size of the memory area
-        long sizeAlloced_;                 //!< Size of the allocated buffer
-        bool isMalloced_;                  //!< Was the buffer allocated?
-        bool eof_;                         //!< EOF indicator
+        byte* data_{0};           //!< Pointer to the start of the memory area
+        long idx_{0};             //!< Index into the memory area
+        long size_{0};            //!< Size of the memory area
+        long sizeAlloced_{0};     //!< Size of the allocated buffer
+        bool isMalloced_{false};  //!< Was the buffer allocated?
+        bool eof_{false};         //!< EOF indicator
 
         // METHODS
         void reserve(long wcount);         //!< Reserve memory
@@ -1063,23 +1063,7 @@ namespace Exiv2 {
         Impl& operator=(const Impl& rhs) = delete;  //!< Assignment
     }; // class MemIo::Impl
 
-    MemIo::Impl::Impl()
-        : data_(0),
-          idx_(0),
-          size_(0),
-          sizeAlloced_(0),
-          isMalloced_(false),
-          eof_(false)
-    {
-    }
-
-    MemIo::Impl::Impl(const byte* data, long size)
-        : data_(const_cast<byte*>(data)),
-          idx_(0),
-          size_(size),
-          sizeAlloced_(0),
-          isMalloced_(false),
-          eof_(false)
+    MemIo::Impl::Impl(const byte* data, long size) : data_(const_cast<byte*>(data)), size_(size)
     {
     }
 
@@ -1094,9 +1078,7 @@ namespace Exiv2 {
         //! @name Creators
         //@{
         //! Default constructor. the init status of the block is bNone.
-        BlockMap() : type_(bNone), data_(NULL), size_(0)
-        {
-        }
+        BlockMap() = default;
 
         //! Destructor. Releases all managed memory.
         ~BlockMap()
@@ -1152,9 +1134,9 @@ namespace Exiv2 {
         }
 
     private:
-        blockType_e type_;
-        byte*       data_;
-        size_t      size_;
+        blockType_e type_{bNone};
+        byte* data_{nullptr};
+        size_t size_{0};
     }; // class BlockMap
 
     void MemIo::Impl::reserve(long wcount)

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -210,7 +210,7 @@ namespace Exiv2 {
     struct ExifKey::Impl {
         //! @name Creators
         //@{
-        Impl();                         //!< Default constructor
+        Impl() = default;  //!< Default constructor
         //@}
 
         //! @name Manipulators
@@ -239,20 +239,15 @@ namespace Exiv2 {
         // DATA
         static const char* familyName_; //!< "Exif"
 
-        const TagInfo* tagInfo_;        //!< Tag info
-        uint16_t tag_;                  //!< Tag value
-        IfdId ifdId_;                   //!< The IFD associated with this tag
-        int idx_;                       //!< Unique id of the Exif key in the image
+        const TagInfo* tagInfo_{0};     //!< Tag info
+        uint16_t tag_{0};               //!< Tag value
+        IfdId ifdId_{ifdIdNotSet};      //!< The IFD associated with this tag
+        int idx_{0};                    //!< Unique id of the Exif key in the image
         std::string groupName_;         //!< The group name
         std::string key_;               //!< %Key
     };
 
     const char* ExifKey::Impl::familyName_ = "Exif";
-
-    ExifKey::Impl::Impl()
-        : tagInfo_(0), tag_(0), ifdId_(ifdIdNotSet), idx_(0)
-    {
-    }
 
     std::string ExifKey::Impl::tagName() const
     {


### PR DESCRIPTION
Found with modernize-use-default-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>