### PR TITLE
Add missing public headers to install target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,6 @@ set(PUBLIC_HEADERS
     ../include/exiv2/cr2image.hpp
     ../include/exiv2/crwimage.hpp
     ../include/exiv2/datasets.hpp
-    ../include/exiv2/easyaccess.hpp
     ../include/exiv2/epsimage.hpp
     ../include/exiv2/error.hpp
     ../include/exiv2/exif.hpp
@@ -91,7 +90,6 @@ add_library( exiv2lib
     cr2image.cpp
     crwimage.cpp
     datasets.cpp
-    easyaccess.cpp
     epsimage.cpp
     error.cpp
     exif.cpp
@@ -136,11 +134,13 @@ generate_export_header(exiv2lib
 
 if( EXIV2_ENABLE_WEBREADY )
     if( EXIV2_ENABLE_CURL)
+        set(PUBLIC_HEADERS ${PUBLIC_HEADERS} ../include/exiv2/easyaccess.hpp)
         target_sources(exiv2lib PRIVATE easyaccess.cpp ../include/exiv2/easyaccess.hpp)
     endif()
 endif()
 
 if( EXIV2_ENABLE_PNG )
+    set(PUBLIC_HEADERS ${PUBLIC_HEADERS} ../include/exiv2/pngimage.hpp)
     target_sources(exiv2lib_int PRIVATE pngchunk_int.cpp)
     target_sources(exiv2lib PRIVATE pngimage.cpp ../include/exiv2/pngimage.hpp)
 endif()


### PR DESCRIPTION
`pngimage.hpp` was not added to the list of `PUBLIC_HEADERS` which are installed as part of the exiv2lib library. 