### PR TITLE
New mergify config file to forward changes to main

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: forward patches to main branch
+    conditions:
+      - base=0.27-maintenance
+      - label=forward-to-main
+    actions:
+      backport:
+        branches:
+          - main
+        assignees:
+          - "{{ author }}"
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}
+
+  - name: remove outdated reviews
+    conditions: []
+    actions:
+      dismiss_reviews:
+        changes_requested: False


### PR DESCRIPTION
By adding this mergify configuration file into `0.27-maintenance`, we can forward changes to `main` when including the label `forward-to-main` in a PR pointing to `0.27-maintenance`. 