### PR TITLE
clang-tidy: use override

### DIFF
--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -142,23 +142,35 @@ namespace Jzon
 		Value(const float value);
 		Value(const double value);
 		Value(const bool value);
-		virtual ~Value();
+        ~Value() override;
 
-		virtual Type GetType() const;
-		ValueType GetValueType() const;
+        Type GetType() const override;
+        ValueType GetValueType() const;
 
-		virtual inline bool IsNull() const { return (type == VT_NULL); }
-		virtual inline bool IsString() const { return (type == VT_STRING); }
-		virtual inline bool IsNumber() const { return (type == VT_NUMBER); }
-		virtual inline bool IsBool() const { return (type == VT_BOOL); }
+        inline bool IsNull() const override
+        {
+            return (type == VT_NULL);
+        }
+        inline bool IsString() const override
+        {
+            return (type == VT_STRING);
+        }
+        inline bool IsNumber() const override
+        {
+            return (type == VT_NUMBER);
+        }
+        inline bool IsBool() const override
+        {
+            return (type == VT_BOOL);
+        }
 
-		virtual std::string ToString() const;
-		virtual int ToInt() const;
-		virtual float ToFloat() const;
-		virtual double ToDouble() const;
-		virtual bool ToBool() const;
+        std::string ToString() const override;
+        int ToInt() const override;
+        float ToFloat() const override;
+        double ToDouble() const override;
+        bool ToBool() const override;
 
-		void SetNull();
+        void SetNull();
 		void Set(const Value &value);
 		void Set(ValueType type, const std::string &value);
 		void Set(const std::string &value);
@@ -184,9 +196,9 @@ namespace Jzon
 		static std::string UnescapeString(const std::string &value);
 
 	protected:
-		virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
-	private:
+    private:
 		std::string valueStr;
 		ValueType type;
 	};
@@ -234,11 +246,11 @@ namespace Jzon
 		Object();
 		Object(const Object &other);
 		Object(const Node &other);
-		virtual ~Object();
+        ~Object() override;
 
-		virtual Type GetType() const;
+        Type GetType() const override;
 
-		void Add(const std::string &name, Node &node);
+        void Add(const std::string &name, Node &node);
 		void Add(const std::string &name, Value node);
 		void Remove(const std::string &name);
 		void Clear();
@@ -248,15 +260,15 @@ namespace Jzon
 		iterator end();
 		const_iterator end() const;
 
-		virtual bool Has(const std::string &name) const;
-		virtual size_t GetCount() const;
-		virtual Node &Get(const std::string &name) const;
-		using Node::Get;
+        bool Has(const std::string &name) const override;
+        size_t GetCount() const override;
+        Node &Get(const std::string &name) const override;
+        using Node::Get;
 
 	protected:
-		virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
-	private:
+    private:
 		typedef std::vector<NamedNodePtr> ChildList;
 		ChildList children;
 	};
@@ -302,11 +314,11 @@ namespace Jzon
 		Array();
 		Array(const Array &other);
 		Array(const Node &other);
-		virtual ~Array();
+        ~Array() override;
 
-		virtual Type GetType() const;
+        Type GetType() const override;
 
-		void Add(Node &node);
+        void Add(Node &node);
 		void Add(Value node);
 		void Remove(size_t index);
 		void Clear();
@@ -316,14 +328,14 @@ namespace Jzon
 		iterator end();
 		const_iterator end() const;
 
-		virtual size_t GetCount() const;
-		virtual Node &Get(size_t index) const;
-		using Node::Get;
+        size_t GetCount() const override;
+        Node &Get(size_t index) const override;
+        using Node::Get;
 
 	protected:
-		virtual Node *GetCopy() const;
+        Node *GetCopy() const override;
 
-	private:
+    private:
 		typedef std::vector<Node*> ChildList;
 		ChildList children;
 	};

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -79,7 +79,7 @@ public:
     }
 
     //! Handle options and their arguments.
-    int option(int opt, const std::string& optarg, int optopt)
+    int option(int opt, const std::string& optarg, int optopt) override
     {
     	std::cout << "Params::option()"
     	          << " opt = "    << opt
@@ -90,7 +90,7 @@ public:
     }
 
     //! Handle non-option parameters.
-    int nonoption(const std::string& argv)
+    int nonoption(const std::string& argv) override
     {
     	std::cout << "Params::nonoption()"
     	          << " " << argv

--- a/samples/metacopy.hpp
+++ b/samples/metacopy.hpp
@@ -62,10 +62,10 @@ public:
     int getopt(int argc, char* const argv[]);
 
     //! Handle options and their arguments.
-    virtual int option(int opt, const std::string& optarg, int optopt);
+    int option(int opt, const std::string& optarg, int optopt) override;
 
     //! Handle non-option parameters.
-    virtual int nonoption(const std::string& argv);
+    int nonoption(const std::string& argv) override;
 
     //! Print a minimal usage note to an output stream.
     void usage(std::ostream& os =std::cout) const;

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -2032,7 +2032,7 @@ namespace Exiv2 {
           @return Return -1 if the size is unknown. Otherwise it returns the length of remote file (in bytes).
           @throw Error if the server returns the error code.
          */
-        long getFileLength();
+        long getFileLength() override;
         /*!
           @brief Get the data by range.
           @param lowBlock The start block index.
@@ -2041,7 +2041,7 @@ namespace Exiv2 {
           @throw Error if the server returns the error code.
           @note Set lowBlock = -1 and highBlock = -1 to get the whole file content.
          */
-        void getDataByRange(long lowBlock, long highBlock, std::string& response);
+        void getDataByRange(long lowBlock, long highBlock, std::string& response) override;
         /*!
           @brief Submit the data to the remote machine. The data replace a part of the remote file.
                 The replaced part of remote file is indicated by from and to parameters.
@@ -2055,7 +2055,7 @@ namespace Exiv2 {
                 "/exiv2.php". More info is available at http://dev.exiv2.org/wiki/exiv2
           @throw Error if it fails.
          */
-        void writeRemote(const byte* data, size_t size, long from, long to);
+        void writeRemote(const byte* data, size_t size, long from, long to) override;
 
         // NOT IMPLEMENTED
         HttpImpl(const HttpImpl& rhs) = delete;             //!< Copy constructor
@@ -2191,7 +2191,7 @@ namespace Exiv2 {
         CurlImpl(const std::wstring& wpath, size_t blockSize);
 #endif
         //! Destructor. Cleans up the curl pointer and releases all managed memory.
-        ~CurlImpl();
+        ~CurlImpl() override;
 
         CURL*        curl_;             //!< libcurl pointer
 
@@ -2201,7 +2201,7 @@ namespace Exiv2 {
           @return Return -1 if the size is unknown. Otherwise it returns the length of remote file (in bytes).
           @throw Error if the server returns the error code.
          */
-        long getFileLength();
+        long getFileLength() override;
         /*!
           @brief Get the data by range.
           @param lowBlock The start block index.
@@ -2210,7 +2210,7 @@ namespace Exiv2 {
           @throw Error if the server returns the error code.
           @note Set lowBlock = -1 and highBlock = -1 to get the whole file content.
          */
-        void getDataByRange(long lowBlock, long highBlock, std::string& response);
+        void getDataByRange(long lowBlock, long highBlock, std::string& response) override;
         /*!
           @brief Submit the data to the remote machine. The data replace a part of the remote file.
                 The replaced part of remote file is indicated by from and to parameters.
@@ -2225,7 +2225,7 @@ namespace Exiv2 {
                 string EXIV2_HTTP_POST. The default value is "/exiv2.php". More info is available at
                 http://dev.exiv2.org/wiki/exiv2
          */
-        void writeRemote(const byte* data, size_t size, long from, long to);
+        void writeRemote(const byte* data, size_t size, long from, long to) override;
 
         // NOT IMPLEMENTED
         CurlImpl(const CurlImpl& rhs) = delete;             //!< Copy constructor

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -133,9 +133,9 @@ namespace {
 
         //! @name Accessors
         //@{
-        Exiv2::DataBuf copy(const Exiv2::ExifData& exifData) const;
-        const char* mimeType() const;
-        const char* extension() const;
+        Exiv2::DataBuf copy(const Exiv2::ExifData& exifData) const override;
+        const char* mimeType() const override;
+        const char* extension() const override;
 #ifdef EXV_UNICODE_PATH
         const wchar_t* wextension() const;
 #endif
@@ -157,9 +157,9 @@ namespace {
 
         //! @name Accessors
         //@{
-        Exiv2::DataBuf copy(const Exiv2::ExifData& exifData) const;
-        const char* mimeType() const;
-        const char* extension() const;
+        Exiv2::DataBuf copy(const Exiv2::ExifData& exifData) const override;
+        const char* mimeType() const override;
+        const char* extension() const override;
 #ifdef EXV_UNICODE_PATH
         const wchar_t* wextension() const;
 #endif

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -152,13 +152,13 @@ namespace {
         LoaderNative(PreviewId id, const Image &image, int parIdx);
 
         //! Get properties of a preview image with given params
-        virtual PreviewProperties getProperties() const;
+        PreviewProperties getProperties() const override;
 
         //! Get a buffer that contains the preview image
-        virtual DataBuf getData() const;
+        DataBuf getData() const override;
 
         //! Read preview image dimensions
-        virtual bool readDimensions();
+        bool readDimensions() override;
 
     protected:
         //! Native preview information
@@ -176,13 +176,13 @@ namespace {
         LoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
 
         //! Get properties of a preview image with given params
-        virtual PreviewProperties getProperties() const;
+        PreviewProperties getProperties() const override;
 
         //! Get a buffer that contains the preview image
-        virtual DataBuf getData() const;
+        DataBuf getData() const override;
 
         //! Read preview image dimensions
-        virtual bool readDimensions();
+        bool readDimensions() override;
 
     protected:
         //! Structure that lists offset/size tag pairs
@@ -209,13 +209,13 @@ namespace {
         LoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
 
         //! Get properties of a preview image with given params
-        virtual PreviewProperties getProperties() const;
+        PreviewProperties getProperties() const override;
 
         //! Get a buffer that contains the preview image
-        virtual DataBuf getData() const;
+        DataBuf getData() const override;
 
         //! Read preview image dimensions
-        virtual bool readDimensions();
+        bool readDimensions() override;
 
     protected:
 
@@ -242,10 +242,10 @@ namespace {
         LoaderTiff(PreviewId id, const Image &image, int parIdx);
 
         //! Get properties of a preview image with given params
-        virtual PreviewProperties getProperties() const;
+        PreviewProperties getProperties() const override;
 
         //! Get a buffer that contains the preview image
-        virtual DataBuf getData() const;
+        DataBuf getData() const override;
 
     protected:
         //! Name of the group that contains the preview image
@@ -279,13 +279,13 @@ namespace {
         LoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
 
         //! Get properties of a preview image with given params
-        virtual PreviewProperties getProperties() const;
+        PreviewProperties getProperties() const override;
 
         //! Get a buffer that contains the preview image
-        virtual DataBuf getData() const;
+        DataBuf getData() const override;
 
         //! Read preview image dimensions
-        virtual bool readDimensions();
+        bool readDimensions() override;
 
     protected:
         //! Preview image data

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -86,7 +86,7 @@ class slice : public ::testing::Test
 public:
     static const size_t vec_size = 10;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         vec_.reserve(vec_size);
         for (unsigned int i = 0; i < vec_size; ++i) {
@@ -360,7 +360,7 @@ struct stringSlice : public ::testing::Test
 {
     std::string sentence;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         sentence = "this is a sentence";
     }
@@ -403,7 +403,7 @@ struct dataBufSlice : public ::testing::Test
     static byte data[4];  // = {0xde, 0xad, 0xbe, 0xef};
     DataBuf buf;
 
-    virtual void SetUp()
+    void SetUp() override
     {
         buf = DataBuf(data, sizeof(data));
     }


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>