### PR TITLE
clang-tidy: use empty() instead of comparing size

### DIFF
--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -68,14 +68,14 @@ void mini1(const char* path)
     // Write nothing to a new structure, without a previous binary image
     wm = ExifParser::encode(blob, 0, 0, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
-    assert(blob.size() == 0);
+    assert(blob.empty());
     std::cout << "Test 1: Writing empty Exif data without original binary data: ok.\n";
 
     // Write nothing, this time with a previous binary image
     DataBuf buf = readFile(path);
     wm = ExifParser::encode(blob, buf.pData_, buf.size_, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
-    assert(blob.size() == 0);
+    assert(blob.empty());
     std::cout << "Test 2: Writing empty Exif data with original binary data: ok.\n";
 
     // Write something to a new structure, without a previous binary image

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -874,7 +874,7 @@ namespace Action {
 
     int Erase::eraseComment(Exiv2::Image* image) const
     {
-        if (Params::instance().verbose_ && image->comment().size() > 0) {
+        if (Params::instance().verbose_ && !image->comment().empty()) {
             std::cout << _("Erasing JPEG comment from the file") << std::endl;
         }
         image->clearComment();
@@ -1575,7 +1575,7 @@ namespace Action {
             return 0;
         }
         std::string timeStr = md->toString();
-        if (timeStr == "" || timeStr[0] == ' ') {
+        if (timeStr.empty() || timeStr[0] == ' ') {
             std::cerr << path << ": " << _("Timestamp of metadatum with key") << " `"
                       << ek << "' " << _("not set\n");
             return 1;
@@ -2014,9 +2014,7 @@ namespace {
             // #1148 use Raw XMP packet if there are no XMP modification commands
             int tRawSidecar = Params::ctXmpSidecar | Params::ctXmpRaw; // option -eXX
             // printTarget("in metacopy",Params::instance().target_,true);
-            if( Params::instance().modifyCmds_.size() == 0
-            && (Params::instance().target_ & tRawSidecar) == tRawSidecar
-            ){
+            if (Params::instance().modifyCmds_.empty() && (Params::instance().target_ & tRawSidecar) == tRawSidecar) {
                 // std::cout << "short cut" << std::endl;
                 // http://www.cplusplus.com/doc/tutorial/files/
                 std::ofstream os;
@@ -2024,7 +2022,7 @@ namespace {
                 sourceImage->printStructure(os,Exiv2::kpsXMP);
                 os.close();
                 rc = 0;
-            } else if ( preserve ) {
+            } else if (preserve) {
                 Exiv2::XmpData::const_iterator end = sourceImage->xmpData().end();
                 for (Exiv2::XmpData::const_iterator i = sourceImage->xmpData().begin(); i != end; ++i) {
                     targetImage->xmpData()[i->key()] = i->value();

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -2086,7 +2086,8 @@ namespace Exiv2 {
         std::string errors;
         request["server"] = hostInfo_.Host;
         request["page"  ] = hostInfo_.Path;
-        if (hostInfo_.Port != "") request["port"] = hostInfo_.Port;
+        if (!hostInfo_.Port.empty())
+            request["port"] = hostInfo_.Port;
         request["verb"]   = "HEAD";
         int serverCode = http(request, response, errors);
         if (serverCode < 0 || serverCode >= 400 || errors.compare("") != 0) {
@@ -2103,7 +2104,8 @@ namespace Exiv2 {
         Exiv2::Dictionary request;
         request["server"] = hostInfo_.Host;
         request["page"  ] = hostInfo_.Path;
-        if (hostInfo_.Port != "") request["port"] = hostInfo_.Port;
+        if (!hostInfo_.Port.empty())
+            request["port"] = hostInfo_.Port;
         request["verb"]   = "GET";
         std::string errors;
         if (lowBlock > -1 && highBlock > -1) {
@@ -2122,7 +2124,7 @@ namespace Exiv2 {
     void HttpIo::HttpImpl::writeRemote(const byte* data, size_t size, long from, long to)
     {
         std::string scriptPath(getEnv(envHTTPPOST));
-        if (scriptPath == "") {
+        if (scriptPath.empty()) {
             throw Error(kerErrorMessage, "Please set the path of the server script to handle http post data to EXIV2_HTTP_POST environmental variable.");
         }
 
@@ -2137,8 +2139,9 @@ namespace Exiv2 {
         std::string errors;
 
         Uri scriptUri = Exiv2::Uri::Parse(scriptPath);
-        request["server"] = scriptUri.Host == "" ? hostInfo_.Host : scriptUri.Host;
-        if (scriptUri.Port != "") request["port"] = scriptUri.Port;
+        request["server"] = scriptUri.Host.empty() ? hostInfo_.Host : scriptUri.Host;
+        if (!scriptUri.Port.empty())
+            request["port"] = scriptUri.Port;
         request["page"] = scriptUri.Path;
         request["verb"] = "POST";
 
@@ -2344,7 +2347,7 @@ namespace Exiv2 {
     void CurlIo::CurlImpl::writeRemote(const byte* data, size_t size, long from, long to)
     {
         std::string scriptPath(getEnv(envHTTPPOST));
-        if (scriptPath == "") {
+        if (scriptPath.empty()) {
             throw Error(kerErrorMessage, "Please set the path of the server script to handle http post data to EXIV2_HTTP_POST environmental variable.");
         }
 

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -134,7 +134,7 @@ namespace Exiv2 {
         // Write new buffer to file
         MemIo::UniquePtr tempIo(new MemIo);
         assert(tempIo.get() != 0);
-        tempIo->write((blob.size() > 0 ? &blob[0] : 0), static_cast<long>(blob.size()));
+        tempIo->write((!blob.empty() ? &blob[0] : 0), static_cast<long>(blob.size()));
         io_->close();
         io_->transfer(*tempIo); // may throw
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -677,9 +677,11 @@ namespace Exiv2 {
         pos1 = key_.find('.', pos0);
         if (pos1 == std::string::npos) throw Error(kerInvalidKey, key_);
         std::string recordName = key_.substr(pos0, pos1 - pos0);
-        if (recordName == "") throw Error(kerInvalidKey, key_);
+        if (recordName.empty())
+            throw Error(kerInvalidKey, key_);
         std::string dataSetName = key_.substr(pos1 + 1);
-        if (dataSetName == "") throw Error(kerInvalidKey, key_);
+        if (dataSetName.empty())
+            throw Error(kerInvalidKey, key_);
 
         // Use the parts of the key to find dataSet and recordId
         uint16_t recId = IptcDataSets::recordId(recordName);

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -501,20 +501,23 @@ namespace {
                 EXV_DEBUG << "readWriteEpsMetadata: Found implicit Page at position: " << startPos << "\n";
                 #endif
             }
-            if (posBeginPageSetup == posEndEps && (implicitPage || (posPage != posEndEps && !inRemovableEmbedding && line.size() >= 1 && line[0] != '%'))) {
+            if (posBeginPageSetup == posEndEps &&
+                (implicitPage || (posPage != posEndEps && !inRemovableEmbedding && !line.empty() && line[0] != '%'))) {
                 posBeginPageSetup = startPos;
                 implicitPageSetup = true;
                 #ifdef DEBUG
                 EXV_DEBUG << "readWriteEpsMetadata: Found implicit BeginPageSetup at position: " << startPos << "\n";
                 #endif
             }
-            if (posEndPageSetup == posEndEps && implicitPageSetup && !inRemovableEmbedding && line.size() >= 1 && line[0] != '%') {
+            if (posEndPageSetup == posEndEps && implicitPageSetup && !inRemovableEmbedding && !line.empty() &&
+                line[0] != '%') {
                 posEndPageSetup = startPos;
                 #ifdef DEBUG
                 EXV_DEBUG << "readWriteEpsMetadata: Found implicit EndPageSetup at position: " << startPos << "\n";
                 #endif
             }
-            if (line.size() >= 1 && line[0] != '%') continue; // performance optimization
+            if (!line.empty() && line[0] != '%')
+                continue;  // performance optimization
             if (line == "%%EOF" || line == "%%Trailer" || line == "%%PageTrailer") {
                 if (posBeginPageSetup == posEndEps) {
                     posBeginPageSetup = startPos;
@@ -637,16 +640,16 @@ namespace {
         bool containsXmp;
         if (line == "%ADO_ContainsXMP: MainFirst" || line == "%ADO_ContainsXMP:MainFirst") {
             containsXmp = true;
-        } else if (line == "" || line == "%ADO_ContainsXMP: NoMain" || line == "%ADO_ContainsXMP:NoMain") {
+        } else if (line.empty() || line == "%ADO_ContainsXMP: NoMain" || line == "%ADO_ContainsXMP:NoMain") {
             containsXmp = false;
         } else {
-            #ifndef SUPPRESS_WARNINGS
+#ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Invalid line \"" << line << "\" at position: " << posContainsXmp << "\n";
             #endif
             throw Error(write ? kerImageWriteFailed : kerFailedToReadImageData);
         }
 
-        const bool deleteXmp = (write && xmpPacket.size() == 0);
+        const bool deleteXmp = (write && xmpPacket.empty());
         bool fixBeginXmlPacket = false;
         bool useFlexibleEmbedding = false;
         size_t xmpPos = posEndEps;
@@ -661,8 +664,8 @@ namespace {
             }
             // check embedding of XMP metadata
             const size_t posLineAfterXmp = readLine(line, data, xmpPos + xmpSize, posEndEps);
-            if (line != "") {
-                #ifndef SUPPRESS_WARNINGS
+            if (!line.empty()) {
+#ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "Unexpected " << line.size() << " bytes of data after XMP at position: " << (xmpPos + xmpSize) << "\n";
                 #endif
             } else if (!deleteXmp) {
@@ -1111,14 +1114,14 @@ namespace Exiv2
         readWriteEpsMetadata(*io_, xmpPacket_, nativePreviews_, /* write = */ false);
 
         // decode XMP metadata
-        if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_) > 1) {
-            #ifndef SUPPRESS_WARNINGS
+        if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_) > 1) {
+#ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to decode XMP metadata.\n";
             #endif
             throw Error(kerFailedToReadImageData);
         }
 
-        #ifdef DEBUG
+#ifdef DEBUG
         EXV_DEBUG << "Exiv2::EpsImage::readMetadata: Finished reading EPS file " << io_->path() << "\n";
         #endif
     }

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -1108,7 +1108,7 @@ int Params::getopt(int argc, char* const Argv[])
                   << _("Modify action requires at least one -c, -m or -M option\n");
         rc = 1;
     }
-    if (0 == files_.size()) {
+    if (files_.empty()) {
         std::cerr << progname() << ": " << _("At least one file is required\n");
         rc = 1;
     }
@@ -1188,13 +1188,13 @@ namespace {
         // check for the -0 special case
         if (hh == 0 && hstr.find('-') != std::string::npos) sign = -1;
         // MM part, if there is one
-        if (mstr != "") {
+        if (!mstr.empty()) {
             if (!Util::strtol(mstr.c_str(), mm)) return false;
             if (mm > 59) return false;
             if (mm < 0) return false;
         }
         // SS part, if there is one
-        if (sstr != "") {
+        if (!sstr.empty()) {
             if (!Util::strtol(sstr.c_str(), ss)) return false;
             if (ss > 59) return false;
             if (ss < 0) return false;

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -289,7 +289,7 @@ int INIReader::ValueHandler(void* user, const char* section, const char* name,
 {
     INIReader* reader = (INIReader*)user;
     string key = MakeKey(section, name);
-    if (reader->_values[key].size() > 0)
+    if (!reader->_values[key].empty())
         reader->_values[key] += "\n";
     reader->_values[key] += value;
     return 1;

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -438,8 +438,7 @@ static void boxes_check(size_t b,size_t m)
                                 xmpPacket_ = xmpPacket_.substr(idx);
                             }
 
-                            if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_))
-                            {
+                            if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                                 EXV_WARNING << "Failed to decode XMP metadata." << std::endl;
 #endif
@@ -830,8 +829,7 @@ static void boxes_check(size_t b,size_t m)
 
                         Blob blob;
                         ExifParser::encode(blob, littleEndian, exifData_);
-                        if (blob.size())
-                        {
+                        if (!blob.empty()) {
                             DataBuf rawExif(static_cast<long>(blob.size()));
                             memcpy(rawExif.pData_, &blob[0], blob.size());
 
@@ -882,8 +880,7 @@ static void boxes_check(size_t b,size_t m)
 #endif
                         }
                     }
-                    if (xmpPacket_.size() > 0)
-                    {
+                    if (!xmpPacket_.empty()) {
                         // Update Xmp data to a new UUID box
 
                         DataBuf xmp(reinterpret_cast<const byte*>(xmpPacket_.data()), static_cast<long>(xmpPacket_.size()));

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -290,7 +290,8 @@ namespace Exiv2 {
             append(psBlob, pPsData + pos, sizePsData - pos);
         }
         // Data is rounded to be even
-        if (psBlob.size() > 0) rc = DataBuf(&psBlob[0], static_cast<long>(psBlob.size()));
+        if (!psBlob.empty())
+            rc = DataBuf(&psBlob[0], static_cast<long>(psBlob.size()));
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cerr << "IRB block at the end of Photoshop::setIptcIrb\n";
         if (rc.size_ == 0) std::cerr << "  None.\n";
@@ -406,7 +407,7 @@ namespace Exiv2 {
                 io_->read(xmpPacket.pData_, xmpPacket.size_);
                 if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
                 xmpPacket_.assign(reinterpret_cast<char*>(xmpPacket.pData_), xmpPacket.size_);
-                if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_)) {
+                if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode XMP metadata.\n";
 #endif
@@ -432,7 +433,7 @@ namespace Exiv2 {
                 // Append to psBlob
                 append(psBlob, psData.pData_, psData.size_);
                 // Check whether psBlob is complete
-                if (psBlob.size() > 0 && Photoshop::valid(&psBlob[0], (long) psBlob.size())) {
+                if (!psBlob.empty() && Photoshop::valid(&psBlob[0], (long)psBlob.size())) {
                     --search;
                     foundCompletePsData = true;
                 }
@@ -531,7 +532,7 @@ namespace Exiv2 {
             }
         } // while there are segments to process
 
-        if (psBlob.size() > 0) {
+        if (!psBlob.empty()) {
             // Find actual IPTC data within the psBlob
             Blob iptcBlob;
             const byte *record = 0;
@@ -550,16 +551,14 @@ namespace Exiv2 {
                 }
                 pCur = record + sizeHdr + sizeIptc + (sizeIptc & 1);
             }
-            if (   iptcBlob.size() > 0
-                && IptcParser::decode(iptcData_,
-                                      &iptcBlob[0],
-                                      static_cast<uint32_t>(iptcBlob.size()))) {
+            if (!iptcBlob.empty() &&
+                IptcParser::decode(iptcData_, &iptcBlob[0], static_cast<uint32_t>(iptcBlob.size()))) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "Failed to decode IPTC metadata.\n";
 #endif
                 iptcData_.clear();
             }
-        } // psBlob.size() > 0
+        }  // psBlob.size() > 0
 
         if (rc != 0) {
 #ifndef SUPPRESS_WARNINGS
@@ -833,7 +832,7 @@ namespace Exiv2 {
                     out << std::endl;
             }
         }
-        if (option == kpsIptcErase && iptcDataSegs.size()) {
+        if (option == kpsIptcErase && !iptcDataSegs.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "iptc data blocks: " << iptcDataSegs.size() << std::endl;
             uint32_t toggle = 0;
@@ -1013,7 +1012,7 @@ namespace Exiv2 {
                 // Append to psBlob
                 append(psBlob, psData.pData_, psData.size_);
                 // Check whether psBlob is complete
-                if (psBlob.size() > 0 && Photoshop::valid(&psBlob[0], (long)psBlob.size())) {
+                if (!psBlob.empty() && Photoshop::valid(&psBlob[0], (long)psBlob.size())) {
                     foundCompletePsData = true;
                 }
             } else if (marker == com_ && skipCom == -1) {
@@ -1046,7 +1045,7 @@ namespace Exiv2 {
             ++count;
         }
 
-        if (!foundCompletePsData && psBlob.size() > 0)
+        if (!foundCompletePsData && !psBlob.empty())
             throw Error(kerNoImageInInputData);
         search += (int)skipApp13Ps3.size() + (int)skipApp2Icc.size();
 
@@ -1061,7 +1060,7 @@ namespace Exiv2 {
             ++search;
         if (!writeXmpFromPacket() && xmpData_.count() > 0)
             ++search;
-        if (writeXmpFromPacket() && xmpPacket_.size() > 0)
+        if (writeXmpFromPacket() && !xmpPacket_.empty())
             ++search;
         if (foundCompletePsData || iptcData_.count() > 0)
             ++search;
@@ -1102,7 +1101,7 @@ namespace Exiv2 {
                     const byte* pExifData = rawExif.pData_;
                     uint32_t exifSize = rawExif.size_;
                     if (wm == wmIntrusive) {
-                        pExifData = blob.size() > 0 ? &blob[0] : 0;
+                        pExifData = !blob.empty() ? &blob[0] : 0;
                         exifSize = static_cast<uint32_t>(blob.size());
                     }
                     if (exifSize > 0) {
@@ -1133,7 +1132,7 @@ namespace Exiv2 {
 #endif
                     }
                 }
-                if (xmpPacket_.size() > 0) {
+                if (!xmpPacket_.empty()) {
                     // Write APP1 marker, size of APP1 field, XMP id and XMP packet
                     tmpBuf[0] = 0xff;
                     tmpBuf[1] = app1_;
@@ -1195,7 +1194,7 @@ namespace Exiv2 {
                     // Set the new IPTC IRB, keeps existing IRBs but removes the
                     // IPTC block if there is no new IPTC data to write
                     DataBuf newPsData =
-                        Photoshop::setIptcIrb(psBlob.size() > 0 ? &psBlob[0] : 0, (long)psBlob.size(), iptcData_);
+                        Photoshop::setIptcIrb(!psBlob.empty() ? &psBlob[0] : 0, (long)psBlob.size(), iptcData_);
                     const long maxChunkSize = 0xffff - 16;
                     const byte* chunkStart = newPsData.pData_;
                     const byte* chunkEnd = chunkStart + newPsData.size_;

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -154,7 +154,8 @@ namespace Exiv2 {
     bool TiffMnRegistry::operator==(const std::string& key) const
     {
         std::string make(make_);
-        if (key.size() > 0 && key[0] == '-') return false;
+        if (!key.empty() && key[0] == '-')
+            return false;
         return make == key.substr(0, make.length());
     }
 

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1486,7 +1486,7 @@ namespace Exiv2 {
                 v = (uint16_t)value.toLong(1);
                 for (int i = 0; focusModes1[i].val != 0; i++) {
                     if ((v & focusModes1[i].val) != 0) {
-                        if (p.size() > 0) {
+                        if (!p.empty()) {
                             os << ", ";
                         }
                         p = focusModes1[i].label;

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -325,10 +325,8 @@ namespace Exiv2 {
                     pCur = record + sizeHdr + sizeIptc;
                     pCur += (sizeIptc & 1);
                 }
-                if (   iptcBlob.size() > 0
-                    && IptcParser::decode(pImage->iptcData(),
-                                          &iptcBlob[0],
-                                          static_cast<uint32_t>(iptcBlob.size()))) {
+                if (!iptcBlob.empty() &&
+                    IptcParser::decode(pImage->iptcData(), &iptcBlob[0], static_cast<uint32_t>(iptcBlob.size()))) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode IPTC metadata.\n";
 #endif

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -614,8 +614,7 @@ namespace Exiv2 {
                     // Update Exif data to a new PNG chunk
                     Blob blob;
                     ExifParser::encode(blob, littleEndian, exifData_);
-                    if (blob.size() > 0)
-                    {
+                    if (!blob.empty()) {
                         static const char exifHeader[] = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
                         std::string rawExif =   std::string(exifHeader, 6)
                                               + std::string((const char*)&blob[0], blob.size());
@@ -685,7 +684,7 @@ namespace Exiv2 {
 #endif
                     }
                 }
-                if (xmpPacket_.size() > 0) {
+                if (!xmpPacket_.empty()) {
                     // Update XMP data to a new PNG chunk
                     std::string chunk = PngChunk::makeMetadataChunk(xmpPacket_, mdXmp);
                     if (outIo.write((const byte*)chunk.data(), static_cast<long>(chunk.size())) != (long)chunk.size()) {

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -419,7 +419,7 @@ namespace {
         width_ = nativePreview_.width_;
         height_ = nativePreview_.height_;
         valid_ = true;
-        if (nativePreview_.filter_ == "") {
+        if (nativePreview_.filter_.empty()) {
             size_ = nativePreview_.size_;
         } else {
             size_ = getData().size_;
@@ -471,7 +471,7 @@ namespace {
 #endif
             return DataBuf();
         }
-        if (nativePreview_.filter_ == "") {
+        if (nativePreview_.filter_.empty()) {
             return DataBuf(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
         } else if (nativePreview_.filter_ == "hex-ai7thumbnail-pnm") {
             const DataBuf ai7thumbnail = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2809,11 +2809,11 @@ namespace Exiv2 {
             throw Error(kerInvalidKey, key);
         }
         std::string prefix = key.substr(pos0, pos1 - pos0);
-        if (prefix == "") {
+        if (prefix.empty()) {
             throw Error(kerInvalidKey, key);
         }
         std::string property = key.substr(pos1 + 1);
-        if (property == "") {
+        if (property.empty()) {
             throw Error(kerInvalidKey, key);
         }
 

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -280,7 +280,7 @@ namespace Exiv2 {
                 io_->read(xmpPacket.pData_, xmpPacket.size_);
                 if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
                 xmpPacket_.assign(reinterpret_cast<char *>(xmpPacket.pData_), xmpPacket.size_);
-                if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_)) {
+                if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode XMP metadata.\n";
 #endif
@@ -610,7 +610,7 @@ namespace Exiv2 {
             }
             ExifParser::encode(blob, bo, exifData);
 
-            if (blob.size() > 0) {
+            if (!blob.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_ExifInfo << "\n";
                 std::cerr << std::dec << "Writing ExifInfo: size: " << blob.size() << "\n";
@@ -654,7 +654,7 @@ namespace Exiv2 {
             }
         }
 
-        if (xmpPacket.size() > 0) {
+        if (!xmpPacket.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_XMPPacket << "\n";
             std::cerr << std::dec << "Writing XMPPacket: size: " << xmpPacket.size() << "\n";

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2808,7 +2808,7 @@ namespace Exiv2 {
             std::string photographer(val, 0, pos);
             if (photographer != " ") os << photographer;
             std::string editor(val, pos + 1);
-            if (editor != "") {
+            if (!editor.empty()) {
                 if (photographer != " ") os << ", ";
                 os << editor;
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -49,7 +49,8 @@ namespace Util {
 
     std::string dirname(const std::string& path)
     {
-        if (path == "") return ".";
+        if (path.empty())
+            return ".";
         // Strip trailing slashes or backslashes
         std::string p = path;
         while (   p.length() > 1
@@ -71,7 +72,8 @@ namespace Util {
 
     std::string basename(const std::string& path, bool delsuffix)
     {
-        if (path == "") return ".";
+        if (path.empty())
+            return ".";
         // Strip trailing slashes or backslashes
         std::string p = path;
         while (   p.length() > 1

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -308,7 +308,8 @@ namespace Exiv2 {
 
     long StringValueBase::copy(byte* buf, ByteOrder /*byteOrder*/) const
     {
-        if (value_.size() == 0) return 0;
+        if (value_.empty())
+            return 0;
         // byteOrder not needed
         assert(buf != 0);
         return static_cast<long>(
@@ -382,7 +383,8 @@ namespace Exiv2 {
     {
         value_ = buf;
         // ensure count>0 and nul terminated # https://github.com/Exiv2/exiv2/issues/1484
-        if (value_.size() == 0 || value_[value_.size()-1] != '\0') value_ += '\0';
+        if (value_.empty() || value_[value_.size() - 1] != '\0')
+            value_ += '\0';
         return 0;
     }
 
@@ -510,7 +512,7 @@ namespace Exiv2 {
             }
             c = value_.substr(0, 8) + c;
         }
-        if (c.size() == 0)
+        if (c.empty())
             return 0;
         assert(buf != 0);
         return static_cast<long>(c.copy(reinterpret_cast<char*>(buf), c.size()));
@@ -625,7 +627,8 @@ namespace Exiv2 {
         std::ostringstream os;
         write(os);
         std::string s = os.str();
-        if (s.size() > 0) std::memcpy(buf, &s[0], s.size());
+        if (!s.empty())
+            std::memcpy(buf, &s[0], s.size());
         return static_cast<long>(s.size());
     }
 
@@ -831,13 +834,14 @@ namespace Exiv2 {
             if (lang[0] == '"') {
                 lang = lang.substr(1);
 
-                if (lang == "" || lang.find('"') != lang.length()-1)
+                if (lang.empty() || lang.find('"') != lang.length() - 1)
                     throw Error(kerInvalidLangAltValue, buf);
             
                 lang = lang.substr(0, lang.length()-1);
             }
-            
-            if (lang == "") throw Error(kerInvalidLangAltValue, buf);
+
+            if (lang.empty())
+                throw Error(kerInvalidLangAltValue, buf);
 
             // Check language is in the correct format (see https://www.ietf.org/rfc/rfc3066.txt)
             std::string::size_type charPos = lang.find_first_not_of(ALPHA);

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -228,7 +228,8 @@ static std::vector<std::string> getLoadedLibraries()
         }
     }
 #endif
-    if ( !libs.size() ) libs.push_back("unknown");
+    if (libs.empty())
+        libs.push_back("unknown");
 
     return libs;
 }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -168,7 +168,7 @@ namespace Exiv2 {
 
         if (exifData_.count() > 0) {
             ExifParser::encode(blob, littleEndian, exifData_);
-            if (blob.size() > 0) {
+            if (!blob.empty()) {
                 has_exif = true;
             }
         }
@@ -178,7 +178,7 @@ namespace Exiv2 {
                               XmpParser::useCompactFormat |
                               XmpParser::omitAllFormatting);
         }
-        has_xmp = xmpPacket_.size() > 0;
+        has_xmp = !xmpPacket_.empty();
         std::string xmp(xmpPacket_);
 
         /* Verify for a VP8X Chunk First before writing in
@@ -714,7 +714,7 @@ namespace Exiv2 {
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP)) {
                 readOrThrow(*io_, payload.pData_, payload.size_, Exiv2::kerCorruptedMetadata);
                 xmpPacket_.assign(reinterpret_cast<char*>(payload.pData_), payload.size_);
-                if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_)) {
+                if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode XMP metadata." << std::endl;
 #endif

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -763,7 +763,7 @@ namespace Exiv2 {
 
                 int idx = 1;
                 for (auto&& k : la->value_) {
-                    if (k.second.size()) {  // remove lang specs with no value
+                    if (!k.second.empty()) {  // remove lang specs with no value
                         printNode(ns, i.tagName(), k.second, 0);
                         meta.AppendArrayItem(ns.c_str(), i.tagName().c_str(), kXMP_PropArrayIsAlternate,
                                              k.second.c_str());

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -92,7 +92,7 @@ namespace Exiv2 {
         if (io_->error()) throw Error(kerFailedToReadImageData);
         clearMetadata();
         xmpPacket_ = xmpPacket;
-        if (xmpPacket_.size() > 0 && XmpParser::decode(xmpData_, xmpPacket_)) {
+        if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to decode XMP metadata.\n";
 #endif
@@ -170,7 +170,7 @@ namespace Exiv2 {
 #endif
             }
         }
-        if (xmpPacket_.size() > 0) {
+        if (!xmpPacket_.empty()) {
             if (xmpPacket_.substr(0, 5)  != "<?xml") {
                 xmpPacket_ = xmlHeader + xmpPacket_ + xmlFooter;
             }


### PR DESCRIPTION
Found with readability-container-size-empty

Signed-off-by: Rosen Penev <rosenp@gmail.com>