### PR TITLE
clang-tidy: fix declartation names

### DIFF
--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -108,14 +108,14 @@ namespace Exiv2
 
           @return 4 if opening or writing to the associated BasicIo fails
          */
-        void doWriteMetadata(BasicIo& oIo);
+        void doWriteMetadata(BasicIo& outIo);
 
         /*!
          @brief reformats the Jp2Header to store iccProfile
          @param oldData DataBufRef to data in the file.
          @param newData DataBufRef with updated data
          */
-        void encodeJp2Header(const DataBuf& oldData,DataBuf& newData);
+        void encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf);
         //@}
 
     }; // class Jp2Image

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -265,7 +265,7 @@ namespace Exiv2 {
 
           @return 4 if opening or writing to the associated BasicIo fails
          */
-        void doWriteMetadata(BasicIo& oIo);
+        void doWriteMetadata(BasicIo& outIo);
         //@}
 
         //! @name Accessors
@@ -328,7 +328,7 @@ namespace Exiv2 {
                  4 if the temporary image can not be written to;<BR>
                 -3 other temporary errors
          */
-        int writeHeader(BasicIo& oIo) const;
+        int writeHeader(BasicIo& outIo) const;
         //@}
 
     private:
@@ -381,7 +381,7 @@ namespace Exiv2 {
         //@}
         //! @name Manipulators
         //@{
-        int writeHeader(BasicIo& oIo) const;
+        int writeHeader(BasicIo& outIo) const;
         //@}
 
     private:

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -92,7 +92,7 @@ namespace Exiv2
 
           @return 4 if opening or writing to the associated BasicIo fails
          */
-        void doWriteMetadata(BasicIo& oIo);
+        void doWriteMetadata(BasicIo& outIo);
         //! Read Magick number. Only version >= 6 is supported.
         byte readPgfMagicNumber(BasicIo& iIo);
         //! Read PGF Header size encoded in 32 bits integer.

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -99,7 +99,7 @@ namespace Exiv2
           @param oIo BasicIo instance to write to (a temporary location).
 
          */
-        void doWriteMetadata(BasicIo& oIo);
+        void doWriteMetadata(BasicIo& outIo);
         //@}
 
         std::string profileName_;

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -105,7 +105,7 @@ namespace Exiv2 {
 
           @return 4 if opening or writing to the associated BasicIo fails
          */
-        void doWriteMetadata(BasicIo& oIo);
+        void doWriteMetadata(BasicIo& outIo);
         uint32_t writeExifData(const ExifData& exifData, BasicIo& out);
         //@}
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -113,10 +113,7 @@ namespace {
                     be kept.
       @return 0 if successful, else an error code
     */
-    int metacopy(const std::string& source,
-                 const std::string& target,
-                 int targetType,
-                 bool preserve);
+    int metacopy(const std::string& source, const std::string& tgt, int targetType, bool preserve);
 
     /*!
       @brief Rename a file according to a timestamp value.

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -318,7 +318,7 @@ namespace Action {
         /*!
           @brief Write embedded iccProfile files.
          */
-        int writeIccProfile(const std::string& path) const;
+        int writeIccProfile(const std::string& target) const;
 
     private:
         virtual Extract* clone_() const;

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1556,7 +1556,7 @@ namespace Exiv2 {
     class RemoteIo::Impl {
     public:
         //! Constructor
-        Impl(const std::string& path, size_t blockSize);
+        Impl(const std::string& url, size_t blockSize);
 #ifdef EXV_UNICODE_PATH
         //! Constructor accepting a unicode path in an std::wstring
         Impl(const std::wstring& wpath, size_t blockSize);
@@ -2001,7 +2001,7 @@ namespace Exiv2 {
     class HttpIo::HttpImpl : public Impl  {
     public:
         //! Constructor
-        HttpImpl(const std::string&  path,  size_t blockSize);
+        HttpImpl(const std::string& url, size_t blockSize);
 #ifdef EXV_UNICODE_PATH
         //! Constructor accepting a unicode path in an std::wstring
         HttpImpl(const std::wstring& wpath, size_t blockSize);

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -344,7 +344,8 @@ public:
     void version(bool verbose =false, std::ostream& os =std::cout) const;
 
     //! Print target_
-    static std::string printTarget(const std::string& before,int target,bool bPrint=false,std::ostream& os=std::cout);
+    static std::string printTarget(const std::string& before, int target, bool bPrint = false,
+                                   std::ostream& out = std::cout);
 
     //! getStdin binary data read from stdin to DataBuf
     /*


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>