### PR TITLE
clang-tidy: remove redundant member init

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -210,10 +210,7 @@ namespace Exiv2 {
         std::cerr << s;
     }
 
-    AnyError::AnyError(): std::exception()
-    {
-
-    }
+    AnyError::AnyError() = default;
 
     AnyError::AnyError(const AnyError& o) = default;
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -137,10 +137,7 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-
-    Image::Image(int              imageType,
-                 uint16_t         supportedMetadata,
-                 BasicIo::UniquePtr io)
+    Image::Image(int imageType, uint16_t supportedMetadata, BasicIo::UniquePtr io)
         : io_(std::move(io)),
           pixelWidth_(0),
           pixelHeight_(0),
@@ -152,7 +149,6 @@ namespace Exiv2 {
           writeXmpFromPacket_(true),
 #endif
           byteOrder_(invalidByteOrder),
-          tags_(),
           init_(true)
     {
     }


### PR DESCRIPTION
Found with readability-redundant-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>