### PR TITLE
Copy mergify file from 0.27-maintenance

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,23 @@
+pull_request_rules:
+  - name: forward patches to main branch
+    conditions:
+      - base=0.27-maintenance
+      - label=forward-to-main
+    actions:
+      backport:
+        branches:
+          - main
+        assignees:
+          - "{{ author }}"
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}
+
+  - name: remove outdated reviews
+    conditions: []
+    actions:
+      dismiss_reviews:
+        changes_requested: False


### PR DESCRIPTION
I am surprised that Mergify did not create an automatic PR for forwarding #1627 to main. Maybe we need to also have the .mergify.yml file on `main` ...