### PR TITLE
clang-tidy: remove duplicate public

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -207,7 +207,7 @@ public:
     static time_t deltaMax_;
 
 // public static member functions
-public:
+
     static int    Adjust() {return Position::adjust_ + Position::tz_ + Position::dst_ ;}
     static int    tz()     {return tz_    ;}
     static int    dst()    {return dst_   ;}

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -113,7 +113,7 @@ namespace Exiv2 {
             ConvertFct  key1ToKey2_; //!< Conversion from first to second key.
             ConvertFct  key2ToKey1_; //!< Conversion from second to first key.
         };
-    public:
+
         //! @name Creators
         //@{
         //! Constructor for Exif tags and XMP properties.


### PR DESCRIPTION
Found with readability-redundant-access-specifiers

Signed-off-by: Rosen Penev <rosenp@gmail.com>