### PR TITLE
clang-tidy: remove pointless const

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -80,7 +80,7 @@ class Options;
 int getFileType(const char* path ,Options& options);
 int getFileType(std::string& path,Options& options);
 
-string getExifTime(const time_t t);
+string getExifTime(time_t t);
 time_t parseTime(const char* ,bool bAdjust=false);
 int    timeZoneAdjust();
 

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -81,7 +81,7 @@
 namespace {
     // Todo: Can be generalized further - get any tag as a string/long/...
     //! Get the model name from tag Exif.Image.Model
-    std::string getExifModel(Exiv2::Internal::TiffComponent* const pRoot);
+    std::string getExifModel(Exiv2::Internal::TiffComponent* pRoot);
     //! Nikon en/decryption function
     void ncrypt(Exiv2::byte* pData, uint32_t size, uint32_t count, uint32_t serial);
 }


### PR DESCRIPTION
Found with readability-avoid-const-params-in-decls

Signed-off-by: Rosen Penev <rosenp@gmail.com>