### PR TITLE
clang-tidy: add ending namespace comments

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -1287,4 +1287,4 @@ namespace Jzon
 
 		return true;
 	}
-}
+}  // namespace Jzon

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -154,7 +154,7 @@ namespace {
 
     //! Print image Structure information
     int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const std::string &path);
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -2200,4 +2200,4 @@ namespace {
         image->printStructure(out,option);
         return 0;
     }
-}
+}  // namespace

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -144,4 +144,4 @@ namespace Exiv2
         }
         return matched;
     }
-}
+}  // namespace Exiv2

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -3227,4 +3227,5 @@ namespace Exiv2 {
         return sign * (val + frac) / 32.0f;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/casiomn_int.cpp
+++ b/src/casiomn_int.cpp
@@ -592,4 +592,5 @@ namespace Exiv2 {
         return os;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -88,7 +88,7 @@ namespace {
       The return code indicates if the operation was successful.
      */
     bool getTextValue(std::string& value, const Exiv2::XmpData::iterator& pos);
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -1592,4 +1592,4 @@ namespace {
         return pos->value().ok();
     }
 
-}
+}  // namespace

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -66,4 +66,5 @@ namespace Exiv2 {
         return isTiffImageTag(tag, group);
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -48,7 +48,7 @@ namespace {
         // DATA
         static const OmList omList_[];
     }; // class RotationMap
-}
+}  // namespace
 
 // *****************************************************************************
 // local definitions
@@ -90,7 +90,7 @@ namespace {
         return d;
     }
     //! @endcond
-}
+}  // namespace
 
 namespace Exiv2 {
     namespace Internal {
@@ -1251,4 +1251,5 @@ namespace Exiv2 {
         return buf;
     }
 
-}}                                       // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -170,7 +170,7 @@ namespace {
           N_("Memory allocation failed")}
     };
 
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -173,7 +173,7 @@ namespace {
     //! Helper function to delete all tags of a specific IFD from the metadata.
     void eraseIfd(Exiv2::ExifData& ed, Exiv2::Internal::IfdId ifdId);
 
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -958,4 +958,4 @@ namespace {
                  ed.end());
     }
     //! @endcond
-}
+}  // namespace

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -116,7 +116,7 @@ namespace {
       @param input Input string, assumed to be UTF-8
      */
     std::string parseEscapes(const std::string& input);
-}
+}  // namespace
 
 // *****************************************************************************
 // Main
@@ -1592,5 +1592,4 @@ namespace {
         return result;
     }
 
-}
-
+}  // namespace

--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -392,4 +392,5 @@ namespace Exiv2 {
         return tagInfo_;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -132,7 +132,7 @@ namespace {
         { ImageType::none, 0,               0,          amNone,      amNone,      amNone,      amNone      }
     };
 
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -74,7 +74,7 @@ namespace {
         uint16_t record_;
 
     }; // class FindIptcdatum
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -567,4 +567,4 @@ namespace {
         return rc;
     }
 
-}
+}  // namespace

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1198,7 +1198,8 @@ namespace Exiv2 {
         }
         return idx;
     }
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2
 
 // *****************************************************************************
 // local definitions
@@ -1260,4 +1261,4 @@ namespace {
             pData[i] ^= cj;
         }
     }
-}
+}  // namespace

--- a/src/minoltamn_int.cpp
+++ b/src/minoltamn_int.cpp
@@ -2492,4 +2492,5 @@ namespace Exiv2 {
         return os;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -2984,5 +2984,5 @@ zmountlens[] = {
         return os;
     }
 
-
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1701,4 +1701,5 @@ value, const ExifData* metadata)
         return os << v;
     } // OlympusMakerNote::print0x0308
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/orfimage_int.cpp
+++ b/src/orfimage_int.cpp
@@ -71,4 +71,5 @@ namespace Exiv2 {
         return buf;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/panasonicmn_int.cpp
+++ b/src/panasonicmn_int.cpp
@@ -759,4 +759,5 @@ namespace Exiv2 {
         return tagInfoRaw_;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1696,4 +1696,5 @@ namespace Exiv2 {
         return tagInfo_;
     }
 
-}}                                       // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -738,6 +738,7 @@ namespace Exiv2 {
 
     } // PngChunk::writeRawProfile
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2
 #endif // ifdef EXV_HAVE_LIBZ
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -50,7 +50,7 @@ namespace {
         Exiv2::PrintFct printFct_;             //!< Print function
     };
 
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/rw2image_int.cpp
+++ b/src/rw2image_int.cpp
@@ -34,4 +34,5 @@ namespace Exiv2 {
         return DataBuf();
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/samsungmn_int.cpp
+++ b/src/samsungmn_int.cpp
@@ -197,4 +197,5 @@ namespace Exiv2 {
         return tagInfoPw_;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/sigmamn_int.cpp
+++ b/src/sigmamn_int.cpp
@@ -159,4 +159,5 @@ namespace Exiv2 {
         return os;
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -888,4 +888,5 @@ namespace Exiv2 {
         return sonyTagCipher(tag,bytes,size,object,false);
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -98,10 +98,8 @@ namespace Exiv2 {
                                     N_("Unknown tag"),
                                     ifdIdNotSet, sectionIdNotSet, asciiString, -1, printValue);
 
-
-
-
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2
 
 namespace Exiv2 {
 

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -52,7 +52,7 @@ namespace {
         if (str[0] != '0') os << str[0];
         return os << str[1] << "." << str[2] << str[3];
     }
-}
+}  // namespace
 
 namespace Exiv2 {
     namespace Internal {
@@ -3257,4 +3257,5 @@ namespace Exiv2 {
         return ii->tagList_();
     }
 
-} }
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -1890,7 +1890,8 @@ namespace Exiv2 {
         return TiffComponent::UniquePtr(new TiffBinaryElement(tag, group));
     }
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2
 
 // *****************************************************************************
 // local definitions
@@ -1906,4 +1907,4 @@ namespace {
         return 0;
 
     } // fillGap
-}
+}  // namespace

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -2136,4 +2136,5 @@ namespace Exiv2 {
         }
     }
 
-}}                                       // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -71,7 +71,7 @@ namespace {
 
         return bo;
     }
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -1715,4 +1715,5 @@ namespace Exiv2 {
 
     } // TiffReader::visitBinaryElement
 
-}}                                      // namespace Internal, Exiv2
+    }  // namespace Internal
+}  // namespace Exiv2

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -92,7 +92,7 @@ namespace {
         { Exiv2::langAlt,          "LangAlt",     1 }
     };
 
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -110,7 +110,7 @@ namespace {
         Exiv2::XmpParser::XmpLockFct xmpLockFct_;
         void* pLockData_;
     };
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions
@@ -981,4 +981,4 @@ namespace {
     } // makeXmpKey
 #endif // EXV_HAVE_XMP_TOOLKIT
 
-}
+}  // namespace


### PR DESCRIPTION
Found with google-readability-namespace-comments

Signed-off-by: Rosen Penev <rosenp@gmail.com>