### PR TITLE
clang-tidy: use uppercase numeric literals

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -243,7 +243,7 @@ namespace Jzon
 		}
 		else
 		{
-			return 0.f;
+			return 0.F;
 		}
 	}
 	double Value::ToDouble() const

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2730,7 +2730,7 @@ namespace Exiv2 {
         auto pos = metadata->findKey(key);
         if (pos != metadata->end() && pos->value().count() >= 3 && pos->value().typeId() == unsignedShort) {
             float fu = pos->value().toFloat(2);
-            if (fu != 0.0f) {
+            if (fu != 0.0F) {
                 float fl = value.toFloat(1) / fu;
                 std::ostringstream oss;
                 oss.copyfmt(os);
@@ -2829,14 +2829,14 @@ namespace Exiv2 {
     {
         ExifKey key("Exif.CanonCs.Lens");
         auto pos = metadata->findKey(key);
-        ltfl.focalLengthMin_ = 0.0f;
-        ltfl.focalLengthMax_ = 0.0f;
+        ltfl.focalLengthMin_ = 0.0F;
+        ltfl.focalLengthMax_ = 0.0F;
         if (pos != metadata->end()) {
             const Value &value = pos->value();
             if (   value.count() >= 3
                 && value.typeId() == unsignedShort) {
                 float fu = value.toFloat(2);
-                if (fu != 0.0f) {
+                if (fu != 0.0F) {
                     ltfl.focalLengthMin_ = value.toLong(1) / fu;
                     ltfl.focalLengthMax_ = value.toLong(0) / fu;
                 }
@@ -2869,9 +2869,9 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0f)
+        if (ltfl.focalLengthMax_ == 0.0F)
             return os << value;
-        convertFocalLength(ltfl, 1.0f);
+        convertFocalLength(ltfl, 1.0F);
 
         ExifKey key("Exif.CanonCs.MaxAperture");
         auto pos = metadata->findKey(key);
@@ -2907,9 +2907,9 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0f)
+        if (ltfl.focalLengthMax_ == 0.0F)
             return os << value;
-        convertFocalLength(ltfl, 1.0f);
+        convertFocalLength(ltfl, 1.0F);
 
         if (ltfl.focalLength_.empty()) return os << value;
 
@@ -2930,15 +2930,15 @@ namespace Exiv2 {
         ltfl.lensType_ = value.toLong();
 
         extractLensFocalLength(ltfl, metadata);
-        if (ltfl.focalLengthMax_ == 0.0f)
+        if (ltfl.focalLengthMax_ == 0.0F)
             return os << value;
-        convertFocalLength(ltfl, 1.0f);  // just lens
+        convertFocalLength(ltfl, 1.0F);  // just lens
         const TagDetails* td = find(canonCsLensType, ltfl);
         if (!td) {
-            convertFocalLength(ltfl, 1.4f); // lens + 1.4x TC
+            convertFocalLength(ltfl, 1.4F);  // lens + 1.4x TC
             td = find(canonCsLensType, ltfl);
             if (!td) {
-                convertFocalLength(ltfl, 2.0f); // lens + 2x TC
+                convertFocalLength(ltfl, 2.0F);  // lens + 2x TC
                 td = find(canonCsLensType, ltfl);
                 if (!td) return os << value;
             }
@@ -2985,7 +2985,7 @@ namespace Exiv2 {
         }
 
         float fu = value.toFloat(2);
-        if (fu == 0.0f)
+        if (fu == 0.0F)
             return os << value;
         float len1 = value.toLong(0) / fu;
         float len2 = value.toLong(1) / fu;
@@ -3009,7 +3009,7 @@ namespace Exiv2 {
         std::ios::fmtflags f( os.flags() );
         if (   value.typeId() == unsignedShort
             && value.count() > 0) {
-            os << std::exp(canonEv(value.toLong()) / 32 * std::log(2.0f)) * 100.0f;
+            os << std::exp(canonEv(value.toLong()) / 32 * std::log(2.0F)) * 100.0F;
         }
         os.flags(f);
         return os;
@@ -3023,7 +3023,7 @@ namespace Exiv2 {
         if (   value.typeId() == unsignedShort
             && value.count() > 0) {
             // Ported from Exiftool by Will Stokes
-            os << std::exp(canonEv(value.toLong()) * std::log(2.0f)) * 100.0f / 32.0f;
+            os << std::exp(canonEv(value.toLong()) * std::log(2.0F)) * 100.0F / 32.0F;
         }
         os.flags(f);
         return os;
@@ -3216,15 +3216,15 @@ namespace Exiv2 {
         val -= long(frac);
         // convert 1/3 (0x0c) and 2/3 (0x14) codes
         if (frac == 0x0c) {
-            frac = 32.0f / 3;
+            frac = 32.0F / 3;
         }
         else if (frac == 0x14) {
-            frac = 64.0f / 3;
+            frac = 64.0F / 3;
         }
         else if ((val == 160) && (frac == 0x08)) { // for Sigma f/6.3 lenses that report f/6.2 to camera
             frac = 30.0F / 3;
         }
-        return sign * (val + frac) / 32.0f;
+        return sign * (val + frac) / 32.0F;
     }
 
 }}                                      // namespace Internal, Exiv2

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -531,7 +531,7 @@ static void boxes_check(size_t b,size_t m)
                                 out << Internal::stringFormat("%8ld | %8ld |  sub:", (size_t)address,
                                                               (size_t)subBox.length)
                                     << toAscii(subBox.type) << " | "
-                                    << Internal::binaryToString(makeSlice(data, 0, std::min(30l, data.size_)));
+                                    << Internal::binaryToString(makeSlice(data, 0, std::min(30L, data.size_)));
                                 bLF = true;
                             }
 

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -2840,7 +2840,7 @@ fmountlens[] = {
         std::ostringstream oss;
         oss.copyfmt(os);
         char sign = value.toLong() < 0 ? '-' : '+';
-        long h    = long(std::abs( (int) (value.toFloat()/60.0f)  ))%24;
+        long h = long(std::abs((int)(value.toFloat() / 60.0F))) % 24;
         long min  = long(std::abs( (int) (value.toFloat()-h*60)  ))%60;
         os << std::fixed << "UTC " << sign << std::setw(2) << std::setfill('0') << h << ":"
            << std::setw(2) << std::setfill('0') << min;

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1183,7 +1183,7 @@ namespace Exiv2 {
             return os << "(" << value << ")";
         }
         float f = value.toFloat();
-        if (f == 0.0f || f == 1.0f)
+        if (f == 0.0F || f == 1.0F)
             return os << _("None");
         std::ostringstream oss;
         oss.copyfmt(os);

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1116,9 +1116,7 @@ namespace Exiv2 {
                << static_cast<float>(l0) / 3
                << " EV";
         } else {
-            os << std::setprecision(2)
-               << static_cast<float>(l0) - 9.5f
-               << " EV";
+            os << std::setprecision(2) << static_cast<float>(l0) - 9.5F << " EV";
         }
 
         if (value.count() == 2) {

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -197,7 +197,7 @@ namespace Exiv2 {
 
             if ((compressionFlag == 0x00) || (compressionFlag == 0x01 && compressionMethod == 0x00)) {
                 enforce(Safe::add(static_cast<unsigned int>(keysize + 3 + languageTextSize + 1),
-                                  Safe::add(translatedKeyTextSize, 1u)) <= static_cast<unsigned int>(data.size_),
+                                  Safe::add(translatedKeyTextSize, 1U)) <= static_cast<unsigned int>(data.size_),
                         Exiv2::kerCorruptedMetadata);
 
                 const byte* text = data.pData_ + keysize + 3 + languageTextSize + 1 + translatedKeyTextSize + 1;

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2577,7 +2577,7 @@ namespace Exiv2 {
 
     float fnumber(float apertureValue)
     {
-        return std::exp(std::log(2.0f) * apertureValue / 2.f);
+        return std::exp(std::log(2.0F) * apertureValue / 2.F);
     }
 
     URational exposureTime(float shutterSpeedValue)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -224,9 +224,9 @@ namespace Exiv2 {
         // http://dev.exiv2.org/boards/3/topics/1912?r=1915
         if ( std::tolower(is.peek()) == 'f' ) {
             char  F = 0;
-            float f = 0.f;
+            float f = 0.F;
             is >> F >> f ;
-            f  = 2.0f * std::log(f) / std::log(2.0f) ;
+            f = 2.0F * std::log(f) / std::log(2.0F);
             r  = Exiv2::floatToRationalCast(f);
         } else {
             int32_t nominator = 0;
@@ -252,9 +252,9 @@ namespace Exiv2 {
         /// \todo This implementation seems to be duplicated for the Rational type. Try to remove duplication
         if ( std::tolower(is.peek()) == 'f' ) {
             char  F = 0;
-            float f = 0.f;
+            float f = 0.F;
             is >> F >> f ;
-            f  = 2.0f * std::log(f) / std::log(2.0f) ;
+            f = 2.0F * std::log(f) / std::log(2.0F);
             r  = Exiv2::floatToRationalCast(f);
         } else {
             uint32_t nominator = 0;
@@ -661,7 +661,8 @@ namespace Exiv2 {
         }
 
         bool b = stringTo<bool>(s, ok);
-        if (ok) return b ? 1.0f : 0.0f;
+        if (ok)
+            return b ? 1.0F : 0.0F;
 
         // everything failed, return from stringTo<float> is probably the best fit
         return ret;
@@ -708,7 +709,7 @@ namespace Exiv2 {
         if (Safe::abs(f_as_long) > 21474836) {
             den = 1;
         }
-        const float rnd = f >= 0 ? 0.5f : -0.5f;
+        const float rnd = f >= 0 ? 0.5F : -0.5F;
         const int32_t nom = static_cast<int32_t>(f * den + rnd);
         const int32_t g = gcd(nom, den);
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -903,7 +903,7 @@ namespace Exiv2 {
     float LangAltValue::toFloat(long /*n*/) const
     {
         ok_ = false;
-        return 0.0f;
+        return 0.0F;
     }
 
     Rational LangAltValue::toRational(long /*n*/) const

--- a/unitTests/test_FileIo.cpp
+++ b/unitTests/test_FileIo.cpp
@@ -51,13 +51,13 @@ TEST(AFileIO, returnsFileSizeIfItsOpened)
 {
     FileIo file(imagePath);
     file.open();
-    ASSERT_EQ(118685ul, file.size());
+    ASSERT_EQ(118685UL, file.size());
 }
 
 TEST(AFileIO, returnsFileSizeEvenWhenFileItIsNotOpened)
 {
     FileIo file(imagePath);
-    ASSERT_EQ(118685ul, file.size());
+    ASSERT_EQ(118685UL, file.size());
 }
 
 TEST(AFileIO, isOpenedAtPosition0)

--- a/unitTests/test_cr2header_int.cpp
+++ b/unitTests/test_cr2header_int.cpp
@@ -30,7 +30,7 @@ TEST(ACr2Header, hasExpectedValuesAfterCreation)
 {
     Internal::Cr2Header header;
     ASSERT_EQ(42, header.tag());
-    ASSERT_EQ(16u, header.size());
+    ASSERT_EQ(16U, header.size());
     ASSERT_EQ(littleEndian, header.byteOrder());
 }
 

--- a/unitTests/test_helper_functions.cpp
+++ b/unitTests/test_helper_functions.cpp
@@ -26,7 +26,7 @@ TEST(string_from_unterminated, terminatedArray)
     const char data[5] = {'a', 'b', 'c', 0, 'd'};
     const std::string res = string_from_unterminated(data, 5);
 
-    ASSERT_EQ(res.size(), 3u);
+    ASSERT_EQ(res.size(), 3U);
     ASSERT_STREQ(res.c_str(), "abc");
 }
 
@@ -35,6 +35,6 @@ TEST(string_from_unterminated, unterminatedArray)
     const char data[4] = {'a', 'b', 'c', 'd'};
     const std::string res = string_from_unterminated(data, 4);
 
-    ASSERT_EQ(res.size(), 4u);
+    ASSERT_EQ(res.size(), 4U);
     ASSERT_STREQ(res.c_str(), "abcd");
 }

--- a/unitTests/test_tiffheader.cpp
+++ b/unitTests/test_tiffheader.cpp
@@ -34,9 +34,9 @@ public:
 
 TEST_F(ATiffHeader, hasExpectedValuesAfterCreation)
 {
-    ASSERT_EQ(8u, header.size());
+    ASSERT_EQ(8U, header.size());
     ASSERT_EQ(42, header.tag());
-    ASSERT_EQ(8u, header.offset());
+    ASSERT_EQ(8U, header.offset());
     ASSERT_EQ(littleEndian, header.byteOrder());
 }
 
@@ -44,7 +44,7 @@ TEST_F(ATiffHeader, canBeWrittenAndItsSizeIs8Bytes)
 {
     DataBuf buffer = header.write();
     ASSERT_EQ(header.size(), buffer.size_);
-    ASSERT_EQ(8u, header.size());
+    ASSERT_EQ(8U, header.size());
 }
 
 TEST_F(ATiffHeader, readDataFromBufferWithCorrectSize)

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -60,12 +60,12 @@ TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
 
 TEST(Rational, floatToRationalCast)
 {
-    static const float floats[] = {0.5f, 0.015f, 0.0000625f};
+    static const float floats[] = {0.5F, 0.015F, 0.0000625F};
 
     for (size_t i = 0; i < sizeof(floats) / sizeof(*floats); ++i) {
         const Rational r = floatToRationalCast(floats[i]);
         const float fraction = static_cast<float>(r.first) / static_cast<float>(r.second);
-        ASSERT_TRUE(std::fabs((floats[i] - fraction) / floats[i]) < 0.01f);
+        ASSERT_TRUE(std::fabs((floats[i] - fraction) / floats[i]) < 0.01F);
     }
 
     const Rational plus_inf = floatToRationalCast(std::numeric_limits<float>::infinity());


### PR DESCRIPTION
Found with readability-uppercase-literal-suffix

Signed-off-by: Rosen Penev <rosenp@gmail.com>