### PR TITLE
clang-tidy: fix badly indented if

### DIFF
--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -340,10 +340,12 @@ namespace Exiv2 {
     {
         if (io_->open() != 0) throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         // Ensure that this is the correct image type
-        if ( imageType() == ImageType::none )
-        if (!isTiffType(*io_, false)) {
-            if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
-            throw Error(kerNotAJpeg);
+        if (imageType() == ImageType::none) {
+            if (!isTiffType(*io_, false)) {
+                if (io_->error() || io_->eof())
+                    throw Error(kerFailedToReadImageData);
+                throw Error(kerNotAJpeg);
+            }
         }
 
         io_->seek(0,BasicIo::beg);


### PR DESCRIPTION
Found with readability-misleading-indentation

Signed-off-by: Rosen Penev <rosenp@gmail.com>