### PR TITLE
Usage of CTest

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -49,7 +49,5 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests
-          cd ../../tests/
-          python runner.py -v
+          cd build
+          ctest --output-on-failure

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -122,6 +122,41 @@ jobs:
           cd ../../tests/
           python runner.py -v
 
+  special_allEnabled:
+    name: 'Ubuntu 20.04 - GCC - All Options Enabled'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install valgrind doxygen graphviz gettext
+          pip3 install conan==1.36.0
+
+      - name: Conan common config
+        run: |
+          conan profile new --detect default
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+
+      - name: Run Conan
+        run: |
+          mkdir build && cd build
+          conan profile list
+          conan profile show default
+          conan install .. -o webready=True --build missing
+
+      - name: Build
+        run: |
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_COVERAGE=ON -DEXIV2_BUILD_DOC=ON -DEXIV2_ENABLE_NLS=ON -DCMAKE_CXX_FLAGS="-DEXIV2_DEBUG_MESSAGES" ..
+          make -j
+
+      - name: Generate documentation
+        run: |
+          make doc
+
   special_FedoraMinGW:
     name: 'Fedora MinGW'
     runs-on: ubuntu-latest

--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -43,7 +43,5 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests
-          cd ../../tests/
-          python3 runner.py -v
+          cd build
+          ctest --output-on-failure

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -78,7 +78,5 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests.exe
-          cd ../../tests/
-          python.exe runner.py -v
+          cd build
+          ctest --output-on-failure

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -83,8 +83,7 @@ jobs:
       - name: Unit Test
         run: |
           cd build
-          cd bin
-          ./unit_tests
+          ctest --output-on-failure
 
   MacOS:
     name: 'MacOS - clang - Arch:x64 BuildType:Release - SHARED'
@@ -113,5 +112,4 @@ jobs:
       - name: Unit Test
         run: |
           cd build
-          cd bin
-          ./unit_tests
+          ctest --output-on-failure

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Unit Test
         run: |
-          cd build/bin
-          ./unit_tests.exe
+          cd build
+          ctest --output-on-failure
 
   Linux:
     name: 'Ubuntu 20.04 - GCC - Arch:x64 BuildType:Release - SHARED'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,35 +99,21 @@ add_custom_target(version_test
 )
 
 if( EXIV2_BUILD_SAMPLES )
-    ##
-    # tests
-    if( EXIV2_BUILD_UNIT_TESTS )
-        add_custom_target(tests
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/unit_test.py
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/testcases.py --verbose
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py 
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/version_test.py
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests"
-        )
-    else()
-        add_custom_target(tests
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/testcases.py --verbose
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py
-            COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/version_test.py
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests"
-        )
-    endif()
-    add_custom_target(python_tests
-        COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests"
+    add_test(NAME bashTests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+        COMMAND env EXIV2_BINDIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY} python3 runner.py bash_tests/testcases.py --verbose
     )
-    add_custom_target(bash_tests
-        COMMAND env EXIV2_BINDIR="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" python3 runner.py bash_tests/testcases.py --verbose
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests"
+    add_test(NAME versionTests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+        COMMAND env EXIV2_BINDIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY} python3 runner.py bash_tests/version_test.py
     )
+    add_test(NAME pythonTests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+        COMMAND env EXIV2_BINDIR=${CMAKE_RUNTIME_OUTPUT_DIRECTORY} python3 runner.py
+    )
+
     add_subdirectory( samples )
     get_directory_property(SAMPLES DIRECTORY samples DEFINITION APPLICATIONS)
-    add_dependencies(tests exiv2lib exiv2 ${SAMPLES})
 endif()
 
 if( EXIV2_ENABLE_NLS )

--- a/cmake/mainSetup.cmake
+++ b/cmake/mainSetup.cmake
@@ -6,6 +6,7 @@ include(CheckFunctionExists)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
 include(cmake/JoinPaths.cmake)
+include(CTest)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class Exiv2Conan(ConanFile):
 
     def configure(self):
         self.options['libcurl'].shared = True
-        self.options['gtest'].shared = True
+        self.options['gtest'].shared = False
 
     def requirements(self):
         self.requires('zlib/1.2.11')

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -40,7 +40,6 @@ foreach(entry ${SAMPLES})
     set_target_properties(${target} PROPERTIES
       COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS})
     list(APPEND APPLICATIONS ${target})
-    add_test( ${target}_test ${target} )
     target_include_directories(${target} PRIVATE ${CMAKE_SOURCE_DIR}/src) # To find unused.h
     if ( NOT ${target} MATCHES ".*test.*")                                # don't install tests
         install( TARGETS ${target} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -50,3 +50,5 @@ set_target_properties(unit_tests PROPERTIES
 if (MSVC)
     set_target_properties(unit_tests PROPERTIES LINK_FLAGS "/ignore:4099")
 endif()
+
+add_test(NAME unit_tests COMMAND unit_tests)


### PR DESCRIPTION
- Addition of CMake code to add support for CTest
- Replace cmake custom targets by `add_tests`
- Addition of new "special" job in CI so that we compile the projects with all the options enabled (as I suggested in #1644) 