### PR TITLE
clang-tidy: make several member functions const

### DIFF
--- a/include/exiv2/ini.hpp
+++ b/include/exiv2/ini.hpp
@@ -165,7 +165,7 @@ public:
     /*! @brief Return the result of ini_parse(), i.e., 0 on success, line number of
         first error on parse error, or -1 on file open error.
     */
-    int ParseError();
+    int ParseError() const;
 
     /*! @brief Get a string value from INI file, returning default_value if not found.
 

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -96,9 +96,9 @@ namespace Exiv2
         //! Read Magick number. Only version >= 6 is supported.
         byte readPgfMagicNumber(BasicIo& iIo);
         //! Read PGF Header size encoded in 32 bits integer.
-        uint32_t readPgfHeaderSize(BasicIo& iIo);
+        uint32_t readPgfHeaderSize(BasicIo& iIo) const;
         //! Read header structure.
-        DataBuf readPgfHeaderStructure(BasicIo& iIo, int& width,int & height);
+        DataBuf readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const;
         //@}
 
     }; // class PgfImage

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -178,16 +178,34 @@ public:
     virtual ~Position() = default;
 
     //  instance methods
-    bool good()                 { return time_ || lon_ || lat_ || ele_ ; }
+    bool good() const
+    {
+        return time_ || lon_ || lat_ || ele_;
+    }
     std::string getTimeString() { if ( times_.empty() ) times_ = getExifTime(time_) ;  return times_; }
-    time_t      getTime()       { return time_ ; }
-    std::string toString();
+    time_t getTime() const
+    {
+        return time_;
+    }
+    std::string toString() const;
 
-//  getters/setters
-    double lat()            {return lat_   ;}
-    double lon()            {return lon_   ;}
-    double ele()            {return ele_   ;}
-    int    delta()          {return delta_ ;}
+    //  getters/setters
+    double lat() const
+    {
+        return lat_;
+    }
+    double lon() const
+    {
+        return lon_;
+    }
+    double ele() const
+    {
+        return ele_;
+    }
+    int delta() const
+    {
+        return delta_;
+    }
     void   delta(int delta) {delta_=delta  ;}
 
 //  data
@@ -263,7 +281,7 @@ std::string Position::toExifString(double d,bool bRational,bool bLat)
     return std::string(result);
 }
 
-std::string Position::toString()
+std::string Position::toString() const
 {
     char result[200];
     std::string sLat = Position::toExifString(lat_,false,true );

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -82,7 +82,7 @@ namespace {
         //! Read the timestamp from a broken-down time in buffer \em tm.
         int read(struct tm* tm);
         //! Set the timestamp of a file
-        int touch(const std::string& path);
+        int touch(const std::string& path) const;
 
     private:
         time_t actime_{0};
@@ -1790,7 +1790,7 @@ namespace {
         return rc;
     }
 
-    int Timestamp::touch(const std::string& path)
+    int Timestamp::touch(const std::string& path) const
     {
         if (0 == actime_) return 1;
         struct utimbuf buf;

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -233,7 +233,7 @@ INIReader::INIReader(const std::string &filename)
     _error = ini_parse(filename.c_str(), ValueHandler, this);
 }
 
-int INIReader::ParseError()
+int INIReader::ParseError() const
 {
     return _error;
 }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -263,7 +263,7 @@ namespace Exiv2 {
         return b;
     } // PgfImage::readPgfMagicNumber
 
-    uint32_t PgfImage::readPgfHeaderSize(BasicIo& iIo)
+    uint32_t PgfImage::readPgfHeaderSize(BasicIo& iIo) const
     {
         DataBuf buffer(4);
         long bufRead = iIo.read(buffer.pData_, buffer.size_);
@@ -280,7 +280,7 @@ namespace Exiv2 {
         return headerSize;
     } // PgfImage::readPgfHeaderSize
 
-    DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, int& width, int& height)
+    DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const
     {
         DataBuf header(16);
         long bufRead = iIo.read(header.pData_, header.size_);


### PR DESCRIPTION
Found with readability-make-member-function-const

Signed-off-by: Rosen Penev <rosenp@gmail.com>