### PR TITLE
clang-tidy: don't use else after return

### DIFF
--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -62,7 +62,8 @@ try {
         exv_grep_keys_t keys;
         Exiv2::dumpLibraryInfo(std::cout,keys);
         return 0;
-    } else if ( _tstrcmp(file,_t("--version-test")) == 0 ) {
+    }
+    if (_tstrcmp(file, _t("--version-test")) == 0) {
         // verifies/test macro EXIV2_TEST_VERSION
         // described in include/exiv2/version.hpp
         std::cout << "EXV_PACKAGE_VERSION             " << EXV_PACKAGE_VERSION             << std::endl

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -104,7 +104,8 @@ Jzon::Node& addToTree(Jzon::Node& r1,Token token)
         Jzon::Object& o1 = r1.AsObject();
         if (   !o1.Has(key) ) o1.Add(key,empty);
         return  o1.Get(key);
-    } else if ( r1.IsArray() ) {
+    }
+    if (r1.IsArray()) {
         Jzon::Array& a1 = r1.AsArray();
         while ( a1.GetCount() <= index ) a1.Add(empty);
         return  a1.Get(index);

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -2315,12 +2315,11 @@ namespace Exiv2 {
 
         if(res != CURLE_OK) {
             throw Error(kerErrorMessage, curl_easy_strerror(res));
-        } else {
-            int serverCode;
-            curl_easy_getinfo (curl_, CURLINFO_RESPONSE_CODE, &serverCode); // get code
-            if (serverCode >= 400 || serverCode < 0) {
-                throw Error(kerFileOpenFailed, "http",Exiv2::Internal::stringFormat("%d",serverCode),path_);
-            }
+        }
+        int serverCode;
+        curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &serverCode);  // get code
+        if (serverCode >= 400 || serverCode < 0) {
+            throw Error(kerFileOpenFailed, "http", Exiv2::Internal::stringFormat("%d", serverCode), path_);
         }
     }
 
@@ -2367,12 +2366,11 @@ namespace Exiv2 {
 
         if(res != CURLE_OK) {
             throw Error(kerErrorMessage, curl_easy_strerror(res));
-        } else {
-            int serverCode;
-            curl_easy_getinfo (curl_, CURLINFO_RESPONSE_CODE, &serverCode);
-            if (serverCode >= 400 || serverCode < 0) {
-                throw Error(kerFileOpenFailed, "http",Exiv2::Internal::stringFormat("%d",serverCode),path_);
-            }
+        }
+        int serverCode;
+        curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE, &serverCode);
+        if (serverCode >= 400 || serverCode < 0) {
+            throw Error(kerFileOpenFailed, "http", Exiv2::Internal::stringFormat("%d", serverCode), path_);
         }
     }
 
@@ -2384,18 +2382,16 @@ namespace Exiv2 {
     {
         if (p_->protocol_ == pHttp || p_->protocol_ == pHttps) {
             return RemoteIo::write(data, wcount);
-        } else {
-            throw Error(kerErrorMessage, "doesnt support write for this protocol.");
         }
+        throw Error(kerErrorMessage, "doesnt support write for this protocol.");
     }
 
     long CurlIo::write(BasicIo& src)
     {
         if (p_->protocol_ == pHttp || p_->protocol_ == pHttps) {
             return RemoteIo::write(src);
-        } else {
-            throw Error(kerErrorMessage, "doesnt support write for this protocol.");
         }
+        throw Error(kerErrorMessage, "doesnt support write for this protocol.");
     }
 
     CurlIo::CurlIo(const std::string& url, size_t blockSize)

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1230,26 +1230,22 @@ namespace Exiv2 {
                 writeExifDigest();
                 return;
             }
-            else {
-                // We have both digests and the values do not match
-                // Exif was modified after XMP, we should update XMP
-                setOverwrite(true);
-                setErase(false);
-
-                cnvToXmp();
-                writeExifDigest();
-                return;
-            }
-        }
-        else {
-            // We don't have both digests, it is probably the first conversion to XMP
-            setOverwrite(false); // to be safe
+            // We have both digests and the values do not match
+            // Exif was modified after XMP, we should update XMP
+            setOverwrite(true);
             setErase(false);
 
             cnvToXmp();
             writeExifDigest();
             return;
         }
+        // We don't have both digests, it is probably the first conversion to XMP
+        setOverwrite(false);  // to be safe
+        setErase(false);
+
+        cnvToXmp();
+        writeExifDigest();
+        return;
     }
 
     std::string Converter::computeIptcDigest()

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -401,7 +401,8 @@ namespace {
                 EXV_WARNING << "Nested document at invalid position: " << startPos << "\n";
                 #endif
                 throw Error(write ? kerImageWriteFailed : kerFailedToReadImageData);
-            } else if (startsWith(line, "%%BeginDocument:")) {
+            }
+            if (startsWith(line, "%%BeginDocument:")) {
                 if (depth == maxDepth) {
                     #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Document too deeply nested at position: " << startPos << "\n";
@@ -418,11 +419,11 @@ namespace {
                 }
                 depth--;
             } else {
-                #ifdef DEBUG
+#ifdef DEBUG
                 significantLine = false;
                 #endif
             }
-            #ifdef DEBUG
+#ifdef DEBUG
             if (significantLine) {
                 EXV_DEBUG << "readWriteEpsMetadata: Found significant line \"" << line << "\" at position: " << startPos << "\n";
             }

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -308,7 +308,7 @@ namespace Exiv2 {
         std::string path = url.substr(7);
         size_t found = path.find('/');
         if (found == std::string::npos) return path;
-        else return path.substr(found);
+        return path.substr(found);
     }
 #ifdef EXV_UNICODE_PATH
     std::wstring pathOfFileUrl(const std::wstring& wurl) {

--- a/src/getopt.cpp
+++ b/src/getopt.cpp
@@ -69,42 +69,40 @@ namespace Util {
 		if (arg && strcmp(arg, "--") == 0) {
 			optind++;
 			return -1;
-		} else if (!arg || arg[0] != '-' || !isalnum(arg[1])) {
-			return -1;
-		} else {
-			const char *opt = strchr(optstring, arg[optpos]);
-			optopt = arg[optpos];
-			if (!opt) {
-				if (opterr && *optstring != ':')
-					fprintf(stderr, "%s: illegal option: %c\n", argv[0], optopt);
-				return '?';
-			} else if (opt[1] == ':') {
-				if (arg[optpos + 1]) {
-					optarg = (char *)arg + optpos + 1;
-					optind++;
-					optpos = 1;
-					return optopt;
-				} else if (argv[optind + 1]) {
-					optarg = (char *)argv[optind + 1];
-					optind += 2;
-					optpos = 1;
-					return optopt;
-				} else {
-					if (opterr && *optstring != ':')
-						fprintf(stderr,
-								"%s: option requires an argument: %c\n",
-								argv[0], optopt);
-					return *optstring == ':' ? ':' : '?';
-				}
-			} else {
-				if (!arg[++optpos]) {
-					optind++;
-					optpos = 1;
-				}
-				return optopt;
-			}
-		}
-	}
+        }
+        if (!arg || arg[0] != '-' || !isalnum(arg[1])) {
+            return -1;
+        }
+        const char *opt = strchr(optstring, arg[optpos]);
+        optopt = arg[optpos];
+        if (!opt) {
+            if (opterr && *optstring != ':')
+                fprintf(stderr, "%s: illegal option: %c\n", argv[0], optopt);
+            return '?';
+        }
+        if (opt[1] == ':') {
+            if (arg[optpos + 1]) {
+                optarg = (char *)arg + optpos + 1;
+                optind++;
+                optpos = 1;
+                return optopt;
+            }
+            if (argv[optind + 1]) {
+                optarg = (char *)argv[optind + 1];
+                optind += 2;
+                optpos = 1;
+                return optopt;
+            }
+            if (opterr && *optstring != ':')
+                fprintf(stderr, "%s: option requires an argument: %c\n", argv[0], optopt);
+            return *optstring == ':' ? ':' : '?';
+        }
+        if (!arg[++optpos]) {
+            optind++;
+            optpos = 1;
+        }
+        return optopt;
+    }
 
 // *****************************************************************************
 // class Getopt

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -270,10 +270,9 @@ bool INIReader::GetBoolean(string section, string name, bool default_value)
     std::transform(valstr.begin(), valstr.end(), valstr.begin(), ::tolower);
     if (valstr == "true" || valstr == "yes" || valstr == "on" || valstr == "1")
         return true;
-    else if (valstr == "false" || valstr == "no" || valstr == "off" || valstr == "0")
+    if (valstr == "false" || valstr == "no" || valstr == "off" || valstr == "0")
         return false;
-    else
-        return default_value;
+    return default_value;
 }
 
 string INIReader::MakeKey(string section, string name)

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -1258,10 +1258,10 @@ namespace Exiv2 {
             }
             if (marker == eoi_) {
                 break;
-            } else if (skipApp1Exif == count || skipApp1Xmp == count ||
-                       std::find(skipApp13Ps3.begin(), skipApp13Ps3.end(), count) != skipApp13Ps3.end() ||
-                       std::find(skipApp2Icc.begin(), skipApp2Icc.end(), count) != skipApp2Icc.end() ||
-                       skipCom == count) {
+            }
+            if (skipApp1Exif == count || skipApp1Xmp == count ||
+                std::find(skipApp13Ps3.begin(), skipApp13Ps3.end(), count) != skipApp13Ps3.end() ||
+                std::find(skipApp2Icc.begin(), skipApp2Icc.end(), count) != skipApp2Icc.end() || skipCom == count) {
                 --search;
                 io_->seek(size - bufRead, BasicIo::cur);
             } else {

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -928,13 +928,14 @@ namespace Exiv2 {
             if (size < PentaxDngMnHeader::sizeOfSignature() + 18)
                 return 0;
             return newPentaxDngMn2(tag, group, (tag == 0xc634 ? pentaxDngId:pentaxId));
-        } else if (size > 4 && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
+        }
+        if (size > 4 && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
             // Require at least the header and an IFD with 1 entry
             if (size < PentaxMnHeader::sizeOfSignature() + 18)
                 return 0;
             return newPentaxMn2(tag, group, pentaxId);
-        } else
-            return 0;
+        }
+        return 0;
     }
 
     TiffComponent* newPentaxMn2(uint16_t tag,
@@ -965,12 +966,11 @@ namespace Exiv2 {
             if (size < PentaxMnHeader::sizeOfSignature() + 18) return 0;
             return newPentaxMn2(tag, group, pentaxId);
         }
-        else {
-            // Genuine Samsung camera:
-            // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
-            return newSamsungMn2(tag, group, mnGroup);
-        }
+        // Genuine Samsung camera:
+        // Require at least an IFD with 1 entry
+        if (size < 18)
+            return 0;
+        return newSamsungMn2(tag, group, mnGroup);
     }
 
     TiffComponent* newSamsungMn2(uint16_t tag,

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -2620,9 +2620,7 @@ fmountlens[] = {
             if (pf->lensname == NULL) {
                 return os << value;
             }
-            else {
-                return os << pf->manuf << " " << pf->lensname;
-            }
+            return os << pf->manuf << " " << pf->lensname;
         }
 
 

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1457,8 +1457,6 @@ namespace Exiv2 {
             { 3, N_("Multi AF")               },
             { 4, N_("Face detect")            },
             { 10, N_("MF")                    },
-            // End of list marker
-            { 0xff, "" }
         };
         static struct {
             uint16_t val;
@@ -1470,39 +1468,37 @@ namespace Exiv2 {
             { 0x0020, N_("Face detect") },
             { 0x0040, N_("Imager AF")   },
             { 0x0100, N_("AF sensor")   },
-            // End of list marker
-            { 0, "" }
         };
 
         if (value.count() < 1 || value.typeId() != unsignedShort) {
             return os << "(" << value << ")";
-        } else {
-            uint16_t v = (uint16_t)value.toLong(0);
+        }
+        auto v = (uint16_t)value.toLong(0);
 
-            // If value 2 is present, it is used instead of value 1.
-            if (value.count() > 1) {
-                std::string p;  // Used to enable ',' separation
+        // If value 2 is present, it is used instead of value 1.
+        if (value.count() > 1) {
+            std::string p;  // Used to enable ',' separation
 
-                v = (uint16_t)value.toLong(1);
-                for (int i = 0; focusModes1[i].val != 0; i++) {
-                    if ((v & focusModes1[i].val) != 0) {
-                        if (!p.empty()) {
-                            os << ", ";
-                        }
-                        p = focusModes1[i].label;
-                        os << p;
+            v = (uint16_t)value.toLong(1);
+            for (auto&& mode : focusModes1) {
+                if ((v &mode.val) != 0) {
+                    if (!p.empty()) {
+                        os << ", ";
                     }
-                }
-            } else {
-                for (int i = 0; focusModes0[i].val != 0xff; i++) {
-                   if (focusModes0[i].val == v) {
-                       os << focusModes0[i].label;
-                       break;
-                   }
+                    p = mode.label;
+                    os << p;
                 }
             }
-            return os << v;
+        } else {
+            for (auto&& mode : focusModes0) {
+                if (mode.val == v) {
+                    os << mode.label;
+                    break;
+                }
+            }
         }
+        return os << v;
+
     } // OlympusMakerNote::printCs0x0301
 
     //! OlympusCs ArtFilter, tag 0x0529, OlympusCs MagicFilter, tag 0x052c

--- a/src/panasonicmn_int.cpp
+++ b/src/panasonicmn_int.cpp
@@ -669,10 +669,9 @@ namespace Exiv2 {
             };
             return os;
         }
-        else
-        {
-            return os << value;
-        };
+
+        return os << value;
+        ;
     } // PanasonicMakerNote::printPanasonicText
 
     // Manometer Pressure

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -464,7 +464,8 @@ namespace Exiv2 {
 
                 if (chunkType == "IEND") {
                     return;  // Last chunk found: we stop parsing.
-                } else if (chunkType == "IHDR" && chunkData.size_ >= 8) {
+                }
+                if (chunkType == "IHDR" && chunkData.size_ >= 8) {
                     PngChunk::decodeIHDRChunk(chunkData, &pixelWidth_, &pixelHeight_);
                 } else if (chunkType == "tEXt") {
                     PngChunk::decodeTXTChunk(this, chunkData, PngChunk::tEXt_Chunk);
@@ -587,12 +588,10 @@ namespace Exiv2 {
                     throw Error(kerImageWriteFailed);
                 return;
             }
-            else if ( !strcmp(szChunk, "eXIf") ) {
+            if (!strcmp(szChunk, "eXIf")) {
                 ; // do nothing  Exif metdata is written following IHDR
                 ; // as zTXt chunk with signature Raw profile type exif__
-            }
-            else if ( !strcmp(szChunk, "IHDR")  )
-            {
+            } else if (!strcmp(szChunk, "IHDR")) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Exiv2::PngImage::doWriteMetadata: Write IHDR chunk (length: " << dataOffset << ")\n";
 #endif
@@ -691,12 +690,8 @@ namespace Exiv2 {
                         throw Error(kerImageWriteFailed);
                     }
                 }
-            }
-            else if (!strcmp(szChunk, "tEXt") ||
-                     !strcmp(szChunk, "zTXt") ||
-                     !strcmp(szChunk, "iTXt") ||
-                     !strcmp(szChunk, "iCCP"))
-            {
+            } else if (!strcmp(szChunk, "tEXt") || !strcmp(szChunk, "zTXt") || !strcmp(szChunk, "iTXt") ||
+                       !strcmp(szChunk, "iCCP")) {
                 DataBuf key = PngChunk::keyTXTChunk(chunkBuf, true);
                 if (compare("Raw profile type exif", key, 21) ||
                     compare("Raw profile type APP1", key, 21) ||
@@ -720,16 +715,13 @@ namespace Exiv2 {
 #endif
                     if (outIo.write(chunkBuf.pData_, chunkBuf.size_) != chunkBuf.size_) throw Error(kerImageWriteFailed);
                 }
-            }
-            else
-            {
+            } else {
                 // Write all others chunk as well.
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Exiv2::PngImage::doWriteMetadata:  copy " << szChunk
                           << " chunk (length: " << dataOffset << ")" << std::endl;
 #endif
                 if (outIo.write(chunkBuf.pData_, chunkBuf.size_) != chunkBuf.size_) throw Error(kerImageWriteFailed);
-
             }
         }
 

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -473,11 +473,13 @@ namespace {
         }
         if (nativePreview_.filter_.empty()) {
             return DataBuf(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
-        } else if (nativePreview_.filter_ == "hex-ai7thumbnail-pnm") {
+        }
+        if (nativePreview_.filter_ == "hex-ai7thumbnail-pnm") {
             const DataBuf ai7thumbnail = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
             const DataBuf rgb = decodeAi7Thumbnail(ai7thumbnail);
             return makePnm(width_, height_, rgb);
-        } else if (nativePreview_.filter_ == "hex-irb") {
+        }
+        if (nativePreview_.filter_ == "hex-irb") {
             const DataBuf psData = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
             const byte *record;
             uint32_t sizeHdr;
@@ -489,9 +491,8 @@ namespace {
                 return DataBuf();
             }
             return DataBuf(record + sizeHdr + 28, sizeData - 28);
-        } else {
-            throw Error(kerErrorMessage, "Invalid native preview filter: " + nativePreview_.filter_);
         }
+        throw Error(kerErrorMessage, "Invalid native preview filter: " + nativePreview_.filter_);
     }
 
     bool LoaderNative::readDimensions()

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -412,10 +412,9 @@ namespace Exiv2 {
                 return;
             }
 #ifndef SUPPRESS_WARNINGS
-            else {
-                EXV_WARNING << "Failed to decode IPTC block found in "
-                            << "Directory Image, entry 0x83bb\n";
-            }
+            EXV_WARNING << "Failed to decode IPTC block found in "
+                        << "Directory Image, entry 0x83bb\n";
+
 #endif
         }
 
@@ -436,10 +435,9 @@ namespace Exiv2 {
                 return;
             }
 #ifndef SUPPRESS_WARNINGS
-            else {
-                EXV_WARNING << "Failed to decode IPTC block found in "
-                            << "Directory Image, entry 0x8649\n";
-            }
+            EXV_WARNING << "Failed to decode IPTC block found in "
+                        << "Directory Image, entry 0x8649\n";
+
 #endif
         }
     } // TiffMetadataDecoder::decodeIptc

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -280,10 +280,7 @@ namespace Exiv2 {
             return   (byte)buf[3] << 24 | (byte)buf[2] << 16
                    | (byte)buf[1] <<  8 | (byte)buf[0];
         }
-        else {
-            return   (byte)buf[0] << 24 | (byte)buf[1] << 16
-                   | (byte)buf[2] <<  8 | (byte)buf[3];
-        }
+        return (byte)buf[0] << 24 | (byte)buf[1] << 16 | (byte)buf[2] << 8 | (byte)buf[3];
     }
 
     uint64_t getULongLong(const byte* buf, ByteOrder byteOrder)
@@ -294,12 +291,8 @@ namespace Exiv2 {
                    | (uint64_t)buf[3] << 24 | (uint64_t)buf[2] << 16
                    | (uint64_t)buf[1] <<  8 | (uint64_t)buf[0];
         }
-        else {
-            return   (uint64_t)buf[0] << 56 | (uint64_t)buf[1] << 48
-                   | (uint64_t)buf[2] << 40 | (uint64_t)buf[3] << 32
-                   | (uint64_t)buf[4] << 24 | (uint64_t)buf[5] << 16
-                   | (uint64_t)buf[6] <<  8 | (uint64_t)buf[7];
-        }
+        return (uint64_t)buf[0] << 56 | (uint64_t)buf[1] << 48 | (uint64_t)buf[2] << 40 | (uint64_t)buf[3] << 32 |
+               (uint64_t)buf[4] << 24 | (uint64_t)buf[5] << 16 | (uint64_t)buf[6] << 8 | (uint64_t)buf[7];
     }
 
     URational getURational(const byte* buf, ByteOrder byteOrder)
@@ -314,9 +307,7 @@ namespace Exiv2 {
         if (byteOrder == littleEndian) {
             return (byte)buf[1] << 8 | (byte)buf[0];
         }
-        else {
-            return (byte)buf[0] << 8 | (byte)buf[1];
-        }
+        return (byte)buf[0] << 8 | (byte)buf[1];
     }
 
     int32_t getLong(const byte* buf, ByteOrder byteOrder)
@@ -325,10 +316,7 @@ namespace Exiv2 {
             return   (byte)buf[3] << 24 | (byte)buf[2] << 16
                    | (byte)buf[1] <<  8 | (byte)buf[0];
         }
-        else {
-            return   (byte)buf[0] << 24 | (byte)buf[1] << 16
-                   | (byte)buf[2] <<  8 | (byte)buf[3];
-        }
+        return (byte)buf[0] << 24 | (byte)buf[1] << 16 | (byte)buf[2] << 8 | (byte)buf[3];
     }
 
     Rational getRational(const byte* buf, ByteOrder byteOrder)


### PR DESCRIPTION
Found with llvm-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>