### PR TITLE
replace {} initialization with fill

### DIFF
--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -152,7 +152,7 @@ namespace Exiv2 {
         static std::array<int, 256> value;
         static bool bFirst = true;
         if ( bFirst ) {
-            value = {};
+            value.fill(0);
             for ( int i = 0 ; i < 16 ; i++ ) {
                 value[tolower(hexdigits[i])]=i+1;
                 value[toupper(hexdigits[i])]=i+1;


### PR DESCRIPTION
Old compilers don't implement {} correctly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>