### PR TITLE
Show CI status in README.md + Fix linux distros jobs

### DIFF
--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -25,6 +25,12 @@ jobs:
         CMAKE_FLAGS: -DEXIV2_TEAM_EXTRA_WARNINGS=OFF -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=OFF -DCMAKE_INSTALL_PREFIX=install
 
     steps:
+    - name: install tar in opensuse
+      run: |
+        distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
+        echo $distro_id
+        if [[ "$distro_id" == "opensuse-tumbleweed" ]]; then zypper --non-interactive install tar gzip; fi
+
     - uses: actions/checkout@v2
     - name: install dependencies
       run: ./ci/install_dependencies.sh

--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         # arch suffering this issue: https://github.com/abseil/abseil-cpp/issues/709
         # centos:8 had linking issues with gtest

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -40,10 +40,8 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests
-          cd ../../tests/
-          python runner.py -v
+          cd build
+          ctest --output-on-failure
           bash <(curl -s https://codecov.io/bash)
 
   special_releaseValgrind:
@@ -119,10 +117,8 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests
-          cd ../../tests/
-          python runner.py -v
+          cd build
+          ctest --output-on-failure
 
   special_allEnabled:
     name: 'Ubuntu 20.04 - GCC - All Options Enabled'

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -41,8 +41,6 @@ jobs:
         env:
           EXIV2_EXT: .exe
         run: |
-          cd build/bin
-          ./unit_tests
-          cd ../../tests/
-          python runner.py -v
+          cd build
+          ctest --output-on-failure
           bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/master/graph/badge.svg?token=O9G7Iswx26)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
 
+CI Status:
+
+[![Basic CI for all platforms on push](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml)
+
+[![CI for different Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml)
+
+[![Linux Special Builds on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_special_buils.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_special_buils.yml)
+
+[![Linux-Ubuntu Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_matrix.yml)
+
+[![Mac Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_mac_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_mac_matrix.yml)
+
+[![Win Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_windows_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_windows_matrix.yml)
+
 <div id="1">
 
 # Welcome to Exiv2

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -63,9 +63,9 @@ case "$distro_id" in
         yum -y install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which python3 dos2unix
         ;;
 
-    'opensuse'|'opensuse-tumbleweed')
+    'opensuse-tumbleweed')
         zypper --non-interactive refresh
-        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel curl tar libcurl-devel git which dos2unix libxml2-tools gzip
+        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel curl libcurl-devel git which dos2unix libxml2-tools
         pushd /tmp
           curl -LO https://github.com/google/googletest/archive/release-1.8.0.tar.gz
           tar xzf   release-1.8.0.tar.gz


### PR DESCRIPTION
I started this PR with the intention of showing the status of the CI jobs in the README as you can see in this screenshot:

![image](https://user-images.githubusercontent.com/102645/118363431-9be20400-b594-11eb-88e1-cbd2d184b556.png)

Then I noticed that the "linux distros" jobs were failing on their nightly build. For some reason I could not understand at the beginning, most of the jobs were being automatically cancelled. After some iterations I noticed that the setting:

```
fail-fast: true
```
was the culprit. Once a job failed (for any reason) the rest of the jobs running in parallel were aborted. Therefore, I turned off that option.

The jobs that were failing were the "opensuse" ones. The github **checkout**  action requires the presence of **tar** and **gzip** in the distribution, and it looks like those packages are not available in opensuse by default

https://github.com/Exiv2/exiv2/runs/2590568382?check_suite_focus=true

I had to add some code to install those packages before the github **checkout**  action. Now, that workflow is green for all the linux distros:

https://github.com/Exiv2/exiv2/actions/runs/844979092