### PR TITLE
clang-tidy: convert to static

### DIFF
--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -149,11 +149,11 @@ namespace Exiv2
         /*!
           @brief box utilities
          */
-        std::string toAscii(long n);
+        static std::string toAscii(long n);
         std::string boxName(uint32_t box);
-        bool        superBox(uint32_t box);
-        bool        fullBox(uint32_t box);
-        std::string uuidName(Exiv2::DataBuf& uuid);
+        static bool superBox(uint32_t box);
+        static bool fullBox(uint32_t box);
+        static std::string uuidName(Exiv2::DataBuf& uuid);
 
     };  // class BmffImage
 

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -331,30 +331,30 @@ namespace Exiv2 {
         /*!
           @brief is the host platform bigEndian
          */
-        bool isBigEndianPlatform();
+        static bool isBigEndianPlatform();
 
         /*!
           @brief is the host platform littleEndian
          */
-        bool isLittleEndianPlatform();
+        static bool isLittleEndianPlatform();
 
-        bool isStringType(uint16_t type);
-        bool isShortType(uint16_t type);
-        bool isLongType(uint16_t type);
-        bool isLongLongType(uint16_t type);
-        bool isRationalType(uint16_t type);
-        bool is2ByteType(uint16_t type);
-        bool is4ByteType(uint16_t type);
-        bool is8ByteType(uint16_t type);
-        bool isPrintXMP(uint16_t type, Exiv2::PrintStructureOption option);
-        bool isPrintICC(uint16_t type, Exiv2::PrintStructureOption option);
+        static bool isStringType(uint16_t type);
+        static bool isShortType(uint16_t type);
+        static bool isLongType(uint16_t type);
+        static bool isLongLongType(uint16_t type);
+        static bool isRationalType(uint16_t type);
+        static bool is2ByteType(uint16_t type);
+        static bool is4ByteType(uint16_t type);
+        static bool is8ByteType(uint16_t type);
+        static bool isPrintXMP(uint16_t type, Exiv2::PrintStructureOption option);
+        static bool isPrintICC(uint16_t type, Exiv2::PrintStructureOption option);
 
-        uint64_t byteSwap(uint64_t value,bool bSwap) const;
-        uint32_t byteSwap(uint32_t value,bool bSwap) const;
-        uint16_t byteSwap(uint16_t value,bool bSwap) const;
-        uint16_t byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) const;
-        uint32_t byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) const;
-        uint64_t byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) const;
+        static uint64_t byteSwap(uint64_t value, bool bSwap);
+        static uint32_t byteSwap(uint32_t value, bool bSwap);
+        static uint16_t byteSwap(uint16_t value, bool bSwap);
+        static uint16_t byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) ;
+        static uint32_t byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) ;
+        static uint64_t byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) ;
 
         //@}
 
@@ -496,7 +496,7 @@ namespace Exiv2 {
         const std::string& tagName(uint16_t tag);
 
         //! Return tag type for given tag id.
-        const char* typeName(uint16_t tag) const;
+        static const char* typeName(uint16_t tag);
 
     private:
         //! @name NOT implemented

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -94,7 +94,7 @@ namespace Exiv2
          */
         void doWriteMetadata(BasicIo& outIo);
         //! Read Magick number. Only version >= 6 is supported.
-        byte readPgfMagicNumber(BasicIo& iIo);
+        static byte readPgfMagicNumber(BasicIo& iIo);
         //! Read PGF Header size encoded in 32 bits integer.
         uint32_t readPgfHeaderSize(BasicIo& iIo) const;
         //! Read header structure.

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -111,7 +111,7 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        uint32_t writeIptcData(const IptcData& iptcData, BasicIo& out) const;
+        static uint32_t writeIptcData(const IptcData& iptcData, BasicIo& out);
         uint32_t writeXmpData(const XmpData& xmpData, BasicIo& out) const;
         //@}
 

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -82,9 +82,8 @@ namespace Exiv2 {
         void doWriteMetadata(BasicIo& outIo);
         //! @name NOT Implemented
         //@{
-        long getHeaderOffset(byte *data, long data_size,
-                             byte *header, long header_size);
-        bool equalsWebPTag(Exiv2::DataBuf& buf ,const char* str);
+        static long getHeaderOffset(byte* data, long data_size, byte* header, long header_size);
+        static bool equalsWebPTag(Exiv2::DataBuf& buf, const char* str);
         void debugPrintHex(byte *data, long size);
         void decodeChunks(long filesize);
         void inject_VP8X(BasicIo& iIo, bool has_xmp, bool has_exif,

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -369,10 +369,10 @@ namespace Jzon
 		const std::string &GetError() const;
 
 	private:
-		bool loadFile(const std::string &filename, std::string &json);
-		std::string json;
-		std::string error;
-	};
+        static bool loadFile(const std::string &filename, std::string &json);
+        std::string json;
+        std::string error;
+    };
 
 	class JzonAPI Writer
 	{

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -831,7 +831,7 @@ namespace Action {
         return 1;
     } // Erase::run
 
-    int Erase::eraseThumbnail(Exiv2::Image* image) const
+    int Erase::eraseThumbnail(Exiv2::Image* image)
     {
         Exiv2::ExifThumb exifThumb(image->exifData());
         std::string thumbExt = exifThumb.extension();
@@ -845,7 +845,7 @@ namespace Action {
         return 0;
     }
 
-    int Erase::eraseExifData(Exiv2::Image* image) const
+    int Erase::eraseExifData(Exiv2::Image* image)
     {
         if (Params::instance().verbose_ && image->exifData().count() > 0) {
             std::cout << _("Erasing Exif data from the file") << std::endl;
@@ -854,7 +854,7 @@ namespace Action {
         return 0;
     }
 
-    int Erase::eraseIptcData(Exiv2::Image* image) const
+    int Erase::eraseIptcData(Exiv2::Image* image)
     {
         if (Params::instance().verbose_ && image->iptcData().count() > 0) {
             std::cout << _("Erasing IPTC data from the file") << std::endl;
@@ -863,7 +863,7 @@ namespace Action {
         return 0;
     }
 
-    int Erase::eraseComment(Exiv2::Image* image) const
+    int Erase::eraseComment(Exiv2::Image* image)
     {
         if (Params::instance().verbose_ && !image->comment().empty()) {
             std::cout << _("Erasing JPEG comment from the file") << std::endl;
@@ -872,7 +872,7 @@ namespace Action {
         return 0;
     }
 
-    int Erase::eraseXmpData(Exiv2::Image* image) const
+    int Erase::eraseXmpData(Exiv2::Image* image)
     {
         if (Params::instance().verbose_ && image->xmpData().count() > 0) {
             std::cout << _("Erasing XMP data from the file") << std::endl;
@@ -881,7 +881,7 @@ namespace Action {
         image->clearXmpPacket();
         return 0;
     }
-    int Erase::eraseIccProfile(Exiv2::Image* image) const
+    int Erase::eraseIccProfile(Exiv2::Image* image)
     {
         if (Params::instance().verbose_ && image->iccProfileDefined() ) {
             std::cout << _("Erasing ICC Profile data from the file") << std::endl;
@@ -1140,7 +1140,7 @@ namespace Action {
         return 1;
     } // Insert::run
 
-    int Insert::insertXmpPacket(const std::string& path,const std::string& xmpPath) const
+    int Insert::insertXmpPacket(const std::string& path,const std::string& xmpPath) 
     {
         int  rc     = 0;
         bool bStdin = xmpPath == "-" ;
@@ -1168,7 +1168,7 @@ namespace Action {
 
     } // Insert::insertXmpPacket
 
-    int Insert::insertXmpPacket(const std::string& path,const Exiv2::DataBuf& xmpBlob,bool usePacket) const
+    int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket)
     {
         std::string xmpPacket;
         for ( long i = 0 ; i < xmpBlob.size_ ; i++ ) {
@@ -1185,7 +1185,7 @@ namespace Action {
         return 0;
     }
 
-    int Insert::insertIccProfile(const std::string& path,const std::string& iccPath) const
+    int Insert::insertIccProfile(const std::string& path,const std::string& iccPath) 
     {
         int rc = 0;
         // for path "foo.XXX", do a binary copy of "foo.icc"
@@ -1207,7 +1207,7 @@ namespace Action {
         return rc;
     } // Insert::insertIccProfile
 
-    int Insert::insertIccProfile(const std::string& path,Exiv2::DataBuf& iccProfileBlob) const
+    int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf& iccProfileBlob)
     {
         int rc = 0;
         // test path exists
@@ -1232,7 +1232,7 @@ namespace Action {
         return rc;
     } // Insert::insertIccProfile
 
-    int Insert::insertThumbnail(const std::string& path) const
+    int Insert::insertThumbnail(const std::string& path)
     {
         std::string thumbPath = newFilePath(path, "-thumb.jpg");
         if (!Exiv2::fileExists(thumbPath, true)) {

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -173,9 +173,9 @@ namespace Action {
         //! Print Exif, IPTC and XMP metadata in user defined format
         int printList();
         //! Return true if key should be printed, else false
-        bool grepTag(const std::string& key);
+        static bool grepTag(const std::string& key);
         //! Return true if key should be printed, else false
-        bool keyTag(const std::string& key);
+        static bool keyTag(const std::string& key);
         //! Print all metadata in a user defined format
         int printMetadata(const Exiv2::Image* image);
         //! Print a metadatum in a user defined format, return true if something was printed
@@ -258,28 +258,27 @@ namespace Action {
         /*!
           @brief Delete the thumbnail image, incl IFD1 metadata from the file.
          */
-        int eraseThumbnail(Exiv2::Image* image) const;
+        static int eraseThumbnail(Exiv2::Image* image);
         /*!
           @brief Erase the complete Exif data block from the file.
          */
-        int eraseExifData(Exiv2::Image* image) const;
+        static int eraseExifData(Exiv2::Image* image);
         /*!
           @brief Erase all Iptc data from the file.
          */
-        int eraseIptcData(Exiv2::Image* image) const;
+        static int eraseIptcData(Exiv2::Image* image);
         /*!
           @brief Erase Jpeg comment from the file.
          */
-        int eraseComment(Exiv2::Image* image) const;
+        static int eraseComment(Exiv2::Image* image);
         /*!
           @brief Erase XMP packet from the file.
          */
-        int eraseXmpData(Exiv2::Image* image) const;
+        static int eraseXmpData(Exiv2::Image* image);
         /*!
           @brief Erase ICCProfile from the file.
          */
-        int eraseIccProfile(Exiv2::Image* image) const;
-
+        static int eraseIccProfile(Exiv2::Image* image);
 
     private:
         virtual Erase* clone_() const;
@@ -341,25 +340,25 @@ namespace Action {
                  The filename of the thumbnail is expected to be the image
                  filename (\em path) minus its suffix plus "-thumb.jpg".
          */
-        int insertThumbnail(const std::string& path) const;
+        static int insertThumbnail(const std::string& path);
 
         /*!
           @brief Insert an XMP packet from a xmpPath into file \em path.
          */
-        int insertXmpPacket(const std::string& path,const std::string& xmpPath) const;
+        static int insertXmpPacket(const std::string& path,const std::string& xmpPath) ;
         /*!
           @brief Insert xmp from a DataBuf into file \em path.
          */
-        int insertXmpPacket(const std::string& path,const Exiv2::DataBuf& xmpBlob,bool usePacket=false) const;
+        static int insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket = false);
 
         /*!
           @brief Insert an ICC profile from iccPath into file \em path.
          */
-        int insertIccProfile(const std::string& path,const std::string& iccPath) const;
+        static int insertIccProfile(const std::string& path,const std::string& iccPath) ;
         /*!
           @brief Insert an ICC profile from binary DataBuf into file \em path.
          */
-        int insertIccProfile(const std::string& path,Exiv2::DataBuf& iccProfileBlob) const;
+        static int insertIccProfile(const std::string& path, Exiv2::DataBuf& iccProfileBlob);
 
     private:
         virtual Insert* clone_() const;

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* const argv[])
         return 0;
     }
     if (params.version_) {
-        params.version(params.verbose_);
+        Params::version(params.verbose_);
         return 0;
     }
 
@@ -174,7 +174,7 @@ int main(int argc, char* const argv[])
         }
 
         taskFactory.cleanup();
-        params.cleanup();
+        Params::cleanup();
         Exiv2::XmpParser::terminate();
 
     } catch (const std::exception& exc) {
@@ -218,7 +218,7 @@ void Params::cleanup()
     instance_ = 0;
 }
 
-void Params::version(bool verbose,std::ostream& os) const
+void Params::version(bool verbose, std::ostream& os)
 {
     os << EXV_PACKAGE_STRING << std::endl;
     if ( Params::instance().greps_.empty() && !verbose) {

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -159,7 +159,7 @@ public:
     */
     static Params& instance();
     //! Destructor
-    void cleanup();
+    static void cleanup();
 
     //! Enumerates print modes
     enum PrintMode {
@@ -341,7 +341,7 @@ public:
     void help(std::ostream& os =std::cout) const;
 
     //! Print version information to an output stream.
-    void version(bool verbose =false, std::ostream& os =std::cout) const;
+    static void version(bool verbose = false, std::ostream& os = std::cout);
 
     //! Print target_
     static std::string printTarget(const std::string& before, int target, bool bPrint = false,

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -225,7 +225,7 @@ namespace Exiv2 {
     }
     bool Image::isLittleEndianPlatform() { return !isBigEndianPlatform(); }
 
-    uint64_t Image::byteSwap(uint64_t value,bool bSwap) const
+    uint64_t Image::byteSwap(uint64_t value, bool bSwap)
     {
         uint64_t result = 0;
         auto source_value = reinterpret_cast<byte*>(&value);
@@ -237,7 +237,7 @@ namespace Exiv2 {
         return bSwap ? result : value;
     }
 
-    uint32_t Image::byteSwap(uint32_t value,bool bSwap) const
+    uint32_t Image::byteSwap(uint32_t value, bool bSwap)
     {
         uint32_t result = 0;
         result |= (value & 0x000000FF) << 24;
@@ -247,7 +247,7 @@ namespace Exiv2 {
         return bSwap ? result : value;
     }
 
-    uint16_t Image::byteSwap(uint16_t value,bool bSwap) const
+    uint16_t Image::byteSwap(uint16_t value, bool bSwap)
     {
         uint16_t result = 0;
         result |= (value & 0x00FF) << 8;
@@ -255,7 +255,7 @@ namespace Exiv2 {
         return bSwap ? result : value;
     }
 
-    uint16_t Image::byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) const
+    uint16_t Image::byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) 
     {
         uint16_t v;
         auto p = (char*)&v;
@@ -264,7 +264,7 @@ namespace Exiv2 {
         return Image::byteSwap(v,bSwap);
     }
 
-    uint32_t Image::byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) const
+    uint32_t Image::byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) 
     {
         uint32_t v;
         auto p = (char*)&v;
@@ -275,7 +275,7 @@ namespace Exiv2 {
         return Image::byteSwap(v,bSwap);
     }
 
-    uint64_t Image::byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) const
+    uint64_t Image::byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) 
     {
         uint64_t v;
         auto p = reinterpret_cast<byte*>(&v);
@@ -286,7 +286,7 @@ namespace Exiv2 {
         return Image::byteSwap(v,bSwap);
     }
 
-    const char* Image::typeName(uint16_t tag) const
+    const char* Image::typeName(uint16_t tag)
     {
         //! List of TIFF image tags
         const char* result = NULL;

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -684,7 +684,7 @@ namespace Exiv2 {
                                 start++;
                                 const std::string xmp_from_start = string_from_unterminated(
                                     reinterpret_cast<const char*>(&xmp.at(start)), size - start);
-                                if (xmp_from_start.find("HasExtendedXMP", start) != xmp_from_start.npos) {
+                                if (xmp_from_start.find("HasExtendedXMP", start) != std::string::npos) {
                                     start = size;  // ignore this packet, we'll get on the next time around
                                     bExtXMP = true;
                                 }

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -563,7 +563,7 @@ namespace Exiv2 {
 
     } // PsdImage::doWriteMetadata
 
-    uint32_t PsdImage::writeIptcData(const IptcData& iptcData, BasicIo& out) const
+    uint32_t PsdImage::writeIptcData(const IptcData& iptcData, BasicIo& out)
     {
         uint32_t resLength = 0;
         byte buf[8];

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -1176,13 +1176,9 @@ namespace Exiv2 {
         return idx;
     } // TiffDirectory::doWrite
 
-    uint32_t TiffDirectory::writeDirEntry(IoWrapper&     ioWrapper,
-                                          ByteOrder      byteOrder,
-                                          int32_t        offset,
-                                          TiffComponent* pTiffComponent,
-                                          uint32_t       valueIdx,
-                                          uint32_t       dataIdx,
-                                          uint32_t&      imageIdx) const
+    uint32_t TiffDirectory::writeDirEntry(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset,
+                                          TiffComponent* pTiffComponent, uint32_t valueIdx, uint32_t dataIdx,
+                                          uint32_t& imageIdx)
     {
         assert(pTiffComponent);
         auto pDirEntry = dynamic_cast<TiffEntryBase*>(pTiffComponent);

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -956,13 +956,9 @@ namespace Exiv2 {
         //! @name Private Accessors
         //@{
         //! Write a binary directory entry for a TIFF component.
-        uint32_t writeDirEntry(IoWrapper&     ioWrapper,
-                               ByteOrder      byteOrder,
-                               int32_t        offset,
-                               TiffComponent* pTiffComponent,
-                               uint32_t       valueIdx,
-                               uint32_t       dataIdx,
-                               uint32_t&      imageIdx) const;
+        static uint32_t writeDirEntry(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset,
+                                      TiffComponent* pTiffComponent, uint32_t valueIdx, uint32_t dataIdx,
+                                      uint32_t& imageIdx);
         //@}
 
     private:

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -729,9 +729,7 @@ namespace Exiv2 {
         }
     }
 
-    uint32_t TiffEncoder::updateDirEntry(byte* buf,
-                                         ByteOrder byteOrder,
-                                         TiffComponent* pTiffComponent) const
+    uint32_t TiffEncoder::updateDirEntry(byte* buf, ByteOrder byteOrder, TiffComponent* pTiffComponent)
     {
         assert(buf);
         assert(pTiffComponent);

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -530,9 +530,7 @@ namespace Exiv2 {
                  entries are encoded. It takes care of type and count changes
                  and size shrinkage for non-intrusive writing.
          */
-        uint32_t updateDirEntry(byte* buf,
-                                ByteOrder byteOrder,
-                                TiffComponent* pTiffComponent) const;
+        static uint32_t updateDirEntry(byte* buf, ByteOrder byteOrder, TiffComponent* pTiffComponent);
         /*!
           @brief Check if the tag is an image tag of an existing image. Such
                  tags are copied from the original image and can't be modifed.

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -526,7 +526,7 @@ namespace Exiv2 {
         }
         bool bAscii = charsetId() == undefined || charsetId() == ascii ;
         // # 1266 Remove trailing nulls
-        if ( bAscii && c.find('\0') != c.std::string::npos) {
+        if ( bAscii && c.find('\0') != std::string::npos) {
             c = c.substr(0,c.find('\0'));
         }
         return c;

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -610,7 +610,7 @@ namespace Exiv2 {
                 // (Namespaces are automatically registered with the XMP Toolkit)
                 if (XmpProperties::prefix(schemaNs).empty()) {
                     std::string prefix;
-                    bool ret = meta.GetNamespacePrefix(schemaNs.c_str(), &prefix);
+                    bool ret = SXMPMeta::GetNamespacePrefix(schemaNs.c_str(), &prefix);
                     if (!ret) throw Error(kerSchemaNamespaceNotRegistered, schemaNs);
                     prefix = prefix.substr(0, prefix.size() - 1);
                     XmpProperties::registerNs(schemaNs, prefix);

--- a/unitTests/test_XmpKey.cpp
+++ b/unitTests/test_XmpKey.cpp
@@ -48,7 +48,7 @@ public:
         XmpProperties::unregisterNs();
     }
 
-    void checkValidity(const XmpKey& key)
+    static void checkValidity(const XmpKey& key)
     {
         ASSERT_EQ(expectedKey, key.key());
         ASSERT_EQ(expectedFamily, key.familyName());


### PR DESCRIPTION
Found with readability-convert-member-functions-to-static

Signed-off-by: Rosen Penev <rosenp@gmail.com>