### PR TITLE
clang-tidy: add missing explicit

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -41,7 +41,7 @@ namespace Jzon
 		{
 			SetFormat(NoFormat);
 		}
-		FormatInterpreter(const Format &format)
+		explicit FormatInterpreter(const Format &format)
 		{
 			SetFormat(format);
 		}

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -81,7 +81,7 @@ namespace Exiv2 {
     class FileIo::Impl {
     public:
         //! Constructor
-        Impl(std::string path);
+        explicit Impl(std::string path);
 #ifdef EXV_UNICODE_PATH
         //! Constructor accepting a unicode path in an std::wstring
         Impl(const std::wstring& wpath);

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -55,7 +55,9 @@ namespace {
     class FindExifdatumByKey {
     public:
         //! Constructor, initializes the object with the key to look for
-        FindExifdatumByKey(const std::string& key) : key_(key) {}
+        explicit FindExifdatumByKey(const std::string& key) : key_(key)
+        {
+        }
         /*!
           @brief Returns true if the key of \em exifdatum is equal
                  to that of the object.

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -49,8 +49,9 @@ namespace {
     class FindXmpdatum {
     public:
         //! Constructor, initializes the object with key
-        FindXmpdatum(const Exiv2::XmpKey& key)
-            : key_(key.key()) {}
+        explicit FindXmpdatum(const Exiv2::XmpKey& key) : key_(key.key())
+        {
+        }
         /*!
           @brief Returns true if prefix and property of the argument
                  Xmpdatum are equal to that of the object.


### PR DESCRIPTION
Found with google-explicit-constructor

Signed-off-by: Rosen Penev <rosenp@gmail.com>