### PR TITLE
clang-tidy: fix ending namespace comnments

### DIFF
--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -84,7 +84,7 @@ namespace {
     std::string getExifModel(Exiv2::Internal::TiffComponent* pRoot);
     //! Nikon en/decryption function
     void ncrypt(Exiv2::byte* pData, uint32_t size, uint32_t count, uint32_t serial);
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -41,7 +41,7 @@
 namespace {
     //! Add \em tobe - \em curr 0x00 filler bytes if necessary
     uint32_t fillGap(Exiv2::Internal::IoWrapper& ioWrapper, uint32_t curr, uint32_t tobe);
-}
+}  // namespace
 
 // *****************************************************************************
 // class member definitions

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -53,11 +53,6 @@
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-    namespace Internal {
-
-    }}                                      // namespace Internal, Exiv2
-
-namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     // This static function is a temporary fix in v0.27. In the next version,

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -39,7 +39,7 @@ namespace {
     const char* xmlHeader = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n";
     const long  xmlHdrCnt = (long) std::strlen(xmlHeader); // without the trailing 0-character
     const char* xmlFooter = "<?xpacket end=\"w\"?>";
-}
+}  // namespace
 
 // class member definitions
 namespace Exiv2 {

--- a/unitTests/test_XmpKey.cpp
+++ b/unitTests/test_XmpKey.cpp
@@ -31,7 +31,7 @@ namespace
     const std::string expectedProperty("prop");
     const std::string expectedKey(expectedFamily + "." + expectedPrefix + "." + expectedProperty);
     const std::string notRegisteredValidKey("Xmp.noregistered.prop");
-}
+}  // namespace
 
 // Test Fixture which register a namespace with a prefix. This is needed to test the correct
 // behavior of the XmpKey class


### PR DESCRIPTION
Found with llvm-namespace-comment

Signed-off-by: Rosen Penev <rosenp@gmail.com>