### PR TITLE
clang-tidy: use dynamic cast

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -92,37 +92,37 @@ namespace Jzon
     Object &Node::AsObject()
     {
         if (IsObject())
-            return static_cast<Object&>(*this);
+            return dynamic_cast<Object &>(*this);
         throw TypeException();
     }
     const Object &Node::AsObject() const
     {
 		if (IsObject())
-			return static_cast<const Object&>(*this);
+            return dynamic_cast<const Object &>(*this);
         throw TypeException();
     }
     Array &Node::AsArray()
     {
         if (IsArray())
-            return static_cast<Array &>(*this);
+            return dynamic_cast<Array &>(*this);
         throw TypeException();
     }
     const Array &Node::AsArray() const
     {
         if (IsArray())
-            return static_cast<const Array &>(*this);
+            return dynamic_cast<const Array &>(*this);
         throw TypeException();
     }
     Value &Node::AsValue()
     {
         if (IsValue())
-            return static_cast<Value &>(*this);
+            return dynamic_cast<Value &>(*this);
         throw TypeException();
     }
     const Value &Node::AsValue() const
     {
         if (IsValue())
-            return static_cast<const Value &>(*this);
+            return dynamic_cast<const Value &>(*this);
         throw TypeException();
     }
 
@@ -1072,15 +1072,14 @@ namespace Jzon
 
 						if (data.front().first == Value::VT_STRING)
 						{
-							static_cast<Value*>(node)->Set(data.front().second); // This method calls UnescapeString()
-						}
-						else
-						{
-							static_cast<Value*>(node)->Set(data.front().first, data.front().second);
-						}
-						data.pop();
+                            dynamic_cast<Value *>(node)->Set(
+                                data.front().second);  // This method calls UnescapeString()
+                        } else {
+                            dynamic_cast<Value *>(node)->Set(data.front().first, data.front().second);
+                        }
+                        data.pop();
 
-						if (!nodeStack.empty())
+                        if (!nodeStack.empty())
 						{
 							if (nodeStack.top().second->IsObject())
 								nodeStack.top().second->AsObject().Add(name, *node);

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -98,7 +98,7 @@ Jzon::Node& addToTree(Jzon::Node& r1, const Token& token)
 
     std::string  key    = token.n  ;
     size_t       index  = token.i-1; // array Eg: "History[1]" indexed from 1.  Jzon expects 0 based index.
-    Jzon::Node&  empty  = token.a ? (Jzon::Node&) array : (Jzon::Node&) object ;
+    auto& empty = token.a ? static_cast<Jzon::Node&>(array) : static_cast<Jzon::Node&>(object);
 
     if (  r1.IsObject() ) {
         Jzon::Object& o1 = r1.AsObject();
@@ -246,7 +246,7 @@ void push(Jzon::Node& node,const std::string& key,T i)
 
 void fileSystemPush(const char* path,Jzon::Node& nfs)
 {
-    auto& fs = (Jzon::Object&)nfs;
+    auto& fs = dynamic_cast<Jzon::Object&>(nfs);
     fs.Add("path",path);
     char resolved_path[2000]; // PATH_MAX];
     fs.Add("realpath",realpath(path,resolved_path));


### PR DESCRIPTION
Found with cppcoreguidelines-pro-type-static-cast-downcast

Signed-off-by: Rosen Penev <rosenp@gmail.com>