### PR TITLE
clang-tidy: no else after return

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -1046,11 +1046,8 @@ namespace Jzon
 							error = "A name has to be a string";
 							return false;
 						}
-						else
-						{
-							name = data.front().second;
-							data.pop();
-						}
+						name = data.front().second;
+						data.pop();
 					}
 					else
 					{


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>