### PR TITLE
clang-tidy: remove pointless member init

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -142,15 +142,15 @@ namespace Jzon
         }
     }
 
-    Value::Value() : Node()
+    Value::Value()
     {
         SetNull();
     }
-    Value::Value(const Value &rhs) : Node()
+    Value::Value(const Value &rhs)
     {
         Set(rhs);
     }
-    Value::Value(const Node &rhs) : Node()
+    Value::Value(const Node &rhs)
     {
         const Value &value = rhs.AsValue();
         Set(value);
@@ -426,10 +426,7 @@ namespace Jzon
 		return unescaped;
     }
 
-    Object::Object() : Node()
-    {
-    }
-    Object::Object(const Object &other) : Node()
+    Object::Object(const Object &other)
     {
         for (auto &&it : other.children) {
             const std::string &name = it.first;
@@ -438,7 +435,7 @@ namespace Jzon
             children.push_back(NamedNodePtr(name, value.GetCopy()));
         }
     }
-    Object::Object(const Node &other) : Node()
+    Object::Object(const Node &other)
     {
         for (auto &&child : other.AsObject().children) {
             children.push_back(NamedNodePtr(child.first, child.second->GetCopy()));
@@ -536,18 +533,14 @@ namespace Jzon
         return new Object(*this);
     }
 
-    Array::Array() : Node()
-    {
-    }
-
-    Array::Array(const Array &other) : Node()
+    Array::Array(const Array &other)
     {
         for (auto &&value : other.children) {
             children.push_back(value->GetCopy());
         }
     }
 
-    Array::Array(const Node &other) : Node()
+    Array::Array(const Node &other)
     {
         const Array &array = other.AsArray();
 

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -243,9 +243,9 @@ namespace Jzon
 			const NamedNodePtr *p;
 		};
 
-		Object();
-		Object(const Object &other);
-		Object(const Node &other);
+        Object() = default;
+        Object(const Object &other);
+        Object(const Node &other);
         ~Object() override;
 
         Type GetType() const override;
@@ -311,9 +311,9 @@ namespace Jzon
 			const Node *const *p;
 		};
 
-		Array();
-		Array(const Array &other);
-		Array(const Node &other);
+        Array() = default;
+        Array(const Array &other);
+        Array(const Node &other);
         ~Array() override;
 
         Type GetType() const override;


### PR DESCRIPTION
Found with readability-redundant-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>