### PR TITLE
clang-tidy: avoid global non const variables

### DIFF
--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -248,7 +248,7 @@ namespace Exiv2 {
         static int dataSetIdx(uint16_t number, uint16_t recordId);
         static int dataSetIdx(const std::string& dataSetName, uint16_t recordId);
 
-        static const DataSet* records_[];
+        static const DataSet* const records_[];
         static const RecordInfo recordInfo_[];
 
     }; // class IptcDataSets
@@ -334,7 +334,7 @@ namespace Exiv2 {
         virtual IptcKey* clone_() const;
 
         // DATA
-        static const char* familyName_;
+        static constexpr auto familyName_ = "Iptc";
 
         uint16_t tag_;                 //!< Tag value
         uint16_t record_;              //!< Record value

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -24,6 +24,8 @@
 // *****************************************************************************
 #include "exiv2lib_export.h"
 
+#include <array>
+
 // included header files
 #include "image.hpp"
 
@@ -46,9 +48,9 @@ namespace Exiv2 {
      */
     struct EXIV2API Photoshop {
         // Todo: Public for now
-        static const char     ps3Id_[]; //!< %Photoshop marker
-        static const char*    irbId_[]; //!< %Photoshop IRB markers
-        static const char     bimId_[]; //!< %Photoshop IRB marker (deprecated)
+        static const char* const ps3Id_;                 //!< %Photoshop marker
+        static const std::array<const char*, 4> irbId_;  //!< %Photoshop IRB markers
+        static const char* const bimId_;                 //!< %Photoshop IRB marker (deprecated)
         static const uint16_t iptc_;    //!< %Photoshop IPTC marker
         static const uint16_t preview_; //!< %Photoshop preview marker
 
@@ -232,10 +234,10 @@ namespace Exiv2 {
         static const byte sof13_;               //!< JPEG Start-Of-Frame marker
         static const byte sof14_;               //!< JPEG Start-Of-Frame marker
         static const byte sof15_;               //!< JPEG Start-Of-Frame marker
-        static const char exifId_[];            //!< Exif identifier
-        static const char jfifId_[];            //!< JFIF identifier
-        static const char xmpId_[];             //!< XMP packet identifier
-        static const char iccId_[];             //!< ICC profile identifier
+        static const char* const exifId_;       //!< Exif identifier
+        static const char* const jfifId_;       //!< JFIF identifier
+        static const char* const xmpId_;        //!< XMP packet identifier
+        static const char* const iccId_;        //!< ICC profile identifier
 
     private:
         //! @name NOT implemented

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -97,21 +97,20 @@ namespace Exiv2 {
         //@}
 
     private:
-        const static byte WEBP_PAD_ODD;
-        const static int WEBP_TAG_SIZE;
-        const static int WEBP_VP8X_ICC_BIT;
-        const static int WEBP_VP8X_ALPHA_BIT;
-        const static int WEBP_VP8X_EXIF_BIT;
-        const static int WEBP_VP8X_XMP_BIT;
-        const static char* WEBP_CHUNK_HEADER_VP8X;
-        const static char* WEBP_CHUNK_HEADER_VP8L;
-        const static char* WEBP_CHUNK_HEADER_VP8;
-        const static char* WEBP_CHUNK_HEADER_ANMF;
-        const static char* WEBP_CHUNK_HEADER_ANIM;
-        const static char* WEBP_CHUNK_HEADER_ICCP;
-        const static char* WEBP_CHUNK_HEADER_EXIF;
-        const static char* WEBP_CHUNK_HEADER_XMP;
-
+        static const byte WEBP_PAD_ODD;
+        static const int WEBP_TAG_SIZE;
+        static const int WEBP_VP8X_ICC_BIT;
+        static const int WEBP_VP8X_ALPHA_BIT;
+        static const int WEBP_VP8X_EXIF_BIT;
+        static const int WEBP_VP8X_XMP_BIT;
+        static const char* const WEBP_CHUNK_HEADER_VP8X;
+        static const char* const WEBP_CHUNK_HEADER_VP8L;
+        static const char* const WEBP_CHUNK_HEADER_VP8;
+        static const char* const WEBP_CHUNK_HEADER_ANMF;
+        static const char* const WEBP_CHUNK_HEADER_ANIM;
+        static const char* const WEBP_CHUNK_HEADER_ICCP;
+        static const char* const WEBP_CHUNK_HEADER_EXIF;
+        static const char* const WEBP_CHUNK_HEADER_XMP;
 
     }; //Class WebPImage
 

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <iomanip>
 
-const char* testcases[] = {
+static constexpr const char* testcases[] = {
     // bool
     "True",
     "False",
@@ -52,7 +52,7 @@ const char* testcases[] = {
     "-4/3",
     "0/0",
     // nok
-    "text"
+    "text",
 };
 
 int main()

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -2,9 +2,6 @@
 
 namespace Exiv2 {
     namespace Internal {
-
-    const char* Cr2Header::cr2sig_ = "CR\2\0";
-
     Cr2Header::Cr2Header(ByteOrder byteOrder)
         : TiffHeaderBase(42, 16, byteOrder, 0x00000010),
           offset2_(0x00000000)

--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
     private:
         // DATA
         uint32_t              offset2_;   //!< Bytes 12-15 from the header
-        static const char*    cr2sig_;    //!< Signature for CR2 type TIFF
+        static constexpr auto cr2sig_ = "CR\2\0";  //!< Signature for CR2 type TIFF
     }; // class Cr2Header
 
 }}                                      // namespace Internal, Exiv2

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -45,7 +45,7 @@ namespace Exiv2 {
         {IptcDataSets::application2, "Application2", N_("IIM application record 2")},
     };
 
-    static const DataSet envelopeRecord[] = {
+    constexpr DataSet envelopeRecord[] = {
         {IptcDataSets::ModelVersion, "ModelVersion", N_("Model Version"),
                 N_("A binary number identifying the version of the Information "
                 "Interchange Model, Part I, utilised by the provider. Version "
@@ -130,7 +130,7 @@ namespace Exiv2 {
         return envelopeRecord;
     }
 
-    static const DataSet application2Record[] = {
+    constexpr DataSet application2Record[] = {
         {IptcDataSets::RecordVersion, "RecordVersion", N_("Record Version"),
                 N_("A binary number identifying the version of the Information "
                 "Interchange Model, Part II, utilised by the provider. "
@@ -407,18 +407,19 @@ namespace Exiv2 {
         return application2Record;
     }
 
-    static const DataSet unknownDataSet{0xffff, "Unknown dataset", N_("Unknown dataset"),
+    constexpr DataSet unknownDataSet{0xffff, "Unknown dataset", N_("Unknown dataset"),
                                         N_("Unknown dataset"),
                                         false, true, 0, 0xffffffff, Exiv2::string,
                                         IptcDataSets::invalidRecord,
-                                        N_("Unknown dataset")};
+                                        N_("Unknown dataset"),};
 
     // Dataset lookup lists.This is an array with pointers to one list per IIM4 Record.
     // The record id is used as the index into the array.
-    const DataSet* IptcDataSets::records_[] = {
+    constexpr const DataSet* IptcDataSets::records_[] = {
         0,
-        envelopeRecord, application2Record,
-        0
+        envelopeRecord,
+        application2Record,
+        0,
     };
 
     int IptcDataSets::dataSetIdx(uint16_t number, uint16_t recordId)
@@ -550,8 +551,6 @@ namespace Exiv2 {
             }
         }
     } // IptcDataSets::dataSetList
-
-    const char* IptcKey::familyName_ = "Iptc";
 
     IptcKey::IptcKey(std::string key) : key_(std::move(key))
     {

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -29,6 +29,7 @@
 // + standard includes
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <array>
 #include <cstdio>
 #include <cerrno>
 #include <sstream>
@@ -67,10 +68,17 @@
 #endif
 
 namespace Exiv2 {
-    const char* ENVARDEF[] = {"/exiv2.php", "40"}; //!< @brief default URL for http exiv2 handler and time-out
-    const char* ENVARKEY[] = {"EXIV2_HTTP_POST", "EXIV2_TIMEOUT"}; //!< @brief request keys for http exiv2 handler and time-out
-// *****************************************************************************
-// free functions
+    constexpr std::array<const char*, 2> ENVARDEF{
+        "/exiv2.php",
+        "40",
+    };  //!< @brief default URL for http exiv2 handler and time-out
+    constexpr std::array<const char*, 2> ENVARKEY{
+        "EXIV2_HTTP_POST",
+        "EXIV2_TIMEOUT",
+    };  //!< @brief request keys for http exiv2 handler and time-out
+
+    // *****************************************************************************
+    // free functions
     std::string getEnv(int env_var)
     {
         // this check is relying on undefined behavior and might not be effective
@@ -140,14 +148,10 @@ namespace Exiv2 {
     }
 
     // https://stackoverflow.com/questions/342409/how-do-i-base64-encode-decode-in-c
-    static char base64_encode[]={'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-                                'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-                                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-                                'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-                                'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-                                'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                                'w', 'x', 'y', 'z', '0', '1', '2', '3',
-                                '4', '5', '6', '7', '8', '9', '+', '/'};
+    static constexpr char base64_encode[] = {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+        'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
 
     int base64encode(const void* data_buf, size_t dataLength, char* result, size_t resultSize) {
         auto encoding_table = base64_encode;
@@ -183,7 +187,7 @@ namespace Exiv2 {
         size_t input_length = in ? ::strlen(in) : 0;
         if (!in || input_length % 4 != 0) return result;
 
-        auto encoding_table = reinterpret_cast<unsigned char*>(base64_encode);
+        auto encoding_table = reinterpret_cast<const unsigned char*>(base64_encode);
         unsigned char decoding_table[256];
         for (unsigned char i = 0; i < 64; i++)
             decoding_table[encoding_table[i]] = i;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -30,6 +30,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <array>
 #include <cstdlib>
 #include <time.h>
 #include <sys/stat.h>
@@ -98,27 +99,26 @@ static void Sleep(int millisecs)
 
 ////////////////////////////////////////
 // code
-static const char* httpTemplate =
-"%s %s HTTP/%s\r\n"            // $verb $page $version
-"User-Agent: exiv2http/1.0.0\r\n"
-"Accept: */*\r\n"
-"Host: %s\r\n"                 // $servername
-"%s"                           // $header
-"\r\n"
-;
+static constexpr auto httpTemplate =
+    "%s %s HTTP/%s\r\n"  // $verb $page $version
+    "User-Agent: exiv2http/1.0.0\r\n"
+    "Accept: */*\r\n"
+    "Host: %s\r\n"  // $servername
+    "%s"            // $header
+    "\r\n";
 
 #define white(c) ((c == ' ') || (c == '\t'))
 
 #define FINISH          -999
 #define OK(s)    (200 <= s  && s < 300)
 
-const char*   blankLines[] =
-{       "\r\n\r\n"             // this is the standard
-,       "\n\n"                 // this is commonly sent by CGI scripts
-}  ;
+static constexpr std::array<const char*, 2> blankLines{
+    "\r\n\r\n",  // this is the standard
+    "\n\n",      // this is commonly sent by CGI scripts
+};
 
-int             snooze    = SNOOZE    ;
-int             sleep_    =  SLEEP    ;
+static constexpr int snooze = SNOOZE;
+static int sleep_ = SLEEP;
 
 static int forgive(int n,int& err)
 {

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -51,49 +51,48 @@
 // class member definitions
 
 namespace Exiv2 {
+    constexpr byte JpegBase::dht_ = 0xc4;
+    constexpr byte JpegBase::dqt_ = 0xdb;
+    constexpr byte JpegBase::dri_ = 0xdd;
+    constexpr byte JpegBase::sos_ = 0xda;
+    constexpr byte JpegBase::eoi_ = 0xd9;
+    constexpr byte JpegBase::app0_ = 0xe0;
+    constexpr byte JpegBase::app1_ = 0xe1;
+    constexpr byte JpegBase::app2_ = 0xe2;
+    constexpr byte JpegBase::app13_ = 0xed;
+    constexpr byte JpegBase::com_ = 0xfe;
 
-    const byte     JpegBase::dht_      = 0xc4;
-    const byte     JpegBase::dqt_      = 0xdb;
-    const byte     JpegBase::dri_      = 0xdd;
-    const byte     JpegBase::sos_      = 0xda;
-    const byte     JpegBase::eoi_      = 0xd9;
-    const byte     JpegBase::app0_     = 0xe0;
-    const byte     JpegBase::app1_     = 0xe1;
-    const byte     JpegBase::app2_     = 0xe2;
-    const byte     JpegBase::app13_    = 0xed;
-    const byte     JpegBase::com_      = 0xfe;
+    // Start of Frame markers, nondifferential Huffman-coding frames
+    constexpr byte JpegBase::sof0_ = 0xc0;  // start of frame 0, baseline DCT
+    constexpr byte JpegBase::sof1_ = 0xc1;  // start of frame 1, extended sequential DCT, Huffman coding
+    constexpr byte JpegBase::sof2_ = 0xc2;  // start of frame 2, progressive DCT, Huffman coding
+    constexpr byte JpegBase::sof3_ = 0xc3;  // start of frame 3, lossless sequential, Huffman coding
 
-// Start of Frame markers, nondifferential Huffman-coding frames
-    const byte     JpegBase::sof0_     = 0xc0;        // start of frame 0, baseline DCT
-    const byte     JpegBase::sof1_     = 0xc1;        // start of frame 1, extended sequential DCT, Huffman coding
-    const byte     JpegBase::sof2_     = 0xc2;        // start of frame 2, progressive DCT, Huffman coding
-    const byte     JpegBase::sof3_     = 0xc3;        // start of frame 3, lossless sequential, Huffman coding
+    // Start of Frame markers, differential Huffman-coding frames
+    constexpr byte JpegBase::sof5_ = 0xc5;  // start of frame 5, differential sequential DCT, Huffman coding
+    constexpr byte JpegBase::sof6_ = 0xc6;  // start of frame 6, differential progressive DCT, Huffman coding
+    constexpr byte JpegBase::sof7_ = 0xc7;  // start of frame 7, differential lossless, Huffman coding
 
-// Start of Frame markers, differential Huffman-coding frames
-    const byte     JpegBase::sof5_     = 0xc5;        // start of frame 5, differential sequential DCT, Huffman coding
-    const byte     JpegBase::sof6_     = 0xc6;        // start of frame 6, differential progressive DCT, Huffman coding
-    const byte     JpegBase::sof7_     = 0xc7;        // start of frame 7, differential lossless, Huffman coding
+    // Start of Frame markers, nondifferential arithmetic-coding frames
+    constexpr byte JpegBase::sof9_ = 0xc9;   // start of frame 9, extended sequential DCT, arithmetic coding
+    constexpr byte JpegBase::sof10_ = 0xca;  // start of frame 10, progressive DCT, arithmetic coding
+    constexpr byte JpegBase::sof11_ = 0xcb;  // start of frame 11, lossless sequential, arithmetic coding
 
-// Start of Frame markers, nondifferential arithmetic-coding frames
-    const byte     JpegBase::sof9_     = 0xc9;        // start of frame 9, extended sequential DCT, arithmetic coding
-    const byte     JpegBase::sof10_    = 0xca;        // start of frame 10, progressive DCT, arithmetic coding
-    const byte     JpegBase::sof11_    = 0xcb;        // start of frame 11, lossless sequential, arithmetic coding
+    // Start of Frame markers, differential arithmetic-coding frames
+    constexpr byte JpegBase::sof13_ = 0xcd;  // start of frame 13, differential sequential DCT, arithmetic coding
+    constexpr byte JpegBase::sof14_ = 0xce;  // start of frame 14, progressive DCT, arithmetic coding
+    constexpr byte JpegBase::sof15_ = 0xcf;  // start of frame 15, differential lossless, arithmetic coding
 
-// Start of Frame markers, differential arithmetic-coding frames
-    const byte     JpegBase::sof13_    = 0xcd;        // start of frame 13, differential sequential DCT, arithmetic coding
-    const byte     JpegBase::sof14_    = 0xce;        // start of frame 14, progressive DCT, arithmetic coding
-    const byte     JpegBase::sof15_    = 0xcf;        // start of frame 15, differential lossless, arithmetic coding
+    constexpr const char* JpegBase::exifId_ = "Exif\0\0";
+    constexpr const char* JpegBase::jfifId_ = "JFIF\0";
+    constexpr const char* JpegBase::xmpId_ = "http://ns.adobe.com/xap/1.0/\0";
+    constexpr const char* JpegBase::iccId_ = "ICC_PROFILE\0";
 
-    const char     JpegBase::exifId_[] = "Exif\0\0";
-    const char     JpegBase::jfifId_[] = "JFIF\0";
-    const char     JpegBase::xmpId_[]  = "http://ns.adobe.com/xap/1.0/\0";
-    const char     JpegBase::iccId_[]  = "ICC_PROFILE\0";
-
-    const char     Photoshop::ps3Id_[] = "Photoshop 3.0\0";
-    const char*    Photoshop::irbId_[] = {"8BIM", "AgHg", "DCSR", "PHUT"};
-    const char     Photoshop::bimId_[] = "8BIM"; // deprecated
-    const uint16_t Photoshop::iptc_    = 0x0404;
-    const uint16_t Photoshop::preview_ = 0x040c;
+    constexpr const char* Photoshop::ps3Id_ = "Photoshop 3.0\0";
+    constexpr std::array<const char*, 4> Photoshop::irbId_{"8BIM", "AgHg", "DCSR", "PHUT"};
+    constexpr const char* Photoshop::bimId_ = "8BIM";  // deprecated
+    constexpr uint16_t Photoshop::iptc_ = 0x0404;
+    constexpr uint16_t Photoshop::preview_ = 0x040c;
 
     static inline bool inRange(int lo,int value, int hi)
     {

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2697,7 +2697,7 @@ namespace Exiv2 {
         void decomposeKey(const std::string& key);  //!< Misterious magic
 
         // DATA
-        static const char* familyName_;  //!< "Xmp"
+        static constexpr auto familyName_ = "Xmp";  //!< "Xmp"
 
         std::string prefix_;    //!< Prefix
         std::string property_;  //!< Property name
@@ -2713,8 +2713,6 @@ namespace Exiv2 {
         property_ = property;
         prefix_ = prefix;
     }
-
-    const char* XmpKey::Impl::familyName_ = "Xmp";
 
     XmpKey::XmpKey(const std::string& key) : p_(new Impl)
     {

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -219,7 +219,7 @@ namespace Exiv2 {
         //@}
 
         // DATA
-        static const char* familyName_; //!< "Exif"
+        static constexpr auto familyName_ = "Exif";  //!< "Exif"
 
         const TagInfo* tagInfo_{0};     //!< Tag info
         uint16_t tag_{0};               //!< Tag value
@@ -228,8 +228,6 @@ namespace Exiv2 {
         std::string groupName_;         //!< The group name
         std::string key_;               //!< %Key
     };
-
-    const char* ExifKey::Impl::familyName_ = "Exif";
 
     std::string ExifKey::Impl::tagName() const
     {

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -82,10 +82,10 @@ namespace Exiv2 {
     };
 
     //! List of TIFF compression to MIME type mappings
-    MimeTypeList mimeTypeList[] = {
-        { 32770, "image/x-samsung-srw" },
-        { 34713, "image/x-nikon-nef"   },
-        { 65535, "image/x-pentax-pef"  }
+    constexpr MimeTypeList mimeTypeList[] = {
+        {32770, "image/x-samsung-srw"},
+        {34713, "image/x-nikon-nef"},
+        {65535, "image/x-pentax-pef"},
     };
 
     std::string TiffImage::mimeType() const

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -76,24 +76,24 @@ namespace Exiv2 {
     /* =========================================== */
 
     /* Misc. */
-    const byte WebPImage::WEBP_PAD_ODD = 0;
-    const int WebPImage::WEBP_TAG_SIZE = 0x4;
+    constexpr byte WebPImage::WEBP_PAD_ODD = 0;
+    constexpr int WebPImage::WEBP_TAG_SIZE = 0x4;
 
     /* VP8X feature flags */
-    const int WebPImage::WEBP_VP8X_ICC_BIT = 0x20;
-    const int WebPImage::WEBP_VP8X_ALPHA_BIT = 0x10;
-    const int WebPImage::WEBP_VP8X_EXIF_BIT = 0x8;
-    const int WebPImage::WEBP_VP8X_XMP_BIT = 0x4;
+    constexpr int WebPImage::WEBP_VP8X_ICC_BIT = 0x20;
+    constexpr int WebPImage::WEBP_VP8X_ALPHA_BIT = 0x10;
+    constexpr int WebPImage::WEBP_VP8X_EXIF_BIT = 0x8;
+    constexpr int WebPImage::WEBP_VP8X_XMP_BIT = 0x4;
 
     /* Chunk header names */
-    const char* WebPImage::WEBP_CHUNK_HEADER_VP8X = "VP8X";
-    const char* WebPImage::WEBP_CHUNK_HEADER_VP8L = "VP8L";
-    const char* WebPImage::WEBP_CHUNK_HEADER_VP8  = "VP8 ";
-    const char* WebPImage::WEBP_CHUNK_HEADER_ANMF = "ANMF";
-    const char* WebPImage::WEBP_CHUNK_HEADER_ANIM = "ANIM";
-    const char* WebPImage::WEBP_CHUNK_HEADER_ICCP = "ICCP";
-    const char* WebPImage::WEBP_CHUNK_HEADER_EXIF = "EXIF";
-    const char* WebPImage::WEBP_CHUNK_HEADER_XMP  = "XMP ";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_VP8X = "VP8X";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_VP8L = "VP8L";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_VP8 = "VP8 ";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_ANMF = "ANMF";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_ANIM = "ANIM";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_ICCP = "ICCP";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_EXIF = "EXIF";
+    constexpr const char* WebPImage::WEBP_CHUNK_HEADER_XMP = "XMP ";
 
     /* =========================================== */
 

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -36,9 +36,9 @@
 
 // *****************************************************************************
 namespace {
-    const char* xmlHeader = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n";
-    const long xmlHdrCnt = static_cast<long>(std::strlen(xmlHeader));  // without the trailing 0-character
-    const char* xmlFooter = "<?xpacket end=\"w\"?>";
+    constexpr auto xmlHeader = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n";
+    const auto xmlHdrCnt = static_cast<long>(std::strlen(xmlHeader));  // without the trailing 0-character
+    constexpr auto xmlFooter = "<?xpacket end=\"w\"?>";
 }  // namespace
 
 // class member definitions


### PR DESCRIPTION
Found with cppcoreguidelines-avoid-non-const-global-variables

Signed-off-by: Rosen Penev <rosenp@gmail.com>