### PR TITLE
feat: Setup github actions workflow to build tagged release and nightly pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           md build
           cd build
-          conan install libgettext/0.20.1@
+          conan install gettext/0.20.1@
           conan profile list
           conan install .. --build missing
           dir ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           #if-no-files-found: error
           #retention-days: 1
 
-publish:
+  publish:
     needs: [linux, macOS]
     runs-on: ubuntu-20.04
     permissions:
@@ -151,8 +151,7 @@ publish:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           fail_on_unmatched_files: true
-          body: |
-          See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
+          body: See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
           files: |
             exiv2-linux64.tar.gz:./exiv2-linux64/exiv2-linux64.tar.gz
             exvi2-macos.tar.gz:./exiv2-macos/exiv2-macos.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install ninja-build
+          sudo apt-get install gettext
           pip3 install conan==1.36.0
 
       - name: Conan common config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: exiv2-linux64
-          path: ./exiv2-*.tar.gz
+          path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -67,7 +67,7 @@ jobs:
       - name: Build packaged release
         run: |
           cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build . -t package
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install ninja
+          brew install tree
           brew install gettext
           pip3 install conan==1.36.0
 
@@ -117,6 +118,7 @@ jobs:
         run: |
           md build
           cd build
+          conan install gettext/0.20.1
           conan profile list
           conan install .. --build missing
           dir ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build packaged release
         run: |
           cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
           cmake --build . -t package
           tree -L 3
 
@@ -69,7 +69,7 @@ jobs:
       - name: Build packaged release
         run: |
           cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build . -t package
           tree -L 3
 
@@ -80,66 +80,67 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  #Windows:
-    #name: 'Build Windows Release'
-    #runs-on: windows-latest
-    #steps:
-      #- uses: actions/checkout@v2
+  Windows:
+    name: 'Build Windows Release'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
 
-      #- name: Set up Visual Studio shell
-        #uses: egor-tensin/vs-shell@v2
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
 
-      #- name: Setup Ninja
-        #uses: ashutoshvarma/setup-ninja@master
-        #with:
-          #version: 1.10.0
+      - name: Setup Ninja
+        uses: ashutoshvarma/setup-ninja@master
+        with:
+          version: 1.10.0
 
-      #- name: Set up Python
-        #uses: actions/setup-python@v1
-        #with:
-          #python-version: 3.7
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-      #- name: Restore conan cache
-        #uses: actions/cache@v2
-        #with:
-            #path: ${{github.workspace}}/conanCache
-            #key: ${{runner.os}}-packaged-win-release-${{ hashFiles('conanfile.py') }}
+      - name: Restore conan cache
+        uses: actions/cache@v2
+        with:
+            path: ${{github.workspace}}/conanCache
+            key: ${{runner.os}}-packaged-win-release-${{ hashFiles('conanfile.py') }}
 
-      #- name: Install Conan & Common config
-        #run: |
-          #pip.exe install conan
-          #conan profile new --detect default
-          #conan profile update settings.build_type=Release default
-          #conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
-          #conan config get storage.path
-          #tree /f ./conanCache
+      - name: Install Conan & Common config
+        run: |
+          pip.exe install conan
+          conan profile new --detect default
+          conan profile update settings.build_type=Release default
+          conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
+          conan config get storage.path
+          tree /f ./conanCache
 
-      #- name: Run Conan
-        #run: |
-          #md build
-          #cd build
-          #conan install gettext/0.20.1@
-          #conan profile list
-          #conan install .. --build missing
-          #dir ..
-          #tree /f ../conanCache
+      - name: Run Conan
+        run: |
+          md build
+          cd build
+          conan install gettext/0.20.1@
+          conan install libgettext/0.20.1@
+          conan profile list
+          conan install .. --build missing
+          dir ..
+          tree /f ../conanCache
 
-      #- name: Build packaged release
-        #run: |
-          #cd build
-          #cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
-          #cmake --build . -t package
-          #tree -L 3
+      - name: Build packaged release
+        run: |
+          cd build
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake --build . -t package
+          tree -L 3
 
-      #- uses: actions/upload-artifact@v2
-        #with:
-          #name: exiv2-win
-          #path: ./build/exiv2-*.zip
-          #if-no-files-found: error
-          #retention-days: 1
+      - uses: actions/upload-artifact@v2
+        with:
+          name: exiv2-win
+          path: ./build/exiv2-*.zip
+          if-no-files-found: error
+          retention-days: 1
 
   publish:
-    needs: [linux, macOS]
+    needs: [Linux, macOS, Windows]
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -157,3 +158,4 @@ jobs:
           files: |
             ./exiv2-linux64/exiv2-*.tar.gz
             ./exiv2-macos/exiv2-*.tar.gz
+            ./exiv2-win/exiv2-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,40 @@ jobs:
         with:
           name: exiv2-linux64
           path: ./exiv2-*.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  Mac:
+    name: 'Build Mac Release'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          brew install ninja
+          brew install gettext
+          pip3 install conan==1.36.0
+
+      - name: Run Conan
+        run: |
+          mkdir build && cd build
+          conan profile new --detect default
+          conan profile show default
+          conan install .. -o webready=False --build missing
+          # Hack: Delete cmake_find_package generated files to fix compilation on mac.
+          rm Find*
+
+      - name: Build packaged release
+        run: |
+          cd build
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake --build . -t package
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: exiv2-macos
+          path: ./build/exiv2-*.tar.gz
+          if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,6 @@ jobs:
         run: |
           md build
           cd build
-          conan install gettext/0.20.1@
-          conan install libgettext/0.20.1@
           conan profile list
           conan install .. --build missing
           dir ..
@@ -128,7 +126,7 @@ jobs:
       - name: Build packaged release
         run: |
           cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=OFF -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
           cmake --build . -t package
           tree -L 3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for release'
+        required: false
+        default: nightly
 
 jobs:
   Linux:
@@ -146,13 +154,78 @@ jobs:
       - uses: actions/download-artifact@v2
       - name: List downloaded files
         run: tree -L 3
+
+      - if: github.event_name == 'workflow_dispatch'
+        run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+
+      - if: github.event_name == 'schedule'
+        run: echo 'TAG_NAME=nightly' >> $GITHUB_ENV
+
+      - if: github.event_name == 'push'
+        run: |
+          TAG_NAME=${{ github.ref }}
+          echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
+
+      - if: env.TAG_NAME == 'nightly'
+        run: |
+          echo 'BODY<<EOF' >> $GITHUB_ENV
+          echo '## Exiv2 nightly prerelease build.' >> $GITHUB_ENV
+          echo 'Please help us improve exiv2 by reporting any issues you encounter :wink:' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+
+      - if: env.TAG_NAME != 'nightly'
+        run: |
+          echo 'BODY<<EOF' >> $GITHUB_ENV
+          echo '## Exiv2 Release ${TAG_NAME}' >> $GITHUB_ENV
+          echo 'See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Cleanup old nightly
+        if: env.TAG_NAME == 'nightly'
+        uses: actions/github-script@v4
+        with:
+          script: |
+            try{
+              const rel_id = await github.repos.getReleaseByTag({
+                ...context.repo,
+                tag: "nightly"
+              }).then(result => result.data.id);
+
+              console.log( "Found existing nightly release with id: ", rel_id);
+
+              await github.repos.deleteRelease({
+                ...context.repo,
+                release_id: rel_id
+              });
+              console.log( "Deletion of release successful")
+
+            }catch(error){
+              console.log( "Deletion of release failed");
+              console.log( "Failed with error\n", error);
+            }
+
+            try{
+              await github.git.deleteRef({
+                ...context.repo,
+                ref: "tags/nightly"
+              });
+              console.log( "Deletion of tag successful")
+            }catch(error){
+              console.log( "Deletion of tag failed");
+              console.log( "Failed with error\n", error);
+            }
+
+
       - uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # needs newer relase, but add it once available
           #fail_on_unmatched_files: true
-          body: See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
+          body: ${{ env.BODY }}
+          prerelease: ${{ env.TAG_NAME == 'nightly' }}
+          tag_name: ${{ env.TAG_NAME }}
           files: |
             ./exiv2-linux64/exiv2-*
             ./exiv2-macos/exiv2-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.build.outputs.version }}
+      release: ${{ steps.build.outputs.release }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install ninja-build
+          pip3 install conan==1.36.0
+
+      - name: Conan common config
+        run: |
+          conan profile new --detect default
+          conan profile update settings.build_type=${{matrix.build_type}} default
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+
+      - name: Run Conan
+        run: |
+          mkdir build && cd build
+          conan profile list
+          conan profile show default
+          conan install .. -o webready=False --build missing
+
+      - name: Build packaged release
+        run: |
+          cd build
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake --build . -t package
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: exiv2-linux64
+          path: ./exiv2-*.tar.gz
+          retention-days: 1
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,6 @@ jobs:
           #fail_on_unmatched_files: true
           body: See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
           files: |
-            ./exiv2-linux64/exiv2-*.tar.gz
-            ./exiv2-macos/exiv2-*.tar.gz
-            ./exiv2-win/exiv2-*.tar.gz
+            ./exiv2-linux64/exiv2-*
+            ./exiv2-macos/exiv2-*
+            ./exiv2-win/exiv2-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,8 @@ on:
 
 jobs:
   Linux:
+    name: 'Build Linux Release'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.build.outputs.version }}
-      release: ${{ steps.build.outputs.release }}
     steps:
       - uses: actions/checkout@v2
 
@@ -21,7 +19,7 @@ jobs:
       - name: Conan common config
         run: |
           conan profile new --detect default
-          conan profile update settings.build_type=${{matrix.build_type}} default
+          conan profile update settings.build_type=Release default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 
       - name: Run Conan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,5 +155,5 @@ jobs:
           #fail_on_unmatched_files: true
           body: See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
           files: |
-            exiv2-linux64.tar.gz:./exiv2-linux64/exiv2-*.tar.gz
-            exvi2-macos.tar.gz:./exiv2-macos/exiv2-*.tar.gz
+            ./exiv2-linux64/exiv2-*.tar.gz
+            ./exiv2-macos/exiv2-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           md build
           cd build
-          conan install gettext/0.20.1
+          conan install libgettext/0.20.1@
           conan profile list
           conan install .. --build missing
           dir ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  Mac:
-    name: 'Build Mac Release'
+  macOS:
+    name: 'Build macOS Release'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -80,62 +80,79 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  Windows:
-    name: 'Build Windows Release'
-    runs-on: windows-latest
+  #Windows:
+    #name: 'Build Windows Release'
+    #runs-on: windows-latest
+    #steps:
+      #- uses: actions/checkout@v2
+
+      #- name: Set up Visual Studio shell
+        #uses: egor-tensin/vs-shell@v2
+
+      #- name: Setup Ninja
+        #uses: ashutoshvarma/setup-ninja@master
+        #with:
+          #version: 1.10.0
+
+      #- name: Set up Python
+        #uses: actions/setup-python@v1
+        #with:
+          #python-version: 3.7
+
+      #- name: Restore conan cache
+        #uses: actions/cache@v2
+        #with:
+            #path: ${{github.workspace}}/conanCache
+            #key: ${{runner.os}}-packaged-win-release-${{ hashFiles('conanfile.py') }}
+
+      #- name: Install Conan & Common config
+        #run: |
+          #pip.exe install conan
+          #conan profile new --detect default
+          #conan profile update settings.build_type=Release default
+          #conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
+          #conan config get storage.path
+          #tree /f ./conanCache
+
+      #- name: Run Conan
+        #run: |
+          #md build
+          #cd build
+          #conan install gettext/0.20.1@
+          #conan profile list
+          #conan install .. --build missing
+          #dir ..
+          #tree /f ../conanCache
+
+      #- name: Build packaged release
+        #run: |
+          #cd build
+          #cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          #cmake --build . -t package
+          #tree -L 3
+
+      #- uses: actions/upload-artifact@v2
+        #with:
+          #name: exiv2-win
+          #path: ./build/exiv2-*.zip
+          #if-no-files-found: error
+          #retention-days: 1
+
+publish:
+    needs: [linux, macOS]
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
-
-      - name: Setup Ninja
-        uses: ashutoshvarma/setup-ninja@master
+      - uses: actions/download-artifact@v2
+        run: tree -L 3
+      - uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: 1.10.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Restore conan cache
-        uses: actions/cache@v2
-        with:
-            path: ${{github.workspace}}/conanCache
-            key: ${{runner.os}}-packaged-win-release-${{ hashFiles('conanfile.py') }}
-
-      - name: Install Conan & Common config
-        run: |
-          pip.exe install conan
-          conan profile new --detect default
-          conan profile update settings.build_type=Release default
-          conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
-          conan config get storage.path
-          tree /f ./conanCache
-
-      - name: Run Conan
-        run: |
-          md build
-          cd build
-          conan install gettext/0.20.1@
-          conan profile list
-          conan install .. --build missing
-          dir ..
-          tree /f ../conanCache
-
-      - name: Build packaged release
-        run: |
-          cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
-          cmake --build . -t package
-          tree -L 3
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: exiv2-win
-          path: ./build/exiv2-*.zip
-          if-no-files-found: error
-          retention-days: 1
-
-
+          fail_on_unmatched_files: true
+          body: |
+          See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
+          files: |
+            exiv2-linux64.tar.gz:./exiv2-linux64/exiv2-linux64.tar.gz
+            exvi2-macos.tar.gz:./exiv2-macos/exiv2-macos.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@v2
+      - name: List downloaded files
         run: tree -L 3
       - uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
       - if: env.TAG_NAME != 'nightly'
         run: |
           echo 'BODY<<EOF' >> $GITHUB_ENV
-          echo '## Exiv2 Release ${TAG_NAME}' >> $GITHUB_ENV
+          echo '## Exiv2 Release ${{ env.TAG_NAME }}' >> $GITHUB_ENV
           echo 'See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           cd build
           cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
           cmake --build . -t package
+          tree -L 3
 
       - uses: actions/upload-artifact@v2
         with:
@@ -69,6 +70,7 @@ jobs:
           cd build
           cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build . -t package
+          tree -L 3
 
       - uses: actions/upload-artifact@v2
         with:
@@ -76,4 +78,62 @@ jobs:
           path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
+
+  Windows:
+    name: 'Build Windows Release'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+
+      - name: Setup Ninja
+        uses: ashutoshvarma/setup-ninja@master
+        with:
+          version: 1.10.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Restore conan cache
+        uses: actions/cache@v2
+        with:
+            path: ${{github.workspace}}/conanCache
+            key: ${{runner.os}}-packaged-win-release-${{ hashFiles('conanfile.py') }}
+
+      - name: Install Conan & Common config
+        run: |
+          pip.exe install conan
+          conan profile new --detect default
+          conan profile update settings.build_type=Release default
+          conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
+          conan config get storage.path
+          tree /f ./conanCache
+
+      - name: Run Conan
+        run: |
+          md build
+          cd build
+          conan profile list
+          conan install .. --build missing
+          dir ..
+          tree /f ../conanCache
+
+      - name: Build packaged release
+        run: |
+          cd build
+          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON ..
+          cmake --build . -t package
+          tree -L 3
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: exiv2-win
+          path: ./build/exiv2-*.zip
+          if-no-files-found: error
+          retention-days: 1
+
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          fail_on_unmatched_files: true
+          # needs newer relase, but add it once available
+          #fail_on_unmatched_files: true
           body: See [ChangeLog](doc/ChangeLog) for more information about the changes in this release.
           files: |
-            exiv2-linux64.tar.gz:./exiv2-linux64/exiv2-linux64.tar.gz
-            exvi2-macos.tar.gz:./exiv2-macos/exiv2-macos.tar.gz
+            exiv2-linux64.tar.gz:./exiv2-linux64/exiv2-*.tar.gz
+            exvi2-macos.tar.gz:./exiv2-macos/exiv2-*.tar.gz


### PR DESCRIPTION
The idea of the workflow right now is to simply build the required releases if a tag gets pushed to the repo. 

Only a first draft to get some feedback.    
You can see the result [in my fork here](https://github.com/hassec/exiv2/actions/runs/861946333)  
Being completely new to conan and also not having a windows machine to test, I'm still fighting to get the windows build to work.   
Was hoping maybe @piponazo could take a quick look and see if you know an easy fix?

In any case, I think it's a nice idea to set it up this way, and we can add more to it, e.g.:
1. The actual release can easily be created as well
2. We could set up an action that automatically keeps tracks of PRs that are merged, and then uses this list for the releas notes
3. soooo much more :D 

Let me know what you guys think: :+1: ? or :-1:   
I'm happy to put some more time into this, if people think it's the way we should go 