### PR TITLE
clang-tidy: use nullptr

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -480,27 +480,27 @@ namespace Jzon
     {
         if (!children.empty())
             return Object::iterator(&children.front());
-        return Object::iterator(NULL);
+        return Object::iterator(nullptr);
     }
 
     Object::const_iterator Object::begin() const
     {
         if (!children.empty())
             return Object::const_iterator(&children.front());
-        return Object::const_iterator(NULL);
+        return Object::const_iterator(nullptr);
     }
 
     Object::iterator Object::end()
     {
         if (!children.empty())
             return Object::iterator(&children.back() + 1);
-        return Object::iterator(NULL);
+        return Object::iterator(nullptr);
     }
     Object::const_iterator Object::end() const
     {
         if (!children.empty())
             return Object::const_iterator(&children.back() + 1);
-        return Object::const_iterator(NULL);
+        return Object::const_iterator(nullptr);
     }
 
     bool Object::Has(const std::string &name) const
@@ -583,25 +583,25 @@ namespace Jzon
     {
         if (!children.empty())
             return Array::iterator(&children.front());
-        return Array::iterator(NULL);
+        return Array::iterator(nullptr);
     }
     Array::const_iterator Array::begin() const
     {
         if (!children.empty())
             return Array::const_iterator(&children.front());
-        return Array::const_iterator(NULL);
+        return Array::const_iterator(nullptr);
     }
     Array::iterator Array::end()
     {
         if (!children.empty())
             return Array::iterator(&children.back() + 1);
-        return Array::iterator(NULL);
+        return Array::iterator(nullptr);
     }
     Array::const_iterator Array::end() const
     {
         if (!children.empty())
             return Array::const_iterator(&children.back() + 1);
-        return Array::const_iterator(NULL);
+        return Array::const_iterator(nullptr);
     }
 
     size_t Array::GetCount() const
@@ -708,36 +708,41 @@ namespace Jzon
 	Writer::~Writer()
 	{
 		delete fi;
-		fi = NULL;
-	}
+        fi = nullptr;
+    }
 
-	void Writer::SetFormat(const Format &format)
-	{
-		fi->SetFormat(format);
-	}
-	const std::string &Writer::Write()
-	{
-		result.clear();
-		writeNode(root, 0);
-		return result;
-	}
+    void Writer::SetFormat(const Format &format)
+    {
+        fi->SetFormat(format);
+    }
+    const std::string &Writer::Write()
+    {
+        result.clear();
+        writeNode(root, 0);
+        return result;
+    }
 
-	const std::string &Writer::GetResult() const
-	{
-		return result;
-	}
+    const std::string &Writer::GetResult() const
+    {
+        return result;
+    }
 
-	void Writer::writeNode(const Node &node, unsigned int level)
-	{
-		switch (node.GetType())
-		{
-		case Node::T_OBJECT : writeObject(node.AsObject(), level); break;
-		case Node::T_ARRAY  : writeArray(node.AsArray(), level);   break;
-		case Node::T_VALUE  : writeValue(node.AsValue());          break;
-		}
-	}
-	void Writer::writeObject(const Object &node, unsigned int level)
-	{
+    void Writer::writeNode(const Node &node, unsigned int level)
+    {
+        switch (node.GetType()) {
+            case Node::T_OBJECT:
+                writeObject(node.AsObject(), level);
+                break;
+            case Node::T_ARRAY:
+                writeArray(node.AsArray(), level);
+                break;
+            case Node::T_VALUE:
+                writeValue(node.AsValue());
+                break;
+        }
+    }
+    void Writer::writeObject(const Object &node, unsigned int level)
+    {
 		result += "{" + fi->GetNewline();
 
         for (auto it = node.begin(); it != node.end(); ++it) {
@@ -929,160 +934,128 @@ namespace Jzon
 				}
 			case T_OBJ_BEGIN :
 				{
-					Node *node = NULL;
-					if (nodeStack.empty())
-					{
-						if (!root.IsObject())
-						{
-							error = "The given root node is not an object";
-							return false;
-						}
+                Node *node = nullptr;
+                if (nodeStack.empty()) {
+                    if (!root.IsObject()) {
+                        error = "The given root node is not an object";
+                        return false;
+                    }
 
-						node = &root;
-					}
-					else
-					{
-						node = new Object;
-					}
+                    node = &root;
+                } else {
+                    node = new Object;
+                }
 
-					nodeStack.push(std::make_pair(name, node));
-					name.clear();
-					break;
-				}
-			case T_ARRAY_BEGIN :
-				{
-					Node *node = NULL;
-					if (nodeStack.empty())
-					{
-						if (!root.IsArray())
-						{
-							error = "The given root node is not an array";
-							return false;
-						}
+                nodeStack.push(std::make_pair(name, node));
+                name.clear();
+                break;
+            }
+            case T_ARRAY_BEGIN: {
+                Node *node = nullptr;
+                if (nodeStack.empty()) {
+                    if (!root.IsArray()) {
+                        error = "The given root node is not an array";
+                        return false;
+                    }
 
-						node = &root;
-					}
-					else
-					{
-						node = new Array;
-					}
+                    node = &root;
+                } else {
+                    node = new Array;
+                }
 
-					nodeStack.push(std::make_pair(name, node));
-					name.clear();
-					break;
-				}
-			case T_OBJ_END :
-			case T_ARRAY_END :
-				{
-					if (nodeStack.empty())
-					{
-						error = "Found end of object or array without beginning";
-						return false;
-					}
-					if (token == T_OBJ_END && !nodeStack.top().second->IsObject())
-					{
-						error = "Mismatched end and beginning of object";
-						return false;
-					}
-					if (token == T_ARRAY_END && !nodeStack.top().second->IsArray())
-					{
-						error = "Mismatched end and beginning of array";
-						return false;
-					}
+                nodeStack.push(std::make_pair(name, node));
+                name.clear();
+                break;
+            }
+            case T_OBJ_END:
+            case T_ARRAY_END: {
+                if (nodeStack.empty()) {
+                    error = "Found end of object or array without beginning";
+                    return false;
+                }
+                if (token == T_OBJ_END && !nodeStack.top().second->IsObject()) {
+                    error = "Mismatched end and beginning of object";
+                    return false;
+                }
+                if (token == T_ARRAY_END && !nodeStack.top().second->IsArray()) {
+                    error = "Mismatched end and beginning of array";
+                    return false;
+                }
 
-					std::string name = nodeStack.top().first;
-					Node *node = nodeStack.top().second;
-					nodeStack.pop();
+                std::string name = nodeStack.top().first;
+                Node *node = nodeStack.top().second;
+                nodeStack.pop();
 
-					if (!nodeStack.empty())
-					{
-						if (nodeStack.top().second->IsObject())
-						{
-							nodeStack.top().second->AsObject().Add(name, *node);
-						}
-						else if (nodeStack.top().second->IsArray())
-						{
-							nodeStack.top().second->AsArray().Add(*node);
-						}
-						else
-						{
-							error = "Can only add elements to objects and arrays";
-							return false;
-						}
+                if (!nodeStack.empty()) {
+                    if (nodeStack.top().second->IsObject()) {
+                        nodeStack.top().second->AsObject().Add(name, *node);
+                    } else if (nodeStack.top().second->IsArray()) {
+                        nodeStack.top().second->AsArray().Add(*node);
+                    } else {
+                        error = "Can only add elements to objects and arrays";
+                        return false;
+                    }
 
-						delete node;
-						node = NULL;
-					}
-					break;
-				}
-			case T_VALUE :
-				{
-					if (!tokens.empty() && tokens.front() == T_SEPARATOR_NAME)
-					{
-						tokens.pop();
-						if (data.front().first != Value::VT_STRING)
-						{
-							error = "A name has to be a string";
-							return false;
-						}
-						name = data.front().second;
-						data.pop();
-					}
-					else
-					{
-						Node *node = NULL;
-						if (nodeStack.empty())
-						{
-							if (!root.IsValue())
-							{
-								error = "The given root node is not a value";
-								return false;
-							}
-
-							node = &root;
-						}
-						else
-						{
-							node = new Value;
-						}
-
-						if (data.front().first == Value::VT_STRING)
-						{
-                            dynamic_cast<Value *>(node)->Set(
-                                data.front().second);  // This method calls UnescapeString()
-                        } else {
-                            dynamic_cast<Value *>(node)->Set(data.front().first, data.front().second);
+                    delete node;
+                    node = nullptr;
+                }
+                break;
+            }
+            case T_VALUE: {
+                if (!tokens.empty() && tokens.front() == T_SEPARATOR_NAME) {
+                    tokens.pop();
+                    if (data.front().first != Value::VT_STRING) {
+                        error = "A name has to be a string";
+                        return false;
+                    }
+                    name = data.front().second;
+                    data.pop();
+                } else {
+                    Node *node = nullptr;
+                    if (nodeStack.empty()) {
+                        if (!root.IsValue()) {
+                            error = "The given root node is not a value";
+                            return false;
                         }
-                        data.pop();
 
-                        if (!nodeStack.empty())
-						{
-							if (nodeStack.top().second->IsObject())
-								nodeStack.top().second->AsObject().Add(name, *node);
-							else if (nodeStack.top().second->IsArray())
-								nodeStack.top().second->AsArray().Add(*node);
+                        node = &root;
+                    } else {
+                        node = new Value;
+                    }
 
-							delete node;
-							node = NULL;
-							name.clear();
-						}
-						else
-						{
-							nodeStack.push(std::make_pair(name, node));
-							name.clear();
-						}
-					}
-					break;
-				}
-			case T_SEPARATOR_NAME :
-			case T_SEPARATOR_NODE : break;
-			}
-		}
+                    if (data.front().first == Value::VT_STRING) {
+                        dynamic_cast<Value *>(node)->Set(data.front().second);  // This method calls UnescapeString()
+                    } else {
+                        dynamic_cast<Value *>(node)->Set(data.front().first, data.front().second);
+                    }
+                    data.pop();
 
-		return true;
-	}
+                    if (!nodeStack.empty()) {
+                        if (nodeStack.top().second->IsObject())
+                            nodeStack.top().second->AsObject().Add(name, *node);
+                        else if (nodeStack.top().second->IsArray())
+                            nodeStack.top().second->AsArray().Add(*node);
 
-	char Parser::peek()
+                        delete node;
+                        node = nullptr;
+                        name.clear();
+                    } else {
+                        nodeStack.push(std::make_pair(name, node));
+                        name.clear();
+                    }
+                }
+                break;
+            }
+            case T_SEPARATOR_NAME:
+            case T_SEPARATOR_NODE:
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    char Parser::peek()
 	{
 		if (cursor < jsonSize-1)
 		{

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -97,7 +97,8 @@ try {
     v = pos->getValue();
     // Downcast the Value pointer to its actual type
     auto prv = dynamic_cast<Exiv2::URationalValue*>(v.release());
-    if (prv == 0) throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
+    if (prv == nullptr)
+        throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
     rv = Exiv2::URationalValue::UniquePtr(prv);
     // Modify the value directly through the interface of URationalValue
     rv->value_[2] = std::make_pair(88,77);

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -63,7 +63,7 @@ struct Token {
 using Tokens = std::vector<Token>;
 
 // "XMP.xmp.MP.RegionInfo/MPRI:Regions[1]/MPReg:Rectangle"
-bool getToken(std::string& in,Token& token, std::set<std::string>* pNS=NULL)
+bool getToken(std::string& in, Token& token, std::set<std::string>* pNS = nullptr)
 {
     bool result = false;
     bool ns     = false;
@@ -119,7 +119,8 @@ Jzon::Node& recursivelyBuildTree(Jzon::Node& root,Tokens& tokens,size_t k)
 }
 
 // build the json tree for this key.  return location and discover the name
-Jzon::Node& objectForKey(const std::string& Key,Jzon::Object& root,std::string& name,std::set<std::string>* pNS=NULL)
+Jzon::Node& objectForKey(const std::string& Key, Jzon::Object& root, std::string& name,
+                         std::set<std::string>* pNS = nullptr)
 {
     // Parse the key
     Tokens      tokens ;

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -150,7 +150,7 @@ class Position;
 using TimeDict_t = std::map<time_t, Position>;
 using TimeDict_i = std::map<time_t, Position>::iterator;
 using strings_t = std::vector<std::string>;
-const char*  gDeg = NULL ; // string "°" or "deg"
+const char* gDeg = nullptr;  // string "°" or "deg"
 TimeDict_t   gTimeDict   ;
 strings_t    gFiles;
 
@@ -439,7 +439,7 @@ time_t parseTime(const char* arg,bool bAdjust)
 // West of GMT is negative (PDT = Pacific Daylight = -07:00 == -25200 seconds
 int timeZoneAdjust()
 {
-    time_t    now   = time(NULL);
+    time_t now = time(nullptr);
     int       offset;
 
 #if   defined(_MSC_VER) || defined(__MINGW__)
@@ -531,14 +531,12 @@ bool readDir(const char* path,Options& options)
     }
 #else
     DIR*    dir = opendir (path);
-    if (dir != NULL)
-    {
+    if (dir != nullptr) {
         bResult = true;
         struct dirent*  ent;
 
         // print all the files and directories within directory
-        while ((ent = readdir (dir)) != NULL)
-        {
+        while ((ent = readdir(dir)) != nullptr) {
             std::string pathName = makePath(path,ent->d_name);
             struct stat  buf     ;
             lstat(path, &buf );
@@ -566,7 +564,7 @@ inline size_t sip(FILE* f,char* buffer,size_t max_len,size_t len)
 bool readXML(const char* path,Options& options)
 {
     FILE*       f       = fopen(path,"r");
-    XML_Parser  parser  = XML_ParserCreate(NULL);
+    XML_Parser parser = XML_ParserCreate(nullptr);
     bool bResult        = f && parser ;
     if ( bResult ) {
         char   buffer[8*1024];
@@ -617,18 +615,14 @@ bool readImage(const char* path,Options& /* options */)
     return bResult ;
 }
 
-time_t readImageTime(const std::string& path,std::string* pS=NULL)
+time_t readImageTime(const std::string& path, std::string* pS = nullptr)
 {
     using namespace Exiv2;
 
     time_t       result       = 0 ;
 
-    const char* dateStrings[] =
-    { "Exif.Photo.DateTimeOriginal"
-    , "Exif.Photo.DateTimeDigitized"
-    , "Exif.Image.DateTime"
-    , NULL
-    };
+    const char* dateStrings[] = {"Exif.Photo.DateTimeOriginal", "Exif.Photo.DateTimeDigitized", "Exif.Image.DateTime",
+                                 nullptr};
     const char* dateString = dateStrings[0] ;
 
     do {
@@ -668,8 +662,8 @@ int readFile(const char* path, const Options& /* options */)
     if (  f ) {
         const char*  ext   = strstr(path,".");
         if  ( ext ) {
-            const char* docs[] = { ".doc",".txt", NULL };
-            const char* code[] = { ".cpp",".h"  ,".pl" ,".py" ,".pyc", NULL };
+            const char* docs[] = {".doc", ".txt", nullptr};
+            const char* code[] = {".cpp", ".h", ".pl", ".py", ".pyc", nullptr};
             if ( sina(ext,docs) )
                 nResult = typeDoc;
             if ( sina(ext,code) )
@@ -683,7 +677,7 @@ int readFile(const char* path, const Options& /* options */)
 
 Position* searchTimeDict(TimeDict_t& td, const time_t& time,long long delta)
 {
-    Position* result = NULL;
+    Position* result = nullptr;
     for ( int t = 0 ; !result && t < delta ; t++ ) {
         for ( int x = 0 ; !result && x < 2 ; x++ ) {
             int T = t * ((x==0)?-1:1);
@@ -857,7 +851,7 @@ int main(int argc,const char* argv[])
 #ifdef __APPLE__
                     char   buffer[1024];
 #else
-                    char*  buffer = NULL;
+                    char* buffer = nullptr;
 #endif
                     char*  path = realpath(arg,buffer);
                     if  ( t && path ) {

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -66,7 +66,7 @@ int main(int argc, char* const argv[])
             int blocksize = argc==6 ? atoi(ba) : 10000;
             // ensure blocksize is sane
             if (blocksize>1024*1024) blocksize=10000;
-            Exiv2::byte* bytes = blocksize>0 ? new Exiv2::byte[blocksize]: NULL;
+            Exiv2::byte* bytes = blocksize > 0 ? new Exiv2::byte[blocksize] : nullptr;
 
             // copy fileIn from a remote location.
             BasicIo::UniquePtr io = Exiv2::ImageFactory::createIo(fr);

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -66,7 +66,7 @@ int main(int argc, char* const argv[])
         std::cout << "IPTC fields: " << iptcData.size() << "\n";
 
         // Set IRB, compare with IPTC raw data
-        Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(0, 0, iptcData);
+        Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(nullptr, 0, iptcData);
         std::cout << "IRB buffer : " << irb.size_ << "\n";
         const Exiv2::byte* record;
         uint32_t sizeHdr;

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -66,7 +66,7 @@ void mini1(const char* path)
     WriteMethod wm;
 
     // Write nothing to a new structure, without a previous binary image
-    wm = ExifParser::encode(blob, 0, 0, bigEndian, exifData);
+    wm = ExifParser::encode(blob, nullptr, 0, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     assert(blob.empty());
     std::cout << "Test 1: Writing empty Exif data without original binary data: ok.\n";
@@ -80,7 +80,7 @@ void mini1(const char* path)
 
     // Write something to a new structure, without a previous binary image
     exifData["Exif.Photo.DateTimeOriginal"] = "Yesterday at noon";
-    wm = ExifParser::encode(blob, 0, 0, bigEndian, exifData);
+    wm = ExifParser::encode(blob, nullptr, 0, bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     std::cout << "Test 3: Wrote non-empty Exif data without original binary data:\n";
     exifData.clear();

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -164,11 +164,11 @@ namespace Action {
         return UniquePtr(clone_());
     }
 
-    TaskFactory* TaskFactory::instance_ = 0;
+    TaskFactory* TaskFactory::instance_ = nullptr;
 
     TaskFactory& TaskFactory::instance()
     {
-        if (0 == instance_) {
+        if (nullptr == instance_) {
             instance_ = new TaskFactory;
         }
         return *instance_;
@@ -176,12 +176,12 @@ namespace Action {
 
     void TaskFactory::cleanup()
     {
-        if (instance_ != 0) {
+        if (instance_ != nullptr) {
             for (auto&& i : registry_) {
                 delete i.second;
             }
             delete instance_;
-            instance_ = 0;
+            instance_ = nullptr;
         }
     } //TaskFactory::cleanup
 
@@ -409,9 +409,7 @@ namespace Action {
         if (md != exifData.end()) {
             md->write(std::cout, &exifData);
             rc = 1;
-        }
-        else if (NULL != easyAccessFctFallback)
-        {
+        } else if (nullptr != easyAccessFctFallback) {
             md = easyAccessFctFallback(exifData);
             if (md != exifData.end()) {
                 md->write(std::cout, &exifData);
@@ -493,7 +491,7 @@ namespace Action {
             if (result)
                 break;
 #if defined(EXV_HAVE_REGEX_H)
-            result = regexec(&g, key.c_str(), 0, NULL, 0) == 0;
+            result = regexec(&g, key.c_str(), 0, nullptr, 0) == 0;
 #else
             std::string Pattern(g.pattern_);
             std::string Key(key);
@@ -1387,7 +1385,7 @@ namespace Action {
         Exiv2::ExifData& exifData = pImage->exifData();
         Exiv2::IptcData& iptcData = pImage->iptcData();
         Exiv2::XmpData&  xmpData  = pImage->xmpData();
-        Exiv2::Metadatum* metadatum = 0;
+        Exiv2::Metadatum* metadatum = nullptr;
         if (modifyCmd.metadataId_ == exif) {
             auto pos = exifData.findKey(Exiv2::ExifKey(modifyCmd.key_));
             if (pos != exifData.end()) {
@@ -1413,9 +1411,7 @@ namespace Action {
         if (metadatum) {
             value = metadatum->getValue();
         }
-        if (   value.get() == 0
-            || (   modifyCmd.explicitType_
-                && modifyCmd.typeId_ != value->typeId())) {
+        if (value.get() == nullptr || (modifyCmd.explicitType_ && modifyCmd.typeId_ != value->typeId())) {
             value = Exiv2::Value::create(modifyCmd.typeId_);
         }
         int rc = value->read(modifyCmd.value_);
@@ -1809,7 +1805,8 @@ namespace {
         if (timeStr.length() < 19) return 2;
         if (  (timeStr[4]  != ':' && timeStr[4] != '-') || (timeStr[7]  != ':' && timeStr[7] != '-') || timeStr[10] != ' '
             || timeStr[13] != ':' || timeStr[16] != ':') return 3;
-        if (0 == tm) return 4;
+        if (nullptr == tm)
+            return 4;
         std::memset(tm, 0x0, sizeof(struct tm));
         tm->tm_isdst = -1;
 
@@ -1842,7 +1839,8 @@ namespace {
 
     std::string tm2Str(const struct tm* tm)
     {
-        if (0 == tm) return "";
+        if (nullptr == tm)
+            return "";
 
         std::ostringstream os;
         os << std::setfill('0')
@@ -2181,7 +2179,7 @@ namespace {
     {
       const std::string& str( strAndWidth.first);
       size_t minChCount( strAndWidth.second);
-      size_t count = mbstowcs( NULL, str.c_str(), 0); // returns 0xFFFFFFFF on error
+      size_t count = mbstowcs(nullptr, str.c_str(), 0);  // returns 0xFFFFFFFF on error
       if( count < minChCount)
       {
         minChCount += str.size() - count;

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -119,7 +119,7 @@ namespace Exiv2 {
         //! Constructor for Exif tags and XMP properties.
         Converter(ExifData& exifData, XmpData& xmpData);
         //! Constructor for Iptc tags and XMP properties.
-        Converter(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+        Converter(IptcData& iptcData, XmpData& xmpData, const char* iptcCharset = nullptr);
         //@}
 
         //! @name Manipulators
@@ -442,12 +442,22 @@ namespace Exiv2 {
     };
 
     Converter::Converter(ExifData& exifData, XmpData& xmpData)
-        : erase_(false), overwrite_(true), exifData_(&exifData), iptcData_(0), xmpData_(&xmpData), iptcCharset_(0)
+        : erase_(false),
+          overwrite_(true),
+          exifData_(&exifData),
+          iptcData_(nullptr),
+          xmpData_(&xmpData),
+          iptcCharset_(nullptr)
     {
     }
 
-    Converter::Converter(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset)
-        : erase_(false), overwrite_(true), exifData_(0), iptcData_(&iptcData), xmpData_(&xmpData), iptcCharset_(iptcCharset)
+    Converter::Converter(IptcData& iptcData, XmpData& xmpData, const char* iptcCharset)
+        : erase_(false),
+          overwrite_(true),
+          exifData_(nullptr),
+          iptcData_(&iptcData),
+          xmpData_(&xmpData),
+          iptcCharset_(iptcCharset)
     {
     }
 
@@ -526,7 +536,7 @@ namespace Exiv2 {
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         const auto cv = dynamic_cast<const CommentValue*>(&pos->value());
-        if (cv == 0) {
+        if (cv == nullptr) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to convert " << from << " to " << to << "\n";
 #endif
@@ -649,7 +659,7 @@ namespace Exiv2 {
             }
         }
 
-        const char* subsecTag = 0;
+        const char* subsecTag = nullptr;
         if (std::string(from) == "Exif.Image.DateTime") {
             subsecTag = "Exif.Photo.SubSecTime";
         }
@@ -878,7 +888,7 @@ namespace Exiv2 {
             (*exifData_)[to] = buf;
 
             if (datetime.nanoSecond) {
-                const char* subsecTag = 0;
+                const char* subsecTag = nullptr;
                 if (std::string(to) == "Exif.Image.DateTime") {
                     subsecTag = "Exif.Photo.SubSecTime";
                 }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -113,7 +113,7 @@ namespace Exiv2 {
         std::cerr << "Writing CR2 file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -134,7 +134,7 @@ namespace Exiv2 {
         // Write new buffer to file
         MemIo::UniquePtr tempIo(new MemIo);
         assert(tempIo.get() != 0);
-        tempIo->write((!blob.empty() ? &blob[0] : 0), static_cast<long>(blob.size()));
+        tempIo->write((!blob.empty() ? &blob[0] : nullptr), static_cast<long>(blob.size()));
         io_->close();
         io_->transfer(*tempIo); // may throw
 

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -562,7 +562,7 @@ namespace Exiv2 {
     {
         if (isAllocated_) {
             delete[] pData_;
-            pData_ = 0;
+            pData_ = nullptr;
             size_ = 0;
         }
         isAllocated_ = true;
@@ -606,7 +606,8 @@ namespace Exiv2 {
     CiffComponent* CiffHeader::findComponent(uint16_t crwTagId,
                                              uint16_t crwDir) const
     {
-        if (pRootDir_ == 0) return 0;
+        if (pRootDir_ == nullptr)
+            return nullptr;
         return pRootDir_->findComponent(crwTagId, crwDir);
     } // CiffHeader::findComponent
 
@@ -622,7 +623,7 @@ namespace Exiv2 {
         if (tagId() == crwTagId && dir() == crwDir) {
             return const_cast<CiffComponent*>(this);
         }
-        return 0;
+        return nullptr;
     } // CiffComponent::doFindComponent
 
     CiffComponent* CiffDirectory::doFindComponent(uint16_t crwTagId,
@@ -633,7 +634,7 @@ namespace Exiv2 {
             cc = component->findComponent(crwTagId, crwDir);
             if (cc) return cc;
         }
-        return 0;
+        return nullptr;
     } // CiffDirectory::doFindComponent
 
     void CiffHeader::add(uint16_t crwTagId, uint16_t crwDir, DataBuf buf)
@@ -658,7 +659,7 @@ namespace Exiv2 {
 
     CiffComponent* CiffComponent::doAdd(CrwDirs& /*crwDirs*/, uint16_t /*crwTagId*/)
     {
-        return 0;
+        return nullptr;
     } // CiffComponent::doAdd
 
     CiffComponent* CiffDirectory::doAdd(CrwDirs& crwDirs, uint16_t crwTagId)
@@ -685,7 +686,7 @@ namespace Exiv2 {
                     break;
                 }
             }
-            if (cc_ == 0) {
+            if (cc_ == nullptr) {
                 // Directory doesn't exist yet, add it
                 m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
                 cc_ = m_.get();
@@ -702,7 +703,7 @@ namespace Exiv2 {
                     break;
                 }
             }
-            if (cc_ == 0) {
+            if (cc_ == nullptr) {
                 // Tag doesn't exist yet, add it
                 m_ = UniquePtr(new CiffEntry(crwTagId, tag()));
                 cc_ = m_.get();
@@ -800,7 +801,7 @@ namespace Exiv2 {
                 return &crw;
             }
         }
-        return 0;
+        return nullptr;
     } // CrwMap::crwMapping
 
     void CrwMap::decode0x0805(const CiffComponent& ciffComponent,
@@ -1001,7 +1002,7 @@ namespace Exiv2 {
     void CrwMap::encode(CiffHeader* pHead, const Image& image)
     {
         for (auto&& crw : crwMapping_) {
-            if (crw.fromExif_ != 0) {
+            if (crw.fromExif_ != nullptr) {
                 crw.fromExif_(image, &crw, pHead);
             }
         }

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -416,17 +416,18 @@ namespace Exiv2 {
     // Dataset lookup lists.This is an array with pointers to one list per IIM4 Record.
     // The record id is used as the index into the array.
     constexpr const DataSet* IptcDataSets::records_[] = {
-        0,
+        nullptr,
         envelopeRecord,
         application2Record,
-        0,
+        nullptr,
     };
 
     int IptcDataSets::dataSetIdx(uint16_t number, uint16_t recordId)
     {
         if( recordId != envelope && recordId != application2 ) return -1;
         const DataSet* dataSet = records_[recordId];
-        if (dataSet == 0) return -1;
+        if (dataSet == nullptr)
+            return -1;
         int idx;
         for (idx = 0; dataSet[idx].number_ != number; ++idx) {
             if (dataSet[idx].number_ == 0xffff) return -1;
@@ -438,7 +439,8 @@ namespace Exiv2 {
     {
         if( recordId != envelope && recordId != application2 ) return -1;
         const DataSet* dataSet = records_[recordId];
-        if (dataSet == 0) return -1;
+        if (dataSet == nullptr)
+            return -1;
         int idx;
         for (idx = 0; dataSet[idx].name_ != dataSetName; ++idx) {
             if (dataSet[idx].number_ == 0xffff) return -1;
@@ -546,7 +548,7 @@ namespace Exiv2 {
     void IptcDataSets::dataSetList(std::ostream& os)
     {
         for (auto&& record : records_) {
-            for (int j=0; record != 0 && record[j].number_ != 0xffff; ++j) {
+            for (int j = 0; record != nullptr && record[j].number_ != 0xffff; ++j) {
                 os << record[j] << "\n";
             }
         }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -209,8 +209,10 @@ namespace Exiv2 {
     Exifdatum::Exifdatum(const Exifdatum& rhs)
         : Metadatum(rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
     }
 
     std::ostream& Exifdatum::write(std::ostream& os, const ExifData* pMetadata) const
@@ -224,7 +226,7 @@ namespace Exiv2 {
             fct = ti->printFct_;
             if ( ti->typeId_ == comment ) {
               os << value().toString();
-              fct=NULL;
+              fct = nullptr;
             }
         }
         if ( fct ) fct(os, value(), pMetadata);
@@ -233,7 +235,8 @@ namespace Exiv2 {
 
     const Value& Exifdatum::value() const
     {
-        if (value_.get() == 0) throw Error(kerValueNotSet);
+        if (value_.get() == nullptr)
+            throw Error(kerValueNotSet);
         return *value_;
     }
 
@@ -243,10 +246,12 @@ namespace Exiv2 {
         Metadatum::operator=(rhs);
 
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
 
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
 
         return *this;
     } // Exifdatum::operator=
@@ -301,7 +306,7 @@ namespace Exiv2 {
 
     int Exifdatum::setValue(const std::string& value)
     {
-        if (value_.get() == 0) {
+        if (value_.get() == nullptr) {
             TypeId type = key_->defaultTypeId();
             value_ = Value::create(type);
         }
@@ -310,62 +315,62 @@ namespace Exiv2 {
 
     int Exifdatum::setDataArea(const byte* buf, long len)
     {
-        return value_.get() == 0 ? -1 : value_->setDataArea(buf, len);
+        return value_.get() == nullptr ? -1 : value_->setDataArea(buf, len);
     }
 
     std::string Exifdatum::key() const
     {
-        return key_.get() == 0 ? "" : key_->key();
+        return key_.get() == nullptr ? "" : key_->key();
     }
 
     const char* Exifdatum::familyName() const
     {
-        return key_.get() == 0 ? "" : key_->familyName();
+        return key_.get() == nullptr ? "" : key_->familyName();
     }
 
     std::string Exifdatum::groupName() const
     {
-        return key_.get() == 0 ? "" : key_->groupName();
+        return key_.get() == nullptr ? "" : key_->groupName();
     }
 
     std::string Exifdatum::tagName() const
     {
-        return key_.get() == 0 ? "" : key_->tagName();
+        return key_.get() == nullptr ? "" : key_->tagName();
     }
 
     std::string Exifdatum::tagLabel() const
     {
-        return key_.get() == 0 ? "" : key_->tagLabel();
+        return key_.get() == nullptr ? "" : key_->tagLabel();
     }
 
     uint16_t Exifdatum::tag() const
     {
-        return key_.get() == 0 ? 0xffff : key_->tag();
+        return key_.get() == nullptr ? 0xffff : key_->tag();
     }
 
     int Exifdatum::ifdId() const
     {
-        return key_.get() == 0 ? ifdIdNotSet : key_->ifdId();
+        return key_.get() == nullptr ? ifdIdNotSet : key_->ifdId();
     }
 
     const char* Exifdatum::ifdName() const
     {
-        return key_.get() == 0 ? "" : Internal::ifdName(static_cast<Internal::IfdId>(key_->ifdId()));
+        return key_.get() == nullptr ? "" : Internal::ifdName(static_cast<Internal::IfdId>(key_->ifdId()));
     }
 
     int Exifdatum::idx() const
     {
-        return key_.get() == 0 ? 0 : key_->idx();
+        return key_.get() == nullptr ? 0 : key_->idx();
     }
 
     long Exifdatum::copy(byte* buf, ByteOrder byteOrder) const
     {
-        return value_.get() == 0 ? 0 : value_->copy(buf, byteOrder);
+        return value_.get() == nullptr ? 0 : value_->copy(buf, byteOrder);
     }
 
     TypeId Exifdatum::typeId() const
     {
-        return value_.get() == 0 ? invalidTypeId : value_->typeId();
+        return value_.get() == nullptr ? invalidTypeId : value_->typeId();
     }
 
     const char* Exifdatum::typeName() const
@@ -380,52 +385,52 @@ namespace Exiv2 {
 
     long Exifdatum::count() const
     {
-        return value_.get() == 0 ? 0 : value_->count();
+        return value_.get() == nullptr ? 0 : value_->count();
     }
 
     long Exifdatum::size() const
     {
-        return value_.get() == 0 ? 0 : value_->size();
+        return value_.get() == nullptr ? 0 : value_->size();
     }
 
     std::string Exifdatum::toString() const
     {
-        return value_.get() == 0 ? "" : value_->toString();
+        return value_.get() == nullptr ? "" : value_->toString();
     }
 
     std::string Exifdatum::toString(long n) const
     {
-        return value_.get() == 0 ? "" : value_->toString(n);
+        return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
     long Exifdatum::toLong(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toLong(n);
+        return value_.get() == nullptr ? -1 : value_->toLong(n);
     }
 
     float Exifdatum::toFloat(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toFloat(n);
+        return value_.get() == nullptr ? -1 : value_->toFloat(n);
     }
 
     Rational Exifdatum::toRational(long n) const
     {
-        return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+        return value_.get() == nullptr ? Rational(-1, 1) : value_->toRational(n);
     }
 
     Value::UniquePtr Exifdatum::getValue() const
     {
-        return value_.get() == 0 ? nullptr : value_->clone();
+        return value_.get() == nullptr ? nullptr : value_->clone();
     }
 
     long Exifdatum::sizeDataArea() const
     {
-        return value_.get() == 0 ? 0 : value_->sizeDataArea();
+        return value_.get() == nullptr ? 0 : value_->sizeDataArea();
     }
 
     DataBuf Exifdatum::dataArea() const
     {
-        return value_.get() == 0 ? DataBuf(0, 0) : value_->dataArea();
+        return value_.get() == nullptr ? DataBuf(nullptr, 0) : value_->dataArea();
     }
 
     ExifThumbC::ExifThumbC(const ExifData& exifData)
@@ -436,14 +441,16 @@ namespace Exiv2 {
     DataBuf ExifThumbC::copy() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return DataBuf();
+        if (thumbnail.get() == nullptr)
+            return DataBuf();
         return thumbnail->copy(exifData_);
     }
 
     long ExifThumbC::writeFile(const std::string& path) const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return 0;
+        if (thumbnail.get() == nullptr)
+            return 0;
         std::string name = path + thumbnail->extension();
         DataBuf buf(thumbnail->copy(exifData_));
         if (buf.size_ == 0) return 0;
@@ -465,14 +472,16 @@ namespace Exiv2 {
     const char* ExifThumbC::mimeType() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return "";
+        if (thumbnail.get() == nullptr)
+            return "";
         return thumbnail->mimeType();
     }
 
     const char* ExifThumbC::extension() const
     {
         Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return "";
+        if (thumbnail.get() == nullptr)
+            return "";
         return thumbnail->extension();
     }
 
@@ -724,16 +733,8 @@ namespace Exiv2 {
         // Encode and check if the result fits into a JPEG Exif APP1 segment
         MemIo mio1;
         std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
-        WriteMethod wm = TiffParserWorker::encode(mio1,
-                                                  pData,
-                                                  size,
-                                                  ed,
-                                                  emptyIptc,
-                                                  emptyXmp,
-                                                  Tag::root,
-                                                  TiffMapping::findEncoder,
-                                                  header.get(),
-                                                  0);
+        WriteMethod wm = TiffParserWorker::encode(mio1, pData, size, ed, emptyIptc, emptyXmp, Tag::root,
+                                                  TiffMapping::findEncoder, header.get(), nullptr);
         if (mio1.size() <= 65527) {
             append(blob, mio1.mmap(), static_cast<uint32_t>(mio1.size()));
             return wm;
@@ -827,16 +828,8 @@ namespace Exiv2 {
 
         // Encode the remaining Exif tags again, don't care if it fits this time
         MemIo mio2;
-        wm = TiffParserWorker::encode(mio2,
-                                      pData,
-                                      size,
-                                      ed,
-                                      emptyIptc,
-                                      emptyXmp,
-                                      Tag::root,
-                                      TiffMapping::findEncoder,
-                                      header.get(),
-                                      0);
+        wm = TiffParserWorker::encode(mio2, pData, size, ed, emptyIptc, emptyXmp, Tag::root, TiffMapping::findEncoder,
+                                      header.get(), nullptr);
         append(blob, mio2.mmap(), static_cast<uint32_t>(mio2.size()));
 #ifdef EXIV2_DEBUG_MESSAGES
         if (wm == wmIntrusive) {
@@ -913,7 +906,7 @@ namespace {
         Exiv2::MemIo io;
         Exiv2::IptcData emptyIptc;
         Exiv2::XmpData  emptyXmp;
-        Exiv2::TiffParser::encode(io, 0, 0, Exiv2::littleEndian, thumb, emptyIptc, emptyXmp);
+        Exiv2::TiffParser::encode(io, nullptr, 0, Exiv2::littleEndian, thumb, emptyIptc, emptyXmp);
         return io.read(static_cast<long>(io.size()));
     }
 

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* const argv[])
 
 // *****************************************************************************
 // class Params
-Params* Params::instance_ = 0;
+Params* Params::instance_ = nullptr;
 
 const Params::YodAdjust Params::emptyYodAdjust_[] = {
     { false, "-Y", 0 },
@@ -198,7 +198,7 @@ const Params::YodAdjust Params::emptyYodAdjust_[] = {
 
 Params& Params::instance()
 {
-    if (0 == instance_) {
+    if (nullptr == instance_) {
         instance_ = new Params;
     }
     return *instance_;
@@ -215,7 +215,7 @@ Params::~Params() {
 void Params::cleanup()
 {
     delete instance_;
-    instance_ = 0;
+    instance_ = nullptr;
 }
 
 void Params::version(bool verbose, std::ostream& os)
@@ -472,7 +472,7 @@ int Params::evalGrep( const std::string& optArg)
 
     // there was an error compiling the regexp
     if( errcode ) {
-        size_t length = regerror (errcode, pRegex, NULL, 0);
+        size_t length = regerror(errcode, pRegex, nullptr, 0);
         auto buffer = new char[length];
         regerror (errcode, pRegex, buffer, length);
         std::cerr << progname()
@@ -958,7 +958,7 @@ static int readFileToBuf(FILE* f,Exiv2::DataBuf& buf)
     const int buff_size = 4*1028;
     auto bytes = static_cast<Exiv2::byte*>(::malloc(buff_size));
     int       nBytes    = 0 ;
-    bool      more      = bytes != NULL;
+    bool more = bytes != nullptr;
     while   ( more ) {
         char buff[buff_size];
         int n = static_cast<int>(fread(buff, 1, buff_size, f));
@@ -974,7 +974,8 @@ static int readFileToBuf(FILE* f,Exiv2::DataBuf& buf)
         buf.alloc(nBytes);
         memcpy(buf.pData_, bytes, nBytes);
     }
-    if ( bytes != NULL ) ::free(bytes) ;
+    if (bytes != nullptr)
+        ::free(bytes);
     return nBytes;
 }
 
@@ -996,7 +997,7 @@ void Params::getStdin(Exiv2::DataBuf& buf)
         struct timeval timeout =  {1,0}; // yes: set timeout seconds,microseconds
 
         // if we have something in the pipe, read it
-        if (select(1, &readfds, NULL, NULL, &timeout)) {
+        if (select(1, &readfds, nullptr, nullptr, &timeout)) {
 #endif
 #ifdef DEBUG
             std::cerr << "stdin has data" << std::endl;
@@ -1038,7 +1039,7 @@ using long_t = std::map<std::string, std::string>;
 int Params::getopt(int argc, char* const Argv[])
 {
     auto argv = new char*[argc + 1];
-    argv[argc] = NULL;
+    argv[argc] = nullptr;
     long_t longs;
 
     longs["--adjust"   ] = "-a";
@@ -1170,9 +1171,9 @@ namespace {
         strcpy(cts, ts.c_str());
         char *tmp = ::strtok(cts, ":");
         if (tmp) hstr = tmp;
-        tmp = ::strtok(0, ":");
+        tmp = ::strtok(nullptr, ":");
         if (tmp) mstr = tmp;
-        tmp = ::strtok(0, ":");
+        tmp = ::strtok(nullptr, ":");
         if (tmp) sstr = tmp;
         delete[] cts;
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -330,7 +330,7 @@ namespace Exiv2 {
 #ifdef EXV_HAVE_STRERROR_R
         const size_t n = 1024;
 #ifdef EXV_STRERROR_R_CHAR_P
-        char *buf = 0;
+        char* buf = nullptr;
         char buf2[n];
         std::memset(buf2, 0x0, n);
         buf = strerror_r(error, buf2, n);

--- a/src/getopt.cpp
+++ b/src/getopt.cpp
@@ -121,7 +121,7 @@ namespace Util {
             if (c == -1) {
                 break;
             }
-            errcnt_ += option(c, Util::optarg == 0 ? "" : Util::optarg, Util::optopt);
+            errcnt_ += option(c, Util::optarg == nullptr ? "" : Util::optarg, Util::optopt);
             if (c == '?' ) {
                 break;
             }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -133,7 +133,7 @@ static int forgive(int n,int& err)
     return n ;
 }
 
-static int error(std::string& errors, const char* msg, const char* x = NULL, const char* y = NULL, int z = 0)
+static int error(std::string& errors, const char* msg, const char* x = nullptr, const char* y = nullptr, int z = 0)
 {
     static const size_t buffer_size = 512;
     char buffer[buffer_size];
@@ -250,7 +250,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
     // open the socket
     int sockfd = static_cast<int>(socket(AF_INET , SOCK_STREAM,IPPROTO_TCP));
     if (sockfd < 0)
-        return error(errors, "unable to create socket\n", NULL, NULL, 0);
+        return error(errors, "unable to create socket\n", nullptr, nullptr, 0);
 
     // connect the socket to the server
     int     server  = -1 ;
@@ -392,7 +392,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
                 ,   sleep_
                 ,   status
                 ) ;
-        error(errors,buffer,NULL,NULL,0) ;
+        error(errors, buffer, nullptr, nullptr, 0);
     } else if ( bSearching && OK(status) ) {
         if ( end ) {
         //  we finished OK without finding headers, flush the buffer

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -129,7 +129,7 @@ namespace {
         { ImageType::bmff, newBmffInstance, isBmffType, amRead,      amRead,      amRead,      amNone      },
 #endif // EXV_ENABLE_BMFF
         // End of list marker
-        { ImageType::none, 0,               0,          amNone,      amNone,      amNone,      amNone      }
+        { ImageType::none, nullptr,               nullptr,          amNone,      amNone,      amNone,      amNone      }
     };
 
 }  // namespace
@@ -289,7 +289,7 @@ namespace Exiv2 {
     const char* Image::typeName(uint16_t tag)
     {
         //! List of TIFF image tags
-        const char* result = NULL;
+        const char* result = nullptr;
         switch (tag ) {
             case Exiv2::unsignedByte     : result = "BYTE"      ; break;
             case Exiv2::asciiString      : result = "ASCII"     ; break;
@@ -791,7 +791,7 @@ namespace Exiv2 {
     bool ImageFactory::checkType(int type, BasicIo& io, bool advance)
     {
         const Registry* r = find(registry, type);
-        if (0 != r) {
+        if (nullptr != r) {
             return r->isThisType_(io, advance);
         }
         return false;
@@ -872,7 +872,7 @@ namespace Exiv2 {
     Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
     {
         Image::UniquePtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
-        if (image.get() == 0) throw Error(kerFileContainsUnknownImageType, path);
+        if (image.get() == nullptr) throw Error(kerFileContainsUnknownImageType, path);
         return image;
     }
 
@@ -889,7 +889,7 @@ namespace Exiv2 {
     {
         BasicIo::UniquePtr io(new MemIo(data, size));
         Image::UniquePtr image = open(std::move(io)); // may throw
-        if (image.get() == 0) throw Error(kerMemoryContainsUnknownImageType);
+        if (image.get() == nullptr) throw Error(kerMemoryContainsUnknownImageType);
         return image;
     }
 
@@ -917,7 +917,7 @@ namespace Exiv2 {
         fileIo->close();
         BasicIo::UniquePtr io(std::move(fileIo));
         Image::UniquePtr image = create(type, std::move(io));
-        if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+        if (image.get() == nullptr) throw Error(kerUnsupportedImageType, type);
         return image;
     }
 
@@ -942,7 +942,7 @@ namespace Exiv2 {
     {
         BasicIo::UniquePtr io(new MemIo);
         Image::UniquePtr image = create(type, std::move(io));
-        if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+        if (image.get() == nullptr) throw Error(kerUnsupportedImageType, type);
         return image;
     }
 
@@ -951,7 +951,7 @@ namespace Exiv2 {
     {
         // BasicIo instance does not need to be open
         const Registry* r = find(registry, type);
-        if (0 != r) {
+        if (nullptr != r) {
             return r->newInstance_(std::move(io), true);
         }
         return Image::UniquePtr();

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -132,7 +132,7 @@ int Exiv2::ini_parse_stream(ini_reader reader, void* stream, ini_handler handler
 #endif
 
     /* Scan through stream line by line */
-    while (reader(line, INI_MAX_LINE, stream) != NULL) {
+    while (reader(line, INI_MAX_LINE, stream) != nullptr) {
         lineno++;
 
         start = line;
@@ -177,7 +177,7 @@ int Exiv2::ini_parse_stream(ini_reader reader, void* stream, ini_handler handler
                 name = rstrip(start);
                 value = lskip(end + 1);
 #if INI_ALLOW_INLINE_COMMENTS
-                end = find_chars_or_comment(value, NULL);
+                end = find_chars_or_comment(value, nullptr);
                 if (*end)
                     *end = '\0';
 #endif

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -90,13 +90,15 @@ namespace Exiv2 {
     Iptcdatum::Iptcdatum(const Iptcdatum& rhs)
         : Metadatum(rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
     }
 
     long Iptcdatum::copy(byte* buf, ByteOrder byteOrder) const
     {
-        return value_.get() == 0 ? 0 : value_->copy(buf, byteOrder);
+        return value_.get() == nullptr ? 0 : value_->copy(buf, byteOrder);
     }
 
     std::ostream& Iptcdatum::write(std::ostream& os, const ExifData*) const
@@ -106,47 +108,47 @@ namespace Exiv2 {
 
     std::string Iptcdatum::key() const
     {
-        return key_.get() == 0 ? "" : key_->key();
+        return key_.get() == nullptr ? "" : key_->key();
     }
 
     std::string Iptcdatum::recordName() const
     {
-        return key_.get() == 0 ? "" : key_->recordName();
+        return key_.get() == nullptr ? "" : key_->recordName();
     }
 
     uint16_t Iptcdatum::record() const
     {
-        return key_.get() == 0 ? 0 : key_->record();
+        return key_.get() == nullptr ? 0 : key_->record();
     }
 
     const char* Iptcdatum::familyName() const
     {
-        return key_.get() == 0 ? "" : key_->familyName();
+        return key_.get() == nullptr ? "" : key_->familyName();
     }
 
     std::string Iptcdatum::groupName() const
     {
-        return key_.get() == 0 ? "" : key_->groupName();
+        return key_.get() == nullptr ? "" : key_->groupName();
     }
 
     std::string Iptcdatum::tagName() const
     {
-        return key_.get() == 0 ? "" : key_->tagName();
+        return key_.get() == nullptr ? "" : key_->tagName();
     }
 
     std::string Iptcdatum::tagLabel() const
     {
-        return key_.get() == 0 ? "" : key_->tagLabel();
+        return key_.get() == nullptr ? "" : key_->tagLabel();
     }
 
     uint16_t Iptcdatum::tag() const
     {
-        return key_.get() == 0 ? 0 : key_->tag();
+        return key_.get() == nullptr ? 0 : key_->tag();
     }
 
     TypeId Iptcdatum::typeId() const
     {
-        return value_.get() == 0 ? invalidTypeId : value_->typeId();
+        return value_.get() == nullptr ? invalidTypeId : value_->typeId();
     }
 
     const char* Iptcdatum::typeName() const
@@ -161,47 +163,48 @@ namespace Exiv2 {
 
     long Iptcdatum::count() const
     {
-        return value_.get() == 0 ? 0 : value_->count();
+        return value_.get() == nullptr ? 0 : value_->count();
     }
 
     long Iptcdatum::size() const
     {
-        return value_.get() == 0 ? 0 : value_->size();
+        return value_.get() == nullptr ? 0 : value_->size();
     }
 
     std::string Iptcdatum::toString() const
     {
-        return value_.get() == 0 ? "" : value_->toString();
+        return value_.get() == nullptr ? "" : value_->toString();
     }
 
     std::string Iptcdatum::toString(long n) const
     {
-        return value_.get() == 0 ? "" : value_->toString(n);
+        return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
     long Iptcdatum::toLong(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toLong(n);
+        return value_.get() == nullptr ? -1 : value_->toLong(n);
     }
 
     float Iptcdatum::toFloat(long n) const
     {
-        return value_.get() == 0 ? -1 : value_->toFloat(n);
+        return value_.get() == nullptr ? -1 : value_->toFloat(n);
     }
 
     Rational Iptcdatum::toRational(long n) const
     {
-        return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+        return value_.get() == nullptr ? Rational(-1, 1) : value_->toRational(n);
     }
 
     Value::UniquePtr Iptcdatum::getValue() const
     {
-        return value_.get() == 0 ? nullptr : value_->clone();
+        return value_.get() == nullptr ? nullptr : value_->clone();
     }
 
     const Value& Iptcdatum::value() const
     {
-        if (value_.get() == 0) throw Error(kerValueNotSet);
+        if (value_.get() == nullptr)
+            throw Error(kerValueNotSet);
         return *value_;
     }
 
@@ -211,10 +214,12 @@ namespace Exiv2 {
         Metadatum::operator=(rhs);
 
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
 
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
 
         return *this;
     } // Iptcdatum::operator=
@@ -247,7 +252,7 @@ namespace Exiv2 {
 
     int Iptcdatum::setValue(const std::string& value)
     {
-        if (value_.get() == 0) {
+        if (value_.get() == nullptr) {
             TypeId type = IptcDataSets::dataSetType(tag(), record());
             value_ = Value::create(type);
         }
@@ -411,7 +416,7 @@ namespace Exiv2 {
 
         if (ascii) return "ASCII";
         if (utf8) return "UTF-8";
-        return NULL;
+        return nullptr;
     }
 
     const byte IptcParser::marker_ = 0x1C;          // Dataset marker

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -119,7 +119,7 @@ namespace Exiv2 {
     bool Photoshop::valid(const byte* pPsData,
                           long        sizePsData)
     {
-        const byte *record = 0;
+        const byte* record = nullptr;
         uint32_t sizeIptc = 0;
         uint32_t sizeHdr = 0;
         const byte* pCur = pPsData;
@@ -534,7 +534,7 @@ namespace Exiv2 {
         if (!psBlob.empty()) {
             // Find actual IPTC data within the psBlob
             Blob iptcBlob;
-            const byte *record = 0;
+            const byte* record = nullptr;
             uint32_t sizeIptc = 0;
             uint32_t sizeHdr = 0;
             const byte* pCur = &psBlob[0];
@@ -1100,7 +1100,7 @@ namespace Exiv2 {
                     const byte* pExifData = rawExif.pData_;
                     uint32_t exifSize = rawExif.size_;
                     if (wm == wmIntrusive) {
-                        pExifData = !blob.empty() ? &blob[0] : 0;
+                        pExifData = !blob.empty() ? &blob[0] : nullptr;
                         exifSize = static_cast<uint32_t>(blob.size());
                     }
                     if (exifSize > 0) {
@@ -1192,7 +1192,7 @@ namespace Exiv2 {
                 if (foundCompletePsData || iptcData_.count() > 0) {
                     // Set the new IPTC IRB, keeps existing IRBs but removes the
                     // IPTC block if there is no new IPTC data to write
-                    DataBuf newPsData = Photoshop::setIptcIrb(!psBlob.empty() ? &psBlob[0] : 0,
+                    DataBuf newPsData = Photoshop::setIptcIrb(!psBlob.empty() ? &psBlob[0] : nullptr,
                                                               static_cast<long>(psBlob.size()), iptcData_);
                     const long maxChunkSize = 0xffff - 16;
                     const byte* chunkStart = newPsData.pData_;

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -128,27 +128,27 @@ namespace Exiv2 {
         { "FUJI",           fujiId,      newFujiMn,      newFujiMn2      },
         { "KONICA MINOLTA", minoltaId,   newIfdMn,       newIfdMn2       },
         { "Minolta",        minoltaId,   newIfdMn,       newIfdMn2       },
-        { "NIKON",          ifdIdNotSet, newNikonMn,     0               }, // mnGroup_ is not used
-        { "OLYMPUS",        ifdIdNotSet, newOlympusMn,   0               }, // mnGroup_ is not used
+        { "NIKON",          ifdIdNotSet, newNikonMn,     nullptr               }, // mnGroup_ is not used
+        { "OLYMPUS",        ifdIdNotSet, newOlympusMn,   nullptr               }, // mnGroup_ is not used
         { "Panasonic",      panasonicId, newPanasonicMn, newPanasonicMn2 },
-        { "PENTAX",         ifdIdNotSet, newPentaxMn,    0               }, // mnGroup_ is not used
-        { "RICOH",          ifdIdNotSet, newPentaxMn,    0               }, // mnGroup_ is not used
+        { "PENTAX",         ifdIdNotSet, newPentaxMn,    nullptr               }, // mnGroup_ is not used
+        { "RICOH",          ifdIdNotSet, newPentaxMn,    nullptr               }, // mnGroup_ is not used
         { "SAMSUNG",        samsung2Id,  newSamsungMn,   newSamsungMn2   },
         { "SIGMA",          sigmaId,     newSigmaMn,     newSigmaMn2     },
-        { "SONY",           ifdIdNotSet, newSonyMn,      0               }, // mnGroup_ is not used
-        { "CASIO",          ifdIdNotSet, newCasioMn,     0               }, // mnGroup_ is not used
+        { "SONY",           ifdIdNotSet, newSonyMn,      nullptr               }, // mnGroup_ is not used
+        { "CASIO",          ifdIdNotSet, newCasioMn,     nullptr               }, // mnGroup_ is not used
         // Entries below are only used for lookup by group
-        { "-",              nikon1Id,    0,              newIfdMn2       },
-        { "-",              nikon2Id,    0,              newNikon2Mn2    },
-        { "-",              nikon3Id,    0,              newNikon3Mn2    },
-        { "-",              sony1Id,     0,              newSony1Mn2     },
-        { "-",              sony2Id,     0,              newSony2Mn2     },
-        { "-",              olympusId,   0,              newOlympusMn2   },
-        { "-",              olympus2Id,  0,              newOlympus2Mn2  },
-        { "-",              pentaxId,    0,              newPentaxMn2    },
-        { "-",              pentaxDngId, 0,              newPentaxDngMn2 },
-        { "-",              casioId,     0,              newIfdMn2       },
-        { "-",              casio2Id,    0,              newCasio2Mn2    }
+        { "-",              nikon1Id,    nullptr,              newIfdMn2       },
+        { "-",              nikon2Id,    nullptr,              newNikon2Mn2    },
+        { "-",              nikon3Id,    nullptr,              newNikon3Mn2    },
+        { "-",              sony1Id,     nullptr,              newSony1Mn2     },
+        { "-",              sony2Id,     nullptr,              newSony2Mn2     },
+        { "-",              olympusId,   nullptr,              newOlympusMn2   },
+        { "-",              olympus2Id,  nullptr,              newOlympus2Mn2  },
+        { "-",              pentaxId,    nullptr,              newPentaxMn2    },
+        { "-",              pentaxDngId, nullptr,              newPentaxDngMn2 },
+        { "-",              casioId,     nullptr,              newIfdMn2       },
+        { "-",              casio2Id,    nullptr,              newCasio2Mn2    }
     };
 
     bool TiffMnRegistry::operator==(const std::string& key) const
@@ -171,7 +171,7 @@ namespace Exiv2 {
                                          uint32_t           size,
                                          ByteOrder          byteOrder)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         const TiffMnRegistry* tmr = find(registry_, make);
         if (tmr) {
             assert(tmr->newMnFct_);
@@ -189,11 +189,11 @@ namespace Exiv2 {
                                          IfdId              group,
                                          IfdId              mnGroup)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         const TiffMnRegistry* tmr = find(registry_, mnGroup);
         if (tmr) {
 
-            if (tmr->newMnFct2_ == 0) {
+            if (tmr->newMnFct2_ == nullptr) {
 
                 std::cout << "mnGroup = " << mnGroup << "\n";
 
@@ -616,7 +616,7 @@ namespace Exiv2 {
 
     SamsungMnHeader::SamsungMnHeader()
     {
-        read(0, 0, invalidByteOrder);
+        read(nullptr, 0, invalidByteOrder);
     }
 
     uint32_t SamsungMnHeader::size() const
@@ -793,7 +793,7 @@ namespace Exiv2 {
                             ByteOrder   /*byteOrder*/)
     {
         // Require at least an IFD with 1 entry, but not necessarily a next pointer
-        if (size < 14) return 0;
+        if (size < 14) return nullptr;
         return newIfdMn2(tag, group, mnGroup);
     }
 
@@ -801,7 +801,7 @@ namespace Exiv2 {
                              IfdId    group,
                              IfdId    mnGroup)
     {
-        return new TiffIfdMakernote(tag, group, mnGroup, 0);
+        return new TiffIfdMakernote(tag, group, mnGroup, nullptr);
     }
 
     TiffComponent* newOlympusMn(uint16_t    tag,
@@ -814,11 +814,11 @@ namespace Exiv2 {
         if (size < 10 ||   std::string(reinterpret_cast<const char*>(pData), 10)
                         != std::string("OLYMPUS\0II", 10)) {
             // Require at least the header and an IFD with 1 entry
-            if (size < OlympusMnHeader::sizeOfSignature() + 18) return 0;
+            if (size < OlympusMnHeader::sizeOfSignature() + 18) return nullptr;
             return newOlympusMn2(tag, group, olympusId);
         }
         // Require at least the header and an IFD with 1 entry
-        if (size < Olympus2MnHeader::sizeOfSignature() + 18) return 0;
+        if (size < Olympus2MnHeader::sizeOfSignature() + 18) return nullptr;
         return newOlympus2Mn2(tag, group, olympus2Id);
     }
 
@@ -844,7 +844,7 @@ namespace Exiv2 {
                              ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry
-        if (size < FujiMnHeader::sizeOfSignature() + 18) return 0;
+        if (size < FujiMnHeader::sizeOfSignature() + 18) return nullptr;
         return newFujiMn2(tag, group, mnGroup);
     }
 
@@ -866,7 +866,7 @@ namespace Exiv2 {
         if (size < 6 ||    std::string(reinterpret_cast<const char*>(pData), 6)
                         != std::string("Nikon\0", 6)) {
             // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
+            if (size < 18) return nullptr;
             return newIfdMn2(tag, group, nikon1Id);
         }
         // If the "Nikon" string is not followed by a TIFF header, we assume
@@ -876,12 +876,12 @@ namespace Exiv2 {
             || !tiffHeader.read(pData + 10, size - 10)
             || tiffHeader.tag() != 0x002a) {
             // Require at least the header and an IFD with 1 entry
-            if (size < Nikon2MnHeader::sizeOfSignature() + 18) return 0;
+            if (size < Nikon2MnHeader::sizeOfSignature() + 18) return nullptr;
             return newNikon2Mn2(tag, group, nikon2Id);
         }
         // Else we have a Nikon3 makernote
         // Require at least the header and an IFD with 1 entry
-        if (size < Nikon3MnHeader::sizeOfSignature() + 18) return 0;
+        if (size < Nikon3MnHeader::sizeOfSignature() + 18) return nullptr;
         return newNikon3Mn2(tag, group, nikon3Id);
     }
 
@@ -907,7 +907,7 @@ namespace Exiv2 {
                                   ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry, but without a next pointer
-        if (size < PanasonicMnHeader::sizeOfSignature() + 14) return 0;
+        if (size < PanasonicMnHeader::sizeOfSignature() + 14) return nullptr;
         return newPanasonicMn2(tag, group, mnGroup);
     }
 
@@ -924,16 +924,16 @@ namespace Exiv2 {
         if (size > 8 && std::string(reinterpret_cast<const char*>(pData), 8) == std::string("PENTAX \0", 8)) {
             // Require at least the header and an IFD with 1 entry
             if (size < PentaxDngMnHeader::sizeOfSignature() + 18)
-                return 0;
+                return nullptr;
             return newPentaxDngMn2(tag, group, (tag == 0xc634 ? pentaxDngId:pentaxId));
         }
         if (size > 4 && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
             // Require at least the header and an IFD with 1 entry
             if (size < PentaxMnHeader::sizeOfSignature() + 18)
-                return 0;
+                return nullptr;
             return newPentaxMn2(tag, group, pentaxId);
         }
-        return 0;
+        return nullptr;
     }
 
     TiffComponent* newPentaxMn2(uint16_t tag,
@@ -961,13 +961,13 @@ namespace Exiv2 {
             && std::string(reinterpret_cast<const char*>(pData), 4) == std::string("AOC\0", 4)) {
             // Samsung branded Pentax camera:
             // Require at least the header and an IFD with 1 entry
-            if (size < PentaxMnHeader::sizeOfSignature() + 18) return 0;
+            if (size < PentaxMnHeader::sizeOfSignature() + 18) return nullptr;
             return newPentaxMn2(tag, group, pentaxId);
         }
         // Genuine Samsung camera:
         // Require at least an IFD with 1 entry
         if (size < 18)
-            return 0;
+            return nullptr;
         return newSamsungMn2(tag, group, mnGroup);
     }
 
@@ -986,7 +986,7 @@ namespace Exiv2 {
                               ByteOrder   /*byteOrder*/)
     {
         // Require at least the header and an IFD with 1 entry
-        if (size < SigmaMnHeader::sizeOfSignature() + 18) return 0;
+        if (size < SigmaMnHeader::sizeOfSignature() + 18) return nullptr;
         return newSigmaMn2(tag, group, mnGroup);
     }
 
@@ -1008,11 +1008,11 @@ namespace Exiv2 {
         if (size < 12 ||   std::string(reinterpret_cast<const char*>(pData), 12)
                         != std::string("SONY DSC \0\0\0", 12)) {
             // Require at least an IFD with 1 entry
-            if (size < 18) return 0;
+            if (size < 18) return nullptr;
             return newSony2Mn2(tag, group, sony2Id);
         }
         // Require at least the header and an IFD with 1 entry, but without a next pointer
-        if (size < SonyMnHeader::sizeOfSignature() + 14) return 0;
+        if (size < SonyMnHeader::sizeOfSignature() + 14) return nullptr;
         return newSony1Mn2(tag, group, sony1Id);
     }
 
@@ -1027,7 +1027,7 @@ namespace Exiv2 {
                                IfdId    group,
                                IfdId    mnGroup)
     {
-        return new TiffIfdMakernote(tag, group, mnGroup, 0, true);
+        return new TiffIfdMakernote(tag, group, mnGroup, nullptr, true);
     }
 
     TiffComponent* newCasioMn(uint16_t    tag,
@@ -1042,7 +1042,7 @@ namespace Exiv2 {
             return newCasio2Mn2(tag, group, casio2Id);
         };
         // Require at least an IFD with 1 entry, but not necessarily a next pointer
-        if (size < 14) return 0;
+        if (size < 14) return nullptr;
         return newIfdMn2(tag, group, casioId);
     }
 
@@ -1120,7 +1120,7 @@ namespace Exiv2 {
     {
         if (size < 4) return -1;
         const NikonArrayIdx* aix = find(nikonArrayIdx, NikonArrayIdx::Key(tag, reinterpret_cast<const char*>(pData), size));
-        return aix == 0 ? -1 : aix->idx_;
+        return aix == nullptr ? -1 : aix->idx_;
     }
 
     int nikonAf2Selector(uint16_t tag, const byte* /*pData*/, uint32_t size, TiffComponent* const /*pRoot*/)
@@ -1138,7 +1138,7 @@ namespace Exiv2 {
 
         if (size < 4) return buf;
         const NikonArrayIdx* nci = find(nikonArrayIdx, NikonArrayIdx::Key(tag, reinterpret_cast<const char*>(pData), size));
-        if (nci == 0 || nci->start_ == NA || size <= nci->start_) return buf;
+        if (nci == nullptr || nci->start_ == NA || size <= nci->start_) return buf;
 
         // Find Exif.Nikon3.ShutterCount
         TiffFinder finder(0x00a7, nikon3Id);

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1733,7 +1733,7 @@ namespace Exiv2 {
 
         UShortValue v;
         v.value_.push_back(val);
-        return EXV_PRINT_TAG_BITMASK(nikonAfPointsInFocus)(os, v, 0);
+        return EXV_PRINT_TAG_BITMASK(nikonAfPointsInFocus)(os, v, nullptr);
     }
 
     std::ostream& Nikon3MakerNote::print0x0089(std::ostream& os,
@@ -1758,10 +1758,10 @@ namespace Exiv2 {
             }
         }
         if (d70) {
-            EXV_PRINT_TAG_BITMASK(nikonShootingModeD70)(os, value, 0);
+            EXV_PRINT_TAG_BITMASK(nikonShootingModeD70)(os, value, nullptr);
         }
         else {
-            EXV_PRINT_TAG_BITMASK(nikonShootingMode)(os, value, 0);
+            EXV_PRINT_TAG_BITMASK(nikonShootingMode)(os, value, nullptr);
         }
         return os;
     }
@@ -2579,7 +2579,7 @@ fmountlens[] = {
 // https://github.com/Exiv2/exiv2/issues/1208
 {0xC8,0x54,0x62,0x62,0x0C,0x0C,0x4B,0x46,0x00,0x00,0x00, "Sigma", "321550", "85mm F1.4 DG HSM | A"},
 // Always leave this at the end!
-{0,0,0,0,0,0,0,0,0,0,0, NULL, NULL, NULL}
+{0,0,0,0,0,0,0,0,0,0,0, nullptr, nullptr, nullptr}
 };
 //------------------------------------------------------------------------------
 #endif
@@ -2588,7 +2588,7 @@ fmountlens[] = {
     /* if no meta obj is provided, try to use the value param that *may*
      * be the pre-parsed lensid
      */
-        if (metadata == 0)
+        if (metadata == nullptr)
         {
             const unsigned char vid = static_cast<unsigned>(value.toLong(0));
 
@@ -2608,7 +2608,7 @@ fmountlens[] = {
                 ++pf;
             }
 
-            if (pf->lensname == NULL) {
+            if (pf->lensname == nullptr) {
                 return os << value;
             }
             return os << pf->manuf << " " << pf->lensname;
@@ -2643,7 +2643,7 @@ fmountlens[] = {
         }
         raw[7] = static_cast<byte>(md->toLong());
 
-        for (int i = 0; fmountlens[i].lensname != NULL; ++i) {
+        for (int i = 0; fmountlens[i].lensname != nullptr; ++i) {
             if (   raw[0] == fmountlens[i].lid ) {
                 // #1034
                 const std::string  undefined("undefined") ;

--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1648,7 +1648,7 @@ value, const ExifData* metadata)
 
         bool E3_E30model = false;
 
-        if (metadata != NULL) {
+        if (metadata != nullptr) {
             auto pos = metadata->findKey(ExifKey("Exif.Image.Model"));
             if (pos != metadata->end() && pos->count() != 0) {
                 std::string model = pos->toString();

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -119,7 +119,7 @@ namespace Exiv2 {
         std::cerr << "Writing ORF file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {
@@ -184,16 +184,8 @@ namespace Exiv2 {
         }
 
         std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
-        return TiffParserWorker::encode(io,
-                                        pData,
-                                        size,
-                                        ed,
-                                        iptcData,
-                                        xmpData,
-                                        Tag::root,
-                                        TiffMapping::findEncoder,
-                                        header.get(),
-                                        0);
+        return TiffParserWorker::encode(io, pData, size, ed, iptcData, xmpData, Tag::root, TiffMapping::findEncoder,
+                                        header.get(), nullptr);
     }
 
     // *************************************************************************

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -300,7 +300,7 @@ namespace Exiv2 {
             DataBuf psData = readRawProfile(arr,false);
             if (psData.size_ > 0) {
                 Blob iptcBlob;
-                const byte *record = 0;
+                const byte* record = nullptr;
                 uint32_t sizeIptc = 0;
                 uint32_t sizeHdr = 0;
 

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -630,7 +630,7 @@ namespace Exiv2 {
                 if (iptcData_.count() > 0)
                 {
                     // Update IPTC data to a new PNG chunk
-                    DataBuf newPsData = Photoshop::setIptcIrb(0, 0, iptcData_);
+                    DataBuf newPsData = Photoshop::setIptcIrb(nullptr, 0, iptcData_);
                     if (newPsData.size_ > 0)
                     {
                         std::string rawIptc(reinterpret_cast<const char*>(newPsData.pData_), newPsData.size_);

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -299,51 +299,51 @@ namespace {
 // class member definitions
 
     const Loader::LoaderList Loader::loaderList_[] = {
-        { 0,                       createLoaderNative,       0 },
-        { 0,                       createLoaderNative,       1 },
-        { 0,                       createLoaderNative,       2 },
-        { 0,                       createLoaderNative,       3 },
-        { 0,                       createLoaderExifDataJpeg, 0 },
-        { 0,                       createLoaderExifDataJpeg, 1 },
-        { 0,                       createLoaderExifDataJpeg, 2 },
-        { 0,                       createLoaderExifDataJpeg, 3 },
-        { 0,                       createLoaderExifDataJpeg, 4 },
-        { 0,                       createLoaderExifDataJpeg, 5 },
-        { 0,                       createLoaderExifDataJpeg, 6 },
-        { 0,                       createLoaderExifDataJpeg, 7 },
-        { 0,                       createLoaderExifDataJpeg, 8 },
+        { nullptr,                       createLoaderNative,       0 },
+        { nullptr,                       createLoaderNative,       1 },
+        { nullptr,                       createLoaderNative,       2 },
+        { nullptr,                       createLoaderNative,       3 },
+        { nullptr,                       createLoaderExifDataJpeg, 0 },
+        { nullptr,                       createLoaderExifDataJpeg, 1 },
+        { nullptr,                       createLoaderExifDataJpeg, 2 },
+        { nullptr,                       createLoaderExifDataJpeg, 3 },
+        { nullptr,                       createLoaderExifDataJpeg, 4 },
+        { nullptr,                       createLoaderExifDataJpeg, 5 },
+        { nullptr,                       createLoaderExifDataJpeg, 6 },
+        { nullptr,                       createLoaderExifDataJpeg, 7 },
+        { nullptr,                       createLoaderExifDataJpeg, 8 },
         { "image/x-panasonic-rw2", createLoaderExifDataJpeg, 9 },
-        { 0,                       createLoaderExifDataJpeg,10 },
-        { 0,                       createLoaderExifDataJpeg,11 },
-        { 0,                       createLoaderTiff,         0 },
-        { 0,                       createLoaderTiff,         1 },
-        { 0,                       createLoaderTiff,         2 },
-        { 0,                       createLoaderTiff,         3 },
-        { 0,                       createLoaderTiff,         4 },
-        { 0,                       createLoaderTiff,         5 },
-        { 0,                       createLoaderTiff,         6 },
+        { nullptr,                       createLoaderExifDataJpeg,10 },
+        { nullptr,                       createLoaderExifDataJpeg,11 },
+        { nullptr,                       createLoaderTiff,         0 },
+        { nullptr,                       createLoaderTiff,         1 },
+        { nullptr,                       createLoaderTiff,         2 },
+        { nullptr,                       createLoaderTiff,         3 },
+        { nullptr,                       createLoaderTiff,         4 },
+        { nullptr,                       createLoaderTiff,         5 },
+        { nullptr,                       createLoaderTiff,         6 },
         { "image/x-canon-cr2",     createLoaderTiff,         7 },
-        { 0,                       createLoaderExifJpeg,     0 },
-        { 0,                       createLoaderExifJpeg,     1 },
-        { 0,                       createLoaderExifJpeg,     2 },
-        { 0,                       createLoaderExifJpeg,     3 },
-        { 0,                       createLoaderExifJpeg,     4 },
-        { 0,                       createLoaderExifJpeg,     5 },
-        { 0,                       createLoaderExifJpeg,     6 },
+        { nullptr,                       createLoaderExifJpeg,     0 },
+        { nullptr,                       createLoaderExifJpeg,     1 },
+        { nullptr,                       createLoaderExifJpeg,     2 },
+        { nullptr,                       createLoaderExifJpeg,     3 },
+        { nullptr,                       createLoaderExifJpeg,     4 },
+        { nullptr,                       createLoaderExifJpeg,     5 },
+        { nullptr,                       createLoaderExifJpeg,     6 },
         { "image/x-canon-cr2",     createLoaderExifJpeg,     7 },
-        { 0,                       createLoaderExifJpeg,     8 },
-        { 0,                       createLoaderXmpJpeg,      0 }
+        { nullptr,                       createLoaderExifJpeg,     8 },
+        { nullptr,                       createLoaderXmpJpeg,      0 }
     };
 
     const LoaderExifJpeg::Param LoaderExifJpeg::param_[] = {
-        { "Exif.Image.JPEGInterchangeFormat",     "Exif.Image.JPEGInterchangeFormatLength",     0 }, // 0
-        { "Exif.SubImage1.JPEGInterchangeFormat", "Exif.SubImage1.JPEGInterchangeFormatLength", 0 }, // 1
-        { "Exif.SubImage2.JPEGInterchangeFormat", "Exif.SubImage2.JPEGInterchangeFormatLength", 0 }, // 2
-        { "Exif.SubImage3.JPEGInterchangeFormat", "Exif.SubImage3.JPEGInterchangeFormatLength", 0 }, // 3
-        { "Exif.SubImage4.JPEGInterchangeFormat", "Exif.SubImage4.JPEGInterchangeFormatLength", 0 }, // 4
-        { "Exif.SubThumb1.JPEGInterchangeFormat", "Exif.SubThumb1.JPEGInterchangeFormatLength", 0 }, // 5
-        { "Exif.Image2.JPEGInterchangeFormat",    "Exif.Image2.JPEGInterchangeFormatLength",    0 }, // 6
-        { "Exif.Image.StripOffsets",              "Exif.Image.StripByteCounts",                 0 }, // 7
+        { "Exif.Image.JPEGInterchangeFormat",     "Exif.Image.JPEGInterchangeFormatLength",     nullptr }, // 0
+        { "Exif.SubImage1.JPEGInterchangeFormat", "Exif.SubImage1.JPEGInterchangeFormatLength", nullptr }, // 1
+        { "Exif.SubImage2.JPEGInterchangeFormat", "Exif.SubImage2.JPEGInterchangeFormatLength", nullptr }, // 2
+        { "Exif.SubImage3.JPEGInterchangeFormat", "Exif.SubImage3.JPEGInterchangeFormatLength", nullptr }, // 3
+        { "Exif.SubImage4.JPEGInterchangeFormat", "Exif.SubImage4.JPEGInterchangeFormatLength", nullptr }, // 4
+        { "Exif.SubThumb1.JPEGInterchangeFormat", "Exif.SubThumb1.JPEGInterchangeFormatLength", nullptr }, // 5
+        { "Exif.Image2.JPEGInterchangeFormat",    "Exif.Image2.JPEGInterchangeFormatLength",    nullptr }, // 6
+        { "Exif.Image.StripOffsets",              "Exif.Image.StripByteCounts",                 nullptr }, // 7
         { "Exif.OlympusCs.PreviewImageStart",     "Exif.OlympusCs.PreviewImageLength",          "Exif.MakerNote.Offset"}  // 8
     };
 
@@ -354,12 +354,12 @@ namespace {
         { "Exif.PentaxDng.PreviewOffset",              "Exif.PentaxDng.PreviewLength"                    }, //  3
         { "Exif.Minolta.ThumbnailOffset",              "Exif.Minolta.ThumbnailLength"                    }, //  4
         { "Exif.SonyMinolta.ThumbnailOffset",          "Exif.SonyMinolta.ThumbnailLength"                }, //  5
-        { "Exif.Olympus.ThumbnailImage",               0                                                 }, //  6
-        { "Exif.Olympus2.ThumbnailImage",              0                                                 }, //  7
-        { "Exif.Minolta.Thumbnail",                    0                                                 }, //  8
-        { "Exif.PanasonicRaw.PreviewImage",            0                                                 }, //  9
+        { "Exif.Olympus.ThumbnailImage",               nullptr                                                 }, //  6
+        { "Exif.Olympus2.ThumbnailImage",              nullptr                                                 }, //  7
+        { "Exif.Minolta.Thumbnail",                    nullptr                                                 }, //  8
+        { "Exif.PanasonicRaw.PreviewImage",            nullptr                                                 }, //  9
         { "Exif.SamsungPreview.JPEGInterchangeFormat", "Exif.SamsungPreview.JPEGInterchangeFormatLength" }, // 10
-        { "Exif.Casio2.PreviewImage",                  0                                                 }  // 11
+        { "Exif.Casio2.PreviewImage",                  nullptr                                                 }  // 11
     };
 
     const LoaderTiff::Param LoaderTiff::param_[] = {
@@ -369,8 +369,8 @@ namespace {
         { "SubImage3", "Exif.SubImage3.NewSubfileType", "1" },  // 3
         { "SubImage4", "Exif.SubImage4.NewSubfileType", "1" },  // 4
         { "SubThumb1", "Exif.SubThumb1.NewSubfileType", "1" },  // 5
-        { "Thumbnail", 0,                               0   },  // 6
-        { "Image2",    0,                               0   }   // 7
+        { "Thumbnail", nullptr,                               nullptr   },  // 6
+        { "Image2",    nullptr,                               nullptr   }   // 7
     };
 
     Loader::UniquePtr Loader::create(PreviewId id, const Image &image)
@@ -504,7 +504,7 @@ namespace {
         if (data.size_ == 0) return false;
         try {
             Image::UniquePtr image = ImageFactory::open(data.pData_, data.size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -593,7 +593,7 @@ namespace {
 
         try {
             Image::UniquePtr image = ImageFactory::open(base + offset_, size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -670,7 +670,7 @@ namespace {
 
         try {
             Image::UniquePtr image = ImageFactory::open(buf.pData_, buf.size_);
-            if (image.get() == 0) return false;
+            if (image.get() == nullptr) return false;
             image->readMetadata();
 
             width_ = image->pixelWidth();
@@ -826,7 +826,7 @@ namespace {
         MemIo mio;
         IptcData emptyIptc;
         XmpData  emptyXmp;
-        TiffParser::encode(mio, 0, 0, Exiv2::littleEndian, preview, emptyIptc, emptyXmp);
+        TiffParser::encode(mio, nullptr, 0, Exiv2::littleEndian, preview, emptyIptc, emptyXmp);
         return DataBuf(mio.mmap(), static_cast<long>(mio.size()));
     }
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -137,18 +137,18 @@ namespace Exiv2 {
 
 
         // Structures
-        { "http://ns.adobe.com/xap/1.0/g/",                   "xmpG",    0, N_("Colorant structure")           },
-        { "http://ns.adobe.com/xap/1.0/g/img/",               "xmpGImg", 0, N_("Thumbnail structure")          },
-        { "http://ns.adobe.com/xap/1.0/sType/Dimensions#",    "stDim",   0, N_("Dimensions structure")         },
-        { "http://ns.adobe.com/xap/1.0/sType/Font#",          "stFnt",   0, N_("Font structure")               },
-        { "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#", "stEvt",   0, N_("Resource Event structure")     },
-        { "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",   "stRef",   0, N_("ResourceRef structure")        },
-        { "http://ns.adobe.com/xap/1.0/sType/Version#",       "stVer",   0, N_("Version structure")            },
-        { "http://ns.adobe.com/xap/1.0/sType/Job#",           "stJob",   0, N_("Basic Job/Workflow structure") },
-        { "http://ns.adobe.com/xmp/sType/Area#",              "stArea",  0, N_("Area structure")               },
+        { "http://ns.adobe.com/xap/1.0/g/",                   "xmpG",    nullptr, N_("Colorant structure")           },
+        { "http://ns.adobe.com/xap/1.0/g/img/",               "xmpGImg", nullptr, N_("Thumbnail structure")          },
+        { "http://ns.adobe.com/xap/1.0/sType/Dimensions#",    "stDim",   nullptr, N_("Dimensions structure")         },
+        { "http://ns.adobe.com/xap/1.0/sType/Font#",          "stFnt",   nullptr, N_("Font structure")               },
+        { "http://ns.adobe.com/xap/1.0/sType/ResourceEvent#", "stEvt",   nullptr, N_("Resource Event structure")     },
+        { "http://ns.adobe.com/xap/1.0/sType/ResourceRef#",   "stRef",   nullptr, N_("ResourceRef structure")        },
+        { "http://ns.adobe.com/xap/1.0/sType/Version#",       "stVer",   nullptr, N_("Version structure")            },
+        { "http://ns.adobe.com/xap/1.0/sType/Job#",           "stJob",   nullptr, N_("Basic Job/Workflow structure") },
+        { "http://ns.adobe.com/xmp/sType/Area#",              "stArea",  nullptr, N_("Area structure")               },
 
         // Qualifiers
-        { "http://ns.adobe.com/xmp/Identifier/qual/1.0/", "xmpidq", 0, N_("Qualifier for xmp:Identifier") }
+        { "http://ns.adobe.com/xmp/Identifier/qual/1.0/", "xmpidq", nullptr, N_("Qualifier for xmp:Identifier") }
     };
 
     extern const XmpPropertyInfo xmpDcInfo[] = {
@@ -179,7 +179,7 @@ namespace Exiv2 {
                                                                                                        "a name by which the resource is formally known.")                                      },
         { "type",             N_("Type"),             "bag open Choice", xmpBag,       xmpExternal, N_("A document type; for example, novel, poem, or working paper.")                         },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpDigikamInfo[] = {
@@ -192,7 +192,7 @@ namespace Exiv2 {
         { "PickLabel",              N_("Pick Label"),                "Text",     xmpText, xmpExternal, N_("The pick label assigned to this item. Possible values are \"0\": no label; \"1\": item rejected; \"2\": item in pending validation; \"3\": item accepted.") },
         { "Preview",                N_("JPEG preview"),              "Text",     xmpText, xmpExternal, N_("Reduced size JPEG preview image encoded as base64 for a fast screen rendering.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpKipiInfo[] = {
@@ -202,7 +202,7 @@ namespace Exiv2 {
         { "picasawebGPhotoId",      N_("PicasaWeb Item ID"),         "Text",     xmpText, xmpExternal, N_("Item ID from PicasaWeb web service.") },
         { "yandexGPhotoId",         N_("Yandex Fotki Item ID"),      "Text",     xmpText, xmpExternal, N_("Item ID from Yandex Fotki web service.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpInfo[] = {
@@ -237,7 +237,7 @@ namespace Exiv2 {
         { "Thumbnails",       N_("Thumbnails"),       "alt Thumbnail",            xmpText, xmpInternal, N_("An alternative array of thumbnail images for a file, which can differ in "
                                                                                                              "characteristics such as size or image encoding.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpRightsInfo[] = {
@@ -247,7 +247,7 @@ namespace Exiv2 {
         { "UsageTerms",       N_("Usage Terms"),   "Lang Alt",       langAlt,       xmpExternal, N_("Text instructions on how a resource can be legally used.") },
         { "WebStatement",     N_("Web Statement"), "URL",            xmpText,       xmpExternal, N_("The location of a web page describing the owner and/or rights statement for this resource.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpMMInfo[] = {
@@ -309,7 +309,7 @@ namespace Exiv2 {
                                                                                                         "a rendition.") },
         { "SaveID",           N_("Save ID"),           "Integer",           xmpText,    xmpInternal, N_("Deprecated. Previously used only to support the xmpMM:LastURL property.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpBJInfo[] = {
@@ -318,7 +318,7 @@ namespace Exiv2 {
                                                                                                 "There are multiple values because there can be more than one job using a particular document at any time, and it can "
                                                                                                 "also be useful to keep historical information about what jobs a document was part of previously.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpTPgInfo[] = {
@@ -328,7 +328,7 @@ namespace Exiv2 {
         { "Colorants",        N_("Colorants"),         "seq Colorant", xmpText,    xmpInternal, N_("An ordered array of colorants (swatches) that are used in the document (including any in contained documents).") },
         { "PlateNames",       N_("Plate Names"),       "seq Text",     xmpSeq,     xmpInternal, N_("An ordered array of plate names that are needed to print the document (including any in contained documents).") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpXmpDMInfo[] = {
@@ -418,7 +418,7 @@ namespace Exiv2 {
         { "discNumber",                   N_("Disc Number"),                      "Text",                  xmpText, xmpExternal, N_("If in a multi-disc set, might contain total number of discs. For example: 2/3.") },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftInfo[] = {
@@ -432,14 +432,14 @@ namespace Exiv2 {
         { "LensModel",          N_("Lens Model"),           "Text",     xmpText, xmpExternal, N_("Lens Model.")           },
         { "Rating",             N_("Rating Percent"),       "Text",     xmpText, xmpExternal, N_("Rating Percent.")       },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpLrInfo[] = {
         { "hierarchicalSubject",    N_("Hierarchical Subject"),    "bag Text",  xmpBag,      xmpExternal, N_("Adobe Lightroom hierarchical keywords.")   },
         { "privateRTKInfo",         N_("Private RTK Info"),        "Text",      xmpText,     xmpExternal, N_("Adobe Lightroom private RTK info.")        },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpPdfInfo[] = {
@@ -448,7 +448,7 @@ namespace Exiv2 {
         { "Producer",   N_("Producer"),    "AgentName", xmpText, xmpInternal, N_("The name of the tool that created the PDF document.") },
         { "Trapped",    N_("Trapped"),     "Boolean",   xmpText, xmpExternal, N_("True when the document has been trapped.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpPhotoshopInfo[] = {
@@ -482,7 +482,7 @@ namespace Exiv2 {
         { "SidecarForExtension",    N_("Sidecar F or Extension"),  "Text",       xmpText, xmpExternal, N_("Filename extension of associated image file.") },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP crs:CropUnits
@@ -498,7 +498,7 @@ namespace Exiv2 {
         { "Type",  			N_("Type"),   			"Text",            	xmpText,    xmpExternal, N_("Camera Raw Saved Settings Type.")              },
         { "Parameters", 	N_("Parameters"), 		"Parameters", 		xmpText, 	xmpInternal, N_("*Main structure* Camera Raw Saved Settings Parameters.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpCrsInfo[] = {
@@ -738,7 +738,7 @@ namespace Exiv2 {
         { "Feather",              			N_("Feather"),                  		"Real",                             xmpText, xmpExternal, N_("Not in XMP Specification. Found in sample files.") },
         { "Seed",              				N_("Seed"),                  			"Integer",                          xmpText, xmpExternal, N_("Not in XMP Specification. Found in sample files.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpTiffInfo[] = {
@@ -788,7 +788,7 @@ namespace Exiv2 {
         { "Copyright",                 N_("Copyright"),                  "Lang Alt",                     langAlt, xmpExternal, N_("TIFF tag 33432, 0x8298. Copyright information. "
                                                                                                                                   "Note: This property is stored in XMP as dc:rights.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExifInfo[] = {
@@ -891,7 +891,7 @@ namespace Exiv2 {
         { "GPSAreaInformation",       N_("GPS Area Information"),                "Text",                         xmpText, xmpInternal, N_("GPS tag 28, 0x1C. A character string recording the name of the GPS area.") },
         { "GPSDifferential",          N_("GPS Differential"),                    "Closed Choice of Integer",     xmpText, xmpInternal, N_("GPS tag 30, 0x1E. Indicates whether differential correction is applied to the GPS receiver.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExifEXInfo[] = {
@@ -922,14 +922,14 @@ namespace Exiv2 {
                                                                                                                                  "THM = Indicates a file conforming to DCF thumbnail file stipulated by Design rule for Camera File System. "
                                                                                                                                  "R03 = Indicates a file conforming to DCF Option File stipulated by Design rule for Camera File System.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAuxInfo[] = {
         { "Lens",             N_("Lens"),             "Text",        xmpText,          xmpInternal, N_("A description of the lens used to take the photograph. For example, \"70-200 mm f/2.8-4.0\".") },
         { "SerialNumber",     N_("Serial Number"),     "Text",       xmpText,          xmpInternal, N_("The serial number of the camera or camera body used to take the photograph.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpIptcInfo[] = {
@@ -960,7 +960,7 @@ namespace Exiv2 {
                                                                                                                          "a top-down geographical hierarchy. The code should be taken from ISO 3166 two or three "
                                                                                                                          "letter code. The full name of a country should go to the \"Country\" element.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpIptcExtInfo[] = {
@@ -995,7 +995,7 @@ namespace Exiv2 {
         { "AOSourceInvNo",           N_("Artwork or object-Source inventory number"), "Text",             xmpText, xmpExternal, N_("The inventory number issued by the organisation or body holding and registering the artwork or object in the image.") },
         { "AOTitle",                 N_("Artwork or object-Title"),         "Lang Alt",                   langAlt, xmpExternal, N_("A reference for the artwork or object in the image.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP iptcExt:DigitalSourcefileType
@@ -1095,7 +1095,7 @@ namespace Exiv2 {
         { "Custom9", N_("Custom 9"), "bag Lang Alt", xmpBag, xmpExternal, N_("Optional field for use at Licensee's discretion.") },
         { "Custom10", N_("Custom 10"), "bag Lang Alt", xmpBag, xmpExternal, N_("Optional field for use at Licensee's discretion.") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     //! XMP plus:AdultContentWarning
@@ -1233,7 +1233,7 @@ namespace Exiv2 {
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
         { "CatalogSets", N_("Catalog Sets"), "bag Text", xmpBag,  xmpExternal, N_("Descriptive markers of catalog items by content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpExpressionMediaInfo[] = {
@@ -1242,20 +1242,20 @@ namespace Exiv2 {
         { "People",      N_("People"),      "bag Text", xmpBag,  xmpExternal, N_("Contact")                                         },
         { "CatalogSets", N_("Catalog Sets"), "bag Text", xmpBag,  xmpExternal, N_("Descriptive markers of catalog items by content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoInfo[] = {
         { "RegionInfo", N_("RegionInfo"), "RegionInfo", xmpText, xmpInternal, N_("Microsoft Photo people-tagging metadata root") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfoInfo[] = {
         { "Regions",          N_("Regions"),            "bag Region", xmpBag,  xmpExternal, N_("Contains Regions/person tags") },
         { "DateRegionsValid", N_("Date Regions Valid"), "Date",       xmpText, xmpExternal, N_("Date the last region was created")  },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMicrosoftPhotoRegionInfo[] = {
@@ -1264,7 +1264,7 @@ namespace Exiv2 {
         { "PersonEmailDigest", N_("Person Email Digest"),   "Text", xmpText, xmpExternal, N_("SHA-1 encrypted message hash of the person's Windows Live e-mail address"), },
         { "PersonLiveIdCID",   N_("Person LiveId CID"),     "Text", xmpText, xmpExternal, N_("Signed decimal representation of the person's Windows Live CID")            },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMWGRegionsInfo[] = {
@@ -1279,7 +1279,7 @@ namespace Exiv2 {
         { "BarCodeValue",        N_("Bar Code Value"),        "Text",             xmpText, xmpExternal,        N_("Decoded BarCode value string")                         },
         { "Extensions",          N_("Extensions"),            "Text",             xmpText, xmpInternal,        N_("Any top level XMP property to describe the region content") },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpMWGKeywordInfo[] = {
@@ -1290,7 +1290,7 @@ namespace Exiv2 {
         { "Children",       N_("Children"),     "bag KeywordStruct",    xmpBag,  xmpExternal,   N_("List of children keyword structures")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpGPanoInfo[] = {
@@ -1318,7 +1318,7 @@ namespace Exiv2 {
         { "InitialCameraDolly",             N_("Initial Camera Dolly"),             "Real",                 xmpText, xmpExternal,   N_("This optional parameter moves the virtual camera position along the line of sight, away from the center of the photo sphere. A rear surface position is represented by the value -1.0, while a front surface position is represented by 1.0. For normal viewing, this parameter should be set to 0.")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpVideoInfo[] = {
@@ -1661,7 +1661,7 @@ namespace Exiv2 {
         { "XResolution",            N_("X Resolution"),                     "Rational",                 xmpText, xmpInternal, N_("Horizontal resolution in pixels per unit.") },
         { "Year",                   N_("Year"),                             "Integer",                  xmpText, xmpExternal, N_("Year in which the video was made.")   },
         { "YResolution",            N_("Y Resolution"),                     "Rational",                 xmpText, xmpInternal, N_("Vertical resolution in pixels per unit.") },
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAudioInfo[] = {
@@ -1712,7 +1712,7 @@ namespace Exiv2 {
         { "URL",                N_("Audio URL"),                    "Text",                  xmpText, xmpExternal, N_("A C string that specifies a URL. There may be additional data after the C string.")   },
         { "URN",                N_("Audio URN"),                    "Text",                  xmpText, xmpExternal, N_("A C string that specifies a URN. There may be additional data after the C string.")   },
         { "VendorID",           N_("Vendor ID"),                    "Text",                  xmpText, xmpExternal, N_("A 32-bit integer that specifies the developer of the compressor that generated the compressed data. Often this field contains 'appl' to indicate Apple Computer, Inc.")   },
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpDctermsInfo[] = {
@@ -1730,7 +1730,7 @@ namespace Exiv2 {
                                     N_("*Main structure* containing Darwin Core location based information."),
         },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
    extern const XmpPropertyInfo xmpDwCInfo[] = {
@@ -2365,7 +2365,7 @@ namespace Exiv2 {
                                                 N_("Comments or notes accompanying the MeasurementOrFact.")
             },
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPropertyInfo xmpAcdseeInfo[] = {
@@ -2378,7 +2378,7 @@ namespace Exiv2 {
         { "categories",    N_("Categories"),  "Text",                 xmpText, xmpExternal,   N_("Catalog of hierarchical keywords and groups")   },
 
         // End of list marker
-        { 0, 0, 0, invalidTypeId, xmpInternal, 0 }
+        { nullptr, nullptr, nullptr, invalidTypeId, xmpInternal, nullptr }
     };
 
     extern const XmpPrintInfo xmpPrintInfo[] = {
@@ -2488,7 +2488,7 @@ namespace Exiv2 {
             if (ns.second == prefix)
                 return &(ns.second);
         }
-        return 0;
+        return nullptr;
     }
 
     void XmpProperties::registerNs(const std::string& ns,
@@ -2519,7 +2519,7 @@ namespace Exiv2 {
         c = static_cast<char*>(std::malloc(prefix.size() + 1));
         std::strcpy(c, prefix.c_str());
         xn.prefix_ = c;
-        xn.xmpPropertyInfo_ = 0;
+        xn.xmpPropertyInfo_ = nullptr;
         xn.desc_ = "";
         nsRegistry_[ns2] = xn;
     }
@@ -2572,20 +2572,20 @@ namespace Exiv2 {
     {
         std::lock_guard<std::mutex> scoped_read_lock(mutex_);
         const XmpNsInfo* xn = lookupNsRegistryUnsafe(XmpNsInfo::Prefix(prefix));
-        if (xn != 0) return xn->ns_;
+        if (xn != nullptr) return xn->ns_;
         return nsInfoUnsafe(prefix)->ns_;
     }
 
     const char* XmpProperties::propertyTitle(const XmpKey& key)
     {
         const XmpPropertyInfo* pi = propertyInfo(key);
-        return pi ? pi->title_ : 0;
+        return pi ? pi->title_ : nullptr;
     }
 
     const char* XmpProperties::propertyDesc(const XmpKey& key)
     {
         const XmpPropertyInfo* pi = propertyInfo(key);
-        return pi ? pi->desc_ : 0;
+        return pi ? pi->desc_ : nullptr;
     }
 
     TypeId XmpProperties::propertyType(const XmpKey& key)
@@ -2614,9 +2614,9 @@ namespace Exiv2 {
 #endif
         }
         const XmpPropertyInfo* pl = propertyList(prefix);
-        if (!pl) return 0;
-        const XmpPropertyInfo* pi = 0;
-        for (int j = 0; pl[j].name_ != 0; ++j) {
+        if (!pl) return nullptr;
+        const XmpPropertyInfo* pi = nullptr;
+        for (int j = 0; pl[j].name_ != nullptr; ++j) {
             if (0 == strcmp(pl[j].name_, property.c_str())) {
                 pi = pl + j;
                 break;
@@ -2662,7 +2662,7 @@ namespace Exiv2 {
     {
         const XmpPropertyInfo* pl = propertyList(prefix);
         if (pl) {
-            for (int i = 0; pl[i].name_ != 0; ++i) {
+            for (int i = 0; pl[i].name_ != nullptr; ++i) {
                 os << pl[i];
             }
         }
@@ -2678,7 +2678,7 @@ namespace Exiv2 {
             const XmpPrintInfo* info = find(xmpPrintInfo, key);
             if (info) fct = info->printFct_;
         }
-        return fct(os, value, 0);
+        return fct(os, value, nullptr);
     }
 
     //! @brief Internal Pimpl structure with private members and data of class XmpKey.

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -137,7 +137,7 @@ namespace Exiv2 {
         ExifData exifData;
         PreviewImage preview = loader.getPreviewImage(*list.begin());
         Image::UniquePtr image = ImageFactory::open(preview.pData(), preview.size());
-        if (image.get() == 0) {
+        if (image.get() == nullptr) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to open RW2 preview image.\n";
 #endif

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -122,14 +122,16 @@ namespace Exiv2 {
     const char* ExifTags::sectionName(const ExifKey& key)
     {
         const TagInfo* ti = tagInfo(key.tag(), static_cast<Internal::IfdId>(key.ifdId()));
-        if (ti == 0) return sectionInfo[unknownTag.sectionId_].name_;
+        if (ti == nullptr)
+            return sectionInfo[unknownTag.sectionId_].name_;
         return sectionInfo[ti->sectionId_].name_;
     }
 
     uint16_t ExifTags::defaultCount(const ExifKey& key)
     {
         const TagInfo* ti = tagInfo(key.tag(), static_cast<Internal::IfdId>(key.ifdId()));
-        if (ti == 0) return unknownTag.count_;
+        if (ti == nullptr)
+            return unknownTag.count_;
         return ti->count_;
     }
 
@@ -221,7 +223,7 @@ namespace Exiv2 {
         // DATA
         static constexpr auto familyName_ = "Exif";  //!< "Exif"
 
-        const TagInfo* tagInfo_{0};     //!< Tag info
+        const TagInfo* tagInfo_{nullptr};  //!< Tag info
         uint16_t tag_{0};               //!< Tag value
         IfdId ifdId_{ifdIdNotSet};      //!< The IFD associated with this tag
         int idx_{0};                    //!< Unique id of the Exif key in the image
@@ -231,7 +233,7 @@ namespace Exiv2 {
 
     std::string ExifKey::Impl::tagName() const
     {
-        if (tagInfo_ != 0 && tagInfo_->tag_ != 0xffff) {
+        if (tagInfo_ != nullptr && tagInfo_->tag_ != 0xffff) {
             return tagInfo_->name_;
         }
         std::ostringstream os;
@@ -267,7 +269,8 @@ namespace Exiv2 {
         uint16_t tag = tagNumber(tn, ifdId);
         // Get tag info
         tagInfo_ = tagInfo(tag, ifdId);
-        if (tagInfo_ == 0) throw Error(kerInvalidKey, key);
+        if (tagInfo_ == nullptr)
+            throw Error(kerInvalidKey, key);
 
         tag_ = tag;
         ifdId_ = ifdId;
@@ -295,7 +298,7 @@ namespace Exiv2 {
             throw Error(kerInvalidIfdId, ifdId);
         }
         const TagInfo* ti = tagInfo(tag, ifdId);
-        if (ti == 0) {
+        if (ti == nullptr) {
             throw Error(kerInvalidIfdId, ifdId);
         }
         p_->groupName_ = groupName;
@@ -361,19 +364,22 @@ namespace Exiv2 {
 
     std::string ExifKey::tagLabel() const
     {
-        if (p_->tagInfo_ == 0 || p_->tagInfo_->tag_ == 0xffff) return "";
+        if (p_->tagInfo_ == nullptr || p_->tagInfo_->tag_ == 0xffff)
+            return "";
         return _(p_->tagInfo_->title_);
     }
 
     std::string ExifKey::tagDesc() const
     {
-        if (p_->tagInfo_ == 0 || p_->tagInfo_->tag_ == 0xffff) return "";
+        if (p_->tagInfo_ == nullptr || p_->tagInfo_->tag_ == 0xffff)
+            return "";
         return _(p_->tagInfo_->desc_);
     }
 
     TypeId ExifKey::defaultTypeId() const
     {
-        if (p_->tagInfo_ == 0) return unknownTag.typeId_;
+        if (p_->tagInfo_ == nullptr)
+            return unknownTag.typeId_;
         return p_->tagInfo_->typeId_;
     }
 

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -59,7 +59,7 @@ namespace Exiv2 {
 
     //! List of all known Exif groups. Important: Group name (3rd column) must be unique!
     constexpr GroupInfo groupInfo[] = {
-        { ifdIdNotSet,     "Unknown IFD", "Unknown", 0 },
+        { ifdIdNotSet,     "Unknown IFD", "Unknown", nullptr },
         { ifd0Id,          "IFD0",      "Image",        ifdTagList                     },
         { ifd1Id,          "IFD1",      "Thumbnail",    ifdTagList                     },
         { ifd2Id,          "IFD2",      "Image2",       ifdTagList                     },
@@ -168,7 +168,7 @@ namespace Exiv2 {
         { sony2Cs2Id,      "Makernote", "Sony2Cs2",     SonyMakerNote::tagListCs2      },
         { sony2FpId,       "Makernote", "Sony2Fp",      SonyMakerNote::tagListFp       },
         { sony2010eId,     "Makernote", "Sony2010e",    SonyMakerNote::tagList2010e    },
-        { lastId,          "(Last IFD info)", "(Last IFD item)", 0 }
+        { lastId,          "(Last IFD info)", "(Last IFD item)", nullptr }
     };
 
     //! Units for measuring X and Y resolution, tags 0x0128, 0xa210
@@ -2446,7 +2446,7 @@ namespace Exiv2 {
     {
         bool rc = false;
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii != 0 && 0 == strcmp(ii->ifdName_, "Makernote")) {
+        if (ii != nullptr && 0 == strcmp(ii->ifdName_, "Makernote")) {
             rc = true;
         }
         return rc;
@@ -2483,7 +2483,7 @@ namespace Exiv2 {
     void taglist(std::ostream& os, IfdId ifdId)
     {
         const TagInfo* ti = Internal::tagList(ifdId);
-        if (ti != 0) {
+        if (ti != nullptr) {
             for (int k = 0; ti[k].tag_ != 0xffff; ++k) {
                 os << ti[k] << "\n";
             }
@@ -2493,14 +2493,14 @@ namespace Exiv2 {
     const TagInfo* tagList(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0 || ii->tagList_ == 0) return 0;
+        if (ii == nullptr || ii->tagList_ == nullptr) return nullptr;
         return ii->tagList_();
     } // tagList
 
     const TagInfo* tagInfo(uint16_t tag, IfdId ifdId)
     {
         const TagInfo* ti = tagList(ifdId);
-        if (ti == 0) return 0;
+        if (ti == nullptr) return nullptr;
         int idx = 0;
         for (idx = 0; ti[idx].tag_ != 0xffff; ++idx) {
             if (ti[idx].tag_ == tag) break;
@@ -2511,36 +2511,36 @@ namespace Exiv2 {
     const TagInfo* tagInfo(const std::string& tagName, IfdId ifdId)
     {
         const TagInfo* ti = tagList(ifdId);
-        if (ti == 0) return 0;
+        if (ti == nullptr) return nullptr;
         const char* tn = tagName.c_str();
-        if (tn == 0) return 0;
+        if (tn == nullptr) return nullptr;
         for (int idx = 0; ti[idx].tag_ != 0xffff; ++idx) {
             if (0 == strcmp(ti[idx].name_, tn)) {
                 return &ti[idx];
             }
         }
-        return 0;
+        return nullptr;
     } // tagInfo
 
     IfdId groupId(const std::string& groupName)
     {
         IfdId ifdId = ifdIdNotSet;
         const GroupInfo* ii = find(groupInfo, GroupInfo::GroupName(groupName));
-        if (ii != 0) ifdId = static_cast<IfdId>(ii->ifdId_);
+        if (ii != nullptr) ifdId = static_cast<IfdId>(ii->ifdId_);
         return ifdId;
     }
 
     const char* ifdName(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0) return groupInfo[0].ifdName_;
+        if (ii == nullptr) return groupInfo[0].ifdName_;
         return ii->ifdName_;
     }
 
     const char* groupName(IfdId ifdId)
     {
         const GroupInfo* ii = find(groupInfo, ifdId);
-        if (ii == 0) return groupInfo[0].groupName_;
+        if (ii == nullptr) return groupInfo[0].groupName_;
         return ii->groupName_;
     }
 
@@ -2596,7 +2596,7 @@ namespace Exiv2 {
     uint16_t tagNumber(const std::string& tagName, IfdId ifdId)
     {
         const TagInfo* ti = tagInfo(tagName, ifdId);
-        if (ti != 0 && ti->tag_ != 0xffff) return ti->tag_;
+        if (ti != nullptr && ti->tag_ != 0xffff) return ti->tag_;
         if (!isHex(tagName, 4, "0x")) throw Error(kerInvalidTag, tagName, ifdId);
         std::istringstream is(tagName);
         uint16_t tag;
@@ -3246,8 +3246,8 @@ namespace Exiv2 {
     const TagInfo* tagList(const std::string& groupName)
     {
         const GroupInfo* ii = find(groupInfo, GroupInfo::GroupName(groupName));
-        if (ii == 0 || ii->tagList_ == 0) {
-            return 0;
+        if (ii == nullptr || ii->tagList_ == nullptr) {
+            return nullptr;
         }
         return ii->tagList_();
     }

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -59,7 +59,8 @@ namespace Exiv2 {
     IoWrapper::IoWrapper(BasicIo& io, const byte* pHeader, long size, OffsetWriter* pow)
         : io_(io), pHeader_(pHeader), size_(size), wroteHeader_(false), pow_(pow)
     {
-        if (pHeader_ == 0 || size_ == 0) wroteHeader_ = true;
+        if (pHeader_ == nullptr || size_ == 0)
+            wroteHeader_ = true;
     }
 
     long IoWrapper::write(const byte* pData, long wcount)
@@ -85,16 +86,20 @@ namespace Exiv2 {
         if (pow_) pow_->setTarget(OffsetWriter::OffsetId(id), target);
     }
 
-    TiffComponent::TiffComponent(uint16_t tag, IfdId group)
-        : tag_(tag), group_(group), pStart_(0)
+    TiffComponent::TiffComponent(uint16_t tag, IfdId group) : tag_(tag), group_(group), pStart_(nullptr)
     {
     }
 
     TiffEntryBase::TiffEntryBase(uint16_t tag, IfdId group, TiffType tiffType)
         : TiffComponent(tag, group),
-          tiffType_(tiffType), count_(0), offset_(0),
-          size_(0), pData_(0), isMalloced_(false), idx_(0),
-          pValue_(0)
+          tiffType_(tiffType),
+          count_(0),
+          offset_(0),
+          size_(0),
+          pData_(nullptr),
+          isMalloced_(false),
+          idx_(0),
+          pValue_(nullptr)
     {
     }
 
@@ -104,7 +109,7 @@ namespace Exiv2 {
     }
 
     TiffMnEntry::TiffMnEntry(uint16_t tag, IfdId group, IfdId mnGroup)
-        : TiffEntryBase(tag, group, ttUndefined), mnGroup_(mnGroup), mn_(0)
+        : TiffEntryBase(tag, group, ttUndefined), mnGroup_(mnGroup), mn_(nullptr)
     {
     }
 
@@ -121,41 +126,35 @@ namespace Exiv2 {
     {
     }
 
-    TiffBinaryArray::TiffBinaryArray(uint16_t tag,
-                                     IfdId group,
-                                     const ArrayCfg* arrayCfg,
-                                     const ArrayDef* arrayDef,
+    TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArrayCfg* arrayCfg, const ArrayDef* arrayDef,
                                      int defSize)
         : TiffEntryBase(tag, group, arrayCfg->elTiffType_),
-          cfgSelFct_(0),
-          arraySet_(0),
+          cfgSelFct_(nullptr),
+          arraySet_(nullptr),
           arrayCfg_(arrayCfg),
           arrayDef_(arrayDef),
           defSize_(defSize),
           setSize_(0),
-          origData_(0),
+          origData_(nullptr),
           origSize_(0),
-          pRoot_(0),
+          pRoot_(nullptr),
           decoded_(false)
     {
         assert(arrayCfg != 0);
     }
 
-    TiffBinaryArray::TiffBinaryArray(uint16_t tag,
-                                     IfdId group,
-                                     const ArraySet* arraySet,
-                                     int setSize,
+    TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arraySet, int setSize,
                                      CfgSelFct cfgSelFct)
-        : TiffEntryBase(tag, group), // Todo: Does it make a difference that there is no type?
+        : TiffEntryBase(tag, group),  // Todo: Does it make a difference that there is no type?
           cfgSelFct_(cfgSelFct),
           arraySet_(arraySet),
-          arrayCfg_(0),
-          arrayDef_(0),
+          arrayCfg_(nullptr),
+          arrayDef_(nullptr),
           defSize_(0),
           setSize_(setSize),
-          origData_(0),
+          origData_(nullptr),
           origSize_(0),
-          pRoot_(0),
+          pRoot_(nullptr),
           decoded_(false)
     {
         // We'll figure out the correct cfg later
@@ -221,7 +220,7 @@ namespace Exiv2 {
           pData_(rhs.pData_),
           isMalloced_(rhs.isMalloced_),
           idx_(rhs.idx_),
-          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : 0)
+          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : nullptr)
     {
         if (rhs.isMalloced_) {
             pData_ = new byte[rhs.size_];
@@ -229,10 +228,7 @@ namespace Exiv2 {
         }
     }
 
-    TiffDirectory::TiffDirectory(const TiffDirectory& rhs)
-        : TiffComponent(rhs),
-          hasNext_(rhs.hasNext_),
-          pNext_(0)
+    TiffDirectory::TiffDirectory(const TiffDirectory& rhs) : TiffComponent(rhs), hasNext_(rhs.hasNext_), pNext_(nullptr)
     {
     }
 
@@ -295,13 +291,13 @@ namespace Exiv2 {
     TiffMnEntry* TiffMnEntry::doClone() const
     {
         assert(false); // Not implemented
-        return 0;
+        return nullptr;
     }
 
     TiffIfdMakernote* TiffIfdMakernote::doClone() const
     {
         assert(false); // Not implemented
-        return 0;
+        return nullptr;
     }
 
     TiffBinaryArray* TiffBinaryArray::doClone() const
@@ -338,17 +334,19 @@ namespace Exiv2 {
         }
         pData_ = pData;
         size_  = size;
-        if (pData_ == 0) size_ = 0;
+        if (pData_ == nullptr)
+            size_ = 0;
     }
 
     void TiffEntryBase::updateValue(Value::UniquePtr value, ByteOrder byteOrder)
     {
-        if (value.get() == 0) return;
+        if (value.get() == nullptr)
+            return;
         uint32_t newSize = value->size();
         if (newSize > size_) {
             setData(DataBuf(newSize));
         }
-        if (pData_ != NULL) {
+        if (pData_ != nullptr) {
             memset(pData_, 0x0, size_);
         }
         size_ = value->copy(pData_, byteOrder);
@@ -358,7 +356,8 @@ namespace Exiv2 {
 
     void TiffEntryBase::setValue(Value::UniquePtr value)
     {
-        if (value.get() == 0) return;
+        if (value.get() == nullptr)
+            return;
         tiffType_ = toTiffType(value->typeId());
         count_ = value->count();
         delete pValue_;
@@ -537,7 +536,8 @@ namespace Exiv2 {
 
     bool TiffBinaryArray::initialize(IfdId group)
     {
-        if (arrayCfg_ != 0) return true; // Not a complex array or already initialized
+        if (arrayCfg_ != nullptr)
+            return true;  // Not a complex array or already initialized
 
         for (int idx = 0; idx < setSize_; ++idx) {
             if (arraySet_[idx].cfg_.group_ == group) {
@@ -552,7 +552,8 @@ namespace Exiv2 {
 
     bool TiffBinaryArray::initialize(TiffComponent* const pRoot)
     {
-        if (cfgSelFct_ == 0) return true; // Not a complex array
+        if (cfgSelFct_ == nullptr)
+            return true;  // Not a complex array
 
         int idx = cfgSelFct_(tag(), pData(), TiffEntryBase::doSize(), pRoot);
         if (idx > -1) {
@@ -621,7 +622,7 @@ namespace Exiv2 {
         tiffPath.pop();
         const TiffPathItem tpi = tiffPath.top();
 
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         // Try to use an existing component if there is still at least one
         // composite tag on the stack or the tag to add is the MakerNote tag.
         // This is used to prevent duplicate entries. Sub-IFDs also, but the > 1
@@ -640,19 +641,19 @@ namespace Exiv2 {
                 }
             }
         }
-        if (tc == 0) {
+        if (tc == nullptr) {
             TiffComponent::UniquePtr atc;
-            if (tiffPath.size() == 1 && object.get() != 0) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
-            }
-            else {
+            } else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
             assert(atc.get() != 0);
 
             // Prevent dangling sub-IFD tags: Do not add a sub-IFD component without children.
             // Todo: How to check before creating the component?
-            if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != 0) return 0;
+            if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != nullptr)
+                return nullptr;
 
             if (tpi.extendedTag() == Tag::next) {
                 tc = this->addNext(std::move(atc));
@@ -679,18 +680,17 @@ namespace Exiv2 {
         }
         const TiffPathItem tpi2 = tiffPath.top();
         tiffPath.push(tpi1);
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         for (auto&& ifd : ifds_) {
             if (ifd->group() == tpi2.group()) {
                 tc = ifd;
                 break;
             }
         }
-        if (tc == 0) {
-            if (tiffPath.size() == 1 && object.get() != 0) {
+        if (tc == nullptr) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 tc = addChild(std::move(object));
-            }
-            else {
+            } else {
                 TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
                 tc = addChild(std::move(atc));
             }
@@ -713,7 +713,7 @@ namespace Exiv2 {
         }
         const TiffPathItem tpi2 = tiffPath.top();
         tiffPath.push(tpi1);
-        if (mn_ == 0) {
+        if (mn_ == nullptr) {
             mnGroup_ = tpi2.group();
             mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
             assert(mn_);
@@ -743,7 +743,7 @@ namespace Exiv2 {
         const TiffPathItem tpi = tiffPath.top();
         // Initialize the binary array (if it is a complex array)
         initialize(tpi.group());
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         // Todo: Duplicates are not allowed!
         // To allow duplicate entries, we only check if the new component already
         // exists if there is still at least one composite tag on the stack
@@ -755,12 +755,11 @@ namespace Exiv2 {
                 }
             }
         }
-        if (tc == 0) {
+        if (tc == nullptr) {
             TiffComponent::UniquePtr atc;
-            if (tiffPath.size() == 1 && object.get() != 0) {
+            if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
-            }
-            else {
+            } else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
             assert(atc.get() != 0);
@@ -778,7 +777,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/)
     {
-        return 0;
+        return nullptr;
     } // TiffComponent::doAddChild
 
     TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent)
@@ -798,7 +797,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddChild(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc =  mn_->addChild(std::move(tiffComponent));
         }
@@ -825,12 +824,12 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
     {
-        return 0;
+        return nullptr;
     } // TiffComponent::doAddNext
 
     TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (hasNext_) {
             tc = tiffComponent.release();
             pNext_ = tc;
@@ -840,7 +839,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffMnEntry::doAddNext(TiffComponent::UniquePtr tiffComponent)
     {
-        TiffComponent* tc = 0;
+        TiffComponent* tc = nullptr;
         if (mn_) {
             tc = mn_->addNext(std::move(tiffComponent));
         }
@@ -906,7 +905,7 @@ namespace Exiv2 {
         if (mn_) mn_->accept(visitor);
         if (!visitor.go(TiffVisitor::geKnownMakernote)) {
             delete mn_;
-            mn_ = 0;
+            mn_ = nullptr;
         }
 
     } // TiffMnEntry::doAccept
@@ -1013,7 +1012,8 @@ namespace Exiv2 {
 
     uint32_t TiffBinaryArray::doCount() const
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doCount();
+        if (cfg() == nullptr || !decoded())
+            return TiffEntryBase::doCount();
 
         if (elements_.empty()) return 0;
 
@@ -1359,18 +1359,14 @@ namespace Exiv2 {
                                       uint32_t  dataIdx,
                                       uint32_t& imageIdx)
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doWrite(ioWrapper,
-                                                                    byteOrder,
-                                                                    offset,
-                                                                    valueIdx,
-                                                                    dataIdx,
-                                                                    imageIdx);
+        if (cfg() == nullptr || !decoded())
+            return TiffEntryBase::doWrite(ioWrapper, byteOrder, offset, valueIdx, dataIdx, imageIdx);
         if (cfg()->byteOrder_ != invalidByteOrder) byteOrder = cfg()->byteOrder_;
         // Tags must be sorted in ascending order
         std::sort(elements_.begin(), elements_.end(), cmpTagLt);
         uint32_t idx = 0;
         MemIo mio; // memory stream in which to store data
-        IoWrapper mioWrapper(mio, 0, 0, 0);
+        IoWrapper mioWrapper(mio, nullptr, 0, nullptr);
         // Some array entries need to have the size in the first element
         if (cfg()->hasSize_) {
             byte buf[4];
@@ -1533,7 +1529,7 @@ namespace Exiv2 {
                                          ByteOrder byteOrder) const
     {
         uint32_t len = 0;
-        TiffComponent* pSubIfd = 0;
+        TiffComponent* pSubIfd = nullptr;
         for (auto&& component : components_) {
             if (component->tag() == 0x014a) {
                 // Hack: delay writing of sub-IFD image data to get the order correct
@@ -1681,7 +1677,8 @@ namespace Exiv2 {
 
     uint32_t TiffBinaryArray::doSize() const
     {
-        if (cfg() == 0 || !decoded()) return TiffEntryBase::doSize();
+        if (cfg() == nullptr || !decoded())
+            return TiffEntryBase::doSize();
 
         if (elements_.empty()) return 0;
 
@@ -1810,13 +1807,12 @@ namespace Exiv2 {
 
     static const TagInfo* findTagInfo(uint16_t tag,IfdId group)
     {
-        const TagInfo* result = NULL ;
-        const TagInfo* tags   = group == exifId ? Internal::exifTagList()
-                              : group == gpsId  ? Internal::gpsTagList()
-                              : NULL
-                              ;
+        const TagInfo* result = nullptr;
+        const TagInfo* tags = group == exifId  ? Internal::exifTagList()
+                              : group == gpsId ? Internal::gpsTagList()
+                                               : nullptr;
         if ( tags ) {
-            for ( size_t idx = 0; result==NULL && tags[idx].tag_ != 0xffff; ++idx) {
+            for (size_t idx = 0; result == nullptr && tags[idx].tag_ != 0xffff; ++idx) {
                 if ( tags[idx].tag_ == tag ) {
                       result = tags+idx;
                 }
@@ -1831,7 +1827,7 @@ namespace Exiv2 {
     {
         auto ti = TypeId(tiffType);
         // On the fly type conversion for Exif.Photo.UserComment, Exif.GPSProcessingMethod, GPSAreaInformation
-        if ( const TagInfo* pTag = ti == undefined ? findTagInfo(tag,group) : NULL ) {
+        if (const TagInfo* pTag = ti == undefined ? findTagInfo(tag, group) : nullptr) {
             if ( pTag->typeId_ == comment ) {
                 ti = comment;
             }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -205,7 +205,7 @@ namespace Exiv2 {
         std::cerr << "Writing TIFF file " << io_->path() << "\n";
 #endif
         ByteOrder bo = byteOrder();
-        byte* pData = 0;
+        byte* pData = nullptr;
         long size = 0;
         IoCloser closer(*io_);
         if (io_->open() == 0) {
@@ -294,16 +294,8 @@ namespace Exiv2 {
         }
 
         std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
-        return TiffParserWorker::encode(io,
-                                        pData,
-                                        size,
-                                        ed,
-                                        iptcData,
-                                        xmpData,
-                                        Tag::root,
-                                        TiffMapping::findEncoder,
-                                        header.get(),
-                                        0);
+        return TiffParserWorker::encode(io, pData, size, ed, iptcData, xmpData, Tag::root, TiffMapping::findEncoder,
+                                        header.get(), nullptr);
     } // TiffParser::encode
 
     // *************************************************************************

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -115,7 +115,7 @@ namespace Exiv2 {
     {
         tag_ = tag;
         group_ = group;
-        tiffComponent_ = 0;
+        tiffComponent_ = nullptr;
         setGo(geTraverse, true);
     }
 
@@ -370,7 +370,7 @@ namespace Exiv2 {
         // add Exif tag anyway
         decodeStdTiffEntry(object);
 
-        byte const* pData = 0;
+        byte const* pData = nullptr;
         long size = 0;
         getObjData(pData, size, 0x02bc, ifd0Id, object);
         if (pData) {
@@ -404,7 +404,7 @@ namespace Exiv2 {
         }
         decodedIptc_ = true;
         // 1st choice: IPTCNAA
-        byte const* pData = 0;
+        byte const* pData = nullptr;
         long size = 0;
         getObjData(pData, size, 0x83bb, ifd0Id, object);
         if (pData) {
@@ -420,11 +420,11 @@ namespace Exiv2 {
 
         // 2nd choice if no IPTCNAA record found or failed to decode it:
         // ImageResources
-        pData = 0;
+        pData = nullptr;
         size = 0;
         getObjData(pData, size, 0x8649, ifd0Id, object);
         if (pData) {
-            byte const* record = 0;
+            byte const* record = nullptr;
             uint32_t sizeHdr = 0;
             uint32_t sizeData = 0;
             if (0 != Photoshop::locateIptcIrb(pData, size,
@@ -445,7 +445,7 @@ namespace Exiv2 {
     static const TagInfo* findTag(const TagInfo* pList,uint16_t tag)
     {
         while ( pList->tag_ != 0xffff && pList->tag_ != tag ) pList++;
-        return  pList->tag_ != 0xffff  ? pList : NULL;
+        return pList->tag_ != 0xffff ? pList : nullptr;
     }
 
     void TiffDecoder::decodeCanonAFInfo(const TiffEntryBase* object) {
@@ -545,7 +545,7 @@ namespace Exiv2 {
 
     void TiffDecoder::visitBinaryArray(TiffBinaryArray* object)
     {
-        if (object->cfg() == 0 || !object->decoded()) {
+        if (object->cfg() == nullptr || !object->decoded()) {
             decodeTiffEntry(object);
         }
     }
@@ -566,7 +566,7 @@ namespace Exiv2 {
           pRoot_(pRoot),
           isNewImage_(isNewImage),
           pPrimaryGroups_(pPrimaryGroups),
-          pSourceTree_(0),
+          pSourceTree_(nullptr),
           findEncoderFct_(findEncoderFct),
           dirty_(false),
           writeMethod_(wmNonIntrusive)
@@ -807,7 +807,7 @@ namespace Exiv2 {
 
     void TiffEncoder::visitBinaryArray(TiffBinaryArray* object)
     {
-        if (object->cfg() == 0 || !object->decoded()) {
+        if (object->cfg() == nullptr || !object->decoded()) {
             encodeTiffComponent(object);
         }
     }
@@ -816,7 +816,8 @@ namespace Exiv2 {
     {
         assert(object != 0);
 
-        if (object->cfg() == 0 || !object->decoded()) return;
+        if (object->cfg() == nullptr || !object->decoded())
+            return;
         int32_t size = object->TiffEntryBase::doSize();
         if (size == 0) return;
         if (!object->initialize(pRoot_)) return;
@@ -826,7 +827,7 @@ namespace Exiv2 {
         if ( cryptFct == sonyTagDecipher ) {
              cryptFct  = sonyTagEncipher;
         }
-        if (cryptFct != 0) {
+        if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
             if (buf.size_ > 0) {
@@ -862,7 +863,7 @@ namespace Exiv2 {
 
         auto pos = exifData_.end();
         const Exifdatum* ed = datum;
-        if (ed == 0) {
+        if (ed == nullptr) {
             // Non-intrusive writing: find matching tag
             ExifKey key(object->tag(), groupName(object->group()));
             pos = exifData_.findKey(key);
@@ -885,8 +886,7 @@ namespace Exiv2 {
                 std::cerr << "DELETING          " << key << ", idx = " << object->idx() << "\n";
 #endif
             }
-        }
-        else {
+        } else {
             // For intrusive writing, the index is used to preserve the order of
             // duplicate tags
             object->idx_ = ed->idx();
@@ -982,7 +982,7 @@ namespace Exiv2 {
             // Set pseudo strips (without a data pointer) from the size tag
             ExifKey key(object->szTag(), groupName(object->szGroup()));
             auto pos = exifData_.findKey(key);
-            const byte* zero = 0;
+            const byte* zero = nullptr;
             if (pos == exifData_.end()) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_ERROR << "Size tag " << key
@@ -1146,7 +1146,7 @@ namespace Exiv2 {
                           << std::hex << i->tag() << "\n";
             }
 #endif
-            if (object != 0) {
+            if (object != nullptr) {
                 encodeTiffComponent(object, &(*i));
             }
         }
@@ -1199,7 +1199,7 @@ namespace Exiv2 {
 
     void TiffReader::setMnState(const TiffRwState* state)
     {
-        if (state != 0) {
+        if (state != nullptr) {
             // invalidByteOrder indicates 'no change'
             if (state->byteOrder() == invalidByteOrder) {
                 mnState_ = TiffRwState(origState_.byteOrder(), state->baseOffset());
@@ -1353,7 +1353,7 @@ namespace Exiv2 {
             if (next) {
                 tc = TiffCreator::create(Tag::next, object->group());
 #ifndef SUPPRESS_WARNINGS
-                if (tc.get() == 0) {
+                if (tc.get() == nullptr) {
                     EXV_WARNING << "Directory " << groupName(object->group())
                                 << " has an unexpected next pointer; ignored.\n";
                 }
@@ -1590,7 +1590,7 @@ namespace Exiv2 {
             }
         }
         Value::UniquePtr v = Value::create(typeId);
-        enforce(v.get() != NULL, kerCorruptedMetadata);
+        enforce(v.get() != nullptr, kerCorruptedMetadata);
         if ( !isize ) {
             v->read(pData, size, byteOrder());
         } else {
@@ -1641,10 +1641,11 @@ namespace Exiv2 {
         if (object->TiffEntryBase::doSize() == 0) return;
         if (!object->initialize(pRoot_)) return;
         const ArrayCfg* cfg = object->cfg();
-        if (cfg == 0) return;
+        if (cfg == nullptr)
+            return;
 
         const CryptFct cryptFct = cfg->cryptFct_;
-        if (cryptFct != 0) {
+        if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             int32_t size = object->TiffEntryBase::doSize();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
@@ -1698,7 +1699,7 @@ namespace Exiv2 {
         if (bo == invalidByteOrder) bo = byteOrder();
         TypeId typeId = toTypeId(object->elDef()->tiffType_, object->tag(), object->group());
         Value::UniquePtr v = Value::create(typeId);
-        enforce(v.get() != NULL, kerCorruptedMetadata);
+        enforce(v.get() != nullptr, kerCorruptedMetadata);
         v->read(pData, size, bo);
 
         object->setValue(std::move(v));

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -101,7 +101,8 @@ namespace Exiv2 {
     const char* TypeInfo::typeName(TypeId typeId)
     {
         const TypeInfoTable* tit = find(typeInfoTable, typeId);
-        if (!tit) return 0;
+        if (!tit)
+            return nullptr;
         return tit->name_;
     }
 
@@ -129,14 +130,13 @@ namespace Exiv2 {
     DataBuf::~DataBuf()
     { delete[] pData_; }
 
-    DataBuf::DataBuf() : pData_(0), size_(0)
+    DataBuf::DataBuf() : pData_(nullptr), size_(0)
     {}
 
     DataBuf::DataBuf(long size) : pData_(new byte[size]()), size_(size)
     {}
 
-    DataBuf::DataBuf(const byte* pData, long size)
-        : pData_(0), size_(0)
+    DataBuf::DataBuf(const byte* pData, long size) : pData_(nullptr), size_(0)
     {
         if (size > 0) {
             pData_ = new byte[size];
@@ -156,7 +156,7 @@ namespace Exiv2 {
     {
         if (size > size_) {
             delete[] pData_;
-            pData_ = 0;
+            pData_ = nullptr;
             size_ = 0;
             pData_ = new byte[size];
             size_ = size;
@@ -166,7 +166,7 @@ namespace Exiv2 {
     EXV_WARN_UNUSED_RESULT std::pair<byte*, long> DataBuf::release()
     {
         std::pair<byte*, long> p = std::make_pair(pData_, size_);
-        pData_ = 0;
+        pData_ = nullptr;
         size_ = 0;
         return p;
     }
@@ -174,7 +174,7 @@ namespace Exiv2 {
     void DataBuf::free()
     {
         delete[] pData_;
-        pData_ = 0;
+        pData_ = nullptr;
         size_ = 0;
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,7 +101,7 @@ namespace Util {
     bool strtol(const char* nptr, long& n)
     {
         if (!nptr || *nptr == '\0') return false;
-        char* endptr = 0;
+        char* endptr = nullptr;
         long tmp = std::strtol(nptr, &endptr, 10);
         if (*endptr != '\0') return false;
         if (tmp == LONG_MAX || tmp == LONG_MIN) return false;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -173,7 +173,7 @@ namespace Exiv2 {
 
     DataBuf Value::dataArea() const
     {
-        return DataBuf(0, 0);
+        return DataBuf(nullptr, 0);
     }
 
     DataValue::DataValue(TypeId typeId)
@@ -521,7 +521,7 @@ namespace Exiv2 {
         }
         c = value_.substr(8);
         if (charsetId() == unicode) {
-            const char* from = encoding == 0 || *encoding == '\0' ? detectCharset(c) : encoding;
+            const char* from = encoding == nullptr || *encoding == '\0' ? detectCharset(c) : encoding;
             convertStringCharset(c, from, "UTF-8");
         }
         bool bAscii = charsetId() == undefined || charsetId() == ascii ;

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -118,9 +118,7 @@ static bool shouldOutput(const exv_grep_keys_t& greps,const char* key,const std:
     for (auto g = greps.begin(); !bPrint && g != greps.end(); ++g) {
         std::string Key(key);
 #if defined(EXV_HAVE_REGEX_H)
-        bPrint = (  0 == regexec( &(*g), key          , 0, NULL, 0)
-                 || 0 == regexec( &(*g), value.c_str(), 0, NULL, 0)
-                 );
+        bPrint = (0 == regexec(&(*g), key, 0, nullptr, 0) || 0 == regexec(&(*g), value.c_str(), 0, nullptr, 0));
 #else
             std::string Pattern(g->pattern_);
             std::string Value(value);

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -639,7 +639,7 @@ namespace Exiv2 {
                 byte  exifShortHeader[]  = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
                 byte  exifTiffLEHeader[] = { 0x49, 0x49, 0x2A };       // "MM*"
                 byte  exifTiffBEHeader[] = { 0x4D, 0x4D, 0x00, 0x2A }; // "II\0*"
-                byte* rawExifData = NULL;
+                byte* rawExifData = nullptr;
                 long  offset = 0;
                 bool  s_header = false;
                 bool  le_header = false;

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -136,17 +136,21 @@ namespace Exiv2 {
 
     Xmpdatum::Impl::Impl(const Impl& rhs)
     {
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
     }
 
     Xmpdatum::Impl& Xmpdatum::Impl::operator=(const Impl& rhs)
     {
         if (this == &rhs) return *this;
         key_.reset();
-        if (rhs.key_.get() != 0) key_ = rhs.key_->clone(); // deep copy
+        if (rhs.key_.get() != nullptr)
+            key_ = rhs.key_->clone();  // deep copy
         value_.reset();
-        if (rhs.value_.get() != 0) value_ = rhs.value_->clone(); // deep copy
+        if (rhs.value_.get() != nullptr)
+            value_ = rhs.value_->clone();  // deep copy
         return *this;
     }
 
@@ -172,37 +176,37 @@ namespace Exiv2 {
 
     std::string Xmpdatum::key() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->key();
+        return p_->key_.get() == nullptr ? "" : p_->key_->key();
     }
 
     const char* Xmpdatum::familyName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->familyName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->familyName();
     }
 
     std::string Xmpdatum::groupName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->groupName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->groupName();
     }
 
     std::string Xmpdatum::tagName() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagName();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagName();
     }
 
     std::string Xmpdatum::tagLabel() const
     {
-        return p_->key_.get() == 0 ? "" : p_->key_->tagLabel();
+        return p_->key_.get() == nullptr ? "" : p_->key_->tagLabel();
     }
 
     uint16_t Xmpdatum::tag() const
     {
-        return p_->key_.get() == 0 ? 0 : p_->key_->tag();
+        return p_->key_.get() == nullptr ? 0 : p_->key_->tag();
     }
 
     TypeId Xmpdatum::typeId() const
     {
-        return p_->value_.get() == 0 ? invalidTypeId : p_->value_->typeId();
+        return p_->value_.get() == nullptr ? invalidTypeId : p_->value_->typeId();
     }
 
     const char* Xmpdatum::typeName() const
@@ -217,47 +221,48 @@ namespace Exiv2 {
 
     long Xmpdatum::count() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->count();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->count();
     }
 
     long Xmpdatum::size() const
     {
-        return p_->value_.get() == 0 ? 0 : p_->value_->size();
+        return p_->value_.get() == nullptr ? 0 : p_->value_->size();
     }
 
     std::string Xmpdatum::toString() const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString();
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString();
     }
 
     std::string Xmpdatum::toString(long n) const
     {
-        return p_->value_.get() == 0 ? "" : p_->value_->toString(n);
+        return p_->value_.get() == nullptr ? "" : p_->value_->toString(n);
     }
 
     long Xmpdatum::toLong(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toLong(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toLong(n);
     }
 
     float Xmpdatum::toFloat(long n) const
     {
-        return p_->value_.get() == 0 ? -1 : p_->value_->toFloat(n);
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toFloat(n);
     }
 
     Rational Xmpdatum::toRational(long n) const
     {
-        return p_->value_.get() == 0 ? Rational(-1, 1) : p_->value_->toRational(n);
+        return p_->value_.get() == nullptr ? Rational(-1, 1) : p_->value_->toRational(n);
     }
 
     Value::UniquePtr Xmpdatum::getValue() const
     {
-        return p_->value_.get() == 0 ? nullptr : p_->value_->clone();
+        return p_->value_.get() == nullptr ? nullptr : p_->value_->clone();
     }
 
     const Value& Xmpdatum::value() const
     {
-        if (p_->value_.get() == 0) throw Error(kerValueNotSet);
+        if (p_->value_.get() == nullptr)
+            throw Error(kerValueNotSet);
         return *p_->value_;
     }
 
@@ -292,9 +297,9 @@ namespace Exiv2 {
 
     int Xmpdatum::setValue(const std::string& value)
     {
-        if (p_->value_.get() == 0) {
+        if (p_->value_.get() == nullptr) {
             TypeId type = xmpText;
-            if (0 != p_->key_.get()) {
+            if (nullptr != p_->key_.get()) {
                 type = XmpProperties::propertyType(*p_->key_.get());
             }
             p_->value_ = Value::create(type);
@@ -408,8 +413,8 @@ namespace Exiv2 {
 
 
     bool XmpParser::initialized_ = false;
-    XmpParser::XmpLockFct XmpParser::xmpLockFct_ = 0;
-    void* XmpParser::pLockData_ = 0;
+    XmpParser::XmpLockFct XmpParser::xmpLockFct_ = nullptr;
+    void* XmpParser::pLockData_ = nullptr;
 
 #ifdef EXV_HAVE_XMP_TOOLKIT
     bool XmpParser::initialize(XmpParser::XmpLockFct xmpLockFct, void* pLockData)
@@ -759,7 +764,7 @@ namespace Exiv2 {
             if (i.typeId() == langAlt) {
                 // Encode Lang Alt property
                 const auto la = dynamic_cast<const LangAltValue*>(&i.value());
-                if (la == 0)
+                if (la == nullptr)
                     throw Error(kerEncodeLangAltPropertyFailed, i.key());
 
                 int idx = 1;
@@ -777,13 +782,13 @@ namespace Exiv2 {
 
             // Todo: Xmpdatum should have an XmpValue, not a Value
             const auto val = dynamic_cast<const XmpValue*>(&i.value());
-            if (val == 0)
+            if (val == nullptr)
                 throw Error(kerInvalidKeyXmpValue, i.key(), i.typeName());
             options =   xmpArrayOptionBits(val->xmpArrayType())
                       | xmpArrayOptionBits(val->xmpStruct());
             if (i.typeId() == xmpBag || i.typeId() == xmpSeq || i.typeId() == xmpAlt) {
                 printNode(ns, i.tagName(), "", options);
-                meta.SetProperty(ns.c_str(), i.tagName().c_str(), 0, options);
+                meta.SetProperty(ns.c_str(), i.tagName().c_str(), nullptr, options);
                 for (int idx = 0; idx < i.count(); ++idx) {
                     const std::string item = i.tagName() + "[" + toString(idx + 1) + "]";
                     printNode(ns, item, i.toString(idx), 0);
@@ -794,7 +799,7 @@ namespace Exiv2 {
             if (i.typeId() == xmpText) {
                 if (i.count() == 0) {
                     printNode(ns, i.tagName(), "", options);
-                    meta.SetProperty(ns.c_str(), i.tagName().c_str(), 0, options);
+                    meta.SetProperty(ns.c_str(), i.tagName().c_str(), nullptr, options);
                 } else {
                     printNode(ns, i.tagName(), i.toString(0), options);
                     meta.SetProperty(ns.c_str(), i.tagName().c_str(), i.toString(0).c_str(), options);

--- a/unitTests/test_cr2header_int.cpp
+++ b/unitTests/test_cr2header_int.cpp
@@ -52,7 +52,7 @@ TEST(ACr2Header, readDataFromBufferWithCorrectSize)
 TEST(ACr2Header, failToReadDataFromBufferWithCorrectSizeButNull)
 {
     Internal::Cr2Header header;
-    ASSERT_FALSE(header.read(NULL, 16));
+    ASSERT_FALSE(header.read(nullptr, 16));
 }
 
 TEST(ACr2Header, failToReadDataFromBufferWithSizeDifferentThan16)

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -322,7 +322,7 @@ TYPED_TEST_P(mutableSlice, at)
 
 TEST(pointerSlice, failedConstructionFromNullpointer)
 {
-    ASSERT_THROW(Slice<long*>(NULL, 1, 2), std::invalid_argument);
+    ASSERT_THROW(Slice<long*>(nullptr, 1, 2), std::invalid_argument);
 }
 
 /*!

--- a/unitTests/test_tiffheader.cpp
+++ b/unitTests/test_tiffheader.cpp
@@ -54,13 +54,13 @@ TEST_F(ATiffHeader, readDataFromBufferWithCorrectSize)
 
 TEST_F(ATiffHeader, failToReadDataFromBufferWithCorrectSizeButNull)
 {
-    ASSERT_FALSE(header.read(NULL, 8));
+    ASSERT_FALSE(header.read(nullptr, 8));
 }
 
 TEST_F(ATiffHeader, failToReadDataFromBufferWithSizeDifferentThan8)
 {
-    ASSERT_FALSE(header.read(NULL, 7));
-    ASSERT_FALSE(header.read(NULL, 9));
+    ASSERT_FALSE(header.read(nullptr, 7));
+    ASSERT_FALSE(header.read(nullptr, 9));
 }
 
 TEST_F(ATiffHeader, failToReadDataFromBufferWithInvalidByteOrder)

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -47,14 +47,14 @@ TEST(ExivTime, doesNotGetTimeWithBadFormedString)
 TEST(DataBuf, pointsToNullByDefault)
 {
     DataBuf instance;
-    ASSERT_EQ(NULL, instance.pData_);
+    ASSERT_EQ(nullptr, instance.pData_);
     ASSERT_EQ(0,    instance.size_);
 }
 
 TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
 {
     DataBuf instance (5);
-    ASSERT_NE(static_cast<byte *>(NULL), instance.pData_); /// \todo use nullptr once we move to c++11
+    ASSERT_NE(static_cast<byte *>(nullptr), instance.pData_);  /// \todo use nullptr once we move to c++11
     ASSERT_EQ(5,    instance.size_);
 }
 


### PR DESCRIPTION
Found with modernize-use-nullptr

Signed-off-by: Rosen Penev <rosenp@gmail.com>