### PR TITLE
Remove free() function from DataBuf 

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -196,8 +196,7 @@ namespace Exiv2 {
              be as a stack variable in functions that need a temporary data
              buffer.
      */
-    class EXIV2API DataBuf {
-    public:
+    struct EXIV2API DataBuf {
         //! @name Creators
         //@{
         //! Default constructor
@@ -237,13 +236,8 @@ namespace Exiv2 {
          */
         EXV_WARN_UNUSED_RESULT std::pair<byte*, long> release();
 
-         /*!
-           @brief Free the internal buffer and reset the size to 0.
-          */
-        void free();
-
         //! Reset value
-        void reset(std::pair<byte*, long> =std::make_pair((byte*)(0),long(0)));
+        void reset(std::pair<byte*, long> = std::make_pair(nullptr, long(0)));
         //@}
 
         /*!

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -662,7 +662,7 @@ namespace Exiv2 {
 
     void Image::clearIccProfile()
     {
-        iccProfile_.free();
+        iccProfile_.reset();
     }
 
     void Image::setByteOrder(ByteOrder byteOrder)

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -106,14 +106,14 @@ namespace Exiv2 {
             zlibResult = uncompress(result.pData_,&uncompressedLen,bytes,length);
             // if result buffer is large than necessary, redo to fit perfectly.
             if (zlibResult == Z_OK && static_cast<long>(uncompressedLen) < result.size_) {
-                result.free();
+                result.reset();
 
                 result.alloc(uncompressedLen);
                 zlibResult = uncompress(result.pData_,&uncompressedLen,bytes,length);
             }
             if (zlibResult == Z_BUF_ERROR) {
                 // the uncompressed buffer needs to be larger
-                result.free();
+                result.reset();
 
                 // Sanity - never bigger than 16mb
                 if  (uncompressedLen > 16*1024*1024) zlibResult = Z_DATA_ERROR;
@@ -134,10 +134,10 @@ namespace Exiv2 {
             zlibResult = compress(result.pData_,&compressedLen,bytes,length);
             if (zlibResult == Z_BUF_ERROR) {
                 // the compressedArray needs to be larger
-                result.free();
+                result.reset();
                 compressedLen *= 2;
             } else {
-                result.free();
+                result.reset();
                 result.alloc(compressedLen);
                 zlibResult = compress(result.pData_,&compressedLen,bytes,length);
             }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -171,13 +171,6 @@ namespace Exiv2 {
         return p;
     }
 
-    void DataBuf::free()
-    {
-        delete[] pData_;
-        pData_ = nullptr;
-        size_ = 0;
-    }
-
     void DataBuf::reset(std::pair<byte*, long> p)
     {
         if (pData_ != p.first) {


### PR DESCRIPTION
Small PR aiming to address #1542.   

Instead of renaming `free()` I chose to remove it since we already have `reset()` in `DataBuf` which does the same when called with its default argument.