### PR TITLE
Add identification for Canon EF 100-400mm f/4.5-5.6L IS II USM + 2x

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2012,7 +2012,8 @@ namespace Exiv2 {
         {  748, "Canon EF 100-400mm f/4.5-5.6L IS II USM + 1.4x"            },
         {  748, "Tamron 100-400mm f/4.5-6.3 Di VC USD + 1.4x"               }, // 1
         {  748, "Tamron 70-210mm f/4 Di VC USD + 2x"                        }, // 2
-        {  749, "Tamron 100-400mm f/4.5-6.3 Di VC USD + 2x"                 },
+        {  749, "Canon EF 100-400mm f/4.5-5.6L IS II USM + 2x"              },
+        {  749, "Tamron 100-400mm f/4.5-6.3 Di VC USD + 2x"                 }, // 1
         {  750, "Canon EF 35mm f/1.4L II USM"                               },
         {  750, "Tamron SP 85mm f/1.8 Di VC USD"                            }, // 1
         {  750, "Tamron SP 45mm f/1.8 Di VC USD"                            }, // 2


### PR DESCRIPTION
Canon      LensType   749
was just identified as a Tamron lens - this wasn't a relevant issue until Canon R makes this combination usable.
added: {  749, "Canon EF 100-400mm f/4.5-5.6L IS II USM + 2x"            },