### PR TITLE
fix: prevent creation of nightly release with  draf==true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,9 +151,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v2
-      - name: List downloaded files
-        run: tree -L 3
 
       - if: github.event_name == 'workflow_dispatch'
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
@@ -216,6 +213,9 @@ jobs:
               console.log( "Failed with error\n", error);
             }
 
+      - uses: actions/download-artifact@v2
+      - name: List downloaded files
+        run: tree -L 3
 
       - uses: softprops/action-gh-release@v1
         env:


### PR DESCRIPTION
Sometimes the nightly pre-release would be in "draft" status on GitHub.   
It's hard to reproduce, but I had the guess that maybe the deletion of
old tag and release on the GitHub side wasn't quite done when the
new release was being created. Of course only speculation...
But, moving the download of the artifacts in between these two steps
seems to have fixed the symptom. 

Given how difficult it is to debug GitHub actions, I'd say let's merge this and keep an eye on it. 
I can spend more time in the case the problem persists.