### PR TITLE
clang-tidy: use = default

### DIFF
--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -40,7 +40,7 @@ namespace Exiv2
     struct Iloc
     {
         Iloc(uint32_t ID = 0, uint32_t start = 0, uint32_t length = 0) : ID_(ID), start_(start), length_(length){};
-        virtual ~Iloc(){};
+        virtual ~Iloc() = default;
 
         uint32_t ID_;
         uint32_t start_;

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -366,10 +366,8 @@ namespace Exiv2 {
         setMsg();
     }
 
-    template<typename charT>
-    BasicError<charT>::~BasicError() throw()
-    {
-    }
+    template <typename charT>
+    BasicError<charT>::~BasicError() throw() = default;
 
     template<typename charT>
     int BasicError<charT>::code() const throw()


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>