### PR TITLE
clang-tidy: use std::move

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -179,7 +179,9 @@ namespace Exiv2 {
      */
     struct EXIV2API DataBufRef {
         //! Constructor
-        explicit DataBufRef(std::pair<byte*, long> rhs) : p(rhs) {}
+        explicit DataBufRef(std::pair<byte*, long> rhs) : p(std::move(rhs))
+        {
+        }
         //! Pointer to a byte array and its size
         std::pair<byte*, long> p;
     };


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>