### PR TITLE
clang-tidy: do not use else after return

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -281,9 +281,8 @@ namespace Exiv2 {
     {
         if (byteOrder == littleEndian) {
             return static_cast<byte>(buf.at(1)) << 8 | static_cast<byte>(buf.at(0));
-        } else {
-            return static_cast<byte>(buf.at(0)) << 8 | static_cast<byte>(buf.at(1));
         }
+        return static_cast<byte>(buf.at(0)) << 8 | static_cast<byte>(buf.at(1));
     }
 
     //! Read a 4 byte unsigned long value from the data buffer


### PR DESCRIPTION
Found with llvm-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>