### PR TITLE
clang-tidy: simplify bools

### DIFF
--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -232,7 +232,10 @@ namespace Exiv2 {
           @brief Erase iccProfile. the profile is not removed from
               the actual image until the writeMetadata() method is called.
          */
-        virtual bool iccProfileDefined() { return iccProfile_.size_?true:false;}
+        virtual bool iccProfileDefined()
+        {
+            return iccProfile_.size_ != 0;
+        }
 
         /*!
           @brief return iccProfile

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -524,7 +524,7 @@ namespace Exiv2 {
     {
         std::istringstream is(s);
         T tmp;
-        ok = (is >> tmp) ? true : false;
+        ok = bool(is >> tmp);
         std::string rest;
         is >> std::skipws >> rest;
         if (!rest.empty()) ok = false;


### PR DESCRIPTION
Found with readability-simplify-boolean-expr

Signed-off-by: Rosen Penev <rosenp@gmail.com>