### PR TITLE
clang-tidy: avoid const in declarations

### DIFF
--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -91,28 +91,18 @@ namespace Exiv2 {
                   3 if no data for psTag was found in pPsData;<BR>
                  -2 if the pPsData buffer does not contain valid data.
         */
-        static int locateIrb(const byte *pPsData,
-                             long sizePsData,
-                             uint16_t psTag,
-                             const byte **record,
-                             uint32_t *const sizeHdr,
-                             uint32_t *const sizeData);
+        static int locateIrb(const byte* pPsData, long sizePsData, uint16_t psTag, const byte** record,
+                             uint32_t* sizeHdr, uint32_t* sizeData);
         /*!
           @brief Forwards to locateIrb() with \em psTag = \em iptc_
          */
-        static int locateIptcIrb(const byte *pPsData,
-                                 long sizePsData,
-                                 const byte **record,
-                                 uint32_t *const sizeHdr,
-                                 uint32_t *const sizeData);
+        static int locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
+                                 uint32_t* sizeData);
         /*!
           @brief Forwards to locatePreviewIrb() with \em psTag = \em preview_
          */
-        static int locatePreviewIrb(const byte *pPsData,
-                                    long sizePsData,
-                                    const byte **record,
-                                    uint32_t *const sizeHdr,
-                                    uint32_t *const sizeData);
+        static int locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
+                                    uint32_t* sizeData);
         /*!
           @brief Set the new IPTC IRB, keeps existing IRBs but removes the
                  IPTC block if there is no new IPTC data to write.

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -92,17 +92,17 @@ namespace Exiv2 {
                  -2 if the pPsData buffer does not contain valid data.
         */
         static int locateIrb(const byte* pPsData, long sizePsData, uint16_t psTag, const byte** record,
-                             uint32_t* sizeHdr, uint32_t* sizeData);
+                             uint32_t& sizeHdr, uint32_t& sizeData);
         /*!
           @brief Forwards to locateIrb() with \em psTag = \em iptc_
          */
-        static int locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
-                                 uint32_t* sizeData);
+        static int locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t& sizeHdr,
+                                 uint32_t& sizeData);
         /*!
           @brief Forwards to locatePreviewIrb() with \em psTag = \em preview_
          */
-        static int locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
-                                    uint32_t* sizeData);
+        static int locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t& sizeHdr,
+                                    uint32_t& sizeData);
         /*!
           @brief Set the new IPTC IRB, keeps existing IRBs but removes the
                  IPTC block if there is no new IPTC data to write.

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* const argv[])
         const Exiv2::byte* record;
         uint32_t sizeHdr;
         uint32_t sizeData;
-        Exiv2::Photoshop::locateIptcIrb(irb.pData_, irb.size_, &record, &sizeHdr, &sizeData);
+        Exiv2::Photoshop::locateIptcIrb(irb.pData_, irb.size_, &record, sizeHdr, sizeData);
         Exiv2::DataBuf rawIptc = Exiv2::IptcParser::encode(iptcData);
         std::cout << "Comparing IPTC and IRB size... ";
         if (static_cast<uint32_t>(rawIptc.size_) != sizeData) {

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -125,9 +125,8 @@ namespace Exiv2 {
         const byte* pCur = pPsData;
         const byte* pEnd = pPsData + sizePsData;
         int ret = 0;
-        while (pCur < pEnd
-               && 0 == (ret = Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
-                                                       &record, &sizeHdr, &sizeIptc))) {
+        while (pCur < pEnd && 0 == (ret = Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur), &record,
+                                                                   sizeHdr, sizeIptc))) {
             pCur = record + sizeHdr + sizeIptc + (sizeIptc & 1);
         }
         return ret >= 0;
@@ -137,7 +136,7 @@ namespace Exiv2 {
     //       the format (in particular the header). So it remains to be confirmed
     //       if this also makes sense for psTag != Photoshop::iptc
     int Photoshop::locateIrb(const byte* pPsData, long sizePsData, uint16_t psTag, const byte** record,
-                             uint32_t* sizeHdr, uint32_t* sizeData)
+                             uint32_t& sizeHdr, uint32_t& sizeData)
     {
         assert(record);
         assert(sizeHdr);
@@ -188,8 +187,8 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "ok\n";
 #endif
-                *sizeData = dataSize;
-                *sizeHdr = psSize + 10;
+                sizeData = dataSize;
+                sizeHdr = psSize + 10;
                 *record = hrd;
                 return 0;
             }
@@ -209,15 +208,15 @@ namespace Exiv2 {
         return 3;
     } // Photoshop::locateIrb
 
-    int Photoshop::locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
-                                 uint32_t* sizeData)
+    int Photoshop::locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t& sizeHdr,
+                                 uint32_t& sizeData)
     {
         return locateIrb(pPsData, sizePsData, iptc_,
                          record, sizeHdr, sizeData);
     }
 
-    int Photoshop::locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
-                                    uint32_t* sizeData)
+    int Photoshop::locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t& sizeHdr,
+                                    uint32_t& sizeData)
     {
         return locateIrb(pPsData, sizePsData, preview_,
                          record, sizeHdr, sizeData);
@@ -238,8 +237,7 @@ namespace Exiv2 {
         uint32_t    sizeHdr   = 0;
         DataBuf rc;
         // Safe to call with zero psData.size_
-        if (0 > Photoshop::locateIptcIrb(pPsData, sizePsData,
-                                         &record, &sizeHdr, &sizeIptc)) {
+        if (0 > Photoshop::locateIptcIrb(pPsData, sizePsData, &record, sizeHdr, sizeIptc)) {
             return rc;
         }
         Blob psBlob;
@@ -265,8 +263,7 @@ namespace Exiv2 {
         // Write existing stuff after record,
         // skip the current and all remaining IPTC blocks
         long pos = sizeFront;
-        while (0 == Photoshop::locateIptcIrb(pPsData + pos, sizePsData - pos,
-                                             &record, &sizeHdr, &sizeIptc)) {
+        while (0 == Photoshop::locateIptcIrb(pPsData + pos, sizePsData - pos, &record, sizeHdr, sizeIptc)) {
             const long newPos = static_cast<long>(record - pPsData);
             // Copy data up to the IPTC IRB
             if (newPos > pos) {
@@ -527,9 +524,8 @@ namespace Exiv2 {
             uint32_t sizeHdr = 0;
             const byte* pCur = &psBlob[0];
             const byte* pEnd = pCur + psBlob.size();
-            while (   pCur < pEnd
-                   && 0 == Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur),
-                                                    &record, &sizeHdr, &sizeIptc)) {
+            while (pCur < pEnd &&
+                   0 == Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur), &record, sizeHdr, sizeIptc)) {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cerr << "Found IPTC IRB, size = " << sizeIptc << "\n";
 #endif

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -136,12 +136,8 @@ namespace Exiv2 {
     // Todo: Generalised from JpegBase::locateIptcData without really understanding
     //       the format (in particular the header). So it remains to be confirmed
     //       if this also makes sense for psTag != Photoshop::iptc
-    int Photoshop::locateIrb(const byte*     pPsData,
-                             long            sizePsData,
-                             uint16_t        psTag,
-                             const byte**    record,
-                             uint32_t *const sizeHdr,
-                             uint32_t *const sizeData)
+    int Photoshop::locateIrb(const byte* pPsData, long sizePsData, uint16_t psTag, const byte** record,
+                             uint32_t* sizeHdr, uint32_t* sizeData)
     {
         assert(record);
         assert(sizeHdr);
@@ -213,21 +209,15 @@ namespace Exiv2 {
         return 3;
     } // Photoshop::locateIrb
 
-    int Photoshop::locateIptcIrb(const byte*     pPsData,
-                                 long            sizePsData,
-                                 const byte**    record,
-                                 uint32_t *const sizeHdr,
-                                 uint32_t *const sizeData)
+    int Photoshop::locateIptcIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
+                                 uint32_t* sizeData)
     {
         return locateIrb(pPsData, sizePsData, iptc_,
                          record, sizeHdr, sizeData);
     }
 
-    int Photoshop::locatePreviewIrb(const byte*     pPsData,
-                                    long            sizePsData,
-                                    const byte**    record,
-                                    uint32_t *const sizeHdr,
-                                    uint32_t *const sizeData)
+    int Photoshop::locatePreviewIrb(const byte* pPsData, long sizePsData, const byte** record, uint32_t* sizeHdr,
+                                    uint32_t* sizeData)
     {
         return locateIrb(pPsData, sizePsData, preview_,
                          record, sizeHdr, sizeData);

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -306,12 +306,8 @@ namespace Exiv2 {
 
                 const byte* pEnd = psData.pData_ + psData.size_;
                 const byte* pCur = psData.pData_;
-                while (   pCur < pEnd
-                       && 0 == Photoshop::locateIptcIrb(pCur,
-                                                        static_cast<long>(pEnd - pCur),
-                                                        &record,
-                                                        &sizeHdr,
-                                                        &sizeIptc)) {
+                while (pCur < pEnd && 0 == Photoshop::locateIptcIrb(pCur, static_cast<long>(pEnd - pCur), &record,
+                                                                    sizeHdr, sizeIptc)) {
                     if (sizeIptc) {
 #ifdef EXIV2_DEBUG_MESSAGES
                         std::cerr << "Found IPTC IRB, size = " << sizeIptc << "\n";

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -484,7 +484,7 @@ namespace {
             const byte *record;
             uint32_t sizeHdr;
             uint32_t sizeData;
-            if (Photoshop::locatePreviewIrb(psData.pData_, psData.size_, &record, &sizeHdr, &sizeData) != 0) {
+            if (Photoshop::locatePreviewIrb(psData.pData_, psData.size_, &record, sizeHdr, sizeData) != 0) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "Missing preview IRB in Photoshop EPS preview.\n";
 #endif

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -427,8 +427,7 @@ namespace Exiv2 {
             byte const* record = nullptr;
             uint32_t sizeHdr = 0;
             uint32_t sizeData = 0;
-            if (0 != Photoshop::locateIptcIrb(pData, size,
-                                              &record, &sizeHdr, &sizeData)) {
+            if (0 != Photoshop::locateIptcIrb(pData, size, &record, sizeHdr, sizeData)) {
                 return;
             }
             if (0 == IptcParser::decode(iptcData_, record + sizeHdr, sizeData)) {


### PR DESCRIPTION
Found with readability-avoid-const-params-in-decls

Signed-off-by: Rosen Penev <rosenp@gmail.com>