### PR TITLE
clang-tidy: add ending namespace comments

### DIFF
--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -32,7 +32,7 @@
 namespace Exiv2
 {
     EXIV2API bool enableBMFF(bool enable = true);
-}
+}  // namespace Exiv2
 
 #ifdef EXV_ENABLE_BMFF
 namespace Exiv2
@@ -56,7 +56,7 @@ namespace Exiv2
     namespace ImageType
     {
         const int bmff = 19;  //!< BMFF (bmff) image type (see class BMFF)
-    }
+    }                         // namespace ImageType
 
     /*!
       @brief Class to access BMFF images.

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -43,7 +43,7 @@ namespace Exiv2 {
     // Add Windows Bitmap (BMP) to the supported image formats
     namespace ImageType {
         const int bmp = 14; //!< Windows bitmap (bmp) image type (see class BmpImage)
-    }
+    }                       // namespace ImageType
 
     /*!
       @brief Class to access Windows bitmaps. This is just a stub - we only

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -43,7 +43,7 @@ namespace Exiv2 {
     // Add CR2 to the supported image formats
     namespace ImageType {
         const int cr2 = 7;          //!< CR2 image type (see class Cr2Image)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access raw Canon CR2 images.  Exif metadata

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -50,7 +50,7 @@ namespace Exiv2 {
     // Add CRW to the supported image formats
     namespace ImageType {
         const int crw = 3;          //!< CRW image type (see class CrwImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access raw Canon CRW images. Only Exif metadata and a

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -51,7 +51,7 @@ namespace Exiv2
     // Add EPS to the supported image formats
     namespace ImageType {
         const int eps = 18;                     //!< EPS image type
-    }
+    }                                           // namespace ImageType
 
     /*!
       @brief Class to access EPS images.

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add GIF to the supported image formats
     namespace ImageType {
         const int gif = 11;          //!< GIF image type (see class GifImage)
-    }
+    }                                // namespace ImageType
 
     /*!
       @brief Class to access raw GIF images. Exif/IPTC metadata are supported

--- a/include/exiv2/http.hpp
+++ b/include/exiv2/http.hpp
@@ -37,6 +37,6 @@ namespace Exiv2 {
      @return Server response 200 = OK, 404 = Not Found etc...
     */
     EXIV2API int http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::string& errors);
-}
+}  // namespace Exiv2
 
 #endif

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -43,7 +43,7 @@ namespace Exiv2 {
     //! Supported image formats
     namespace ImageType {
         const int none = 0;         //!< Not an image
-    }
+    }                               // namespace ImageType
 
     //! Native preview information. This is meant to be used only by the PreviewManager.
     struct NativePreview {

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -43,7 +43,7 @@ namespace Exiv2
     namespace ImageType
     {
         const int jp2 = 15;                     //!< JPEG-2000 image type
-    }
+    }                                           // namespace ImageType
 
     /*!
       @brief Class to access JPEG-2000 images.

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -40,7 +40,7 @@ namespace Exiv2 {
     namespace ImageType {
         const int jpeg = 1;         //!< JPEG image type (see class JpegImage)
         const int exv  = 2;         //!< EXV image type (see class ExvImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Helper class, has methods to deal with %Photoshop "Information

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add MRW to the supported image formats
     namespace ImageType {
         const int mrw = 5;          //!< MRW image type (see class MrwImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access raw Minolta MRW images. Exif metadata is supported

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add ORF to the supported image formats
     namespace ImageType {
         const int orf = 9;          //!< ORF image type (see class OrfImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access raw Olympus ORF images. Exif metadata is supported

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -38,7 +38,7 @@ namespace Exiv2
     namespace ImageType
     {
         const int pgf = 17;          //!< PGF image type (see class PgfImage)
-    }
+    }                                // namespace ImageType
 
     /*!
       @brief Class to access PGF images. Exif and IPTC metadata are supported

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -38,7 +38,7 @@ namespace Exiv2
     namespace ImageType
     {
         const int png = 6;          //!< PNG image type (see class PngImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access PNG images. Exif and IPTC metadata are supported

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add PSD to the supported image formats
     namespace ImageType {
         const int psd = 12; //!< Photoshop (PSD) image type (see class PsdImage)
-    }
+    }                       // namespace ImageType
 
     /*!
       @brief Class to access raw Photoshop images.

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -41,7 +41,7 @@ namespace Exiv2 {
     // Add RAF to the supported image formats
     namespace ImageType {
         const int raf = 8;          //!< RAF image type (see class RafImage)
-    }
+    }                               // namespace ImageType
 
     /*!
       @brief Class to access raw Fujifilm RAF images. Exif metadata is

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add RW2 to the supported image formats
     namespace ImageType {
         const int rw2 = 16;             //!< RW2 image type (see class Rw2Image)
-    }
+    }                                   // namespace ImageType
 
     /*!
       @brief Class to access raw Panasonic RW2 images.  Exif metadata is

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add TARGA to the supported image formats
     namespace ImageType {
         const int tga = 13; //!< Truevision TARGA (tga) image type (see class TgaImage)
-    }
+    }                       // namespace ImageType
 
     /*!
       @brief Class to access raw TARGA images. This is just a stub - we only

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -43,7 +43,7 @@ namespace Exiv2 {
         const int arw = 4;           //!< ARW image type (see class TiffImage)
         const int sr2 = 4;           //!< SR2 image type (see class TiffImage)
         const int srw = 4;           //!< SRW image type (see class TiffImage)
-    }
+    }                                // namespace ImageType
 
     /*!
       @brief Class to access TIFF images. Exif metadata is

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add WEBP to the supported image formats
     namespace ImageType {
         const int webp = 23; //!< Treating webp as an image type>
-    }
+    }                        // namespace ImageType
 
     /*!
       @brief Class to access WEBP video files.

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -36,7 +36,7 @@ namespace Exiv2 {
     // Add XMP to the supported image formats
     namespace ImageType {
         const int xmp = 10;          //!< XMP sidecar files (see class XmpSidecar)
-    }
+    }                                // namespace ImageType
 
     /*!
       @brief Class to access XMP sidecar files. They contain only XMP metadata.


### PR DESCRIPTION
Found with llvm-namespace-comment

Signed-off-by: Rosen Penev <rosenp@gmail.com>