### PR TITLE
clang-tidy: replace virtual with override

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -305,7 +305,7 @@ namespace Exiv2 {
         FileIo(const std::wstring& wpath);
 #endif
         //! Destructor. Flushes and closes an open file.
-        virtual ~FileIo();
+        ~FileIo() override;
         //@}
 
         //! @name Manipulators
@@ -331,14 +331,14 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
               Nonzero if failure.
          */
-        virtual int open();
+        int open() override;
         /*!
           @brief Flush and unwritten data and close the file . It is
               safe to call close on an already closed instance.
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-        virtual int close();
+        int close() override;
         /*!
           @brief Write data to the file. The file position is advanced
               by the number of bytes written.
@@ -348,7 +348,7 @@ namespace Exiv2 {
           @return Number of bytes written to the file successfully;<BR>
                  0 if failure;
          */
-        virtual long write(const byte* data, long wcount);
+        long write(const byte* data, long wcount) override;
         /*!
           @brief Write data that is read from another BasicIo instance to
               the file. The file position is advanced by the number
@@ -358,7 +358,7 @@ namespace Exiv2 {
           @return Number of bytes written to the file successfully;<BR>
                  0 if failure;
          */
-        virtual long write(BasicIo& src);
+        long write(BasicIo& src) override;
         /*!
           @brief Write one byte to the file. The file position is
               advanced by one byte.
@@ -366,7 +366,7 @@ namespace Exiv2 {
           @return The value of the byte written if successful;<BR>
                  EOF if failure;
          */
-        virtual int putb(byte data);
+        int putb(byte data) override;
         /*!
           @brief Read data from the file. Reading starts at the current
               file position and the position is advanced by the number of
@@ -377,7 +377,7 @@ namespace Exiv2 {
                 DataBuf::size_ member to find the number of bytes read.
                 DataBuf::size_ will be 0 on failure.
          */
-        virtual DataBuf read(long rcount);
+        DataBuf read(long rcount) override;
         /*!
           @brief Read data from the file. Reading starts at the current
               file position and the position is advanced by the number of
@@ -390,14 +390,14 @@ namespace Exiv2 {
           @return Number of bytes read from the file successfully;<BR>
                  0 if failure;
          */
-        virtual long read(byte* buf, long rcount);
+        long read(byte* buf, long rcount) override;
         /*!
           @brief Read one byte from the file. The file position is
               advanced by one byte.
           @return The byte read from the file if successful;<BR>
                  EOF if failure;
          */
-        virtual int getb();
+        int getb() override;
         /*!
           @brief Remove the contents of the file and then transfer data from
               the \em src BasicIo object into the empty file.
@@ -416,7 +416,7 @@ namespace Exiv2 {
               invalidated by the method.
           @throw Error In case of failure
          */
-        virtual void transfer(BasicIo& src);
+        void transfer(BasicIo& src) override;
         /*!
           @brief Move the current file position.
           @param offset Number of bytes to move the file position
@@ -426,9 +426,9 @@ namespace Exiv2 {
                  Nonzero if failure;
          */
 #if defined(_MSC_VER)
-        virtual int seek(int64_t offset, Position pos);
+        int seek(int64_t offset, Position pos) override;
 #else
-        virtual int seek(long offset, Position pos);
+        int seek(long offset, Position pos) override;
 #endif
         /*!
           @brief Map the file into the process's address space. The file must be
@@ -441,7 +441,7 @@ namespace Exiv2 {
           @return A pointer to the mapped area.
           @throw Error In case of failure.
          */
-        virtual byte* mmap(bool isWriteable =false);
+        byte* mmap(bool isWriteable = false) override;
         /*!
           @brief Remove a mapping established with mmap(). If the mapped area is
                  writeable, this ensures that changes are written back to the
@@ -449,7 +449,7 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                   Nonzero if failure;
          */
-        virtual int munmap();
+        int munmap() override;
         /*!
           @brief close the file source and set a new path.
          */
@@ -470,22 +470,22 @@ namespace Exiv2 {
           @return Offset from the start of the file if successful;<BR>
                  -1 if failure;
          */
-        virtual long tell() const;
+        long tell() const override;
         /*!
           @brief Flush any buffered writes and get the current file size
               in bytes.
           @return Size of the file in bytes;<BR>
                  -1 if failure;
          */
-        virtual size_t size() const;
+        size_t size() const override;
         //! Returns true if the file is open, otherwise false.
-        virtual bool isopen() const;
+        bool isopen() const override;
         //! Returns 0 if the file is in a valid state, otherwise nonzero.
-        virtual int error() const;
+        int error() const override;
         //! Returns true if the file position has reached the end, otherwise false.
-        virtual bool eof() const;
+        bool eof() const override;
         //! Returns the path of the file
-        virtual std::string path() const;
+        std::string path() const override;
 #ifdef EXV_UNICODE_PATH
         /*
           @brief Like path() but returns the unicode path of the file in an std::wstring.
@@ -501,7 +501,7 @@ namespace Exiv2 {
           @note This method should be only called after the concerned data (metadata)
                 are all downloaded from the remote file to memory.
          */
-        virtual void populateFakeData();
+        void populateFakeData() override;
         //@}
 
         // NOT IMPLEMENTED
@@ -545,7 +545,7 @@ namespace Exiv2 {
          */
         MemIo(const byte* data, long size);
         //! Destructor. Releases all managed memory
-        virtual ~MemIo();
+        ~MemIo() override;
         //@}
 
         //! @name Manipulators
@@ -556,12 +556,12 @@ namespace Exiv2 {
 
           @return 0
          */
-        virtual int open();
+        int open() override;
         /*!
           @brief Does nothing on MemIo objects.
           @return 0
          */
-        virtual int close();
+        int close() override;
         /*!
           @brief Write data to the memory block. If needed, the size of the
               internal memory block is expanded. The IO position is advanced
@@ -572,7 +572,7 @@ namespace Exiv2 {
           @return Number of bytes written to the memory block successfully;<BR>
                  0 if failure;
          */
-        virtual long write(const byte* data, long wcount);
+        long write(const byte* data, long wcount) override;
         /*!
           @brief Write data that is read from another BasicIo instance to
               the memory block. If needed, the size of the internal memory
@@ -583,7 +583,7 @@ namespace Exiv2 {
           @return Number of bytes written to the memory block successfully;<BR>
                  0 if failure;
          */
-        virtual long write(BasicIo& src);
+        long write(BasicIo& src) override;
         /*!
           @brief Write one byte to the memory block. The IO position is
               advanced by one byte.
@@ -591,7 +591,7 @@ namespace Exiv2 {
           @return The value of the byte written if successful;<BR>
                  EOF if failure;
          */
-        virtual int putb(byte data);
+        int putb(byte data) override;
         /*!
           @brief Read data from the memory block. Reading starts at the current
               IO position and the position is advanced by the number of
@@ -602,7 +602,7 @@ namespace Exiv2 {
                 DataBuf::size_ member to find the number of bytes read.
                 DataBuf::size_ will be 0 on failure.
          */
-        virtual DataBuf read(long rcount);
+        DataBuf read(long rcount) override;
         /*!
           @brief Read data from the memory block. Reading starts at the current
               IO position and the position is advanced by the number of
@@ -615,14 +615,14 @@ namespace Exiv2 {
           @return Number of bytes read from the memory block successfully;<BR>
                  0 if failure;
          */
-        virtual long read(byte* buf, long rcount);
+        long read(byte* buf, long rcount) override;
         /*!
           @brief Read one byte from the memory block. The IO position is
               advanced by one byte.
           @return The byte read from the memory block if successful;<BR>
                  EOF if failure;
          */
-        virtual int getb();
+        int getb() override;
         /*!
           @brief Clear the memory block and then transfer data from
               the \em src BasicIo object into a new block of memory.
@@ -638,7 +638,7 @@ namespace Exiv2 {
               invalidated by the method.
           @throw Error In case of failure
          */
-        virtual void transfer(BasicIo& src);
+        void transfer(BasicIo& src) override;
         /*!
           @brief Move the current IO position.
           @param offset Number of bytes to move the IO position
@@ -650,7 +650,7 @@ namespace Exiv2 {
 #if defined(_MSC_VER)
         virtual int seek(int64_t offset, Position pos);
 #else
-        virtual int seek(long offset, Position pos);
+        int seek(long offset, Position pos) override;
 #endif
         /*!
           @brief Allow direct access to the underlying data buffer. The buffer
@@ -660,8 +660,8 @@ namespace Exiv2 {
                  returned pointer remains valid and allocated as long as the
                  MemIo object exists.
          */
-        virtual byte* mmap(bool /*isWriteable*/ =false);
-        virtual int munmap();
+        byte* mmap(bool /*isWriteable*/ = false) override;
+        int munmap() override;
         //@}
 
         //! @name Accessors
@@ -670,21 +670,21 @@ namespace Exiv2 {
           @brief Get the current IO position.
           @return Offset from the start of the memory block
          */
-        virtual long tell() const;
+        long tell() const override;
         /*!
           @brief Get the current memory buffer size in bytes.
           @return Size of the in memory data in bytes;<BR>
                  -1 if failure;
          */
-        virtual size_t size() const;
+        size_t size() const override;
         //!Always returns true
-        virtual bool isopen() const;
+        bool isopen() const override;
         //!Always returns 0
-        virtual int error() const;
+        int error() const override;
         //!Returns true if the IO position has reached the end, otherwise false.
-        virtual bool eof() const;
+        bool eof() const override;
         //! Returns a dummy path, indicating that memory access is used
-        virtual std::string path() const;
+        std::string path() const override;
 #ifdef EXV_UNICODE_PATH
         /*
           @brief Like path() but returns a unicode dummy path in an std::wstring.
@@ -700,7 +700,7 @@ namespace Exiv2 {
           @note This method should be only called after the concerned data (metadata)
                 are all downloaded from the remote file to memory.
          */
-        virtual void populateFakeData();
+        void populateFakeData() override;
 
         //@}
 
@@ -776,7 +776,7 @@ namespace Exiv2 {
         XPathIo(const std::wstring& wOrgPathpath);
 #endif
         //! Destructor. Releases all managed memory and removes the temp file.
-        virtual ~XPathIo();
+        ~XPathIo() override;
         //@}
 
         //! @name Manipulators
@@ -785,7 +785,7 @@ namespace Exiv2 {
             @brief Change the name of the temp file and make it untemporary before
                     calling the method of superclass FileIo::transfer.
          */
-        virtual void transfer(BasicIo& src);
+        void transfer(BasicIo& src) override;
 
         //@}
 
@@ -824,7 +824,7 @@ namespace Exiv2 {
     class EXIV2API RemoteIo : public BasicIo {
     public:
         //! Destructor. Releases all managed memory.
-        virtual ~RemoteIo();
+        ~RemoteIo() override;
         //@}
 
         //! @name Manipulators
@@ -838,19 +838,19 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
               Nonzero if failure.
          */
-        virtual int open();
+        int open() override;
 
         /*!
           @brief Reset the IO position to the start. It does not release the data.
           @return 0 if successful;<BR>
               Nonzero if failure.
          */
-        virtual int close();
+        int close() override;
         /*!
           @brief Not support this method.
           @return 0 means failure
          */
-        virtual long write(const byte* data, long wcount);
+        long write(const byte* data, long wcount) override;
         /*!
           @brief Write data that is read from another BasicIo instance to the remote file.
 
@@ -865,50 +865,50 @@ namespace Exiv2 {
 
           @note The write access is only supported by http, https, ssh.
          */
-        virtual long write(BasicIo& src);
+        long write(BasicIo& src) override;
 
         /*!
          @brief Not support
          @return 0 means failure
         */
-       virtual int putb(byte data);
-       /*!
-         @brief Read data from the memory blocks. Reading starts at the current
-             IO position and the position is advanced by the number of
-             bytes read.
-             If the memory blocks are not populated (False), it will connect to server
-             and populate the data to memory blocks.
-         @param rcount Maximum number of bytes to read. Fewer bytes may be
-             read if \em rcount bytes are not available.
-         @return DataBuf instance containing the bytes read. Use the
-               DataBuf::size_ member to find the number of bytes read.
-               DataBuf::size_ will be 0 on failure.
-        */
-       virtual DataBuf read(long rcount);
-       /*!
-         @brief Read data from the the memory blocks. Reading starts at the current
-             IO position and the position is advanced by the number of
-             bytes read.
-             If the memory blocks are not populated (!= bMemory), it will connect to server
-             and populate the data to memory blocks.
-         @param buf Pointer to a block of memory into which the read data
-             is stored. The memory block must be at least \em rcount bytes
-             long.
-         @param rcount Maximum number of bytes to read. Fewer bytes may be
-             read if \em rcount bytes are not available.
-         @return Number of bytes read from the memory block successfully;<BR>
-                0 if failure;
-        */
-       virtual long read(byte* buf, long rcount);
-       /*!
-         @brief Read one byte from the memory blocks. The IO position is
-             advanced by one byte.
-             If the memory block is not populated (!= bMemory), it will connect to server
-             and populate the data to the memory block.
-         @return The byte read from the memory block if successful;<BR>
-                EOF if failure;
-        */
-       virtual int getb();
+        int putb(byte data) override;
+        /*!
+          @brief Read data from the memory blocks. Reading starts at the current
+              IO position and the position is advanced by the number of
+              bytes read.
+              If the memory blocks are not populated (False), it will connect to server
+              and populate the data to memory blocks.
+          @param rcount Maximum number of bytes to read. Fewer bytes may be
+              read if \em rcount bytes are not available.
+          @return DataBuf instance containing the bytes read. Use the
+                DataBuf::size_ member to find the number of bytes read.
+                DataBuf::size_ will be 0 on failure.
+         */
+        DataBuf read(long rcount) override;
+        /*!
+          @brief Read data from the the memory blocks. Reading starts at the current
+              IO position and the position is advanced by the number of
+              bytes read.
+              If the memory blocks are not populated (!= bMemory), it will connect to server
+              and populate the data to memory blocks.
+          @param buf Pointer to a block of memory into which the read data
+              is stored. The memory block must be at least \em rcount bytes
+              long.
+          @param rcount Maximum number of bytes to read. Fewer bytes may be
+              read if \em rcount bytes are not available.
+          @return Number of bytes read from the memory block successfully;<BR>
+                 0 if failure;
+         */
+        long read(byte* buf, long rcount) override;
+        /*!
+          @brief Read one byte from the memory blocks. The IO position is
+              advanced by one byte.
+              If the memory block is not populated (!= bMemory), it will connect to server
+              and populate the data to the memory block.
+          @return The byte read from the memory block if successful;<BR>
+                 EOF if failure;
+         */
+        int getb() override;
         /*!
           @brief Remove the contents of the file and then transfer data from
               the \em src BasicIo object into the empty file.
@@ -923,30 +923,30 @@ namespace Exiv2 {
 
           @note The write access is only supported by http, https, ssh.
          */
-       virtual void transfer(BasicIo& src);
-       /*!
-         @brief Move the current IO position.
-         @param offset Number of bytes to move the IO position
-             relative to the starting position specified by \em pos
-         @param pos Position from which the seek should start
-         @return 0 if successful;<BR>
-                Nonzero if failure;
-        */
+        void transfer(BasicIo& src) override;
+        /*!
+          @brief Move the current IO position.
+          @param offset Number of bytes to move the IO position
+              relative to the starting position specified by \em pos
+          @param pos Position from which the seek should start
+          @return 0 if successful;<BR>
+                 Nonzero if failure;
+         */
 #if defined(_MSC_VER)
        virtual int seek(int64_t offset, Position pos);
 #else
-       virtual int seek(long offset, Position pos);
+        int seek(long offset, Position pos) override;
 #endif
        /*!
          @brief Not support
          @return NULL
         */
-       virtual byte* mmap(bool /*isWriteable*/ =false);
-        /*!
-          @brief Not support
-          @return 0
-         */
-       virtual int munmap();
+       byte* mmap(bool /*isWriteable*/ = false) override;
+       /*!
+         @brief Not support
+         @return 0
+        */
+       int munmap() override;
        //@}
        //! @name Accessors
        //@{
@@ -954,21 +954,21 @@ namespace Exiv2 {
          @brief Get the current IO position.
          @return Offset from the start of the memory block
         */
-       virtual long tell() const;
+       long tell() const override;
        /*!
          @brief Get the current memory buffer size in bytes.
          @return Size of the in memory data in bytes;<BR>
                 -1 if failure;
         */
-       virtual size_t size() const;
+       size_t size() const override;
        //!Returns true if the memory area is allocated.
-       virtual bool isopen() const;
+       bool isopen() const override;
        //!Always returns 0
-       virtual int error() const;
+       int error() const override;
        //!Returns true if the IO position has reached the end, otherwise false.
-       virtual bool eof() const;
+       bool eof() const override;
        //!Returns the URL of the file.
-       virtual std::string path() const;
+       std::string path() const override;
 #ifdef EXV_UNICODE_PATH
        /*
          @brief Like path() but returns a unicode URL path in an std::wstring.
@@ -984,7 +984,7 @@ namespace Exiv2 {
           @note This method should be only called after the concerned data (metadata)
                 are all downloaded from the remote file to memory.
          */
-       virtual void populateFakeData();
+       void populateFakeData() override;
 
        //@}
 
@@ -1064,13 +1064,13 @@ namespace Exiv2 {
                 will call RemoteIo::write(const byte* data, long wcount) if the write
                 access is available for the protocol. Otherwise, it throws the Error.
          */
-        long write(const byte* data, long wcount);
+        long write(const byte* data, long wcount) override;
         /*!
           @brief Write access is only available for some protocols. This method
                 will call RemoteIo::write(BasicIo& src) if the write access is available
                 for the protocol. Otherwise, it throws the Error.
          */
-        long write(BasicIo& src);
+        long write(BasicIo& src) override;
 
         // NOT IMPLEMENTED
         //! Copy constructor

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -107,17 +107,17 @@ namespace Exiv2
 
         //! @name Manipulators
         //@{
-        void readMetadata() /* override */;
-        void writeMetadata() /* override */;
-        void setComment(const std::string& comment) /* override */;
-        void printStructure(std::ostream& out, Exiv2::PrintStructureOption option,int depth);
+        void readMetadata() override /* override */;
+        void writeMetadata() override /* override */;
+        void setComment(const std::string& comment) override /* override */;
+        void printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const /* override */;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override /* override */;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
         
         Exiv2::ByteOrder endian_{Exiv2::bigEndian};

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -78,32 +78,32 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet(?) implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. Calling this function will throw an instance
               of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
     }; // class BmpImage

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -73,27 +73,27 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Print out the structure of image file.
           @throw Error if reading of the file fails or the image data is
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -pS for debugging.
          */
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
         /*!
           @brief Not supported. CR2 format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -80,20 +80,20 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Not supported. CRW format does not contain IPTC metadata.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
 
         //! @name NOT Implemented

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -279,7 +279,7 @@ namespace Exiv2 {
         //! Copy constructor
         IptcKey(const IptcKey& rhs);
         //! Destructor
-        virtual ~IptcKey() = default;
+        ~IptcKey() override = default;
         //@}
 
         //! @name Manipulators
@@ -292,16 +292,16 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        virtual std::string key() const;
-        virtual const char* familyName() const;
+        std::string key() const override;
+        const char* familyName() const override;
         /*!
           @brief Return the name of the group (the second part of the key).
                  For IPTC keys, the group name is the record name.
         */
-        virtual std::string groupName() const;
-        virtual std::string tagName() const;
-        virtual std::string tagLabel() const;
-        virtual uint16_t tag() const;
+        std::string groupName() const override;
+        std::string tagName() const override;
+        std::string tagLabel() const override;
+        uint16_t tag() const override;
         UniquePtr clone() const;
         //! Return the name of the record
         std::string recordName() const;
@@ -329,7 +329,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual IptcKey* clone_() const;
+        IptcKey* clone_() const override;
 
         // DATA
         static constexpr auto familyName_ = "Iptc";

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -79,18 +79,18 @@ namespace Exiv2
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Not supported.
               Calling this function will throw an instance of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         //! @name NOT Implemented

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -176,7 +176,7 @@ namespace Exiv2 {
         AnyError() = default;
         AnyError(const AnyError& o) = default;
 
-        virtual ~AnyError() throw() = default;
+        ~AnyError() throw() override = default;
         ///@brief  Return the error code.
         virtual int code() const throw() =0;
     };
@@ -281,17 +281,17 @@ namespace Exiv2 {
         inline BasicError(ErrorCode code, const A& arg1, const B& arg2, const C& arg3);
 
         //! Virtual destructor. (Needed because of throw())
-        virtual inline ~BasicError() throw();
+        inline ~BasicError() throw() override;
         //@}
 
         //! @name Accessors
         //@{
-        virtual inline int code() const throw();
+        inline int code() const throw() override;
         /*!
           @brief Return the error message as a C-string. The pointer returned by what()
                  is valid only as long as the BasicError object exists.
          */
-        virtual inline const char* what() const throw();
+        inline const char* what() const throw() override;
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Return the error message as a wchar_t-string. The pointer returned by

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -76,7 +76,7 @@ namespace Exiv2 {
         //! Copy constructor
         Exifdatum(const Exifdatum& rhs);
         //! Destructor
-        virtual ~Exifdatum() = default;
+        ~Exifdatum() override = default;
         //@}
 
         //! @name Manipulators
@@ -123,7 +123,7 @@ namespace Exiv2 {
                  Calls setValue(const Value*).
          */
         Exifdatum& operator=(const Value& value);
-        void setValue(const Value* pValue);
+        void setValue(const Value* pValue) override;
         /*!
           @brief Set the value to the string \em value.  Uses Value::read(const
                  std::string&).  If the %Exifdatum does not have a Value yet,
@@ -131,7 +131,7 @@ namespace Exiv2 {
                  created. An AsciiValue is created for unknown tags. Return
                  0 if the value was read successfully.
          */
-        int setValue(const std::string& value);
+        int setValue(const std::string& value) override;
         /*!
           @brief Set the data area by copying (cloning) the buffer pointed to
                  by \em buf.
@@ -151,12 +151,12 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         //! Return the key of the %Exifdatum.
-        std::string key() const;
-        const char* familyName() const;
-        std::string groupName() const;
-        std::string tagName() const;
-        std::string tagLabel() const;
-        uint16_t tag() const;
+        std::string key() const override;
+        const char* familyName() const override;
+        std::string groupName() const override;
+        std::string tagName() const override;
+        std::string tagLabel() const override;
+        uint16_t tag() const override;
         //! Return the IFD id as an integer. (Do not use, this is meant for library internal use.)
         int ifdId() const;
         //! Return the name of the IFD
@@ -174,26 +174,26 @@ namespace Exiv2 {
           @param byteOrder Applicable byte order (little or big endian).
           @return Number of characters written.
         */
-        long copy(byte* buf, ByteOrder byteOrder) const;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const;
+        long copy(byte* buf, ByteOrder byteOrder) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
         //! Return the type id of the value
-        TypeId typeId() const;
+        TypeId typeId() const override;
         //! Return the name of the type
-        const char* typeName() const;
+        const char* typeName() const override;
         //! Return the size in bytes of one component of this type
-        long typeSize() const;
+        long typeSize() const override;
         //! Return the number of components in the value
-        long count() const;
+        long count() const override;
         //! Return the size of the value in bytes
-        long size() const;
+        long size() const override;
         //! Return the value as a string.
-        std::string toString() const;
-        std::string toString(long n) const;
-        long toLong(long n =0) const;
-        float toFloat(long n =0) const;
-        Rational toRational(long n =0) const;
-        Value::UniquePtr getValue() const;
-        const Value& value() const;
+        std::string toString() const override;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
+        Value::UniquePtr getValue() const override;
+        const Value& value() const override;
         //! Return the size of the data area.
         long sizeDataArea() const;
         /*!

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -71,32 +71,32 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet(?) implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. Calling this function will throw an instance
               of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
     }; // class GifImage

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -67,7 +67,7 @@ namespace Exiv2 {
         //! Copy constructor
         Iptcdatum(const Iptcdatum& rhs);
         //! Destructor
-        virtual ~Iptcdatum() = default;
+        ~Iptcdatum() override = default;
         //@}
 
         //! @name Manipulators
@@ -89,7 +89,7 @@ namespace Exiv2 {
                  Calls setValue(const Value*).
          */
         Iptcdatum& operator=(const Value& value);
-        void setValue(const Value* pValue);
+        void setValue(const Value* pValue) override;
         /*!
           @brief Set the value to the string \em value, using
                  Value::read(const std::string&).
@@ -98,20 +98,20 @@ namespace Exiv2 {
                  fails (because of an unknown dataset), a StringValue is
                  created. Return 0 if the value was read successfully.
          */
-        int setValue(const std::string& value);
+        int setValue(const std::string& value) override;
         //@}
 
         //! @name Accessors
         //@{
-        long copy(byte* buf, ByteOrder byteOrder) const;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const;
+        long copy(byte* buf, ByteOrder byteOrder) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
         /*!
           @brief Return the key of the Iptcdatum. The key is of the form
                  '<b>Iptc</b>.recordName.datasetName'. Note however that the key
                  is not necessarily unique, i.e., an IptcData object may contain
                  multiple metadata with the same key.
          */
-        std::string key() const;
+        std::string key() const override;
         /*!
            @brief Return the name of the record (deprecated)
            @return record name
@@ -122,28 +122,28 @@ namespace Exiv2 {
            @return record id
          */
         uint16_t record() const;
-        const char* familyName() const;
-        std::string groupName() const;
+        const char* familyName() const override;
+        std::string groupName() const override;
         /*!
            @brief Return the name of the tag (aka dataset)
            @return tag name
          */
-        std::string tagName() const;
-        std::string tagLabel() const;
+        std::string tagName() const override;
+        std::string tagLabel() const override;
         //! Return the tag (aka dataset) number
-        uint16_t tag() const;
-        TypeId typeId() const;
-        const char* typeName() const;
-        long typeSize() const;
-        long count() const;
-        long size() const;
-        std::string toString() const;
-        std::string toString(long n) const;
-        long toLong(long n =0) const;
-        float toFloat(long n =0) const;
-        Rational toRational(long n =0) const;
-        Value::UniquePtr getValue() const;
-        const Value& value() const;
+        uint16_t tag() const override;
+        TypeId typeId() const override;
+        const char* typeName() const override;
+        long typeSize() const override;
+        long count() const override;
+        long size() const override;
+        std::string toString() const override;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
+        Value::UniquePtr getValue() const override;
+        const Value& value() const override;
         //@}
 
     private:

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -71,8 +71,8 @@ namespace Exiv2
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
 
         /*!
           @brief Print out the structure of image file.
@@ -80,18 +80,18 @@ namespace Exiv2
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -pS for debugging.
          */
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
 
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         //! @name NOT Implemented

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -135,8 +135,8 @@ namespace Exiv2 {
     public:
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
 
         /*!
           @brief Print out the structure of image file.
@@ -144,7 +144,7 @@ namespace Exiv2 {
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -pS for debugging.
          */
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
         //@}
 
         //! @name NOT implemented
@@ -312,7 +312,7 @@ namespace Exiv2 {
         //@}
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         // NOT Implemented
@@ -326,7 +326,7 @@ namespace Exiv2 {
     protected:
         //! @name Accessors
         //@{
-        bool isThisType(BasicIo& iIo, bool advance) const;
+        bool isThisType(BasicIo& iIo, bool advance) const override;
         //@}
         //! @name Manipulators
         //@{
@@ -338,7 +338,7 @@ namespace Exiv2 {
                  4 if the temporary image can not be written to;<BR>
                 -3 other temporary errors
          */
-        int writeHeader(BasicIo& outIo) const;
+        int writeHeader(BasicIo& outIo) const override;
         //@}
 
     private:
@@ -372,7 +372,7 @@ namespace Exiv2 {
         //@}
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         // NOT Implemented
@@ -386,11 +386,11 @@ namespace Exiv2 {
     protected:
         //! @name Accessors
         //@{
-        bool isThisType(BasicIo& iIo, bool advance) const;
+        bool isThisType(BasicIo& iIo, bool advance) const override;
         //@}
         //! @name Manipulators
         //@{
-        int writeHeader(BasicIo& outIo) const;
+        int writeHeader(BasicIo& outIo) const override;
         //@}
 
     private:

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -74,34 +74,34 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. MRW format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
     }; // class MrwImage
 

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -74,21 +74,21 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
-        void readMetadata();
-        void writeMetadata();
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Not supported. ORF format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
     }; // class OrfImage
 

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -68,13 +68,16 @@ namespace Exiv2
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const { return "image/pgf"; }
+        std::string mimeType() const override
+        {
+            return "image/pgf";
+        }
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -68,8 +68,8 @@ namespace Exiv2
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
 
         /*!
           @brief Print out the structure of image file.
@@ -77,12 +77,12 @@ namespace Exiv2
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -pS for debugging.
          */
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -264,7 +264,7 @@ namespace Exiv2 {
         //! Copy constructor.
         XmpKey(const XmpKey& rhs);
         //! Virtual destructor.
-        virtual ~XmpKey();
+        ~XmpKey() override;
         //@}
 
         //! @name Manipulators
@@ -275,17 +275,17 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        virtual std::string key() const;
-        virtual const char* familyName() const;
+        std::string key() const override;
+        const char* familyName() const override;
         /*!
           @brief Return the name of the group (the second part of the key).
                  For XMP keys, the group name is the schema prefix name.
         */
-        virtual std::string groupName() const;
-        virtual std::string tagName() const;
-        virtual std::string tagLabel() const;
+        std::string groupName() const override;
+        std::string tagName() const override;
+        std::string tagLabel() const override;
         //! Properties don't have a tag number. Return 0.
-        virtual uint16_t tag() const;
+        uint16_t tag() const override;
 
         UniquePtr clone() const;
 
@@ -296,7 +296,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual XmpKey* clone_() const;
+        XmpKey* clone_() const override;
 
     private:
         // Pimpl idiom

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -70,12 +70,12 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Not supported. Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
@@ -91,7 +91,7 @@ namespace Exiv2 {
               but Apple, as of Tiger (10.4.8), maps this official MIME type to a
               dynamic UTI, rather than "com.adobe.photoshop-image" as it should.
          */
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
     private:

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -71,35 +71,35 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
-        void readMetadata();
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. RAF format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -64,35 +64,35 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
-        void readMetadata();
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet, requires writeMetadata(). Calling
               this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. RW2 format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -162,7 +162,7 @@ namespace Exiv2 {
         //! Copy constructor
         ExifKey(const ExifKey& rhs);
         //! Destructor
-        virtual ~ExifKey();
+        ~ExifKey() override;
         //@}
 
         //! @name Manipulators
@@ -177,14 +177,14 @@ namespace Exiv2 {
 
         //! @name Accessors
         //@{
-        virtual std::string key() const;
-        virtual const char* familyName() const;
-        virtual std::string groupName() const;
+        std::string key() const override;
+        const char* familyName() const override;
+        std::string groupName() const override;
         //! Return the IFD id as an integer. (Do not use, this is meant for library internal use.)
         int ifdId() const;
-        virtual std::string tagName() const;
-        virtual uint16_t tag() const;
-        virtual std::string tagLabel() const;
+        std::string tagName() const override;
+        uint16_t tag() const override;
+        std::string tagLabel() const override;
         //! Return the tag description.
         std::string tagDesc() const;        // Todo: should be in the base class
         //! Return the default type id for this tag.
@@ -197,7 +197,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual ExifKey* clone_() const;
+        ExifKey* clone_() const override;
 
     private:
         // Pimpl idiom

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -71,32 +71,32 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
+        void readMetadata() override;
         /*!
           @brief Todo: Write metadata back to the image. This method is not
               yet(?) implemented. Calling it will throw an Error(kerWritingImageFormatUnsupported).
          */
-        void writeMetadata();
+        void writeMetadata() override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setExifData(const ExifData& exifData);
+        void setExifData(const ExifData& exifData) override;
         /*!
           @brief Todo: Not supported yet(?). Calling this function will throw
               an instance of Error(kerInvalidSettingForImage).
          */
-        void setIptcData(const IptcData& iptcData);
+        void setIptcData(const IptcData& iptcData) override;
         /*!
           @brief Not supported. Calling this function will throw an instance
               of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
     }; // class TgaImage

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -73,8 +73,8 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
 
         /*!
           @brief Print out the structure of image file.
@@ -82,20 +82,20 @@ namespace Exiv2 {
                 not valid (does not look like data of the specific image type).
           @warning This function is not thread safe and intended for exiv2 -p{S|R} as a file debugging aid
          */
-        virtual void printStructure(std::ostream& out, PrintStructureOption option,int depth=0);
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth = 0) override;
 
         /*!
           @brief Not supported. TIFF format does not contain a comment.
               Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
-        int pixelWidth() const;
-        int pixelHeight() const;
+        std::string mimeType() const override;
+        int pixelWidth() const override;
+        int pixelHeight() const override;
         //@}
 
         //! @name NOT Implemented

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -261,7 +261,7 @@ namespace Exiv2 {
                   long len, ByteOrder byteOrder =invalidByteOrder,
                   TypeId typeId =undefined);
 
-        virtual ~DataValue() = default;
+        ~DataValue() override = default;
 
         //! @name Manipulators
         //@{
@@ -277,11 +277,9 @@ namespace Exiv2 {
 
           @return 0 if successful.
          */
-        virtual int read(const byte* buf,
-                          long len,
-                          ByteOrder byteOrder =invalidByteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder = invalidByteOrder) override;
         //! Set the data from a string of integer values (e.g., "0 1 2 3")
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //@}
 
         //! @name Accessors
@@ -300,24 +298,24 @@ namespace Exiv2 {
           @param byteOrder Byte order. Not needed.
           @return Number of characters written.
         */
-        virtual long copy(byte* buf, ByteOrder byteOrder =invalidByteOrder) const;
-        virtual long count() const;
-        virtual long size() const;
-        virtual std::ostream& write(std::ostream& os) const;
+        long copy(byte* buf, ByteOrder byteOrder = invalidByteOrder) const override;
+        long count() const override;
+        long size() const override;
+        std::ostream& write(std::ostream& os) const override;
         /*!
           @brief Return the <EM>n</EM>-th component of the value as a string.
                  The behaviour of this method may be undefined if there is no
                  <EM>n</EM>-th component.
          */
-        virtual std::string toString(long n) const;
-        virtual long toLong(long n =0) const;
-        virtual float toFloat(long n =0) const;
-        virtual Rational toRational(long n =0) const;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual DataValue* clone_() const;
+        DataValue* clone_() const override;
 
         //! Type used to store the data.
         typedef std::vector<byte> ValueType;
@@ -346,13 +344,13 @@ namespace Exiv2 {
         //! Copy constructor
         StringValueBase(const StringValueBase& rhs) = default;
         //! Virtual destructor.
-        virtual ~StringValueBase() = default;
+        ~StringValueBase() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Read the value from buf. This default implementation uses buf as it is.
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         /*!
           @brief Read the value from a character buffer.
 
@@ -365,9 +363,7 @@ namespace Exiv2 {
 
           @return 0 if successful.
          */
-        virtual int read(const byte* buf,
-                         long len,
-                         ByteOrder byteOrder =invalidByteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder = invalidByteOrder) override;
         //@}
 
         //! @name Accessors
@@ -386,20 +382,20 @@ namespace Exiv2 {
           @param byteOrder Byte order. Not used.
           @return Number of characters written.
         */
-        virtual long copy(byte* buf, ByteOrder byteOrder =invalidByteOrder) const;
-        virtual long count() const;
-        virtual long size() const;
-        virtual long toLong(long n =0) const;
-        virtual float toFloat(long n =0) const;
-        virtual Rational toRational(long n =0) const;
-        virtual std::ostream& write(std::ostream& os) const;
+        long copy(byte* buf, ByteOrder byteOrder = invalidByteOrder) const override;
+        long count() const override;
+        long size() const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
+        std::ostream& write(std::ostream& os) const override;
         //@}
 
     protected:
         //! Assignment operator.
         StringValueBase& operator=(const StringValueBase& rhs);
         //! Internal virtual copy constructor.
-        virtual StringValueBase* clone_() const =0;
+        StringValueBase* clone_() const override = 0;
 
     public:
         // DATA
@@ -426,7 +422,7 @@ namespace Exiv2 {
         //! Constructor
         explicit StringValue(const std::string& buf);
         //! Virtual destructor.
-        virtual ~StringValue() = default;
+        ~StringValue() override = default;
         //@}
 
         //! @name Accessors
@@ -436,7 +432,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual StringValue* clone_() const;
+        StringValue* clone_() const override;
 
     }; // class StringValue
 
@@ -458,7 +454,7 @@ namespace Exiv2 {
         //! Constructor
         explicit AsciiValue(const std::string& buf);
         //! Virtual destructor.
-        virtual ~AsciiValue() = default;
+        ~AsciiValue() override = default;
         //@}
 
         //! @name Manipulators
@@ -469,7 +465,7 @@ namespace Exiv2 {
                  to append a terminating '\\0' character if buf doesn't end
                  with '\\0'.
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //@}
 
         //! @name Accessors
@@ -480,12 +476,12 @@ namespace Exiv2 {
                  output stream.  Any further characters are ignored and not
                  written to the output stream.
         */
-        virtual std::ostream& write(std::ostream& os) const;
+        std::ostream& write(std::ostream& os) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual AsciiValue* clone_() const;
+        AsciiValue* clone_() const override;
 
     }; // class AsciiValue
 
@@ -546,7 +542,7 @@ namespace Exiv2 {
         //! Constructor, uses read(const std::string& comment)
         explicit CommentValue(const std::string& comment);
         //! Virtual destructor.
-        virtual ~CommentValue() = default;
+        ~CommentValue() override = default;
         //@}
 
         //! @name Manipulators
@@ -563,22 +559,22 @@ namespace Exiv2 {
           @return 0 if successful<BR>
                   1 if an invalid character set is encountered
         */
-        int read(const std::string& comment);
+        int read(const std::string& comment) override;
         /*!
           @brief Read the comment from a byte buffer.
          */
-        int read(const byte* buf, long len, ByteOrder byteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder) override;
         //@}
 
         //! @name Accessors
         //@{
         UniquePtr clone() const { return UniquePtr(clone_()); }
-        long copy(byte* buf, ByteOrder byteOrder) const;
+        long copy(byte* buf, ByteOrder byteOrder) const override;
         /*!
           @brief Write the comment in a format which can be read by
           read(const std::string& comment).
          */
-        std::ostream& write(std::ostream& os) const;
+        std::ostream& write(std::ostream& os) const override;
         /*!
           @brief Return the comment (without a charset="..." prefix)
 
@@ -610,7 +606,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual CommentValue* clone_() const;
+        CommentValue* clone_() const override;
 
     public:
         // DATA
@@ -642,7 +638,7 @@ namespace Exiv2 {
         XmpArrayType xmpArrayType() const;
         //! Return XMP struct, indicates if an XMP value is a structure.
         XmpStruct xmpStruct() const;
-        virtual long size() const;
+        long size() const override;
         /*!
           @brief Write value to a character data buffer.
 
@@ -656,7 +652,7 @@ namespace Exiv2 {
           @param byteOrder Byte order. Not used.
           @return Number of characters written.
         */
-        virtual long copy(byte* buf, ByteOrder byteOrder =invalidByteOrder) const;
+        long copy(byte* buf, ByteOrder byteOrder = invalidByteOrder) const override;
         //@}
 
         //! @name Manipulators
@@ -679,10 +675,8 @@ namespace Exiv2 {
 
           @return 0 if successful.
          */
-        virtual int read(const byte* buf,
-                         long len,
-                         ByteOrder byteOrder =invalidByteOrder);
-        virtual int read(const std::string& buf) =0;
+        int read(const byte* buf, long len, ByteOrder byteOrder = invalidByteOrder) override;
+        int read(const std::string& buf) override = 0;
         //@}
 
         /*!
@@ -743,41 +737,41 @@ namespace Exiv2 {
           @return 0 if successful.
          */
 
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //@}
 
         //! @name Accessors
         //@{
         UniquePtr clone() const;
-        long size() const;
-        virtual long count() const;
+        long size() const override;
+        long count() const override;
         /*!
           @brief Convert the value to a long.
                  The optional parameter \em n is not used and is ignored.
 
           @return The converted value.
          */
-        virtual long toLong(long n =0) const;
+        long toLong(long n = 0) const override;
         /*!
           @brief Convert the value to a float.
                  The optional parameter \em n is not used and is ignored.
 
           @return The converted value.
          */
-        virtual float toFloat(long n =0) const;
+        float toFloat(long n = 0) const override;
         /*!
           @brief Convert the value to a Rational.
                  The optional parameter \em n is not used and is ignored.
 
           @return The converted value.
          */
-        virtual Rational toRational(long n =0) const;
-        virtual std::ostream& write(std::ostream& os) const;
+        Rational toRational(long n = 0) const override;
+        std::ostream& write(std::ostream& os) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual XmpTextValue* clone_() const;
+        XmpTextValue* clone_() const override;
 
     public:
         // DATA
@@ -818,34 +812,34 @@ namespace Exiv2 {
 
           @return 0 if successful.
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //@}
 
         //! @name Accessors
         //@{
         UniquePtr clone() const;
-        virtual long count() const;
+        long count() const override;
         /*!
           @brief Return the <EM>n</EM>-th component of the value as a string.
                  The behaviour of this method may be undefined if there is no
                  <EM>n</EM>-th component.
          */
-        virtual std::string toString(long n) const;
-        virtual long toLong(long n =0) const;
-        virtual float toFloat(long n =0) const;
-        virtual Rational toRational(long n =0) const;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
         /*!
           @brief Write all elements of the value to \em os, separated by commas.
 
           @note The output of this method cannot directly be used as the parameter
                 for read().
          */
-        virtual std::ostream& write(std::ostream& os) const;
+        std::ostream& write(std::ostream& os) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual XmpArrayValue* clone_() const;
+        XmpArrayValue* clone_() const override;
 
         std::vector<std::string> value_;        //!< Stores the string values.
 
@@ -920,13 +914,13 @@ namespace Exiv2 {
 
           @return 0 if successful.
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //@}
 
         //! @name Accessors
         //@{
         UniquePtr clone() const;
-        virtual long count() const;
+        long count() const override;
         /*!
           @brief Return the text value associated with the default language
                  qualifier \c x-default. The parameter \em n is not used, but
@@ -934,28 +928,28 @@ namespace Exiv2 {
                  string and sets the ok-flag to \c false if there is no
                  default value.
          */
-        virtual std::string toString(long n) const;
+        std::string toString(long n) const override;
         /*!
           @brief Return the text value associated with the language qualifier
                  \em qualifier. Returns an empty string and sets the ok-flag
                  to \c false if there is no entry for the language qualifier.
          */
         std::string toString(const std::string& qualifier) const;
-        virtual long toLong(long n =0) const;
-        virtual float toFloat(long n =0) const;
-        virtual Rational toRational(long n =0) const;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
         /*!
           @brief Write all elements of the value to \em os, separated by commas.
 
           @note The output of this method cannot directly be used as the parameter
                 for read().
          */
-        virtual std::ostream& write(std::ostream& os) const;
+        std::ostream& write(std::ostream& os) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual LangAltValue* clone_() const;
+        LangAltValue* clone_() const override;
 
     public:
         //! Type used to store language alternative arrays.
@@ -987,7 +981,7 @@ namespace Exiv2 {
         //! Constructor
         DateValue(int year, int month, int day);
         //! Virtual destructor.
-        virtual ~DateValue() = default;
+        ~DateValue() override = default;
         //@}
 
         //! Simple Date helper structure
@@ -1013,9 +1007,7 @@ namespace Exiv2 {
           @return 0 if successful<BR>
                   1 in case of an unsupported date format
          */
-        virtual int read(const byte* buf,
-                         long len,
-                         ByteOrder byteOrder =invalidByteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder = invalidByteOrder) override;
         /*!
           @brief Set the value to that of the string buf.
 
@@ -1024,7 +1016,7 @@ namespace Exiv2 {
           @return 0 if successful<BR>
                   1 in case of an unsupported date format
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //! Set the date
         void setDate(const Date& src);
         //@}
@@ -1045,23 +1037,23 @@ namespace Exiv2 {
           @param byteOrder Byte order. Not used.
           @return Number of characters written.
         */
-        virtual long copy(byte* buf, ByteOrder byteOrder =invalidByteOrder) const;
+        long copy(byte* buf, ByteOrder byteOrder = invalidByteOrder) const override;
         //! Return date struct containing date information
         virtual const Date& getDate() const;
-        virtual long count() const;
-        virtual long size() const;
-        virtual std::ostream& write(std::ostream& os) const;
+        long count() const override;
+        long size() const override;
+        std::ostream& write(std::ostream& os) const override;
         //! Return the value as a UNIX calender time converted to long.
-        virtual long toLong(long n =0) const;
+        long toLong(long n = 0) const override;
         //! Return the value as a UNIX calender time converted to float.
-        virtual float toFloat(long n =0) const;
+        float toFloat(long n = 0) const override;
         //! Return the value as a UNIX calender time  converted to Rational.
-        virtual Rational toRational(long n =0) const;
+        Rational toRational(long n = 0) const override;
         //@}
 
     private:
         //! Internal virtual copy constructor.
-        virtual DateValue* clone_() const;
+        DateValue* clone_() const override;
 
         // DATA
         Date date_;
@@ -1090,7 +1082,7 @@ namespace Exiv2 {
                   int tzHour =0, int tzMinute =0);
 
         //! Virtual destructor.
-        virtual ~TimeValue() = default;
+        ~TimeValue() override = default;
         //@}
 
         //! Simple Time helper structure
@@ -1120,9 +1112,7 @@ namespace Exiv2 {
           @return 0 if successful<BR>
                   1 in case of an unsupported time format
          */
-        virtual int read(const byte* buf,
-                         long len,
-                         ByteOrder byteOrder =invalidByteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder = invalidByteOrder) override;
         /*!
           @brief Set the value to that of the string buf.
 
@@ -1131,7 +1121,7 @@ namespace Exiv2 {
           @return 0 if successful<BR>
                   1 in case of an unsupported time format
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         //! Set the time
         void setTime(const Time& src);
         //@}
@@ -1152,18 +1142,18 @@ namespace Exiv2 {
           @param byteOrder Byte order. Not used.
           @return Number of characters written.
         */
-        virtual long copy(byte* buf, ByteOrder byteOrder =invalidByteOrder) const;
+        long copy(byte* buf, ByteOrder byteOrder = invalidByteOrder) const override;
         //! Return time struct containing time information
         virtual const Time& getTime() const;
-        virtual long count() const;
-        virtual long size() const;
-        virtual std::ostream& write(std::ostream& os) const;
+        long count() const override;
+        long size() const override;
+        std::ostream& write(std::ostream& os) const override;
         //! Returns number of seconds in the day in UTC.
-        virtual long toLong(long n =0) const;
+        long toLong(long n = 0) const override;
         //! Returns number of seconds in the day in UTC converted to float.
-        virtual float toFloat(long n =0) const;
+        float toFloat(long n = 0) const override;
         //! Returns number of seconds in the day in UTC converted to Rational.
-        virtual Rational toRational(long n =0) const;
+        Rational toRational(long n = 0) const override;
         //@}
 
     private:
@@ -1196,7 +1186,7 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         //! Internal virtual copy constructor.
-        virtual TimeValue* clone_() const;
+        TimeValue* clone_() const override;
         //@}
 
         // DATA
@@ -1251,52 +1241,52 @@ namespace Exiv2 {
         //! Copy constructor
         ValueType(const ValueType<T>& rhs);
         //! Virtual destructor.
-        virtual ~ValueType();
+        ~ValueType() override;
         //@}
 
         //! @name Manipulators
         //@{
         //! Assignment operator.
         ValueType<T>& operator=(const ValueType<T>& rhs);
-        virtual int read(const byte* buf, long len, ByteOrder byteOrder);
+        int read(const byte* buf, long len, ByteOrder byteOrder) override;
         /*!
           @brief Set the data from a string of values of type T (e.g.,
                  "0 1 2 3" or "1/2 1/3 1/4" depending on what T is).
                  Generally, the accepted input format is the same as that
                  produced by the write() method.
          */
-        virtual int read(const std::string& buf);
+        int read(const std::string& buf) override;
         /*!
           @brief Set the data area. This method copies (clones) the buffer
                  pointed to by buf.
          */
-        virtual int setDataArea(const byte* buf, long len);
+        int setDataArea(const byte* buf, long len) override;
         //@}
 
         //! @name Accessors
         //@{
         UniquePtr clone() const { return UniquePtr(clone_()); }
-        virtual long copy(byte* buf, ByteOrder byteOrder) const;
-        virtual long count() const;
-        virtual long size() const;
-        virtual std::ostream& write(std::ostream& os) const;
+        long copy(byte* buf, ByteOrder byteOrder) const override;
+        long count() const override;
+        long size() const override;
+        std::ostream& write(std::ostream& os) const override;
         /*!
           @brief Return the <EM>n</EM>-th component of the value as a string.
                  The behaviour of this method may be undefined if there is no
                  <EM>n</EM>-th
                  component.
          */
-        virtual std::string toString(long n) const;
-        virtual long toLong(long n =0) const;
-        virtual float toFloat(long n =0) const;
-        virtual Rational toRational(long n =0) const;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
         //! Return the size of the data area.
-        virtual long sizeDataArea() const;
+        long sizeDataArea() const override;
         /*!
           @brief Return a copy of the data area in a DataBuf. The caller owns
                  this copy and DataBuf ensures that it will be deleted.
          */
-        virtual DataBuf dataArea() const;
+        DataBuf dataArea() const override;
         //@}
 
         //! Container for values
@@ -1317,7 +1307,7 @@ namespace Exiv2 {
 
     private:
         //! Internal virtual copy constructor.
-        virtual ValueType<T>* clone_() const;
+        ValueType<T>* clone_() const override;
 
         // DATA
         //! Pointer to the buffer, nullptr if none has been allocated

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -62,20 +62,20 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
-        void printStructure(std::ostream& out, PrintStructureOption option,int depth);
+        void readMetadata() override;
+        void writeMetadata() override;
+        void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
         //@}
 
         /*!
           @brief Not supported. Calling this function will throw an Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
-        void setIptcData(const IptcData& /*iptcData*/);
+        void setComment(const std::string& comment) override;
+        void setIptcData(const IptcData& /*iptcData*/) override;
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
         //! Copy constructor

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -63,7 +63,7 @@ namespace Exiv2 {
         //! Copy constructor
         Xmpdatum(const Xmpdatum& rhs);
         //! Destructor
-        virtual ~Xmpdatum();
+        ~Xmpdatum() override;
         //@}
 
         //! @name Manipulators
@@ -96,7 +96,7 @@ namespace Exiv2 {
                  Calls setValue(const Value*).
          */
         Xmpdatum& operator=(const Value& value);
-        void setValue(const Value* pValue);
+        void setValue(const Value* pValue) override;
         /*!
           @brief Set the value to the string \em value. Uses Value::read(const
                  std::string&).  If the %Xmpdatum does not have a Value yet,
@@ -104,43 +104,43 @@ namespace Exiv2 {
                  created. If the key is unknown, a XmpTextValue is used as
                  default. Return 0 if the value was read successfully.
          */
-        int setValue(const std::string& value);
+        int setValue(const std::string& value) override;
         //@}
 
         //! @name Accessors
         //@{
         //! Not implemented. Calling this method will raise an exception.
-        long copy(byte* buf, ByteOrder byteOrder) const;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata =0) const;
+        long copy(byte* buf, ByteOrder byteOrder) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
         /*!
           @brief Return the key of the Xmpdatum. The key is of the form
                  '<b>Xmp</b>.prefix.property'. Note however that the
                  key is not necessarily unique, i.e., an XmpData object may
                  contain multiple metadata with the same key.
          */
-        std::string key() const;
-        const char* familyName() const;
+        std::string key() const override;
+        const char* familyName() const override;
         //! Return the (preferred) schema namespace prefix.
-        std::string groupName() const;
+        std::string groupName() const override;
         //! Return the property name.
-        std::string tagName() const;
-        std::string tagLabel() const;
+        std::string tagName() const override;
+        std::string tagLabel() const override;
         //! Properties don't have a tag number. Return 0.
-        uint16_t tag() const;
-        TypeId typeId() const;
-        const char* typeName() const;
+        uint16_t tag() const override;
+        TypeId typeId() const override;
+        const char* typeName() const override;
         // Todo: Remove this method from the baseclass
         //! The Exif typeSize doesn't make sense here. Return 0.
-        long typeSize() const;
-        long count() const;
-        long size() const;
-        std::string toString() const;
-        std::string toString(long n) const;
-        long toLong(long n =0) const;
-        float toFloat(long n =0) const;
-        Rational toRational(long n =0) const;
-        Value::UniquePtr getValue() const;
-        const Value& value() const;
+        long typeSize() const override;
+        long count() const override;
+        long size() const override;
+        std::string toString() const override;
+        std::string toString(long n) const override;
+        long toLong(long n = 0) const override;
+        float toFloat(long n = 0) const override;
+        Rational toRational(long n = 0) const override;
+        Value::UniquePtr getValue() const override;
+        const Value& value() const override;
         //@}
 
     private:

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -63,18 +63,18 @@ namespace Exiv2 {
 
         //! @name Manipulators
         //@{
-        void readMetadata();
-        void writeMetadata();
+        void readMetadata() override;
+        void writeMetadata() override;
         /*!
           @brief Not supported. XMP sidecar files do not contain a comment.
               Calling this function will throw an instance of Error(kerInvalidSettingForImage).
          */
-        void setComment(const std::string& comment);
+        void setComment(const std::string& comment) override;
         //@}
 
         //! @name Accessors
         //@{
-        std::string mimeType() const;
+        std::string mimeType() const override;
         //@}
 
     private:


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>