### PR TITLE
clang-tidy: do not use 0 for bool

### DIFF
--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -257,7 +257,7 @@ namespace Exiv2 {
         // DATA
         XmpMetadata xmpMetadata_;
         std::string xmpPacket_  ;
-        bool usePacket_{0};
+        bool usePacket_{};
     }; // class XmpData
 
     /*!


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>