### PR TITLE
clang-tidy: add explicit

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -1012,7 +1012,7 @@ namespace Exiv2 {
                 divided into the memory blocks. These blocks are populated
                 on demand from the server, so it avoids copying the complete file.
          */
-        HttpIo(const std::string&  url,  size_t blockSize = 1024);
+        explicit HttpIo(const std::string& url, size_t blockSize = 1024);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like HttpIo(const std::string& url, size_t blockSize = 1024) but accepts a
@@ -1050,7 +1050,7 @@ namespace Exiv2 {
                 on demand from the server, so it avoids copying the complete file.
           @throw Error if it is unable to init curl pointer.
          */
-        CurlIo(const std::string&  url,  size_t blockSize = 0);
+        explicit CurlIo(const std::string& url, size_t blockSize = 0);
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Like CurlIo(const std::string&  url,  size_t blockSize = 0) but accepts a

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -39,7 +39,8 @@ namespace Exiv2
 {
     struct Iloc
     {
-        Iloc(uint32_t ID = 0, uint32_t start = 0, uint32_t length = 0) : ID_(ID), start_(start), length_(length){};
+        explicit Iloc(uint32_t ID = 0, uint32_t start = 0, uint32_t length = 0)
+            : ID_(ID), start_(start), length_(length){};
         virtual ~Iloc() = default;
 
         uint32_t ID_;

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -57,7 +57,7 @@ namespace Exiv2 {
               instance after it is passed to this method. Use the Image::io()
               method to get a temporary reference.
          */
-        WebPImage(BasicIo::UniquePtr io);
+        explicit WebPImage(BasicIo::UniquePtr io);
         //@}
 
         //! @name Manipulators


### PR DESCRIPTION
Found with hicpp-explicit-conversions

Signed-off-by: Rosen Penev <rosenp@gmail.com>