### PR TITLE
clang-tidy: use override

### DIFF
--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -161,8 +161,8 @@ namespace Action {
     //! %Print the Exif (or other metadata) of a file to stdout
     class Print : public Task {
     public:
-        virtual ~Print() = default;
-        virtual int run(const std::string& path);
+        ~Print() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Print>;
         UniquePtr clone() const;
 
@@ -205,7 +205,7 @@ namespace Action {
                      EasyAccessFct easyAccessFctFallback =NULL) const;
 
     private:
-        virtual Print* clone_() const;
+        Print* clone_() const override;
 
         std::string path_;
         int align_{0};                // for the alignment of the summary output
@@ -217,25 +217,25 @@ namespace Action {
      */
     class Rename : public Task {
     public:
-        virtual ~Rename() = default;
-        virtual int run(const std::string& path);
+        ~Rename() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Rename>;
         UniquePtr clone() const;
 
     private:
-        virtual Rename* clone_() const;
+        Rename* clone_() const override;
     }; // class Rename
 
     //! %Adjust the Exif (or other metadata) timestamps
     class Adjust : public Task {
     public:
-        virtual ~Adjust() = default;
-        virtual int run(const std::string& path);
+        ~Adjust() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Adjust>;
         UniquePtr clone() const;
 
     private:
-        virtual Adjust* clone_() const;
+        Adjust* clone_() const override;
         int adjustDateTime(Exiv2::ExifData& exifData,
                            const std::string& key,
                            const std::string& path) const;
@@ -252,8 +252,8 @@ namespace Action {
      */
     class Erase : public Task {
     public:
-        virtual ~Erase() = default;
-        virtual int run(const std::string& path);
+        ~Erase() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Erase>;
         UniquePtr clone() const;
 
@@ -283,7 +283,7 @@ namespace Action {
         static int eraseIccProfile(Exiv2::Image* image);
 
     private:
-        virtual Erase* clone_() const;
+        Erase* clone_() const override;
         std::string path_;
 
     }; // class Erase
@@ -293,8 +293,8 @@ namespace Action {
      */
     class Extract : public Task {
     public:
-        virtual ~Extract() = default;
-        virtual int run(const std::string& path);
+        ~Extract() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Extract>;
         UniquePtr clone() const;
 
@@ -322,7 +322,7 @@ namespace Action {
         int writeIccProfile(const std::string& target) const;
 
     private:
-        virtual Extract* clone_() const;
+        Extract* clone_() const override;
         std::string path_;
 
     }; // class Extract
@@ -332,8 +332,8 @@ namespace Action {
      */
     class Insert : public Task {
     public:
-        virtual ~Insert() = default;
-        virtual int run(const std::string& path);
+        ~Insert() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Insert>;
         UniquePtr clone() const;
 
@@ -363,7 +363,7 @@ namespace Action {
         static int insertIccProfile(const std::string& path, Exiv2::DataBuf& iccProfileBlob);
 
     private:
-        virtual Insert* clone_() const;
+        Insert* clone_() const override;
 
     }; // class Insert
 
@@ -373,8 +373,8 @@ namespace Action {
      */
     class Modify : public Task {
     public:
-        virtual ~Modify() = default;
-        virtual int run(const std::string& path);
+        ~Modify() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<Modify>;
         UniquePtr clone() const;
         Modify() {}
@@ -382,7 +382,7 @@ namespace Action {
         static int applyCommands(Exiv2::Image* pImage);
 
     private:
-        virtual Modify* clone_() const;
+        Modify* clone_() const override;
         //! Copy constructor needed because of UniquePtr member
         Modify(const Modify& /*src*/) : Task() {}
 
@@ -406,13 +406,13 @@ namespace Action {
      */
     class FixIso : public Task {
     public:
-        virtual ~FixIso() = default;
-        virtual int run(const std::string& path);
+        ~FixIso() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<FixIso>;
         UniquePtr clone() const;
 
     private:
-        virtual FixIso* clone_() const;
+        FixIso* clone_() const override;
         std::string path_;
 
     }; // class FixIso
@@ -424,13 +424,13 @@ namespace Action {
      */
     class FixCom : public Task {
     public:
-        virtual ~FixCom() = default;
-        virtual int run(const std::string& path);
+        ~FixCom() override = default;
+        int run(const std::string& path) override;
         using UniquePtr = std::unique_ptr<FixCom>;
         UniquePtr clone() const;
 
     private:
-        virtual FixCom* clone_() const;
+        FixCom* clone_() const override;
         std::string path_;
 
     }; // class FixCom

--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -47,20 +47,18 @@ namespace Exiv2 {
         //! Default constructor
         explicit Cr2Header(ByteOrder byteOrder =littleEndian);
         //! Destructor.
-        ~Cr2Header() = default;
+        ~Cr2Header() override = default;
         //@}
 
         //! @name Manipulators
         //@{
-        bool read(const byte* pData, uint32_t size);
+        bool read(const byte* pData, uint32_t size) override;
         //@}
 
         //! @name Accessors
         //@{
-        DataBuf write() const;
-        bool isImageTag(      uint16_t       tag,
-                              IfdId          group,
-                        const PrimaryGroups* pPrimaryGroups) const;
+        DataBuf write() const override;
+        bool isImageTag(uint16_t tag, IfdId group, const PrimaryGroups* pPrimaryGroups) const override;
         //@}
 
         //! Return the address of offset2 from the start of the header

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -306,7 +306,7 @@ namespace Exiv2 {
         CiffEntry(uint16_t tag, uint16_t dir) : CiffComponent(tag, dir) {}
 
         //! Virtual destructor.
-        virtual ~CiffEntry() = default;
+        ~CiffEntry() override = default;
         //@}
 
         // Default assignment operator is fine
@@ -316,20 +316,18 @@ namespace Exiv2 {
         //@{
         using CiffComponent::doAdd;
         // See base class comment
-        virtual void doAdd(UniquePtr component);
+        void doAdd(UniquePtr component) override;
         /*!
           @brief Implements write(). Writes only the value data of the entry,
                  using writeValueData().
          */
-        virtual uint32_t doWrite(Blob&     blob,
-                                 ByteOrder byteOrder,
-                                 uint32_t  offset);
+        uint32_t doWrite(Blob& blob, ByteOrder byteOrder, uint32_t offset) override;
         //@}
 
         //! @name Accessors
         //@{
         // See base class comment
-        virtual void doDecode(Image& image, ByteOrder byteOrder) const;
+        void doDecode(Image& image, ByteOrder byteOrder) const override;
         //@}
 
     }; // class CiffEntry
@@ -345,7 +343,7 @@ namespace Exiv2 {
         CiffDirectory(uint16_t tag, uint16_t dir) : CiffComponent(tag, dir), cc_(NULL) {}
 
         //! Virtual destructor
-        virtual ~CiffDirectory();
+        ~CiffDirectory() override;
         //@}
 
         //! @name Manipulators
@@ -368,42 +366,33 @@ namespace Exiv2 {
         //! @name Manipulators
         //@{
         // See base class comment
-        virtual void doAdd(UniquePtr component);
+        void doAdd(UniquePtr component) override;
         // See base class comment
-        virtual CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId);
+        CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId) override;
         // See base class comment
-        virtual void doRemove(CrwDirs& crwDirs, uint16_t crwTagId);
+        void doRemove(CrwDirs& crwDirs, uint16_t crwTagId) override;
         /*!
           @brief Implements write(). Writes the complete Ciff directory to
                  the blob.
          */
-        virtual uint32_t doWrite(Blob&     blob,
-                                 ByteOrder byteOrder,
-                                 uint32_t  offset);
+        uint32_t doWrite(Blob& blob, ByteOrder byteOrder, uint32_t offset) override;
         // See base class comment
-        virtual void doRead(const byte* pData,
-                            uint32_t    size,
-                            uint32_t    start,
-                            ByteOrder   byteOrder);
+        void doRead(const byte* pData, uint32_t size, uint32_t start, ByteOrder byteOrder) override;
         //@}
 
         //! @name Accessors
         //@{
         // See base class comment
-        virtual void doDecode(Image&    image,
-                              ByteOrder byteOrder) const;
+        void doDecode(Image& image, ByteOrder byteOrder) const override;
 
         // See base class comment
-        virtual void doPrint(std::ostream&      os,
-                             ByteOrder          byteOrder,
-                             const std::string& prefix) const;
+        void doPrint(std::ostream& os, ByteOrder byteOrder, const std::string& prefix) const override;
 
         //! See base class comment. A directory is empty if it has no components.
-        virtual bool doEmpty() const;
+        bool doEmpty() const override;
 
         // See base class comment
-        virtual CiffComponent* doFindComponent(uint16_t crwTagId,
-                                               uint16_t crwDir) const;
+        CiffComponent* doFindComponent(uint16_t crwTagId, uint16_t crwDir) const override;
         //@}
 
     private:

--- a/src/exiv2app.hpp
+++ b/src/exiv2app.hpp
@@ -298,7 +298,7 @@ private:
     }
 
     //! Destructor, frees any allocated regexes in greps_
-    ~Params();
+    ~Params() override;
 
     //! @name Helpers
     //@{
@@ -330,10 +330,10 @@ public:
     int getopt(int argc, char* const argv[]);
 
     //! Handle options and their arguments.
-    virtual int option(int opt, const std::string& optarg, int optopt);
+    int option(int opt, const std::string& optarg, int optopt) override;
 
     //! Handle non-option parameters.
-    virtual int nonoption(const std::string& argv);
+    int nonoption(const std::string& argv) override;
 
     //! Print a minimal usage note to an output stream.
     void usage(std::ostream& os =std::cout) const;

--- a/src/makernote_int.hpp
+++ b/src/makernote_int.hpp
@@ -177,19 +177,17 @@ namespace Exiv2 {
         //! Default constructor
         OlympusMnHeader();
         //! Virtual destructor.
-        virtual ~OlympusMnHeader() = default;
+        ~OlympusMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -208,20 +206,18 @@ namespace Exiv2 {
         //! Default constructor
         Olympus2MnHeader();
         //! Virtual destructor.
-        virtual ~Olympus2MnHeader() = default;
+        ~Olympus2MnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
-        virtual uint32_t baseOffset(uint32_t mnOffset) const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
+        uint32_t baseOffset(uint32_t mnOffset) const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -240,22 +236,20 @@ namespace Exiv2 {
         //! Default constructor
         FujiMnHeader();
         //! Virtual destructor.
-        virtual ~FujiMnHeader() = default;
+        ~FujiMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         // setByteOrder not implemented
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t  size() const;
-        virtual uint32_t  write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t  ifdOffset() const;
-        virtual ByteOrder byteOrder() const;
-        virtual uint32_t  baseOffset(uint32_t mnOffset) const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
+        ByteOrder byteOrder() const override;
+        uint32_t baseOffset(uint32_t mnOffset) const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -276,19 +270,17 @@ namespace Exiv2 {
         //! Default constructor
         Nikon2MnHeader();
         //! Virtual destructor.
-        virtual ~Nikon2MnHeader() = default;
+        ~Nikon2MnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -308,22 +300,20 @@ namespace Exiv2 {
         //! Default constructor
         Nikon3MnHeader();
         //! Virtual destructor.
-        virtual ~Nikon3MnHeader() = default;
+        ~Nikon3MnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
-        virtual void setByteOrder(ByteOrder byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
+        void setByteOrder(ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t  size()      const;
-        virtual uint32_t  write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t  ifdOffset() const;
-        virtual ByteOrder byteOrder() const;
-        virtual uint32_t  baseOffset(uint32_t mnOffset) const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
+        ByteOrder byteOrder() const override;
+        uint32_t baseOffset(uint32_t mnOffset) const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -344,19 +334,17 @@ namespace Exiv2 {
         //! Default constructor
         PanasonicMnHeader();
         //! Virtual destructor.
-        virtual ~PanasonicMnHeader() = default;
+        ~PanasonicMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -376,20 +364,18 @@ namespace Exiv2 {
         //! Default constructor
         PentaxDngMnHeader();
         //! Virtual destructor.
-        virtual ~PentaxDngMnHeader() = default;
+        ~PentaxDngMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
-        virtual uint32_t baseOffset(uint32_t mnOffset) const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
+        uint32_t baseOffset(uint32_t mnOffset) const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -408,19 +394,17 @@ namespace Exiv2 {
         //! Default constructor
         PentaxMnHeader();
         //! Virtual destructor.
-        virtual ~PentaxMnHeader() = default;
+        ~PentaxMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -441,15 +425,13 @@ namespace Exiv2 {
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t baseOffset(uint32_t mnOffset) const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t baseOffset(uint32_t mnOffset) const override;
         //@}
 
     }; // class SamsungMnHeader
@@ -462,19 +444,17 @@ namespace Exiv2 {
         //! Default constructor
         SigmaMnHeader();
         //! Virtual destructor.
-        virtual ~SigmaMnHeader() = default;
+        ~SigmaMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -495,19 +475,17 @@ namespace Exiv2 {
         //! Default constructor
         SonyMnHeader();
         //! Virtual destructor.
-        virtual ~SonyMnHeader() = default;
+        ~SonyMnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();
@@ -527,20 +505,18 @@ namespace Exiv2 {
         //! Default constructor
         Casio2MnHeader();
         //! Virtual destructor.
-        virtual ~Casio2MnHeader() = default;
+        ~Casio2MnHeader() override = default;
         //@}
         //! @name Manipulators
         //@{
-        virtual bool read(const byte* pData,
-                          uint32_t    size,
-                          ByteOrder   byteOrder);
+        bool read(const byte* pData, uint32_t size, ByteOrder byteOrder) override;
         //@}
         //! @name Accessors
         //@{
-        virtual uint32_t size() const;
-        virtual uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const;
-        virtual uint32_t ifdOffset() const;
-        virtual ByteOrder byteOrder() const;
+        uint32_t size() const override;
+        uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
+        uint32_t ifdOffset() const override;
+        ByteOrder byteOrder() const override;
         //@}
         //! Return the size of the makernote header signature
         static uint32_t sizeOfSignature();

--- a/src/orfimage_int.hpp
+++ b/src/orfimage_int.hpp
@@ -43,17 +43,17 @@ namespace Exiv2 {
         //! Default constructor
         explicit OrfHeader(ByteOrder byteOrder =littleEndian);
         //! Destructor.
-        ~OrfHeader() = default;
+        ~OrfHeader() override = default;
         //@}
 
         //! @name Manipulators
         //@{
-        bool read(const byte* pData, uint32_t size);
+        bool read(const byte* pData, uint32_t size) override;
         //@}
 
         //! @name Accessors
         //@{
-        DataBuf write() const;
+        DataBuf write() const override;
         //@}
     private:
         // DATA

--- a/src/rw2image_int.hpp
+++ b/src/rw2image_int.hpp
@@ -46,13 +46,13 @@ namespace Exiv2 {
         //! Default constructor
         Rw2Header();
         //! Destructor.
-        ~Rw2Header() = default;
+        ~Rw2Header() override = default;
         //@}
 
         //! @name Accessors
         //@{
         //! Not yet implemented. Does nothing and returns an empty buffer.
-        DataBuf write() const;
+        DataBuf write() const override;
         //@}
 
     }; // class Rw2Header

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -419,7 +419,7 @@ namespace Exiv2 {
         //! Default constructor.
         TiffEntryBase(uint16_t tag, IfdId group, TiffType tiffType =ttUndefined);
         //! Virtual destructor.
-        virtual ~TiffEntryBase();
+        ~TiffEntryBase() override;
         //@}
 
         //! @name Manipulators
@@ -464,7 +464,7 @@ namespace Exiv2 {
         /*!
           @brief Return the unique id of the entry in the image
          */
-        virtual int idx()        const;
+        int idx() const override;
         /*!
           @brief Return a pointer to the binary representation of the
                  value of this component.
@@ -494,39 +494,31 @@ namespace Exiv2 {
                  the \em ioWrapper, return the number of bytes written. Only the
                  \em ioWrapper and \em byteOrder arguments are used.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
         //! Implements count().
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         /*!
           @brief Implements writeData(). Standard TIFF entries have no data:
                  write nothing and return 0.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         /*!
           @brief Implements writeImage(). Standard TIFF entries have no image data:
                  write nothing and return 0.
          */
-        virtual uint32_t doWriteImage(IoWrapper& ioWrapper,
-                                      ByteOrder byteOrder) const;
+        uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
         //! Implements size(). Return the size of a standard TIFF entry
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         //! Implements sizeData(). Return 0.
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         //! Implements sizeImage(). Return 0.
-        virtual uint32_t doSizeImage() const;
+        uint32_t doSizeImage() const override;
         //@}
 
         //! Helper function to write an \em offset to a preallocated binary buffer
@@ -568,19 +560,19 @@ namespace Exiv2 {
         //! Constructor
         TiffEntry(uint16_t tag, IfdId group) : TiffEntryBase(tag, group) {}
         //! Virtual destructor.
-        virtual ~TiffEntry() = default;
+        ~TiffEntry() override = default;
         //@}
 
     protected:
         //! @name Manipulators
         //@{
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffEntry* doClone() const;
+        TiffEntry* doClone() const override;
         //@}
 
     }; // class TiffEntry
@@ -602,7 +594,7 @@ namespace Exiv2 {
             : TiffEntryBase(tag, group),
               szTag_(szTag), szGroup_(szGroup) {}
         //! Virtual destructor.
-        virtual ~TiffDataEntryBase() = default;
+        ~TiffDataEntryBase() override = default;
         //@}
 
         //! @name Manipulators
@@ -658,22 +650,19 @@ namespace Exiv2 {
             : TiffDataEntryBase(tag, group, szTag, szGroup),
               pDataArea_(0), sizeDataArea_(0) {}
         //! Virtual destructor.
-        virtual ~TiffDataEntry() = default;
+        ~TiffDataEntry() override = default;
         //@}
 
         //! @name Manipulators
         //@{
-        virtual void setStrips(const Value* pSize,
-                               const byte*  pData,
-                               uint32_t     sizeData,
-                               uint32_t     baseOffset);
+        void setStrips(const Value* pSize, const byte* pData, uint32_t sizeData, uint32_t baseOffset) override;
         //@}
 
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write(). Write pointers into the data area to the
                  \em ioWrapper, relative to the offsets in the value. Return the
@@ -685,30 +674,23 @@ namespace Exiv2 {
           on write. The type of the value can only be signed or unsigned short or
           long.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffDataEntry* doClone() const;
+        TiffDataEntry* doClone() const override;
         /*!
           @brief Implements writeData(). Write the data area to the \em ioWrapper.
                  Return the number of bytes written.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         // Using doWriteImage from base class
         // Using doSize() from base class
         //! Implements sizeData(). Return the size of the data area.
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         // Using doSizeImage from base class
         //@}
 
@@ -740,38 +722,31 @@ namespace Exiv2 {
         TiffImageEntry(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup)
             : TiffDataEntryBase(tag, group, szTag, szGroup) {}
         //! Virtual destructor.
-        virtual ~TiffImageEntry() = default;
+        ~TiffImageEntry() override = default;
         //@}
 
         //! @name Manipulators
         //@{
-        virtual void setStrips(const Value* pSize,
-                               const byte*  pData,
-                               uint32_t     sizeData,
-                               uint32_t     baseOffset);
+        void setStrips(const Value* pSize, const byte* pData, uint32_t sizeData, uint32_t baseOffset) override;
         //@}
 
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write(). Write pointers into the image data area to the
                  \em ioWrapper. Return the number of bytes written. The \em valueIdx
                  and \em dataIdx  arguments are not used.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffImageEntry* doClone() const;
+        TiffImageEntry* doClone() const override;
         /*!
           @brief Implements writeData(). Write the image data area to the \em ioWrapper.
                  Return the number of bytes written.
@@ -780,23 +755,19 @@ namespace Exiv2 {
           directory. It is used for TIFF image entries in the makernote (large
           preview images) so that the image data remains in the makernote IFD.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         /*!
           @brief Implements writeImage(). Write the image data area to the \em ioWrapper.
                  Return the number of bytes written.
          */
-        virtual uint32_t doWriteImage(IoWrapper& ioWrapper,
-                                      ByteOrder byteOrder) const;
+        uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
         //! Implements size(). Return the size of the strip pointers.
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         //! Implements sizeData(). Return the size of the image data area.
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         //! Implements sizeImage(). Return the size of the image data area.
-        virtual uint32_t doSizeImage() const;
+        uint32_t doSizeImage() const override;
         //@}
 
     private:
@@ -822,7 +793,7 @@ namespace Exiv2 {
         TiffSizeEntry(uint16_t tag, IfdId group, uint16_t dtTag, IfdId dtGroup)
             : TiffEntryBase(tag, group), dtTag_(dtTag), dtGroup_(dtGroup) {}
         //! Virtual destructor.
-        virtual ~TiffSizeEntry() = default;
+        ~TiffSizeEntry() override = default;
         //@}
 
         //! @name Accessors
@@ -836,13 +807,13 @@ namespace Exiv2 {
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffSizeEntry* doClone() const;
+        TiffSizeEntry* doClone() const override;
         //@}
 
     private:
@@ -866,7 +837,7 @@ namespace Exiv2 {
         TiffDirectory(uint16_t tag, IfdId group, bool hasNext =true)
             : TiffComponent(tag, group), hasNext_(hasNext), pNext_(0) {}
         //! Virtual destructor
-        virtual ~TiffDirectory();
+        ~TiffDirectory() override;
         //@}
 
         //! @name Accessors
@@ -884,66 +855,56 @@ namespace Exiv2 {
 
         //! @name Protected Manipulators
         //@{
-        virtual TiffComponent* doAddPath(uint16_t tag,
-                                         TiffPath& tiffPath,
-                                         TiffComponent* const pRoot,
-                                         TiffComponent::UniquePtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
-        virtual void doAccept(TiffVisitor& visitor);
+        TiffComponent* doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
+                                 TiffComponent::UniquePtr object) override;
+        TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent) override;
+        TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent) override;
+        void doAccept(TiffVisitor& visitor) override;
         /*!
           @brief Implements write(). Write the TIFF directory, values and
                  additional data, including the next-IFD, if any, to the
                  \em ioWrapper, return the number of bytes written.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffDirectory* doClone() const;
+        TiffDirectory* doClone() const override;
         /*!
           @brief This class does not really implement writeData(), it only has
                  write(). This method must not be called; it commits suicide.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         /*!
           @brief Implements writeImage(). Write the image data of the TIFF
                  directory to the \em ioWrapper by forwarding the call to each
                  component as well as the next-IFD, if there is any. Return the
                  number of bytes written.
          */
-        virtual uint32_t doWriteImage(IoWrapper& ioWrapper,
-                                      ByteOrder byteOrder) const;
+        uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
         /*!
           @brief Implements size(). Return the size of the TIFF directory,
                  values and additional data, including the next-IFD, if any.
          */
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         /*!
           @brief Implements count(). Return the number of entries in the TIFF
                  directory. Does not count entries which are marked as deleted.
          */
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         /*!
           @brief This class does not really implement sizeData(), it only has
                  size(). This method must not be called; it commits suicide.
          */
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         /*!
           @brief Implements sizeImage(). Return the sum of the image sizes of
                  all components plus that of the next-IFD, if there is any.
          */
-        virtual uint32_t doSizeImage() const;
+        uint32_t doSizeImage() const override;
         //@}
 
     private:
@@ -984,7 +945,7 @@ namespace Exiv2 {
         //! Default constructor
         TiffSubIfd(uint16_t tag, IfdId group, IfdId newGroup);
         //! Virtual destructor
-        virtual ~TiffSubIfd();
+        ~TiffSubIfd() override;
         //@}
 
     protected:
@@ -996,50 +957,40 @@ namespace Exiv2 {
 
         //! @name Protected Manipulators
         //@{
-        virtual TiffComponent* doAddPath(uint16_t tag,
-                                         TiffPath& tiffPath,
-                                         TiffComponent* const pRoot,
-                                         TiffComponent::UniquePtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        TiffComponent* doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
+                                 TiffComponent::UniquePtr object) override;
+        TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent) override;
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write(). Write the sub-IFD pointers to the \em ioWrapper,
                  return the number of bytes written. The \em valueIdx and
                  \em imageIdx arguments are not used.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffSubIfd* doClone() const;
+        TiffSubIfd* doClone() const override;
         /*!
           @brief Implements writeData(). Write the sub-IFDs to the \em ioWrapper.
                  Return the number of bytes written.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         /*!
           @brief Implements writeImage(). Write the image data of each sub-IFD to
                  the \em ioWrapper. Return the number of bytes written.
          */
-        virtual uint32_t doWriteImage(IoWrapper& ioWrapper,
-                                      ByteOrder byteOrder) const;
+        uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
         //! Implements size(). Return the size of the sub-Ifd pointers.
-        uint32_t doSize() const;
+        uint32_t doSize() const override;
         //! Implements sizeData(). Return the sum of the sizes of all sub-IFDs.
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         //! Implements sizeImage(). Return the sum of the image sizes of all sub-IFDs.
-        virtual uint32_t doSizeImage() const;
+        uint32_t doSizeImage() const override;
         //@}
 
     private:
@@ -1075,44 +1026,38 @@ namespace Exiv2 {
         //! Default constructor
         TiffMnEntry(uint16_t tag, IfdId group, IfdId mnGroup);
         //! Virtual destructor
-        virtual ~TiffMnEntry();
+        ~TiffMnEntry() override;
         //@}
 
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual TiffComponent* doAddPath(uint16_t tag,
-                                         TiffPath& tiffPath,
-                                         TiffComponent* const pRoot,
-                                         TiffComponent::UniquePtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        TiffComponent* doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
+                                 TiffComponent::UniquePtr object) override;
+        TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent) override;
+        TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent) override;
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write() by forwarding the call to the actual
                  concrete Makernote, if there is one.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffMnEntry* doClone() const;
+        TiffMnEntry* doClone() const override;
         //! Implements count(). Return number of components in the entry.
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         // Using doWriteData from base class
         // Using doWriteImage from base class
         /*!
           @brief Implements size() by forwarding the call to the actual
                  concrete Makernote, if there is one.
          */
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         // Using doSizeData from base class
         // Using doSizeImage from base class
         //@}
@@ -1153,7 +1098,7 @@ namespace Exiv2 {
                          MnHeader* pHeader,
                          bool      hasNext =true);
         //! Virtual destructor
-        virtual ~TiffIfdMakernote();
+        ~TiffIfdMakernote() override;
         //@}
 
         //! @name Manipulators
@@ -1213,65 +1158,55 @@ namespace Exiv2 {
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual TiffComponent* doAddPath(uint16_t tag,
-                                         TiffPath& tiffPath,
-                                         TiffComponent* const pRoot,
-                                         TiffComponent::UniquePtr object);
-        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
-        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
-        virtual void doAccept(TiffVisitor& visitor);
+        TiffComponent* doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
+                                 TiffComponent::UniquePtr object) override;
+        TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent) override;
+        TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent) override;
+        void doAccept(TiffVisitor& visitor) override;
         /*!
           @brief Implements write(). Write the Makernote header, TIFF directory,
                  values and additional data to the \em ioWrapper, return the
                  number of bytes written.
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffIfdMakernote* doClone() const;
+        TiffIfdMakernote* doClone() const override;
         /*!
           @brief This class does not really implement writeData(), it only has
                  write(). This method must not be called; it commits suicide.
          */
-        virtual uint32_t doWriteData(IoWrapper& ioWrapper,
-                                     ByteOrder byteOrder,
-                                     int32_t   offset,
-                                     uint32_t  dataIdx,
-                                     uint32_t& imageIdx) const;
+        uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t dataIdx,
+                             uint32_t& imageIdx) const override;
         /*!
           @brief Implements writeImage(). Write the image data of the IFD of
                  the Makernote. Return the number of bytes written.
          */
-        virtual uint32_t doWriteImage(IoWrapper& ioWrapper,
-                                      ByteOrder byteOrder) const;
+        uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const override;
         /*!
           @brief Implements size(). Return the size of the Makernote header,
                  TIFF directory, values and additional data.
          */
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         /*!
           @brief Implements count(). Return the number of entries in the IFD
                  of the Makernote. Does not count entries which are marked as
                  deleted.
          */
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         /*!
           @brief This class does not really implement sizeData(), it only has
                  size(). This method must not be called; it commits suicide.
          */
-        virtual uint32_t doSizeData() const;
+        uint32_t doSizeData() const override;
         /*!
           @brief Implements sizeImage(). Return the total image data size of the
                  makernote IFD.
          */
-        virtual uint32_t doSizeImage() const;
+        uint32_t doSizeImage() const override;
         //@}
 
     private:
@@ -1365,7 +1300,7 @@ namespace Exiv2 {
                         int setSize,
                         CfgSelFct cfgSelFct);
         //! Virtual destructor
-        virtual ~TiffBinaryArray();
+        ~TiffBinaryArray() override;
         //@}
 
         //! @name Manipulators
@@ -1427,38 +1362,32 @@ namespace Exiv2 {
         /*!
           @brief Implements addPath(). Todo: Document it!
          */
-        virtual TiffComponent* doAddPath(uint16_t tag,
-                                         TiffPath& tiffPath,
-                                         TiffComponent* const pRoot,
-                                         TiffComponent::UniquePtr object);
+        TiffComponent* doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
+                                 TiffComponent::UniquePtr object) override;
         /*!
           @brief Implements addChild(). Todo: Document it!
          */
-        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent) override;
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write(). Todo: Document it!
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffBinaryArray* doClone() const;
+        TiffBinaryArray* doClone() const override;
         //! Implements count(). Todo: Document it!
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         // Using doWriteData from base class
         // Using doWriteImage from base class
         /*!
           @brief Implements size(). Todo: Document it!
          */
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         // Using doSizeData from base class
         // Using doSizeImage from base class
         //@}
@@ -1494,7 +1423,7 @@ namespace Exiv2 {
         //! Constructor
         TiffBinaryElement(uint16_t tag, IfdId group);
         //! Virtual destructor.
-        virtual ~TiffBinaryElement() = default;
+        ~TiffBinaryElement() override = default;
         //@}
 
         //! @name Manipulators
@@ -1524,33 +1453,29 @@ namespace Exiv2 {
     protected:
         //! @name Protected Manipulators
         //@{
-        virtual void doAccept(TiffVisitor& visitor);
-        virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+        void doAccept(TiffVisitor& visitor) override;
+        void doEncode(TiffEncoder& encoder, const Exifdatum* datum) override;
         /*!
           @brief Implements write(). Todo: Document it!
          */
-        virtual uint32_t doWrite(IoWrapper& ioWrapper,
-                                 ByteOrder byteOrder,
-                                 int32_t   offset,
-                                 uint32_t  valueIdx,
-                                 uint32_t  dataIdx,
-                                 uint32_t& imageIdx);
+        uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int32_t offset, uint32_t valueIdx, uint32_t dataIdx,
+                         uint32_t& imageIdx) override;
         //@}
 
         //! @name Protected Accessors
         //@{
-        virtual TiffBinaryElement* doClone() const;
+        TiffBinaryElement* doClone() const override;
         /*!
           @brief Implements count(). Returns the count from the element definition.
          */
-        virtual uint32_t doCount() const;
+        uint32_t doCount() const override;
         // Using doWriteData from base class
         // Using doWriteImage from base class
         /*!
           @brief Implements size(). Returns count * type-size, both taken from
                  the element definition.
          */
-        virtual uint32_t doSize() const;
+        uint32_t doSize() const override;
         // Using doSizeData from base class
         // Using doSizeImage from base class
         //@}

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -148,13 +148,11 @@ namespace Exiv2 {
                    uint32_t  offset       =0x00000008,
                    bool      hasImageTags =true);
         //! Destructor
-        ~TiffHeader() = default;
+        ~TiffHeader() override = default;
         //@}
         //@{
         //! @name Accessors
-        bool isImageTag(      uint16_t       tag,
-                              IfdId          group,
-                        const PrimaryGroups* pPrimaryGroups) const;
+        bool isImageTag(uint16_t tag, IfdId group, const PrimaryGroups* pPrimaryGroups) const override;
         //@}
 
     private:

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -162,31 +162,31 @@ namespace Exiv2 {
         TiffFinder(uint16_t tag, IfdId group)
             : tag_(tag), group_(group), tiffComponent_(0) {}
         //! Virtual destructor
-        virtual ~TiffFinder() = default;
+        ~TiffFinder() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Find tag and group in a TIFF entry
-        virtual void visitEntry(TiffEntry* object);
+        void visitEntry(TiffEntry* object) override;
         //! Find tag and group in a TIFF data entry
-        virtual void visitDataEntry(TiffDataEntry* object);
+        void visitDataEntry(TiffDataEntry* object) override;
         //! Find tag and group in a TIFF image entry
-        virtual void visitImageEntry(TiffImageEntry* object);
+        void visitImageEntry(TiffImageEntry* object) override;
         //! Find tag and group in a TIFF size entry
-        virtual void visitSizeEntry(TiffSizeEntry* object);
+        void visitSizeEntry(TiffSizeEntry* object) override;
         //! Find tag and group in a TIFF directory
-        virtual void visitDirectory(TiffDirectory* object);
+        void visitDirectory(TiffDirectory* object) override;
         //! Find tag and group in a TIFF sub-IFD
-        virtual void visitSubIfd(TiffSubIfd* object);
+        void visitSubIfd(TiffSubIfd* object) override;
         //! Find tag and group in a TIFF makernote
-        virtual void visitMnEntry(TiffMnEntry* object);
+        void visitMnEntry(TiffMnEntry* object) override;
         //! Find tag and group in an IFD makernote
-        virtual void visitIfdMakernote(TiffIfdMakernote* object);
+        void visitIfdMakernote(TiffIfdMakernote* object) override;
         //! Find tag and group in a binary array
-        virtual void visitBinaryArray(TiffBinaryArray* object);
+        void visitBinaryArray(TiffBinaryArray* object) override;
         //! Find tag and group in an element of a binary array
-        virtual void visitBinaryElement(TiffBinaryElement* object);
+        void visitBinaryElement(TiffBinaryElement* object) override;
 
         //! Check if \em object matches \em tag and \em group
         void findObject(TiffComponent* object);
@@ -231,31 +231,31 @@ namespace Exiv2 {
                    const TiffHeaderBase* pHeader,
                    const PrimaryGroups*  pPrimaryGroups);
         //! Virtual destructor
-        virtual ~TiffCopier() = default;
+        ~TiffCopier() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Copy a TIFF entry if it is an image tag
-        virtual void visitEntry(TiffEntry* object);
+        void visitEntry(TiffEntry* object) override;
         //! Copy a TIFF data entry if it is an image tag
-        virtual void visitDataEntry(TiffDataEntry* object);
+        void visitDataEntry(TiffDataEntry* object) override;
         //! Copy a TIFF image entry if it is an image tag
-        virtual void visitImageEntry(TiffImageEntry* object);
+        void visitImageEntry(TiffImageEntry* object) override;
         //! Copy a TIFF size entry if it is an image tag
-        virtual void visitSizeEntry(TiffSizeEntry* object);
+        void visitSizeEntry(TiffSizeEntry* object) override;
         //! Copy a TIFF directory if it is an image tag
-        virtual void visitDirectory(TiffDirectory* object);
+        void visitDirectory(TiffDirectory* object) override;
         //! Copy a TIFF sub-IFD if it is an image tag
-        virtual void visitSubIfd(TiffSubIfd* object);
+        void visitSubIfd(TiffSubIfd* object) override;
         //! Copy a TIFF makernote if it is an image tag
-        virtual void visitMnEntry(TiffMnEntry* object);
+        void visitMnEntry(TiffMnEntry* object) override;
         //! Copy an IFD makernote if it is an image tag
-        virtual void visitIfdMakernote(TiffIfdMakernote* object);
+        void visitIfdMakernote(TiffIfdMakernote* object) override;
         //! Copy a binary array if it is an image tag
-        virtual void visitBinaryArray(TiffBinaryArray* object);
+        void visitBinaryArray(TiffBinaryArray* object) override;
         //! Copy an element of a binary array if it is an image tag
-        virtual void visitBinaryElement(TiffBinaryElement* object);
+        void visitBinaryElement(TiffBinaryElement* object) override;
 
         //! Check if \em object is an image tag and if so, copy it to the target tree.
         void copyObject(TiffComponent* object);
@@ -291,31 +291,31 @@ namespace Exiv2 {
             FindDecoderFct       findDecoderFct
         );
         //! Virtual destructor
-        virtual ~TiffDecoder() = default;
+        ~TiffDecoder() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Decode a TIFF entry
-        virtual void visitEntry(TiffEntry* object);
+        void visitEntry(TiffEntry* object) override;
         //! Decode a TIFF data entry
-        virtual void visitDataEntry(TiffDataEntry* object);
+        void visitDataEntry(TiffDataEntry* object) override;
         //! Decode a TIFF image entry
-        virtual void visitImageEntry(TiffImageEntry* object);
+        void visitImageEntry(TiffImageEntry* object) override;
         //! Decode a TIFF size entry
-        virtual void visitSizeEntry(TiffSizeEntry* object);
+        void visitSizeEntry(TiffSizeEntry* object) override;
         //! Decode a TIFF directory
-        virtual void visitDirectory(TiffDirectory* object);
+        void visitDirectory(TiffDirectory* object) override;
         //! Decode a TIFF sub-IFD
-        virtual void visitSubIfd(TiffSubIfd* object);
+        void visitSubIfd(TiffSubIfd* object) override;
         //! Decode a TIFF makernote
-        virtual void visitMnEntry(TiffMnEntry* object);
+        void visitMnEntry(TiffMnEntry* object) override;
         //! Decode an IFD makernote
-        virtual void visitIfdMakernote(TiffIfdMakernote* object);
+        void visitIfdMakernote(TiffIfdMakernote* object) override;
         //! Decode a binary array
-        virtual void visitBinaryArray(TiffBinaryArray* object);
+        void visitBinaryArray(TiffBinaryArray* object) override;
         //! Decode an element of a binary array
-        virtual void visitBinaryElement(TiffBinaryElement* object);
+        void visitBinaryElement(TiffBinaryElement* object) override;
 
         //! Entry function, determines how to decode each tag
         void decodeTiffEntry(const TiffEntryBase* object);
@@ -387,37 +387,37 @@ namespace Exiv2 {
                     const bool isNewImage, const PrimaryGroups* pPrimaryGroups, const TiffHeaderBase* pHeader,
                     FindEncoderFct findEncoderFct);
         //! Virtual destructor
-        virtual ~TiffEncoder() = default;
+        ~TiffEncoder() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Encode a TIFF entry
-        virtual void visitEntry(TiffEntry* object);
+        void visitEntry(TiffEntry* object) override;
         //! Encode a TIFF data entry
-        virtual void visitDataEntry(TiffDataEntry* object);
+        void visitDataEntry(TiffDataEntry* object) override;
         //! Encode a TIFF image entry
-        virtual void visitImageEntry(TiffImageEntry* object);
+        void visitImageEntry(TiffImageEntry* object) override;
         //! Encode a TIFF size entry
-        virtual void visitSizeEntry(TiffSizeEntry* object);
+        void visitSizeEntry(TiffSizeEntry* object) override;
         //! Encode a TIFF directory
-        virtual void visitDirectory(TiffDirectory* object);
+        void visitDirectory(TiffDirectory* object) override;
         //! Update directory entries
-        virtual void visitDirectoryNext(TiffDirectory* object);
+        void visitDirectoryNext(TiffDirectory* object) override;
         //! Encode a TIFF sub-IFD
-        virtual void visitSubIfd(TiffSubIfd* object);
+        void visitSubIfd(TiffSubIfd* object) override;
         //! Encode a TIFF makernote
-        virtual void visitMnEntry(TiffMnEntry* object);
+        void visitMnEntry(TiffMnEntry* object) override;
         //! Encode an IFD makernote
-        virtual void visitIfdMakernote(TiffIfdMakernote* object);
+        void visitIfdMakernote(TiffIfdMakernote* object) override;
         //! Reset encoder to its original state, undo makernote specific settings
-        virtual void visitIfdMakernoteEnd(TiffIfdMakernote* object);
+        void visitIfdMakernoteEnd(TiffIfdMakernote* object) override;
         //! Encode a binary array
-        virtual void visitBinaryArray(TiffBinaryArray* object);
+        void visitBinaryArray(TiffBinaryArray* object) override;
         //! Re-encrypt binary array if necessary
-        virtual void visitBinaryArrayEnd(TiffBinaryArray* object);
+        void visitBinaryArrayEnd(TiffBinaryArray* object) override;
         //! Encode an element of a binary array
-        virtual void visitBinaryElement(TiffBinaryElement* object);
+        void visitBinaryElement(TiffBinaryElement* object) override;
 
         /*!
           @brief Top level encoder function. Determines how to encode each TIFF
@@ -630,33 +630,33 @@ namespace Exiv2 {
                    TiffRwState          state);
 
         //! Virtual destructor
-        virtual ~TiffReader() = default;
+        ~TiffReader() override = default;
         //@}
 
         //! @name Manipulators
         //@{
         //! Read a TIFF entry from the data buffer
-        virtual void visitEntry(TiffEntry* object);
+        void visitEntry(TiffEntry* object) override;
         //! Read a TIFF data entry from the data buffer
-        virtual void visitDataEntry(TiffDataEntry* object);
+        void visitDataEntry(TiffDataEntry* object) override;
         //! Read a TIFF image entry from the data buffer
-        virtual void visitImageEntry(TiffImageEntry* object);
+        void visitImageEntry(TiffImageEntry* object) override;
         //! Read a TIFF size entry from the data buffer
-        virtual void visitSizeEntry(TiffSizeEntry* object);
+        void visitSizeEntry(TiffSizeEntry* object) override;
         //! Read a TIFF directory from the data buffer
-        virtual void visitDirectory(TiffDirectory* object);
+        void visitDirectory(TiffDirectory* object) override;
         //! Read a TIFF sub-IFD from the data buffer
-        virtual void visitSubIfd(TiffSubIfd* object);
+        void visitSubIfd(TiffSubIfd* object) override;
         //! Read a TIFF makernote entry from the data buffer
-        virtual void visitMnEntry(TiffMnEntry* object);
+        void visitMnEntry(TiffMnEntry* object) override;
         //! Read an IFD makernote from the data buffer
-        virtual void visitIfdMakernote(TiffIfdMakernote* object);
+        void visitIfdMakernote(TiffIfdMakernote* object) override;
         //! Reset reader to its original state, undo makernote specific settings
-        virtual void visitIfdMakernoteEnd(TiffIfdMakernote* object);
+        void visitIfdMakernoteEnd(TiffIfdMakernote* object) override;
         //! Read a binary array from the data buffer
-        virtual void visitBinaryArray(TiffBinaryArray* object);
+        void visitBinaryArray(TiffBinaryArray* object) override;
         //! Read an element of a binary array from the data buffer
-        virtual void visitBinaryElement(TiffBinaryElement* object);
+        void visitBinaryElement(TiffBinaryElement* object) override;
 
         //! Read a standard TIFF entry from the data buffer
         void readTiffEntry(TiffEntryBase* object);


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>