### PR TITLE
clang-tidy: pass by value

### DIFF
--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -397,7 +397,9 @@ namespace Exiv2 {
     //! Search key for TIFF mapping structures.
     struct TiffMappingInfo::Key {
         //! Constructor
-        Key(const std::string& m, uint32_t e, IfdId g) : m_(m), e_(e), g_(g) {}
+        Key(std::string m, uint32_t e, IfdId g) : m_(std::move(m)), e_(e), g_(g)
+        {
+        }
         std::string m_;                    //!< Camera make
         uint32_t    e_;                    //!< Extended tag
         IfdId       g_;                    //!< %Group


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>