### PR TITLE
Fix compilation with -Wunused-variable

### DIFF
--- a/cmake/generateConfigFile.cmake
+++ b/cmake/generateConfigFile.cmake
@@ -32,6 +32,7 @@ check_cxx_source_compiles( "
 int main() {
     char buff[100];
     const char* c = strerror_r(0,buff,100);
+    (void)c;  // ignore unuse-variable
     return 0;
 }" EXV_STRERROR_R_CHAR_P )
 


### PR DESCRIPTION
When compiling with `-Wunused-variable`, `EXT_STRERROR_R_CHAR_P` gets undefined because of a failing compilation check.

An alternative would be to `return c ? 0 : 0`, which works with compilers that do not have `__attribute__((undefined))`, but recent compilers seem to support this and the `__attribute__` approach seems cleaner.