### PR TITLE
Stricter date parsing in value.cpp

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -990,7 +990,10 @@ namespace Exiv2 {
         std::memcpy(b, reinterpret_cast<const char*>(buf), 8);
         int scanned = sscanf(b, "%4d%2d%2d",
                              &date_.year, &date_.month, &date_.day);
-        if (scanned != 3) {
+        if (   scanned != 3
+            || date_.year < 0
+            || date_.month < 1 || date_.month > 12
+            || date_.day < 1 || date_.day > 31) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << Error(kerUnsupportedDateFormat) << "\n";
 #endif
@@ -1008,9 +1011,12 @@ namespace Exiv2 {
 #endif
             return 1;
         }
-        int scanned = sscanf(buf.c_str(), "%4d-%d-%d",
+        int scanned = sscanf(buf.c_str(), "%4d-%2d-%2d",
                              &date_.year, &date_.month, &date_.day);
-        if (scanned != 3) {
+        if (   scanned != 3
+            || date_.year < 0
+            || date_.month < 1 || date_.month > 12
+            || date_.day < 1 || date_.day > 31) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << Error(kerUnsupportedDateFormat) << "\n";
 #endif
@@ -1031,7 +1037,7 @@ namespace Exiv2 {
         // sprintf wants to add the null terminator, so use oversized buffer
         char temp[9];
 
-        int wrote = sprintf(temp, "%04d%02d%02d", date_.year, date_.month, date_.day);
+        int wrote = snprintf(temp, sizeof(temp), "%04d%02d%02d", date_.year, date_.month, date_.day);
         assert(wrote == 8);
         std::memcpy(buf, temp, wrote);
         return wrote;

--- a/test/data/issue_1713_poc.xmp
+++ b/test/data/issue_1713_poc.xmp
@@ -1,0 +1,87 @@
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="3.1.2-113">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+    xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+    xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+    xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+    xmlns:tiff="http://ns.adobe.com/tiff/1.0/"
+    xmlns:exif="http://ns.adobe.com/exif/1.0/"
+   dc:format="image/jpeg"
+   xmp:CreatorTool="Adobe Photoshop CS2 Macintosh"
+   xmp:CreateDate="2005-09-07415:07:40-07:00"
+   xmp:ModifyDate="2005-09-07T15:09:51-07:00"
+   xmp:MetadataDate="2006-04-10T13:37:10-07:00"
+   xmpMM:DocumentID="uuid:9A3B7F52214211DAB6308A7391270C13"
+   xmpMM:InstanceID="uuid:B59AC1B3214311DAB6308A7391270C13"
+   photoshop:ColorMode="3"
+   photoshop:ICCProfile="sRGB IEC61966-2.1"
+   tiff:Orientation="1"
+   tiff:XResolution="720000/10000"
+   tiff:YResŽlution="720000/10000"
+   tiff:ResolutionUnit="2"
+   tiff:ImageWidth="360"
+   tiff:ImageLength="216"
+   tiff:NativeDigest="256,257,258,259,262,274,277,284,530,531,282,28256FC8D17D036C26919E106D"
+   tiff:Make="Nikon"
+   exif:PixelelYDimension="216"
+   exif:ColorSpace="1"
+   exif:NativeDigest="36864,40960,40961,37121,37122,40962,40963,37510,;0964,36867,36868,33434,33437,34850,34852,34855,34856,32,23,24,25,26,27,28,30;76DBD9F0A5E7ED8F62B4CE8EFA6478B4">
+   <dc:title>
+    <rdf:Alt>
+     <rdf:li xml:lang="en-US">Blue Square Test File - .jpg</rdf:li>
+     <rdf:li xml:lang="x-default">Blue Square Test File - .jpg</rdf:li>
+     <rdf:li xml:lang="de-CH">Blaues Quadrat Test Datei - .jpg</rdf:li>
+    </rdf:Alt>
+   </dc:title>
+   <dc:description>
+    <rdf:Alt>
+     <rdf:li xml:lang="x-default">XMPFiles BlueSquare test file, created in Photoshop CS2, saved as .psd, .jpg, and .tif.</rdf:li>
+    </rdf:Alt>
+   </dc:description>
+   <dc:subject>
+    <rdf:Bag>
+     <rdf:li>XMP</rdf:li>
+     <rdf:li>Blue Square</rdf:li>
+     <rdf:li>test file</rdf:li>
+     <rdf:li>Photoshop</rdf:li>
+     <rdf:li>.jpg</rdf:li>
+    </rdf:Bag>
+   </dc:subject>
+   <xmpMM:DerivedFrom
+    stRef:instanceID="uuid:9A3B7F4F214211DAB6308A7391270C13"
+    stRef:documentID="uuid:9A3B7F4E214211DAB6308A7391270C13"/>
+   <tiff:BitsPerSample>
+    <rdf:Seq>
+     <rdf:li>8</rdf:li>
+     <rdf:li>8</rdf:li>
+     <rdf:li>8</rdf:li>
+    </rdf:Seq>
+   </tiff:BitsPerSample>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<?xpacket end="w"?>

--- a/tests/bugfixes/github/test_issue_1713.py
+++ b/tests/bugfixes/github/test_issue_1713.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+
+class WebPImageGetHeaderOffset(metaclass=CaseMeta):
+    """
+    Regression test for the bug described in:
+    https://github.com/Exiv2/exiv2/issues/1713
+    """
+    url = "https://github.com/Exiv2/exiv2/issues/1713"
+
+    filename = path("$data_path/issue_1713_poc.xmp")
+    commands = ["$exiv2 -Ph $filename"]
+    stdout = [
+"""  0000  00 00 01 68                                      ...h
+
+  0000  00 00 00 d8                                      ....
+
+  0000  00 01                                            ..
+
+  0000  00 0a fc 80 00 00 27 10                          ......'.
+
+  0000  00 02                                            ..
+
+  0000  32 30 30 35 3a 30 39 3a 30 37 20 32 33 3a 30 39  2005:09:07 23:09
+  0010  3a 35 31 00                                      :51.
+
+  0000  58 4d 50 46 69 6c 65 73 20 42 6c 75 65 53 71 75  XMPFiles BlueSqu
+  0010  61 72 65 20 74 65 73 74 20 66 69 6c 65 2c 20 63  are test file, c
+  0020  72 65 61 74 65 64 20 69 6e 20 50 68 6f 74 6f 73  reated in Photos
+  0030  68 6f 70 20 43 53 32 2c 20 73 61 76 65 64 20 61  hop CS2, saved a
+  0040  73 20 2e 70 73 64 2c 20 2e 6a 70 67 2c 20 61 6e  s .psd, .jpg, an
+  0050  64 20 2e 74 69 66 2e 00                          d .tif..
+
+  0000  4e 69 6b 6f 6e 00                                Nikon.
+
+  0000  00 01                                            ..
+
+  0000  42 6c 75 65 20 53 71 75 61 72 65 20 54 65 73 74  Blue Square Test
+  0010  20 46 69 6c 65 20 2d 20 2e 6a 70 67               File - .jpg
+
+  0000  1b 25 47                                         .%G
+
+  0000  58 4d 50                                         XMP
+
+  0000  42 6c 75 65 20 53 71 75 61 72 65                 Blue Square
+
+  0000  74 65 73 74 20 66 69 6c 65                       test file
+
+  0000  50 68 6f 74 6f 73 68 6f 70                       Photoshop
+
+  0000  2e 6a 70 67                                      .jpg
+
+  0000  32 30 30 35 30 39 30 37                          20050907
+
+  0000  58 4d 50 46 69 6c 65 73 20 42 6c 75 65 53 71 75  XMPFiles BlueSqu
+  0010  61 72 65 20 74 65 73 74 20 66 69 6c 65 2c 20 63  are test file, c
+  0020  72 65 61 74 65 64 20 69 6e 20 50 68 6f 74 6f 73  reated in Photos
+  0030  68 6f 70 20 43 53 32 2c 20 73 61 76 65 64 20 61  hop CS2, saved a
+  0040  73 20 2e 70 73 64 2c 20 2e 6a 70 67 2c 20 61 6e  s .psd, .jpg, an
+  0050  64 20 2e 74 69 66 2e                             d .tif.
+
+"""]
+    stderr = [
+"""Warning: Failed to convert Xmp.xmp.CreateDate to Exif.Photo.DateTimeDigitized (Day is out of range)
+Exiv2 exception in print action for file $filename:
+Xmpdatum::copy: Not supported
+"""
+]
+    retval = [1]

--- a/tests/bugfixes/github/test_issue_1713.py
+++ b/tests/bugfixes/github/test_issue_1713.py
@@ -3,7 +3,7 @@
 from system_tests import CaseMeta, path
 
 
-class WebPImageGetHeaderOffset(metaclass=CaseMeta):
+class InvalidDateXMP(metaclass=CaseMeta):
     """
     Regression test for the bug described in:
     https://github.com/Exiv2/exiv2/issues/1713
@@ -12,56 +12,7 @@ class WebPImageGetHeaderOffset(metaclass=CaseMeta):
 
     filename = path("$data_path/issue_1713_poc.xmp")
     commands = ["$exiv2 -Ph $filename"]
-    stdout = [
-"""  0000  00 00 01 68                                      ...h
 
-  0000  00 00 00 d8                                      ....
-
-  0000  00 01                                            ..
-
-  0000  00 0a fc 80 00 00 27 10                          ......'.
-
-  0000  00 02                                            ..
-
-  0000  32 30 30 35 3a 30 39 3a 30 37 20 32 33 3a 30 39  2005:09:07 23:09
-  0010  3a 35 31 00                                      :51.
-
-  0000  58 4d 50 46 69 6c 65 73 20 42 6c 75 65 53 71 75  XMPFiles BlueSqu
-  0010  61 72 65 20 74 65 73 74 20 66 69 6c 65 2c 20 63  are test file, c
-  0020  72 65 61 74 65 64 20 69 6e 20 50 68 6f 74 6f 73  reated in Photos
-  0030  68 6f 70 20 43 53 32 2c 20 73 61 76 65 64 20 61  hop CS2, saved a
-  0040  73 20 2e 70 73 64 2c 20 2e 6a 70 67 2c 20 61 6e  s .psd, .jpg, an
-  0050  64 20 2e 74 69 66 2e 00                          d .tif..
-
-  0000  4e 69 6b 6f 6e 00                                Nikon.
-
-  0000  00 01                                            ..
-
-  0000  42 6c 75 65 20 53 71 75 61 72 65 20 54 65 73 74  Blue Square Test
-  0010  20 46 69 6c 65 20 2d 20 2e 6a 70 67               File - .jpg
-
-  0000  1b 25 47                                         .%G
-
-  0000  58 4d 50                                         XMP
-
-  0000  42 6c 75 65 20 53 71 75 61 72 65                 Blue Square
-
-  0000  74 65 73 74 20 66 69 6c 65                       test file
-
-  0000  50 68 6f 74 6f 73 68 6f 70                       Photoshop
-
-  0000  2e 6a 70 67                                      .jpg
-
-  0000  32 30 30 35 30 39 30 37                          20050907
-
-  0000  58 4d 50 46 69 6c 65 73 20 42 6c 75 65 53 71 75  XMPFiles BlueSqu
-  0010  61 72 65 20 74 65 73 74 20 66 69 6c 65 2c 20 63  are test file, c
-  0020  72 65 61 74 65 64 20 69 6e 20 50 68 6f 74 6f 73  reated in Photos
-  0030  68 6f 70 20 43 53 32 2c 20 73 61 76 65 64 20 61  hop CS2, saved a
-  0040  73 20 2e 70 73 64 2c 20 2e 6a 70 67 2c 20 61 6e  s .psd, .jpg, an
-  0050  64 20 2e 74 69 66 2e                             d .tif.
-
-"""]
     stderr = [
 """Warning: Failed to convert Xmp.xmp.CreateDate to Exif.Photo.DateTimeDigitized (Day is out of range)
 Exiv2 exception in print action for file $filename:
@@ -69,3 +20,7 @@ Xmpdatum::copy: Not supported
 """
 ]
     retval = [1]
+
+    def compare_stdout(self, i, command, got_stdout, expected_stdout):
+        """ We don't care about the stdout, just don't crash """
+        pass


### PR DESCRIPTION
Fixes #1713.

The problem in #1713 is caused by a file containing the date "2005-09-07415". It isn't rejected as an invalid date. Later on, it's printed to a string using `sprintf`, causing an out of bounds write. I have improved the parsing logic to reject the invalid date, and also replaced `sprintf` with `snprintf`.