### PR TITLE
Replace sprintf with snprintf.

### DIFF
--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -239,7 +239,7 @@ std::string Position::toExifTimeStamp(std::string& t)
         char a,b,c,d,e   ;
         sscanf(arg,"%d%c%d%c%d%c%d%c%d%c%d",&YY,&a,&MM,&b,&DD,&c,&HH,&d,&mm,&e,&SS1);
     }
-    sprintf(result,"%d/1 %d/1 %d/1",HH,mm,SS1);
+    snprintf(result,sizeof(result),"%d/1 %d/1 %d/1",HH,mm,SS1);
     return std::string(result);
 }
 
@@ -247,7 +247,7 @@ std::string Position::toExifString(double d)
 {
     char result[200];
     d *= 100;
-    sprintf(result, "%d/100", abs(static_cast<int>(d)));
+    snprintf(result, sizeof(result), "%d/100", abs(static_cast<int>(d)));
     return std::string(result);
 }
 
@@ -266,9 +266,9 @@ std::string Position::toExifString(double d,bool bRational,bool bLat)
     int sec = static_cast<int>(d);
     char result[200];
     if ( bRational )
-        sprintf(result,"%d/1 %d/1 %d/1" ,deg,min,sec);
+        snprintf(result,sizeof(result),"%d/1 %d/1 %d/1" ,deg,min,sec);
     else
-        sprintf(result,"%03d%s%02d'%02d\"%s" ,deg,gDeg,min,sec,NSEW);
+        snprintf(result,sizeof(result),"%03d%s%02d'%02d\"%s" ,deg,gDeg,min,sec,NSEW);
     return std::string(result);
 }
 
@@ -277,7 +277,7 @@ std::string Position::toString() const
     char result[200];
     std::string sLat = Position::toExifString(lat_,false,true );
     std::string sLon = Position::toExifString(lon_,false,false);
-    sprintf(result,"%s %s %-8.3f",sLon.c_str(),sLat.c_str(),ele_);
+    snprintf(result,sizeof(result),"%s %s %-8.3f",sLon.c_str(),sLat.c_str(),ele_);
     return std::string(result);
 }
 

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -357,7 +357,7 @@ namespace Exiv2 {
             uint16_t record = bytes.at(i + 1);
             uint16_t dataset = bytes.at(i + 2);
             uint16_t len = getUShort(bytes.subSlice(i + 3, bytes.size()), bigEndian);
-            sprintf(buff, "  %6d | %7d | %-24s | %6d | ", record, dataset,
+            snprintf(buff, sizeof(buff), "  %6d | %7d | %-24s | %6d | ", record, dataset,
                     Exiv2::IptcDataSets::dataSetName(dataset, record).c_str(), len);
 
             out << buff << Internal::binaryToString(makeSlice(bytes, i + 5, i + 5 + (len > 40 ? 40 : len)))

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -597,11 +597,10 @@ namespace Exiv2 {
             nm[0xc4] = "DHT";
             for (int i = 0; i <= 15; i++) {
                 char MN[16];
-                /// \todo to be replaced by std::snprintf on master (only available in c++11)
-                sprintf(MN, "APP%d", i);
+                snprintf(MN, sizeof(MN), "APP%d", i);
                 nm[0xe0 + i] = MN;
                 if (i != 4) {
-                    sprintf(MN, "SOF%d", i);
+                    snprintf(MN, sizeof(MN), "SOF%d", i);
                     nm[0xc0 + i] = MN;
                 }
             }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -204,7 +204,7 @@ static std::vector<std::string> getLoadedLibraries()
     // http://stackoverflow.com/questions/606041/how-do-i-get-the-path-of-a-process-in-unix-linux
     char procsz[100];
     char pathsz[500];
-    sprintf(procsz,"/proc/%d/path/a.out", getpid());
+    snprintf(procsz, sizeof(procsz), "/proc/%d/path/a.out", getpid());
     int l = readlink (procsz, pathsz,sizeof(pathsz));
     if (l>0) {
         pathsz[l]='\0';
@@ -251,7 +251,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
 
 #ifndef __VERSION__
     char  version[40];
-    sprintf(version,"%d.%02d",(_MSC_VER-600)/100,_MSC_VER%100);
+    snprintf(version, sizeof(version), "%d.%02d",(_MSC_VER-600)/100,_MSC_VER%100);
 
     // add edition in brackets
     // 7.10 = 2003 8.00 = 2005 etc 12.00 = 2013 13.00 = 2015 (yet the installer labels it as 14.0!)
@@ -261,7 +261,10 @@ void Exiv2::dumpLibraryInfo(std::ostream& os,const exv_grep_keys_t& keys)
     if (  edition == 14 && _MSC_VER >= 1920 ) edition++ ; // 2019 _MSC_VAR  == 1920
 
     if  ( edition > lengthof(editions) ) edition = 0 ;
-    if  ( edition ) sprintf(version+::strlen(version)," (%s/%s)",editions[edition],bits==64?"x64":"x86");
+    if  ( edition ) {
+      const size_t len = ::strlen(version);
+      snprintf(version+len, sizeof(version) - len, " (%s/%s)",editions[edition],bits==64?"x64":"x86");
+    }
 #define __VERSION__ version
 #endif
 


### PR DESCRIPTION
It turns out (see #1720) that there are still a few uses of `sprintf` in the codebase. According to the comments, that's because the code was written before the switch to C++11. We're using C++11 now, so these can all be replaced with `snprintf`.

I originally submitted this as #1721, but it causes build errors on 0.27-maintenance.