### PR TITLE
clang-tidy: replace throw with noexcept

### DIFF
--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -176,9 +176,9 @@ namespace Exiv2 {
         AnyError() = default;
         AnyError(const AnyError& o) = default;
 
-        ~AnyError() throw() override = default;
+        ~AnyError() noexcept override = default;
         ///@brief  Return the error code.
-        virtual int code() const throw() =0;
+        virtual int code() const noexcept = 0;
     };
 
     //! %AnyError output operator
@@ -281,17 +281,17 @@ namespace Exiv2 {
         inline BasicError(ErrorCode code, const A& arg1, const B& arg2, const C& arg3);
 
         //! Virtual destructor. (Needed because of throw())
-        inline ~BasicError() throw() override;
+        inline ~BasicError() noexcept override;
         //@}
 
         //! @name Accessors
         //@{
-        inline int code() const throw() override;
+        inline int code() const noexcept override;
         /*!
           @brief Return the error message as a C-string. The pointer returned by what()
                  is valid only as long as the BasicError object exists.
          */
-        inline const char* what() const throw() override;
+        inline const char* what() const noexcept override;
 #ifdef EXV_UNICODE_PATH
         /*!
           @brief Return the error message as a wchar_t-string. The pointer returned by
@@ -367,16 +367,16 @@ namespace Exiv2 {
     }
 
     template <typename charT>
-    BasicError<charT>::~BasicError() throw() = default;
+    BasicError<charT>::~BasicError() noexcept = default;
 
-    template<typename charT>
-    int BasicError<charT>::code() const throw()
+    template <typename charT>
+    int BasicError<charT>::code() const noexcept
     {
         return code_;
     }
 
-    template<typename charT>
-    const char* BasicError<charT>::what() const throw()
+    template <typename charT>
+    const char* BasicError<charT>::what() const noexcept
     {
         return msg_.c_str();
     }

--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -95,7 +95,7 @@ namespace Exiv2
             /*!
              * Return the number of elements in the slice.
              */
-            inline size_t size() const throw()
+            inline size_t size() const noexcept
             {
                 // cannot underflow, as we know that begin < end
                 return end_ - begin_;
@@ -184,7 +184,7 @@ namespace Exiv2
             /*!
              * Obtain a constant iterator to the first element in the slice.
              */
-            const_iterator cbegin() const throw()
+            const_iterator cbegin() const noexcept
             {
                 return storage_.unsafeGetIteratorAt(begin_);
             }
@@ -192,7 +192,7 @@ namespace Exiv2
             /*!
              * Obtain a constant iterator to the first beyond the slice.
              */
-            const_iterator cend() const throw()
+            const_iterator cend() const noexcept
             {
                 return storage_.unsafeGetIteratorAt(end_);
             }
@@ -273,7 +273,7 @@ namespace Exiv2
             /*!
              * Obtain an iterator to the first element in the slice.
              */
-            iterator begin() throw()
+            iterator begin() noexcept
             {
                 return this->storage_.unsafeGetIteratorAt(this->begin_);
             }
@@ -281,7 +281,7 @@ namespace Exiv2
             /*!
              * Obtain an iterator to the first element beyond the slice.
              */
-            iterator end() throw()
+            iterator end() noexcept
             {
                 return this->storage_.unsafeGetIteratorAt(this->end_);
             }
@@ -304,7 +304,7 @@ namespace Exiv2
              * the appropriate `slice<const T>` and call its `subSlice() const`,
              * which returns the correct type.
              */
-            ConstSliceBase<storage_type, const data_type> to_const_base() const throw()
+            ConstSliceBase<storage_type, const data_type> to_const_base() const noexcept
             {
                 return ConstSliceBase<storage_type, const data_type>(this->storage_.data_, this->begin_, this->end_);
             }
@@ -442,12 +442,12 @@ namespace Exiv2
              *
              * @throw nothing
              */
-            value_type& unsafeAt(size_t index) throw()
+            value_type& unsafeAt(size_t index) noexcept
             {
                 return data_[index];
             }
 
-            const value_type& unsafeAt(size_t index) const throw()
+            const value_type& unsafeAt(size_t index) const noexcept
             {
                 return data_[index];
             }
@@ -458,12 +458,12 @@ namespace Exiv2
              *
              * @throw nothing
              */
-            iterator unsafeGetIteratorAt(size_t index) throw()
+            iterator unsafeGetIteratorAt(size_t index) noexcept
             {
                 return data_ + index;
             }
 
-            const_iterator unsafeGetIteratorAt(size_t index) const throw()
+            const_iterator unsafeGetIteratorAt(size_t index) const noexcept
             {
                 return data_ + index;
             }


### PR DESCRIPTION
Found with modernize-use-noexcept

Signed-off-by: Rosen Penev <rosenp@gmail.com>