### PR TITLE
clang-tidy: remove redundant specifiers

### DIFF
--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -298,7 +298,6 @@ namespace Exiv2 {
         //! Internal virtual copy constructor.
         XmpKey* clone_() const override;
 
-    private:
         // Pimpl idiom
         struct Impl;
         std::unique_ptr<Impl> p_;

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -199,7 +199,6 @@ namespace Exiv2 {
         //! Internal virtual copy constructor.
         ExifKey* clone_() const override;
 
-    private:
         // Pimpl idiom
         struct Impl;
         std::unique_ptr<Impl> p_;

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -96,7 +96,6 @@ namespace Exiv2 {
                          bool has_alpha, bool has_icc, int width,
                          int height);
 
-    private:
         static const byte WEBP_PAD_ODD;
         static const int WEBP_TAG_SIZE;
         static const int WEBP_VP8X_ICC_BIT;


### PR DESCRIPTION
Found with readability-redundant-access-specifiers

Signed-off-by: Rosen Penev <rosenp@gmail.com>