### PR TITLE
Remove obsolete snprintf macros.

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,9 +43,6 @@
 #include <ios>
 #include <sstream>
 #include <stdio.h> // for snprintf (C99)
-#ifdef _MSC_VER
-# define snprintf _snprintf
-#endif
 #include <cstring>
 
 #if defined WIN32 && !defined __CYGWIN__

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -50,7 +50,6 @@
 #include <string.h>
 #include <io.h>
 #if !defined(__MINGW__) && !defined(__CYGWIN__)
-#define  snprintf sprintf_s
 #define  write    _write
 #define  read     _read
 #define  close    _close

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -38,37 +38,6 @@
 #include <cstdlib>
 #include <ctype.h>
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-
-#define snprintf c99_snprintf
-#define vsnprintf c99_vsnprintf
-
-__inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
-{
-    int count = -1;
-
-    if (size != 0)
-        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
-    if (count == -1)
-        count = _vscprintf(format, ap);
-
-    return count;
-}
-
-__inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
-{
-    int count;
-    va_list ap;
-
-    va_start(ap, format);
-    count = c99_vsnprintf(outBuf, size, format, ap);
-    va_end(ap);
-
-    return count;
-}
-
-#endif
-
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {


### PR DESCRIPTION
This is a follow-up to #1727. In the past (for example on the 0.27-maintenance branch), it wasn't possible to use `snprintf` because it caused build failures on Windows. So a few files have defined their own `snprintf` using macros. Now that we have switched to C++11, I think those macros can be removed.

Note: there are a few similar macros in the xmpsdk directory, which I did not touch because I believe that is 3rd party code that we try to leave undisturbed.