### PR TITLE
Zero initialize local variables.

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -529,7 +529,7 @@ namespace Exiv2 {
     T stringTo(const std::string& s, bool& ok)
     {
         std::istringstream is(s);
-        T tmp;
+        T tmp = T();
         ok = (is >> tmp) ? true : false;
         std::string rest;
         is >> std::skipws >> rest;

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1572,7 +1572,7 @@ namespace Exiv2 {
     int ValueType<T>::read(const std::string& buf)
     {
         std::istringstream is(buf);
-        T tmp;
+        T tmp = T();
         ValueList val;
         while (!(is.eof())) {
             is >> tmp;

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -230,7 +230,7 @@ namespace Jzon
 		if (IsNumber())
 		{
 			std::stringstream sstr(valueStr);
-			int val;
+			int val = 0;
 			sstr >> val;
 			return val;
 		}
@@ -244,7 +244,7 @@ namespace Jzon
 		if (IsNumber())
 		{
 			std::stringstream sstr(valueStr);
-			float val;
+			float val = 0;
 			sstr >> val;
 			return val;
 		}
@@ -258,7 +258,7 @@ namespace Jzon
 		if (IsNumber())
 		{
 			std::stringstream sstr(valueStr);
-			double val;
+			double val = 0;
 			sstr >> val;
 			return val;
 		}

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -242,8 +242,8 @@ std::string Position::toExifTimeStamp(std::string& t)
     int mm = 0 ;
     int SS1 = 0 ;
     if ( strstr(arg,":") || strstr(arg,"-") ) {
-        int  YY,MM,DD    ;
-        char a,b,c,d,e   ;
+        int YY=0,MM=0,DD=0;
+        char a=0,b=0,c=0,d=0,e=0;
         sscanf(arg,"%d%c%d%c%d%c%d%c%d%c%d",&YY,&a,&MM,&b,&DD,&c,&HH,&d,&mm,&e,&SS1);
     }
     sprintf(result,"%d/1 %d/1 %d/1",HH,mm,SS1);
@@ -423,8 +423,8 @@ time_t parseTime(const char* arg,bool bAdjust)
         // <time>2012-07-14T17:33:16Z</time>
 
         if ( strstr(arg,":") || strstr(arg,"-") ) {
-            int  YY,MM,DD,HH,mm,SS1 ;
-            char a,b,c,d,e   ;
+            int  YY=0,MM=0,DD=0,HH=0,mm=0,SS1=0;
+            char a=0,b=0,c=0,d=0,e=0;
             sscanf(arg,"%d%c%d%c%d%c%d%c%d%c%d",&YY,&a,&MM,&b,&DD,&c,&HH,&d,&mm,&e,&SS1);
 
             struct tm T;
@@ -764,7 +764,7 @@ int parseTZ(const char* adjust)
 {
     int   h=0;
     int   m=0;
-    char  c  ;
+    char  c=0;
     try {
         sscanf(adjust,"%d%c%d",&h,&c,&m);
     } catch ( ... ) {} ;

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -69,8 +69,8 @@ int main(int argc, char* const argv[])
         Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(0, 0, iptcData);
         std::cout << "IRB buffer : " << irb.size_ << "\n";
         const Exiv2::byte* record;
-        uint32_t sizeHdr;
-        uint32_t sizeData;
+        uint32_t sizeHdr = 0;
+        uint32_t sizeData = 0;
         Exiv2::Photoshop::locateIptcIrb(irb.pData_, irb.size_, &record, &sizeHdr, &sizeData);
         Exiv2::DataBuf rawIptc = Exiv2::IptcParser::encode(iptcData);
         std::cout << "Comparing IPTC and IRB size... ";

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -75,7 +75,7 @@ int main()
     for (unsigned int i = 0; i < EXV_COUNTOF(testcases); ++i) try {
         std::string s(testcases[i]);
         std::cout << std::setw(12) << std::left << s;
-        bool ok;
+        bool ok = false;
 
         long l = Exiv2::parseLong(s, ok);
         std::cout << std::setw(12) << std::left;

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* const argv[])
 
     std::string testFile = argv[1];
     std::istringstream iss(argv[2]);
-    int testNo;
+    int testNo = 0;
     iss >> testNo;
 
     int rc = 0;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1865,7 +1865,7 @@ namespace {
         std::memset(tm, 0x0, sizeof(struct tm));
         tm->tm_isdst = -1;
 
-        long tmp;
+        long tmp = 0;
         if (!Util::strtol(timeStr.substr(0,4).c_str(), tmp)) return 5;
         tm->tm_year = tmp - 1900;
         if (!Util::strtol(timeStr.substr(5,2).c_str(), tmp)) return 6;

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -565,6 +565,7 @@ namespace Exiv2
         visits_max_ = io_->size() / 16;
         unknownID_ = 0xffff;
         exifID_    = unknownID_;
+        xmpID_     = unknownID_;
 
         long address = 0;
         while (address < (long)io_->size()) {

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2761,7 +2761,7 @@ namespace Exiv2 {
                                               const ExifData*)
     {
         std::istringstream is(value.toString());
-        uint32_t l;
+        uint32_t l = 0;
         is >> l;
         return os << std::setw(4) << std::setfill('0') << std::hex
                   << ((l & 0xffff0000) >> 16)

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -563,7 +563,7 @@ namespace Exiv2 {
         Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
-        int year, month, day, hour, min, sec;
+        int year=0, month=0, day=0, hour=0, min=0, sec=0;
         std::string subsec;
         char buf[30];
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -524,7 +524,7 @@ namespace Exiv2 {
     uint16_t IptcDataSets::dataSet(const std::string& dataSetName,
                                    uint16_t recordId)
     {
-        uint16_t dataSet;
+        uint16_t dataSet = 0;
         int idx = dataSetIdx(dataSetName, recordId);
         if (idx != -1) {
             // dataSetIdx checks the range of recordId

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -311,7 +311,7 @@ int Exiv2::http(Exiv2::Dictionary& request,Exiv2::Dictionary& response,std::stri
 
     ////////////////////////////////////
     // read and process the response
-    int err ;
+    int err = 0;
     n=forgive(recv(sockfd,buffer,(int)buff_l,0),err) ;
     while ( n >= 0 && OK(status) ) {
         if ( n ) {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -277,7 +277,7 @@ namespace Exiv2 {
 
     uint16_t Image::byteSwap2(const DataBuf& buf,size_t offset,bool bSwap) const
     {
-        uint16_t v;
+        uint16_t v = 0;
         char*    p = (char*) &v;
         p[0] = buf.pData_[offset];
         p[1] = buf.pData_[offset+1];
@@ -286,7 +286,7 @@ namespace Exiv2 {
 
     uint32_t Image::byteSwap4(const DataBuf& buf,size_t offset,bool bSwap) const
     {
-        uint32_t v;
+        uint32_t v = 0;
         char*    p = (char*) &v;
         p[0] = buf.pData_[offset];
         p[1] = buf.pData_[offset+1];
@@ -297,7 +297,7 @@ namespace Exiv2 {
 
     uint64_t Image::byteSwap8(const DataBuf& buf,size_t offset,bool bSwap) const
     {
-        uint64_t v;
+        uint64_t v = 0;
         byte*    p = reinterpret_cast<byte *>(&v);
 
         for(int i = 0; i < 8; i++)

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -66,7 +66,7 @@ namespace Exiv2 {
 
     static uint32_t byteSwap_(Exiv2::DataBuf& buf,size_t offset,bool bSwap)
     {
-        uint32_t v;
+        uint32_t v = 0;
         char*    p = (char*) &v;
         int      i;
         for ( i = 0 ; i < 4 ; i++ ) p[i] = buf.pData_[offset+i];
@@ -189,7 +189,7 @@ namespace Exiv2 {
 
         readPgfHeaderSize(*io_);
 
-        int w, h;
+        int w = 0, h = 0;
         DataBuf header      = readPgfHeaderStructure(*io_, w, h);
 
         Image::AutoPtr img  = ImageFactory::create(ImageType::png);

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -479,8 +479,8 @@ namespace {
         } else if (nativePreview_.filter_ == "hex-irb") {
             const DataBuf psData = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
             const byte *record;
-            uint32_t sizeHdr;
-            uint32_t sizeData;
+            uint32_t sizeHdr = 0;
+            uint32_t sizeData = 0;
             if (Photoshop::locatePreviewIrb(psData.pData_, psData.size_, &record, &sizeHdr, &sizeData) != 0) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "Missing preview IRB in Photoshop EPS preview.\n";

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2593,7 +2593,7 @@ namespace Exiv2 {
         if (ti != 0 && ti->tag_ != 0xffff) return ti->tag_;
         if (!isHex(tagName, 4, "0x")) throw Error(kerInvalidTag, tagName, ifdId);
         std::istringstream is(tagName);
-        uint16_t tag;
+        uint16_t tag = 0;
         is >> std::hex >> tag;
         return tag;
     } // tagNumber

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -552,7 +552,7 @@ namespace Exiv2 {
         assert(buf != 0);
         assert(tm != 0);
         int rc = 1;
-        int year, mon, mday, hour, min, sec;
+        int year = 0, mon = 0, mday = 0, hour = 0, min = 0, sec = 0;
         int scanned = std::sscanf(buf, "%4d:%2d:%2d %2d:%2d:%2d",
                                   &year, &mon, &mday, &hour, &min, &sec);
         if (scanned == 6) {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -218,7 +218,7 @@ namespace Exiv2 {
     int DataValue::read(const std::string& buf)
     {
         std::istringstream is(buf);
-        int tmp;
+        int tmp = 0;
         ValueType val;
         while (!(is.eof())) {
             is >> tmp;
@@ -1174,7 +1174,7 @@ namespace Exiv2 {
     {
         int rc = 1;
         Time t;
-        char plusMinus;
+        char plusMinus = 0;
         int scanned = sscanf(buf, format, &t.hour, &t.minute, &t.second,
                              &plusMinus, &t.tzHour, &t.tzMinute);
         if (   scanned    == 6

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -196,7 +196,7 @@ namespace Exiv2 {
             DataBuf payload(size);
             readOrThrow(*io_, payload.pData_, payload.size_, Exiv2::kerCorruptedMetadata);
             if ( payload.size_ % 2 ) {
-              byte c;
+              byte c = 0;
               readOrThrow(*io_, &c, 1, Exiv2::kerCorruptedMetadata);
             }
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -600,7 +600,7 @@ namespace Exiv2 {
         SXMPMeta meta(xmpPacket.data(), static_cast<XMP_StringLen>(xmpPacket.size()));
         SXMPIterator iter(meta);
         std::string schemaNs, propPath, propValue;
-        XMP_OptionBits opt;
+        XMP_OptionBits opt = 0;
         while (iter.Next(&schemaNs, &propPath, &propValue, &opt)) {
             printNode(schemaNs, propPath, propValue, opt);
             if (XMP_PropIsAlias(opt)) {
@@ -655,7 +655,7 @@ namespace Exiv2 {
                 bool simpleArray = true;
                 SXMPIterator aIter(meta, schemaNs.c_str(), propPath.c_str());
                 std::string aSchemaNs, aPropPath, aPropValue;
-                XMP_OptionBits aOpt;
+                XMP_OptionBits aOpt = 0;
                 while (aIter.Next(&aSchemaNs, &aPropPath, &aPropValue, &aOpt)) {
                     if (propPath == aPropPath) continue;
                     if (   !XMP_PropIsSimple(aOpt)


### PR DESCRIPTION
Fixes #1717.

#1717 is caused by a local variable not being initialized at [canonmn_int.cpp, line 2764](https://github.com/Exiv2/exiv2/blob/fec1813a3e7b0e4aaed7fae7ba9f9b49ca526638/src/canonmn_int.cpp#L2764).

I decided it would be best to systematically add zero initializers for all similar cases. I used this CodeQL query to find them all:

```
import cpp
import semmle.code.cpp.dataflow.DataFlow

from LocalVariable v, ArithmeticType t, string path, DataFlow::Node source
where
  v = source.asUninitialized() and
  DataFlow::localFlowStep(source, _) and
  t = v.getType().getUnspecifiedType() and
  path = v.getLocation().getFile().getRelativePath()
select v, t, path
```

There are 90 remaining results in the `xmpsdk` sub-directory which I did not fix, because I believe that is 3rd party code that we try to avoid changing.