### PR TITLE
clang-tidy: use nullptr

### DIFF
--- a/include/exiv2/convert.hpp
+++ b/include/exiv2/convert.hpp
@@ -65,9 +65,9 @@ namespace Exiv2 {
     EXIV2API void syncExifWithXmp(ExifData& exifData, XmpData& xmpData);
 
     //! Convert (copy) IPTC datasets to XMP properties.
-    EXIV2API void copyIptcToXmp(const IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+    EXIV2API void copyIptcToXmp(const IptcData& iptcData, XmpData& xmpData, const char* iptcCharset = nullptr);
     //! Convert (move) IPTC datasets to XMP properties, remove converted IPTC datasets.
-    EXIV2API void moveIptcToXmp(IptcData& iptcData, XmpData& xmpData, const char *iptcCharset = 0);
+    EXIV2API void moveIptcToXmp(IptcData& iptcData, XmpData& xmpData, const char* iptcCharset = nullptr);
 
     //! Convert (copy) XMP properties to IPTC datasets.
     EXIV2API void copyXmpToIptc(const XmpData& xmpData, IptcData& iptcData);

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -72,7 +72,7 @@ namespace Exiv2 {
           @param pValue Pointer to an %Exifdatum value.
           @throw Error if the key cannot be parsed and converted.
          */
-        explicit Exifdatum(const ExifKey& key, const Value* pValue =0);
+        explicit Exifdatum(const ExifKey& key, const Value* pValue = nullptr);
         //! Copy constructor
         Exifdatum(const Exifdatum& rhs);
         //! Destructor
@@ -175,7 +175,7 @@ namespace Exiv2 {
           @return Number of characters written.
         */
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = nullptr) const override;
         //! Return the type id of the value
         TypeId typeId() const override;
         //! Return the name of the type
@@ -617,7 +617,7 @@ namespace Exiv2 {
             const ExifData& exifData
         )
         {
-            encode(blob, 0, 0, byteOrder, exifData);
+            encode(blob, nullptr, 0, byteOrder, exifData);
         }
 
     }; // class ExifParser

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -62,8 +62,7 @@ namespace Exiv2 {
           @throw Error if the key cannot be parsed and converted
                  to a tag number and record id.
          */
-        explicit Iptcdatum(const IptcKey& key,
-                           const Value* pValue =0);
+        explicit Iptcdatum(const IptcKey& key, const Value* pValue = nullptr);
         //! Copy constructor
         Iptcdatum(const Iptcdatum& rhs);
         //! Destructor
@@ -104,7 +103,7 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = nullptr) const override;
         /*!
           @brief Return the key of the Iptcdatum. The key is of the form
                  '<b>Iptc</b>.recordName.datasetName'. Note however that the key

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -147,7 +147,7 @@ namespace Exiv2 {
 
           Implemented in terms of write(), see there.
          */
-        std::string print(const ExifData* pMetadata =0) const;
+        std::string print(const ExifData* pMetadata = nullptr) const;
         /*!
           @brief Write value to a data buffer and return the number
                  of bytes written.
@@ -181,10 +181,7 @@ namespace Exiv2 {
 
           See also print(), which prints the interpreted value to a string.
          */
-        virtual std::ostream& write(
-                  std::ostream& os,
-            const ExifData*     pMetadata =0
-        ) const =0;
+        virtual std::ostream& write(std::ostream& os, const ExifData* pMetadata = nullptr) const = 0;
         /*!
           @brief Return the key of the metadatum. The key is of the form
                  'familyName.groupName.tagName'. Note however that the key

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -589,7 +589,7 @@ namespace Exiv2 {
 
           @return A string containing the comment converted to UTF-8.
          */
-        std::string comment(const char* encoding =0) const;
+        std::string comment(const char* encoding = nullptr) const;
         /*!
           @brief Determine the character encoding that was used to encode the
               UNICODE comment value as an iconv(3) name.
@@ -1531,7 +1531,7 @@ namespace Exiv2 {
         Value::operator=(rhs);
         value_ = rhs.value_;
 
-        byte* tmp = 0;
+        byte* tmp = nullptr;
         if (rhs.sizeDataArea_ > 0) {
             tmp = new byte[rhs.sizeDataArea_];
             std::memcpy(tmp, rhs.pDataArea_, rhs.sizeDataArea_);
@@ -1720,7 +1720,7 @@ namespace Exiv2 {
     template<typename T>
     int ValueType<T>::setDataArea(const byte* buf, long len)
     {
-        byte* tmp = 0;
+        byte* tmp = nullptr;
         if (len > 0) {
             tmp = new byte[len];
             std::memcpy(tmp, buf, len);

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -58,8 +58,7 @@ namespace Exiv2 {
           @throw Error if the key cannot be parsed and converted
                  to a known schema namespace prefix and property name.
          */
-        explicit Xmpdatum(const XmpKey& key,
-                          const Value* pValue =0);
+        explicit Xmpdatum(const XmpKey& key, const Value* pValue = nullptr);
         //! Copy constructor
         Xmpdatum(const Xmpdatum& rhs);
         //! Destructor
@@ -111,7 +110,7 @@ namespace Exiv2 {
         //@{
         //! Not implemented. Calling this method will raise an exception.
         long copy(byte* buf, ByteOrder byteOrder) const override;
-        std::ostream& write(std::ostream& os, const ExifData* pMetadata = 0) const override;
+        std::ostream& write(std::ostream& os, const ExifData* pMetadata = nullptr) const override;
         /*!
           @brief Return the key of the Xmpdatum. The key is of the form
                  '<b>Xmp</b>.prefix.property'. Note however that the
@@ -375,7 +374,7 @@ namespace Exiv2 {
 
           @return True if the initialization was successful, else false.
          */
-        static bool initialize(XmpParser::XmpLockFct xmpLockFct =0, void* pLockData =0);
+        static bool initialize(XmpParser::XmpLockFct xmpLockFct = nullptr, void* pLockData = nullptr);
         /*!
           @brief Terminate the XMP Toolkit and unregister custom namespaces.
 


### PR DESCRIPTION
Found with modernize-use-nullptr

Signed-off-by: Rosen Penev <rosenp@gmail.com>