### PR TITLE
Defensive coding to avoid 0x80000000/0xFFFFFFFF FPE

### DIFF
--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2633,7 +2633,7 @@ namespace Exiv2 {
             Rational deg = value.toRational(0);
             Rational min = value.toRational(1);
             Rational sec = value.toRational(2);
-            if ((deg.second != 1) || (min.second == 0) || (sec.second == 0)) {
+            if ((deg.second != 1) || (min.second <= 0) || (sec.second <= 0)) {
                 return os << "(" << value << ")";
             }
             const int32_t dd = deg.first;


### PR DESCRIPTION
This is a follow-up to #1750. Adding the same defensive code against FPEs caused by `0x80000000/0xFFFFFFFF`. This code is new on the `main` branch.