### PR TITLE
Fix Ubuntu 20.04/Release/Sanitizer test breaker

### DIFF
--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -979,10 +979,12 @@ namespace Exiv2 {
                 std::cerr << "Writing data area for " << key << "\n";
 #endif
                 DataBuf buf = object->pValue()->dataArea();
-                memcpy(object->pDataArea_, buf.pData_, buf.size_);
-                if (object->sizeDataArea_ > static_cast<uint32_t>(buf.size_)) {
-                    memset(object->pDataArea_ + buf.size_,
+                if ( buf.pData_ ) {
+                    memcpy(object->pDataArea_, buf.pData_, buf.size_);
+                    if (object->sizeDataArea_ > static_cast<uint32_t>(buf.size_)) {
+                        memset(object->pDataArea_ + buf.size_,
                            0x0, object->sizeDataArea_ - buf.size_);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Rebasing a [commit](https://github.com/Exiv2/exiv2/commit/3682bce15e1ec55078f6ad005ebd84c5e6bee379) by @clanmills from `main` onto `0.27-maintenance`. This fixes an ASAN error that I think is a false positive, but it prevents running `make tests` with ASAN enabled. The error is that `memcpy` is called with a null pointer. It's not an actual bug though, because the size argument is 0, so it doesn't lead to a null pointer dereference.