### PR TITLE
add BUILD_WITH_STACK_PROTECTOR option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ mark_as_advanced(
     EXIV2_TEAM_USE_SANITIZERS
 )
 
+option( BUILD_WITH_STACK_PROTECTOR    "Build with stack protector"                            ON )
 option( BUILD_WITH_CCACHE             "Use ccache to speed up compilations"                   OFF )
 option( BUILD_WITH_COVERAGE           "Add compiler flags to generate coverage stats"         OFF )
 include(cmake/gcovr.cmake REQUIRED)

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -44,7 +44,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
             if(HAS_FCF_PROTECTION)
                 add_compile_options(-fcf-protection)
             endif()
-            if(HAS_FSTACK_PROTECTOR_STRONG)
+            if(BUILD_WITH_STACK_PROTECTOR AND HAS_FSTACK_PROTECTOR_STRONG)
                 add_compile_options(-fstack-protector-strong)
             endif()
         endif()


### PR DESCRIPTION
Add `BUILD_WITH_STACK_PROTECTOR` to avoid the following build failure with toolchains that don't support stack-protector:

`/home/buildroot/autobuild/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/mipsel-buildroot-linux-uclibc/9.3.0/../../../../mipsel-buildroot-linux-uclibc/bin/ld: utils.cpp:(.text._ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag[_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE12_M_constructIPcEEvT_S7_St20forward_iterator_tag]+0xd0): undefined reference to `__stack_chk_fail'`

Indeed, support for -fstack-protector-strong can't be detected through `check_cxx_compiler_flag` as some toolchains need to link with `-lssp` to enable SSP support

Fixes:
 - http://autobuild.buildroot.org/results/ae4635899124c602c70d2b342a76f95c34aa4a3d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>