### PR TITLE
Extra checking to prevent loop counter from wrapping around

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -625,8 +625,8 @@ namespace Action {
             std::ostringstream os;
             // #1114 - show negative values for SByte
             if (md.typeId() == Exiv2::signedByte) {
-                for ( int c = 0 ; c < md.value().count() ; c++ ) {
-                    int value = md.value().toLong(c);
+                for ( long c = 0 ; c < md.value().count() ; c++ ) {
+                    long value = md.value().toLong(c);
                     os << (c?" ":"") << std::dec << (value < 128 ? value : value - 256);
                 }
             } else {

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1800,9 +1800,10 @@ namespace Exiv2 {
 
         // find $right
         findDiff    = false;
-        blockIndex  = nBlocks - 1;
-        blockSize   = p_->blocksMap_[blockIndex].getSize();
-        while ((blockIndex + 1 > 0) && right < src.size() && !findDiff) {
+        blockIndex  = nBlocks;
+        while (blockIndex > 0 && right < src.size() && !findDiff) {
+            blockIndex--;
+            blockSize = p_->blocksMap_[blockIndex].getSize();
             if(src.seek(-1 * (blockSize + right), BasicIo::end)) {
                 findDiff = true;
             } else {
@@ -1817,8 +1818,6 @@ namespace Exiv2 {
                     }
                 }
             }
-            blockIndex--;
-            blockSize = (long)p_->blocksMap_[blockIndex].getSize();
         }
 
         // free buf

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -545,7 +545,7 @@ namespace Exiv2 {
         Exiv2::ExifData::iterator pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
-        for (int i = 0; i < pos->count(); ++i) {
+        for (long i = 0; i < pos->count(); ++i) {
             std::string value = pos->toString(i);
             if (!pos->value().ok()) {
 #ifndef SUPPRESS_WARNINGS
@@ -692,7 +692,7 @@ namespace Exiv2 {
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         std::ostringstream value;
-        for (int i = 0; i < pos->count(); ++i) {
+        for (long i = 0; i < pos->count(); ++i) {
             value << static_cast<char>(pos->toLong(i));
         }
         (*xmpData_)[to] = value.str();
@@ -705,7 +705,7 @@ namespace Exiv2 {
         if (pos == exifData_->end()) return;
         if (!prepareXmpTarget(to)) return;
         std::ostringstream value;
-        for (int i = 0; i < pos->count(); ++i) {
+        for (long i = 0; i < pos->count(); ++i) {
             if (i > 0) value << '.';
             value << pos->toLong(i);
         }
@@ -823,7 +823,7 @@ namespace Exiv2 {
         Exiv2::XmpData::iterator pos = xmpData_->findKey(XmpKey(from));
         if (pos == xmpData_->end()) return;
         std::ostringstream array;
-        for (int i = 0; i < pos->count(); ++i) {
+        for (long i = 0; i < pos->count(); ++i) {
             std::string value = pos->toString(i);
             if (!pos->value().ok()) {
 #ifndef SUPPRESS_WARNINGS
@@ -972,7 +972,7 @@ namespace Exiv2 {
             return;
         }
 
-        for (unsigned i = 0; i < value.length(); ++i) {
+        for (size_t i = 0; i < value.length(); ++i) {
             if (value[i] == '.') value[i] = ' ';
         }
         (*exifData_)[to] = value;

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -888,12 +888,16 @@ namespace Exiv2 {
         assert(ifdId != ifdIdNotSet);
 
         std::string groupName(Internal::groupName(ifdId));
+        const uint32_t component_size = ciffComponent.size();
+        enforce(component_size % 2 == 0, kerCorruptedMetadata);
+        enforce(component_size/2 <= static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()), kerCorruptedMetadata);
+        const uint16_t num_components = static_cast<uint16_t>(component_size/2);
         uint16_t c = 1;
-        while (uint32_t(c)*2 < ciffComponent.size()) {
+        while (c < num_components) {
             uint16_t n = 1;
             ExifKey key(c, groupName);
             UShortValue value;
-            if (ifdId == canonCsId && c == 23 && ciffComponent.size() > 50) n = 3;
+            if (ifdId == canonCsId && c == 23 && component_size >= 52) n = 3;
             value.read(ciffComponent.pData() + c*2, n*2, byteOrder);
             image.exifData().add(key, &value);
             if (ifdId == canonSiId && c == 21) aperture = value.toLong();

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -963,7 +963,7 @@ namespace {
     long sumToLong(const Exiv2::Exifdatum& md)
     {
         long sum = 0;
-        for (int i = 0; i < md.count(); ++i) {
+        for (long i = 0; i < md.count(); ++i) {
             sum += md.toLong(i);
         }
         return sum;

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -1494,7 +1494,7 @@ namespace {
     std::string parseEscapes(const std::string& input)
     {
         std::string result = "";
-        for (unsigned int i = 0; i < input.length(); ++i) {
+        for (size_t i = 0; i < input.length(); ++i) {
             char ch = input[i];
             if (ch != '\\') {
                 result.push_back(ch);
@@ -1521,7 +1521,7 @@ namespace {
                 result.push_back('\t');
                 break;
             case 'u':                           // Escaping of unicode
-                if (input.length() - 4 > i) {
+                if (input.length() >= 4 && input.length() - 4 > i) {
                     int acc = 0;
                     for (int j = 0; j < 4; ++j) {
                         ++i;

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -1500,7 +1500,7 @@ namespace {
                 result.push_back(ch);
                 continue;
             }
-            int escapeStart = i;
+            size_t escapeStart = i;
             if (!(input.length() - 1 > i)) {
                 result.push_back(ch);
                 continue;

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -346,12 +346,15 @@ namespace Exiv2 {
 
     void IptcData::printStructure(std::ostream& out, const Slice<byte*>& bytes, uint32_t depth)
     {
+        if (bytes.size() < 3) {
+            return;
+        }
         size_t i = 0;
-        while (i + 3 < bytes.size() && bytes.at(i) != 0x1c)
+        while (i < bytes.size() - 3 && bytes.at(i) != 0x1c)
             i++;
         depth++;
         out << Internal::indent(depth) << "Record | DataSet | Name                     | Length | Data" << std::endl;
-        while (i + 3 < bytes.size()) {
+        while (i < bytes.size() - 3) {
             if (bytes.at(i) != 0x1c) {
                 break;
             }

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -804,7 +804,7 @@ namespace {
                     enforce(size_ <= static_cast<uint32_t>(io.size()), kerCorruptedMetadata);
                     DataBuf buf(size_);
                     uint32_t idxBuf = 0;
-                    for (int i = 0; i < sizes.count(); i++) {
+                    for (long i = 0; i < sizes.count(); i++) {
                         uint32_t offset = dataValue.toLong(i);
                         uint32_t size = sizes.toLong(i);
                         enforce(Safe::add(idxBuf, size) < size_, kerCorruptedMetadata);

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -24,6 +24,7 @@
 
 #include "convert.hpp"
 #include "error.hpp"
+#include "enforce.hpp"
 #include "i18n.h"                // NLS support.
 
 #include "canonmn_int.hpp"
@@ -2554,7 +2555,9 @@ namespace Exiv2 {
         {
             uint16_t bit   = 0;
             uint16_t comma = 0;
-            for (uint16_t i = 0; i < value.count(); i++ ) { // for each element in value array
+            long count = value.count();
+            enforce(0 <= count && count <= std::numeric_limits<uint16_t>::max(), kerCorruptedMetadata);
+            for (uint16_t i = 0; i < count; i++ ) { // for each element in value array
                 uint16_t bits = static_cast<uint16_t>(value.toLong(i));
                 for (uint16_t b = 0; b < 16; ++b) { // for every bit
                     if (bits & (1 << b)) {
@@ -3217,7 +3220,7 @@ namespace Exiv2 {
         if (stringValue[19] == 'Z') {
             stringValue = stringValue.substr(0, 19);
         }
-        for (unsigned int i = 0; i < stringValue.length(); ++i) {
+        for (size_t i = 0; i < stringValue.length(); ++i) {
             if (stringValue[i] == 'T') stringValue[i] = ' ';
             if (stringValue[i] == '-') stringValue[i] = ':';
         }

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -427,7 +427,7 @@ namespace Exiv2 {
             return;
         }
         uint32_t size = 0;
-        for (int i = 0; i < pSize->count(); ++i) {
+        for (long i = 0; i < pSize->count(); ++i) {
             size += static_cast<uint32_t>(pSize->toLong(i));
         }
         uint32_t offset = static_cast<uint32_t>(pValue()->toLong(0));
@@ -484,7 +484,7 @@ namespace Exiv2 {
 #endif
             return;
         }
-        for (int i = 0; i < pValue()->count(); ++i) {
+        for (long i = 0; i < pValue()->count(); ++i) {
             const uint32_t offset = static_cast<uint32_t>(pValue()->toLong(i));
             const byte* pStrip = pData + baseOffset + offset;
             const uint32_t size = static_cast<uint32_t>(pSize->toLong(i));

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -476,7 +476,7 @@ namespace Exiv2 {
         // create vector of signedShorts from unsignedShorts in Exif.Canon.AFInfo
         std::vector<int16_t>  ints;
         std::vector<uint16_t> uint;
-        for (int i = 0; i < object->pValue()->count(); i++) {
+        for (long i = 0; i < object->pValue()->count(); i++) {
             ints.push_back((int16_t) object->pValue()->toLong(i));
             uint.push_back((uint16_t) object->pValue()->toLong(i));
         }
@@ -523,9 +523,9 @@ namespace Exiv2 {
                 Exiv2::Value::AutoPtr v = Exiv2::Value::create(records[i].bSigned?Exiv2::signedShort:Exiv2::unsignedShort);
                 std::ostringstream    s;
                 if ( records[i].bSigned ) {
-                    for ( int16_t k = 0 ; k < records[i].size ; k++ ) s << " " << ints.at(nStart++);
+                    for ( uint16_t k = 0 ; k < records[i].size ; k++ ) s << " " << ints.at(nStart++);
                 } else {
-                    for ( int16_t k = 0 ; k < records[i].size ; k++ ) s << " " << uint.at(nStart++);
+                    for ( uint16_t k = 0 ; k < records[i].size ; k++ ) s << " " << uint.at(nStart++);
                 }
 
                 v->read(s.str());

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -606,7 +606,7 @@ namespace Exiv2 {
     bool stringTo<bool>(const std::string& s, bool& ok)
     {
         std::string lcs(s); /* lowercase string */
-        for(unsigned i = 0; i < lcs.length(); i++) {
+        for(size_t i = 0; i < lcs.length(); i++) {
             lcs[i] = std::tolower(s[i]);
         }
         /* handle the same values as xmp sdk */

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -789,7 +789,7 @@ namespace Exiv2 {
                 || i->typeId() == xmpAlt) {
                 printNode(ns, i->tagName(), "", options);
                 meta.SetProperty(ns.c_str(), i->tagName().c_str(), 0, options);
-                for (int idx = 0; idx < i->count(); ++idx) {
+                for (long idx = 0; idx < i->count(); ++idx) {
                     const std::string item = i->tagName() + "[" + toString(idx + 1) + "]";
                     printNode(ns, item, i->toString(idx), 0);
                     meta.SetProperty(ns.c_str(), item.c_str(), i->toString(idx).c_str());

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -232,7 +232,7 @@ namespace Exiv2 {
         std::string head(reinterpret_cast<const char*>(buf + start), len - start);
         if (head.substr(0, 5)  == "<?xml") {
             // Forward to the next tag
-            for (unsigned i = 5; i < head.size(); ++i) {
+            for (size_t i = 5; i < head.size(); ++i) {
                 if (head[i] == '<') {
                     head = head.substr(i);
                     break;

--- a/tests/bugfixes/github/test_issue_ghsa_hqjh_hpv8_8r9p.py
+++ b/tests/bugfixes/github/test_issue_ghsa_hqjh_hpv8_8r9p.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, FileDecoratorBase, path
+from struct import *
+
+# The PoC is a fairly large file, mostly consisting of zero bytes,
+# so it would be a waste of storage to check it into the repo.
+# Instead, we can generate the PoC with a small amount of code:
+class CreatePoC(FileDecoratorBase):
+    """
+    This class copies files from test/data to test/tmp
+    Copied files are NOT removed in tearDown
+    Example: @CopyTmpFiles("$data_path/test_issue_1180.exv")
+    """
+
+    #: override the name of the file list
+    FILE_LIST_NAME = '_tmp_files'
+
+    def setUp_file_action(self, expanded_file_name):
+        size = 0x20040
+        contents = pack('<2sI8sHHIIHHII', bytes(b'II'), 14, bytes(b'HEAPCCDR'), \
+                        1, 0x300b, size - 26, 12, 1, 0x102a, size - 38, 12) + \
+                        bytes(bytearray(size-38))
+        f = open(expanded_file_name, 'wb')
+        f.write(contents)
+        f.close()
+
+    def tearDown_file_action(self, f):
+        """
+        Do nothing.   We don't clean up TmpFiles
+        """
+
+# This decorator generates the PoC file.
+@CreatePoC("$tmp_path/issue_ghsa_hqjh_hpv8_8r9p_poc.crw")
+
+class CrwMapDecodeArrayInfiniteLoop(metaclass=CaseMeta):
+    """
+    Regression test for the bug described in:
+    https://github.com/Exiv2/exiv2/security/advisories/GHSA-hqjh-hpv8-8r9p
+    """
+    url = "https://github.com/Exiv2/exiv2/security/advisories/GHSA-hqjh-hpv8-8r9p"
+
+    filename = path("$tmp_path/issue_ghsa_hqjh_hpv8_8r9p_poc.crw")
+
+    commands = ["$exiv2 $filename"]
+    stdout = [""]
+    stderr = [
+"""Exiv2 exception in print action for file $filename:
+$kerCorruptedMetadata
+"""]
+    retval = [1]


### PR DESCRIPTION
Fixes: https://github.com/Exiv2/exiv2/security/advisories/GHSA-hqjh-hpv8-8r9p

The bug is this [loop condition](https://github.com/Exiv2/exiv2/blob/fec1813a3e7b0e4aaed7fae7ba9f9b49ca526638/src/crwimage_int.cpp#L892) in `CrwMap::decodeArray`. The loop counter, `c`, is a `uint16_t`, so if the component size is greater than `2 * 0xffff` then `c` will wrap around and the loop won't terminate.

There are 3 commits:

1. Regression test
2. Fix for https://github.com/Exiv2/exiv2/security/advisories/GHSA-hqjh-hpv8-8r9p
3. Defensive fixes for similar looking loop conditions

So the 3rd commit is optional. I'll add comments to the code review explaining those changes.