### PR TITLE
Add SonyMisc1 (Tag 0x9403) makernote tags

### DIFF
--- a/doc/templates/Makefile
+++ b/doc/templates/Makefile
@@ -111,7 +111,8 @@ TABLES = Exif \
          Sony1MltCs7D \
          Sony1MltCsOld \
          Sony1MltCsA100 \
-         Sony2Fp
+         Sony2Fp \
+         SonyMisc1
 
 SCHEMA = xmp_dc \
          xmp_dwc \

--- a/man/man1/exiv2.1
+++ b/man/man1/exiv2.1
@@ -642,7 +642,8 @@ SubImage7         MinoltaCs5D     NikonFi                                    Son
 SubImage8         MinoltaCs7D     NikonFl1      Olympus       Panasonic      Sony2Cs
 SubImage9         MinoltaCsNew    NikonFl2      Olympus2      PanasonicRaw   Sony2Cs2
 SubThumb1         MinoltaCsOld    NikonFl3      OlympusCs                    Sony2Fp
-Thumbnail                         NikonIi       OlympusEq     Sigma          SonyMinolta
+Thumbnail                         NikonIi       OlympusEq     Sigma          SonyMisc1
+                                                                             SonyMinolta
 .fi
 .sp 1
 Exiv2 supports Exif 2.2 Standard Tags.  Exiv2 also supports reading and writing manufacturer's MakerNote.  The information in Exif.Photo.MakerNote is encoded as manufacturer's sub-records.  For example, CanonCs are Camera Settings, NikonAf are Nikon Auto Focus records, NikonCb are Nikon Color Balance Records.  Every tag is defined by a unique tagId (16 bit integer) which is unique within a Group.

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -806,6 +806,31 @@ namespace Exiv2 {
         return tagInfoFp_;
     }
 
+    //! Sony Tag 9403 SonyMisc1
+    constexpr TagInfo SonyMakerNote::tagInfoSonyMisc1_[] = {
+        {0x05,  "CameraTemperature", N_("Camera temperature"),
+        		N_("Internal camera temperature (in degrees Celsius)"),
+				sonyMisc1Id, makerTags, signedByte, -1, printTemperatureInDegC},
+        // End of list marker
+        {0xffff, "(UnknownSonyMisc1Tag)", "(UnknownSonyMisc1Tag)",
+        		 "(UnknownSonyMisc1Tag)",
+				 sonyMisc1Id, makerTags, unsignedByte, -1, printValue}
+    };
+
+    const TagInfo* SonyMakerNote::tagListSonyMisc1()
+    {
+        return tagInfoSonyMisc1_;
+    }
+
+    std::ostream& SonyMakerNote::printTemperatureInDegC(std::ostream& os, const Value& value, const ExifData*)
+    {
+        if (value.count() != 1)       os << "(" << value << ")";
+        else                          os << value << " °C";
+
+        return os;
+    }
+
+
     //! Sony Tag 2010 Sony2010 (Miscellaneous)
     constexpr TagInfo SonyMakerNote::tagInfo2010e_[] = {
         {0, "SequenceImageNumber", N_("Sequence Image Number"), N_("Sequence Image Number"), sony2010eId, makerTags, unsignedLong, 1, printValue},

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -824,8 +824,10 @@ namespace Exiv2 {
 
     std::ostream& SonyMakerNote::printTemperatureInDegC(std::ostream& os, const Value& value, const ExifData*)
     {
-        if (value.count() != 1)       os << "(" << value << ")";
-        else                          os << value << " °C";
+        if (value.count() != 1)
+            os << "(" << value << ")";
+        else
+            os << value << " °C";
 
         return os;
     }

--- a/src/sonymn_int.hpp
+++ b/src/sonymn_int.hpp
@@ -49,11 +49,15 @@ namespace Exiv2 {
         static const TagInfo* tagListCs2();
         //! Return read-only list of built-in Sony FocusPosition tags
         static const TagInfo* tagListFp();
+        //! Return read-only list of built-in Sony Misc1 tags (Tag 9403)
+        static const TagInfo* tagListSonyMisc1();
 
         static const TagInfo* tagList2010e();
 
         //! @name Print functions for Sony %MakerNote tags
         //@{
+        //! Print Sony temperature values (in Degrees Celsius)
+        static std::ostream& printTemperatureInDegC(std::ostream&, const Value&, const ExifData*);
         //! Print Sony Camera Model
         static std::ostream& print0xb000(std::ostream&, const Value&, const ExifData*);
         //! Print Full and Preview Image size
@@ -65,6 +69,7 @@ namespace Exiv2 {
         static const TagInfo tagInfoCs_[];
         static const TagInfo tagInfoCs2_[];
         static const TagInfo tagInfoFp_[];
+        static const TagInfo tagInfoSonyMisc1_[];
         static const TagInfo tagInfo2010e_[];
     }; // class SonyMakerNote
 

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -167,6 +167,7 @@ namespace Exiv2 {
         { sony2CsId,       "Makernote", "Sony2Cs",      SonyMakerNote::tagListCs       },
         { sony2Cs2Id,      "Makernote", "Sony2Cs2",     SonyMakerNote::tagListCs2      },
         { sony2FpId,       "Makernote", "Sony2Fp",      SonyMakerNote::tagListFp       },
+        { sonyMisc1Id,     "Makernote", "SonyMisc1",    SonyMakerNote::tagListSonyMisc1},
         { sony2010eId,     "Makernote", "Sony2010e",    SonyMakerNote::tagList2010e    },
         { lastId,          "(Last IFD info)", "(Last IFD item)", nullptr }
     };

--- a/src/tags_int.hpp
+++ b/src/tags_int.hpp
@@ -174,6 +174,7 @@ namespace Exiv2 {
         sony2CsId,
         sony2Cs2Id,
         sony2FpId,
+		sonyMisc1Id,
         sony2010eId,
         sony1MltCs7DId,
         sony1MltCsOldId,

--- a/src/tags_int.hpp
+++ b/src/tags_int.hpp
@@ -174,7 +174,7 @@ namespace Exiv2 {
         sony2CsId,
         sony2Cs2Id,
         sony2FpId,
-		sonyMisc1Id,
+        sonyMisc1Id,
         sony2010eId,
         sony1MltCs7DId,
         sony1MltCsOldId,

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -826,6 +826,21 @@ namespace Exiv2 {
         { 0x2d, ttUnsignedByte, 1 }  // Exif.Sony2Fp.FocusPosition2
     };
 
+    constexpr ArrayCfg sonyMisc1Cfg = {
+        sonyMisc1Id,      // Group for the elements
+        bigEndian,        // Big endian
+        ttUnsignedByte,   // Type for array entry and size element
+        sonyTagDecipher,  // (uint16_t, const byte*, uint32_t, TiffComponent* const);
+        false,            // No size element
+        false,            // No fillers
+        false,            // Don't concatenate gaps
+        { 0, ttUnsignedByte, 1 }
+    };
+
+    constexpr ArrayDef sonyMisc1Def[] = {
+        { 0x05, ttSignedByte  , 1 }, // Exif.SonyMisc1.CameraTemperature
+    };
+
     constexpr ArrayCfg sony2010eCfg = {
         sony2010eId,      // Group for the elements
         invalidByteOrder, // inherit from file.  Usually littleEndian
@@ -1096,6 +1111,7 @@ namespace Exiv2 {
         { Tag::root, sony1Id,          exifId,           0x927c    },
         { Tag::root, sony2010eId,      sony1Id,          0x2010    },
         { Tag::root, sony2FpId,        sony1Id,          0x9402    },
+        { Tag::root, sonyMisc1Id,      sony1Id,          0x9403    },
         { Tag::root, sony1CsId,        sony1Id,          0x0114    },
         { Tag::root, sony1Cs2Id,       sony1Id,          0x0114    },
         { Tag::root, sonyMltId,        sony1Id,          0xb028    },
@@ -1106,6 +1122,7 @@ namespace Exiv2 {
         { Tag::root, sony2Id,          exifId,           0x927c    },
         { Tag::root, sony2010eId,      sony2Id,          0x2010    },
         { Tag::root, sony2FpId,        sony2Id,          0x9402    },
+        { Tag::root, sonyMisc1Id,      sony2Id,          0x9403    },
         { Tag::root, sony2CsId,        sony2Id,          0x0114    },
         { Tag::root, sony2Cs2Id,       sony2Id,          0x0114    },
         { Tag::root, minoltaId,        exifId,           0x927c    },
@@ -1544,6 +1561,10 @@ namespace Exiv2 {
         { Tag::all, sony2FpId,        newTiffBinaryElement },
         { 0x9402, sony1Id,            EXV_BINARY_ARRAY(sony2FpCfg, sony2FpDef) },
 
+        // Tag 0x9403 SonyMisc1
+        { Tag::all, sonyMisc1Id,       newTiffBinaryElement                         },
+        { 0x9403, sony1Id,             EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def) },
+
         // Sony1 makernote
         {    0x0114, sony1Id,          EXV_COMPLEX_BINARY_ARRAY(sony1CsSet, sonyCsSelector) },
         {    0xb028, sony1Id,          newTiffSubIfd<sonyMltId>                  },
@@ -1560,6 +1581,10 @@ namespace Exiv2 {
         // Tag 0x9402 Sony2Fp Focus Position
         {  Tag::all, sony2FpId,        newTiffBinaryElement                      },
         {    0x9402, sony2Id,          EXV_BINARY_ARRAY(sony2FpCfg, sony2FpDef)  },
+
+        // Tag 0x9403 SonyMisc1
+        { Tag::all, sonyMisc1Id,       newTiffBinaryElement                         },
+        { 0x9403, sony2Id,             EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def) },
 
         // Sony2 makernote
         {    0x0114, sony2Id,          EXV_COMPLEX_BINARY_ARRAY(sony2CsSet, sonyCsSelector) },

--- a/tests/bugfixes/github/test_pr_1772.py
+++ b/tests/bugfixes/github/test_pr_1772.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+class SonyMisc1Test(metaclass=CaseMeta):
+
+    filename = path("$data_path/exiv2-pr906.exv")
+    commands = ["$exiv2 -pa --grep SonyMisc1 $filename"]
+
+    stdout = ["""Exif.SonyMisc1.CameraTemperature             SByte       1  26 °C
+"""
+    ]
+    stderr = [""]
+    retval = [0]


### PR DESCRIPTION
Source: Exiftool (https://exiftool.org/TagNames/Sony.html)

Closes #280.