### PR TITLE
Fix code scanning alert: "Multiplication result converted to larger type"

### DIFF
--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -55,7 +55,7 @@ namespace Jzon
 			newline = (format.newline ? "\n" : spacing);
 		}
 
-		std::string GetIndentation(unsigned int level) const
+		std::string GetIndentation(size_t level) const
 		{
             if (format.newline)
                 return std::string(format.indentSize * level, indentationChar);
@@ -727,7 +727,7 @@ namespace Jzon
         return result;
     }
 
-    void Writer::writeNode(const Node &node, unsigned int level)
+    void Writer::writeNode(const Node &node, size_t level)
     {
         switch (node.GetType()) {
             case Node::T_OBJECT:
@@ -741,7 +741,7 @@ namespace Jzon
                 break;
         }
     }
-    void Writer::writeObject(const Object &node, unsigned int level)
+    void Writer::writeObject(const Object &node, size_t level)
     {
 		result += "{" + fi->GetNewline();
 
@@ -757,7 +757,7 @@ namespace Jzon
 
         result += fi->GetNewline() + fi->GetIndentation(level) + "}";
     }
-    void Writer::writeArray(const Array &node, unsigned int level)
+    void Writer::writeArray(const Array &node, size_t level)
     {
         result += "[" + fi->GetNewline();
 

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -389,9 +389,9 @@ namespace Jzon
 		// Disable assignment operator
 		Writer &operator=(const Writer&) = delete;
 	private:
-		void writeNode(const Node &node, unsigned int level);
-		void writeObject(const Object &node, unsigned int level);
-		void writeArray(const Array &node, unsigned int level);
+		void writeNode(const Node &node, size_t level);
+		void writeObject(const Object &node, size_t level);
+		void writeArray(const Array &node, size_t level);
 		void writeValue(const Value &node);
 
 		std::string result;


### PR DESCRIPTION
Fixes a code scanning alert for [this multiplication](https://github.com/Exiv2/exiv2/blob/9284b58bfc99b788b714daddcff1c1f07174b7d2/samples/Jzon.cpp#L61).