### PR TITLE
use localtime_r, rather than localtime

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1828,8 +1828,9 @@ namespace {
 
     std::string time2Str(time_t time)
     {
-        struct tm* tm = localtime(&time);
-        return tm2Str(tm);
+        struct tm tm = {};
+        localtime_r(&time, &tm);
+        return tm2Str(&tm);
     } // time2Str
 
     std::string tm2Str(const struct tm* tm)

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -909,11 +909,11 @@ namespace Exiv2 {
         ULongValue v;
         v.read(ciffComponent.pData(), 8, byteOrder);
         time_t t = v.value_.at(0);
-        struct tm* tm = std::localtime(&t);
-        if (tm) {
+        struct tm tm = {};
+        if (localtime_r(&t, &tm)) {
             const size_t m = 20;
             char s[m];
-            std::strftime(s, m, "%Y:%m:%d %H:%M:%S", tm);
+            std::strftime(s, m, "%Y:%m:%d %H:%M:%S", &tm);
 
             ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
             AsciiValue value;


### PR DESCRIPTION
This fixes code scanning alerts for uses of `localtime`. `localtime` is not thread-safe, so it is better to use `localtime_r`.
Current code scanning alerts can be seen [here](https://github.com/Exiv2/exiv2/security/code-scanning).