### PR TITLE
Ignore results in the xmpsdk directory

### DIFF
--- a/.github/codeql-queries/exiv2-cpp-queries/unsafe_vector_access.ql
+++ b/.github/codeql-queries/exiv2-cpp-queries/unsafe_vector_access.ql
@@ -175,5 +175,7 @@ where
   not index_last_with_check(_, call) and
   // Ignore accesses like this: `vsnprintf(&buffer[0], buffer.size(), format, args)`
   // That's pointer arithmetic, not a deref, so it's usually a false positive.
-  not exists(AddressOfExpr addrExpr | addrExpr.getOperand() = call)
+  not exists(AddressOfExpr addrExpr | addrExpr.getOperand() = call) and
+  // Ignore results in the xmpsdk directory.
+  not call.getLocation().getFile().getRelativePath().matches("xmpsdk/%")
 select call, "Unsafe use of operator[]. Use the at() method instead."


### PR DESCRIPTION
The new CodeQL query that I added in #1771 is producing approximately 200 results in the `xmpsdk` directory. That's third-party code which we want to avoid changing, so those results aren't useful. This PR makes a small change to the query to ignore results in that directory.