### PR TITLE
Fix build error when EXIV2_DEBUG_MESSAGES is enabled

### DIFF
--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -366,7 +366,7 @@ namespace Exiv2 {
             sprintf(buff, "  %6d | %7d | %-24s | %6d | ", record, dataset,
                     Exiv2::IptcDataSets::dataSetName(dataset, record).c_str(), len);
 
-            enforce(bytes.size() - i >= 5 + len, kerCorruptedMetadata);
+            enforce(bytes.size() - i >= 5 + static_cast<size_t>(len), kerCorruptedMetadata);
             out << buff << Internal::binaryToString(makeSlice(bytes, i + 5, i + 5 + (len > 40 ? 40 : len)))
                 << (len > 40 ? "..." : "")
                 << std::endl;

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -693,7 +693,7 @@ namespace Exiv2 {
                         if (size >= 16) {
                             out.write(reinterpret_cast<const char*>(buf.pData_ + 16), size - 16);
 #ifdef EXIV2_DEBUG_MESSAGES
-                            std::cout << "iccProfile size = " << icc.size_ << std::endl;
+                            std::cout << "iccProfile size = " << size - 16 << std::endl;
 #endif
                         }
                     } else if (option == kpsIptcErase && signature.compare("Photoshop 3.0") == 0) {


### PR DESCRIPTION
It turns out that I accidentally broke the build on `0.27-maintenance` when `EXIV2_DEBUG_MESSAGES` is enabled. (In #1790.) This was caught by an [automated check](https://github.com/Exiv2/exiv2/blob/01b109e8ffc5a9bbb9e1be3de04305682a85b298/.github/workflows/on_PR_linux_special_buils.yml) that only runs on `main`. To reproduce:

```bash
mkdir build-all-enabled
cd build-all-enabled
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DBUILD_WITH_COVERAGE=ON -DEXIV2_BUILD_DOC=ON -DEXIV2_ENABLE_NLS=ON -DCMAKE_CXX_FLAGS="-DEXIV2_DEBUG_MESSAGES" ..
make
```

I also fixed a compiler warning that I accidentally introduced in #1766.

No need to forward this to `main` because it was caught by the automated check and is already fixed.