### PR TITLE
Add SonySInfo1 makernote tags (tag 3000)

### DIFF
--- a/doc/templates/Makefile
+++ b/doc/templates/Makefile
@@ -114,7 +114,8 @@ TABLES = Exif \
          Sony2Fp \
          SonyMisc1 \
          SonyMisc2b \
-         SonyMisc3c
+         SonyMisc3c \
+         SonySInfo1
 
 SCHEMA = xmp_dc \
          xmp_dwc \

--- a/man/man1/exiv2.1
+++ b/man/man1/exiv2.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH EXIV2 1 "July 27, 2021"
+.TH EXIV2 1 "July 29, 2021"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:

--- a/man/man1/exiv2.1
+++ b/man/man1/exiv2.1
@@ -627,11 +627,11 @@ The tag is a triplet of Family.Group.Tagname.  The following groups are defined 
 GPSInfo      Canon           Fujifilm     NikonMe         OlympusFe7        SonyMisc2b
 Image        CanonCf                      NikonPc         OlympusFe9        SonyMisc3c
 Image2       CanonCs         Nikon1       NikonPreview    OlympusFi         SonyMinolta
-Image3       CanonFi         Nikon2       NikonSi01xx     OlympusIp
-Iop          CanonPa         Nikon3       NikonSi02xx     OlympusRd         Samsung2
-MakerNote    CanonPi         NikonAFT     NikonSiD300a    OlympusRd2        SamsungPictureWizard
-MpfInfo      CanonPr         NikonAf      NikonSiD300b    OlympusRi         SamsungPreview
-Photo        CanonSi         NikonAf2     NikonSiD40
+Image3       CanonFi         Nikon2       NikonSi01xx     OlympusIp         SonySInfo1
+Iop          CanonPa         Nikon3       NikonSi02xx     OlympusRd
+MakerNote    CanonPi         NikonAFT     NikonSiD300a    OlympusRd2        Samsung2
+MpfInfo      CanonPr         NikonAf      NikonSiD300b    OlympusRi         SamsungPictureWizard
+Photo        CanonSi         NikonAf2     NikonSiD40                        SamsungPreview
 SubImage1    CanonTi         NikonAf22    NikonSiD80      Sigma
 SubImage2                    NikonCb1     NikonVr
 SubImage3    Casio           NikonCb2     NikonWt         Sony1

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -1248,6 +1248,39 @@ namespace Exiv2 {
         return os << "20" << val;
     }
 
+    //! Sony SInfo1 tags (ShotInfo - Tag 3000)
+    constexpr TagInfo SonyMakerNote::tagInfoSonySInfo1_[] = {
+        // TODO: As "FaceInfo1" (72) and "FaceInfo2" (94) are not added, including
+        //       "FaceInfoOffset" (2) and "FaceInfoLength" (50) does not make sense.
+        //       The values are all connected and changing one without the rest will
+        //       corrupt the data.
+        {6,     "SonyDateTime", N_("Sony date/time"),
+                N_("Date and time when the photo was captured"),
+                sonySInfo1Id, makerTags, asciiString, -1, printValue},
+        {26,    "SonyImageHeight", N_("Sony image height"),
+                N_("Height of the image"),
+                sonySInfo1Id, makerTags, unsignedShort, -1, printValue},
+        {28,    "SonyImageWidth", N_("Sony image width"),
+                N_("Width of the image"),
+                sonySInfo1Id, makerTags, unsignedShort, -1, printValue},
+        {48,    "FacesDetected", N_("Faces detected"),
+                N_("Number of faces detected in the image"),
+                sonySInfo1Id, makerTags, unsignedShort, -1, printValue},
+        {52,    "MetaVersion", N_("Meta version"),
+                N_("Sony meta version"),
+                sonySInfo1Id, makerTags, asciiString, -1, printValue},
+        // TODO: Add FaceInfo1 (72) and FaceInfo2 (94) which are sub-groups of tags.
+        // End of list marker
+        {0xffff, "(UnknownsonySInfo1Tag)", "(Unknown SonySInfo1 Tag)",
+                 "(Unknown SonySInfo1 Tag)",
+                 sonySInfo1Id, makerTags, unsignedByte, -1, printValue}
+    };
+
+    const TagInfo* SonyMakerNote::tagListSonySInfo1()
+    {
+        return tagInfoSonySInfo1_;
+    }
+
     //! Sony Tag 2010 Sony2010 (Miscellaneous)
     constexpr TagInfo SonyMakerNote::tagInfo2010e_[] = {
         {0, "SequenceImageNumber", N_("Sequence Image Number"), N_("Sequence Image Number"), sony2010eId, makerTags, unsignedLong, 1, printValue},

--- a/src/sonymn_int.hpp
+++ b/src/sonymn_int.hpp
@@ -55,7 +55,9 @@ namespace Exiv2 {
         static const TagInfo* tagListSonyMisc2b();
         //! Return read-only list of built-in Sony Misc3c tags (Tag 9400)
         static const TagInfo* tagListSonyMisc3c();
-
+        //! Return read-only list of built-in Sony SInfo1 tags (Tag 3000)
+        static const TagInfo* tagListSonySInfo1();
+        //! Return read-only list of built-in Sony 2010e tags (Tag 2010)
         static const TagInfo* tagList2010e();
 
         //! @name Print functions for Sony %MakerNote tags
@@ -94,6 +96,7 @@ namespace Exiv2 {
         static const TagInfo tagInfoSonyMisc1_[];
         static const TagInfo tagInfoSonyMisc2b_[];
         static const TagInfo tagInfoSonyMisc3c_[];
+        static const TagInfo tagInfoSonySInfo1_[];
         static const TagInfo tagInfo2010e_[];
 
     }; // class SonyMakerNote

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -171,6 +171,7 @@ namespace Exiv2 {
         { sonyMisc1Id,     "Makernote", "SonyMisc1",    SonyMakerNote::tagListSonyMisc1},
         { sonyMisc2bId,    "Makernote", "SonyMisc2b",   SonyMakerNote::tagListSonyMisc2b},
         { sonyMisc3cId,    "Makernote", "SonyMisc3c",   SonyMakerNote::tagListSonyMisc3c},
+        { sonySInfo1Id,    "Makernote", "SonySInfo1",   SonyMakerNote::tagListSonySInfo1},
         { sony2010eId,     "Makernote", "Sony2010e",    SonyMakerNote::tagList2010e    },
         { lastId,          "(Last IFD info)", "(Last IFD item)", nullptr }
     };

--- a/src/tags_int.hpp
+++ b/src/tags_int.hpp
@@ -177,6 +177,7 @@ namespace Exiv2 {
         sonyMisc1Id,
         sonyMisc2bId,
         sonyMisc3cId,
+        sonySInfo1Id,
         sony2010eId,
         sony1MltCs7DId,
         sony1MltCsOldId,

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -898,6 +898,25 @@ namespace Exiv2 {
         { sonyMisc3cCfg,  sonyMisc3cDef,  EXV_COUNTOF(sonyMisc3cDef)  }
     };
 
+    constexpr ArrayCfg sonySInfo1Cfg = {
+        sonySInfo1Id,     // Group for the elements
+        littleEndian,     // Little endian
+        ttUnsignedByte,   // Type for array entry and size element
+        notEncrypted,     // (uint16_t, const byte*, uint32_t, TiffComponent* const);
+        false,            // No size element
+        false,            // No fillers
+        false,            // Don't concatenate gaps
+        { 0, ttUnsignedByte, 1 }
+    };
+    constexpr ArrayDef sonySInfo1Def[] = {
+        {  6,  ttAsciiString    , 20 }, // Exif.SonySInfo1.SonyDateTime
+        {  26, ttUnsignedShort  , 1  }, // Exif.SonySInfo1.SonyImageHeight
+        {  28, ttUnsignedShort  , 1  }, // Exif.SonySInfo1.SonyImageWidth
+        {  48, ttUnsignedShort  , 1  }, // Exif.SonySInfo1.FacesDetected
+        {  52, ttAsciiString    , 16 }, // Exif.SonySInfo1.MetaVersion
+        //
+    };
+
     constexpr ArrayCfg sony2010eCfg = {
         sony2010eId,      // Group for the elements
         invalidByteOrder, // inherit from file.  Usually littleEndian
@@ -1171,6 +1190,7 @@ namespace Exiv2 {
         { Tag::root, sonyMisc1Id,      sony1Id,          0x9403    },
         { Tag::root, sonyMisc2bId,     sony1Id,          0x9404    },
         { Tag::root, sonyMisc3cId,     sony1Id,          0x9400    },
+        { Tag::root, sonySInfo1Id,     sony1Id,          0x3000    },
         { Tag::root, sony1CsId,        sony1Id,          0x0114    },
         { Tag::root, sony1Cs2Id,       sony1Id,          0x0114    },
         { Tag::root, sonyMltId,        sony1Id,          0xb028    },
@@ -1184,6 +1204,7 @@ namespace Exiv2 {
         { Tag::root, sonyMisc1Id,      sony2Id,          0x9403    },
         { Tag::root, sonyMisc2bId,     sony2Id,          0x9404    },
         { Tag::root, sonyMisc3cId,     sony2Id,          0x9400    },
+        { Tag::root, sonySInfo1Id,     sony2Id,          0x3000    },
         { Tag::root, sony2CsId,        sony2Id,          0x0114    },
         { Tag::root, sony2Cs2Id,       sony2Id,          0x0114    },
         { Tag::root, minoltaId,        exifId,           0x927c    },
@@ -1634,6 +1655,10 @@ namespace Exiv2 {
         { Tag::all, sonyMisc1Id,       newTiffBinaryElement                         },
         { 0x9403, sony1Id,             EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def) },
 
+        // Tag 0x3000 SonySInfo1
+        { Tag::all, sonySInfo1Id,      newTiffBinaryElement },
+        { 0x3000, sony1Id,             EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def) },
+
         // Sony1 makernote
         {    0x0114, sony1Id,          EXV_COMPLEX_BINARY_ARRAY(sony1CsSet, sonyCsSelector) },
         {    0xb028, sony1Id,          newTiffSubIfd<sonyMltId>                  },
@@ -1662,6 +1687,10 @@ namespace Exiv2 {
         // Tag 0x9400 SonyMisc3c
         {  Tag::all, sonyMisc3cId,     newTiffBinaryElement                      },
         {    0x9400, sony2Id,          EXV_COMPLEX_BINARY_ARRAY(sonyMisc3cSet, sonyMisc3cSelector)  },
+
+        // Tag 0x3000 SonySInfo1
+        { Tag::all, sonySInfo1Id,      newTiffBinaryElement },
+        { 0x3000, sony2Id,             EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def) },
 
         // Sony2 makernote
         {    0x0114, sony2Id,          EXV_COMPLEX_BINARY_ARRAY(sony2CsSet, sonyCsSelector) },

--- a/tests/bugfixes/github/test_pr_1808.py
+++ b/tests/bugfixes/github/test_pr_1808.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+#Full support for SonyMisc3c tags using this model
+class SonyMisc3cSupportedTest(metaclass=CaseMeta):
+
+    filename = path("$data_path/exiv2-SonyDSC-HX60V.exv")
+    commands = ["$exiv2 -pa --grep SonySInfo1 $filename"]
+
+    stdout = ["""Exif.SonySInfo1.SonyDateTime                 Ascii      20  2014:01:01 00:52:22
+Exif.SonySInfo1.SonyImageHeight              Short       1  3888
+Exif.SonySInfo1.SonyImageWidth               Short       1  5184
+Exif.SonySInfo1.FacesDetected                Short       1  0
+Exif.SonySInfo1.MetaVersion                  Ascii      16  DC7303320222000
+"""
+    ]
+    stderr = [""]
+    retval = [0]
+


### PR DESCRIPTION
+ Add all tags, except the face detection sub-groups and related bookkeeping values.
+ Add testing. SonySInfo1 is currently supported by all Sony cameras so does not need to test for unsupported models.

Source: Exiftool (https://exiftool.org/TagNames/Sony.html)