### PR TITLE
update codecov config

### DIFF
--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -44,7 +44,12 @@ jobs:
           ctest --output-on-failure
           pip install gcovr
           gcovr -r ./../ -x --exclude-unreachable-branches --exclude-throw-branches -o coverage.xml .
+          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
           chmod +x codecov
           ./codecov -f build/coverage.xml
 

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -42,7 +42,11 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure
-          bash <(curl -s https://codecov.io/bash)
+          pip install gcovr
+          gcovr -r ./../ -x --exclude-unreachable-branches --exclude-throw-branches -o coverage.xml .
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f build/coverage.xml
 
   special_releaseValgrind:
     name: 'Ubuntu 20.04 - GCC - Release+Valgrind'

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -45,6 +45,11 @@ jobs:
           ctest --output-on-failure
           pip install gcovr
           gcovr -r ./../ -x --exclude-unreachable-branches --exclude-throw-branches -o coverage.xml .
+          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
           chmod +x codecov
           ./codecov -f build/coverage.xml

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -43,4 +43,8 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure
-          bash <(curl -s https://codecov.io/bash)
+          pip install gcovr
+          gcovr -r ./../ -x --exclude-unreachable-branches --exclude-throw-branches -o coverage.xml .
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f build/coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 ignore:
   - "xmpsdk"  # Not interested about the coverage of XMKSDK
+  - "unitTests"
+  - "samples"


### PR DESCRIPTION
This PR includes 3 changes:

1. start using the new codecov uploader because the bash version is deprecated and will soon stop working [see here](https://docs.codecov.com/docs/about-the-codecov-bash-uploader)
2. ignore the `samples` and `unitTests` folders in codecov. I don't think  we should measure these, they aren't really part of the exiv2 application. 
3. start using `gcovr` to generate a summary, which is then used by codecov. This has the benefit that the taken branches are better analyzed. [See this example in my fork](https://codecov.io/gh/hassec/exiv2/tree/24ca4bd4df5ea2469c138feb069e21cf40a2c0e2)    
Bit of a bummer that it drops the coverage by ~7% but I guess it's more accurate. And the information that e.g. only one branch of an `if()` is taken is IMHO potentially useful. 