### PR TITLE
Add sanitizer flags when fuzzing

### DIFF
--- a/.github/workflows/on_PR_linux_fuzz.yml
+++ b/.github/workflows/on_PR_linux_fuzz.yml
@@ -27,4 +27,4 @@ jobs:
       run: |
         cd build
         mkdir corpus
-        ./bin/fuzz-read-print-write corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_total_time=120 -max_len=4096
+        LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/fuzz-read-print-write corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_len=4096 -max_total_time=120

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -83,7 +83,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
                 endif()
             elseif( COMPILER_IS_CLANG )
                 if ( EXIV2_BUILD_FUZZ_TESTS )
-                    set(SANITIZER_FLAGS "-fsanitize=fuzzer-no-link")
+                    set(SANITIZER_FLAGS "-fsanitize=fuzzer-no-link,address,undefined")
                 elseif ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 )
                     set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all")
                 elseif ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.4 )

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -19,7 +19,7 @@ This is the command to run the fuzzer for 2 minutes:
 ```bash
 cd <exiv2dir>/build-fuzz
 mkdir corpus
-./bin/fuzz-read-print-write corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_total_time=120
+LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/fuzz-read-print-write corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_len=20480 -max_total_time=120
 ```
 
 Alternatively, a simple script is provided for running the fuzzer in a continuous loop:

--- a/fuzz/fuzzloop.sh
+++ b/fuzz/fuzzloop.sh
@@ -15,11 +15,11 @@ do
     mv corpus/ corpus2
     mkdir corpus
     echo minimizing corpus
-    ./bin/fuzz-read-print-write -merge=1 corpus ../test/data/ corpus2/
+    LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/fuzz-read-print-write -merge=1 corpus ../test/data/ corpus2/ -max_len=20480
     rm -r corpus2
 
     # Run the fuzzer for 4 hours
     date
     echo start fuzzer
-    ./bin/fuzz-read-print-write corpus -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_total_time=14400
+    LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/fuzz-read-print-write corpus -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_len=20480 -max_total_time=14400
 done

--- a/fuzz/knownleaks.txt
+++ b/fuzz/knownleaks.txt
@@ -1,0 +1,4 @@
+# Known memory leak in expat, caused by xmpsdk throwing an exception.
+# See https://github.com/Exiv2/exiv2/issues/1821
+leak:libexpat.so
+


### PR DESCRIPTION
When I added the new fuzzer, I mistakenly assumed that the `-fsanitize=fuzzer` flag would automatically include other checks like ASAN. That was wrong: those flags need to be added separately.