### PR TITLE
Corrected JPEG XL file type

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -56,7 +56,6 @@
 #define TAG_heix 0x68656978 /**< "heix" HEIC */
 #define TAG_mif1 0x6d696631 /**< "mif1" HEIF */
 #define TAG_crx  0x63727820 /**< "crx " Canon CR3 */
-#define TAG_JXL  0x4a584c20 /**< "JXL " JPEG XL */
 #define TAG_jxl  0x6a786c20 /**< "jxl " JPEG XL file type */
 #define TAG_moov 0x6d6f6f76 /**< "moov" Movie */
 #define TAG_meta 0x6d657461 /**< "meta" Metadata */

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -56,7 +56,8 @@
 #define TAG_heix 0x68656978 /**< "heix" HEIC */
 #define TAG_mif1 0x6d696631 /**< "mif1" HEIF */
 #define TAG_crx  0x63727820 /**< "crx " Canon CR3 */
-#define TAG_jxl  0x4a584c20 /**< "JXL " JPEG XL   */
+#define TAG_JXL  0x4a584c20 /**< "JXL " JPEG XL */
+#define TAG_jxl  0x6a786c20 /**< "jxl " JPEG XL file type */
 #define TAG_moov 0x6d6f6f76 /**< "moov" Movie */
 #define TAG_meta 0x6d657461 /**< "meta" Metadata */
 #define TAG_mdat 0x6d646174 /**< "mdat" Media data */

--- a/tests/bugfixes/github/test_issue_1503.py
+++ b/tests/bugfixes/github/test_issue_1503.py
@@ -33,7 +33,7 @@ Xmp.xmp.MetadataDate                         XmpText    25  2016-09-13T11:58:16+
 Xmp.photoshop.DateCreated                    XmpText    10  2004-06-21
 ""","""File name       : $filename
 File size       : 32892 Bytes
-MIME type       : image/generic
+MIME type       : image/jxl
 Image size      : 200 x 130
 Thumbnail       : image/jpeg, 4196 Bytes
 Camera make     : NIKON CORPORATION


### PR DESCRIPTION
Before:
```
€ exiv2 pr IMG_20210618_081111.jxl
File name       : IMG_20210618_081111.jxl
File size       : 1638062 Bytes
MIME type       : image/generic
Image size      : 3264 x 2448
Thumbnail       : image/jpeg, 15556 Bytes
Camera make     : LENOVO
Camera model    : Lenovo TAB3 10 Business
Image timestamp : 2021:06:18 08:11:11
File number     : 
Exposure time   : 0.000818 s
Aperture        : F2.2
Exposure bias   : 0 EV
Flash           : No flash
Flash bias      : 
Focal length    : 3.5 mm
Subject distance: 
ISO speed       : 94
Exposure mode   : Not defined
Metering mode   : Center weighted average
Macro mode      : 
Image quality   : 
White balance   : Auto
Copyright       : 
Exif comment    : 
```

After:
```
€ exiv2 pr IMG_20210618_081111.jxl
File name       : IMG_20210618_081111.jxl
File size       : 1638062 Bytes
MIME type       : image/jxl
Image size      : 3264 x 2448
Thumbnail       : image/jpeg, 15556 Bytes
Camera make     : LENOVO
Camera model    : Lenovo TAB3 10 Business
Image timestamp : 2021:06:18 08:11:11
File number     : 
Exposure time   : 0.000818 s
Aperture        : F2.2
Exposure bias   : 0 EV
Flash           : No flash
Flash bias      : 
Focal length    : 3.5 mm
Subject distance: 
ISO speed       : 94
Exposure mode   : Not defined
Metering mode   : Center weighted average
Macro mode      : 
Image quality   : 
White balance   : Auto
Copyright       : 
Exif comment    : 

```

In other words, MIME type was not correctly reported.