### PR TITLE
fix: incorrectly triggered enforce check during preview extraction

### DIFF
--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -807,9 +807,16 @@ namespace {
                     for (long i = 0; i < sizes.count(); i++) {
                         uint32_t offset = dataValue.toLong(i);
                         uint32_t size = sizes.toLong(i);
-                        enforce(Safe::add(idxBuf, size) < size_, kerCorruptedMetadata);
-                        if (size!=0 && Safe::add(offset, size) <= static_cast<uint32_t>(io.size()))
+
+                        // the size_ parameter is originally computed by summing all values inside sizes
+                        // see the constructor of LoaderTiff
+                        // But e.g in malicious files some of thes values could be negative
+                        // That's why we check again for each step here to really make sure we don't overstep
+                        enforce(Safe::add(idxBuf, size) <= size_, kerCorruptedMetadata);
+                        if (size!=0 && Safe::add(offset, size) <= static_cast<uint32_t>(io.size())){
                             memcpy(&buf.pData_[idxBuf], base + offset, size);
+                        }
+
                         idxBuf += size;
                     }
                     dataValue.setDataArea(buf.pData_, buf.size_);


### PR DESCRIPTION
This should close #1829.

The problem was an `enforce` statement inside `LoaderTiff::getData()`

I'm not an expert on the entire preview extraction stuff so take the below with a grain of salt. 
But it seems that there are previews inside a file which are defined by "stripes" or "tiles" 
If that is the case, they are inside the exifdata like below: 
```
0x0111 Exif.Image.StripOffsets                      StripOffsets                Long        1  134354
0x0117 Exif.Image.StripByteCounts                   StripByteCounts             Long        1  131328
```
Where the first one tells you at what offset into the file the preview starts and the second tells you how large the preview is in bytes.

But sometimes you get many offsets and counts, (who knows why, didn't really look into that yet, but the resulting image is in fact a preview :man_shrugging:)
```
0x0144 Exif.SubImage3.TileOffsets                   TileOffsets                 Long       12  301748 323396 354506 429600 459954 490748 523812 592136 630472 652932 678910 726818
0x0145 Exif.SubImage3.TileByteCounts                TileByteCounts              Long       12  21647 31110 75094 30354 30793 33063 68323 38336 22459 25978 47908 46601
```

And that's what would trigger the bug.
You can see that the function `LoaderTiff::getData()` behaves differently if you need to copy many chunks.
It checks each loop iteration to make sure that the value of `IdxBuf + size of current chunk` doesn't overflow the `DataBuf` we are copying the entire image into.  
It just ignored that by construction this check is going to be false on the last iteration where the two should be equal. 

I'm not sure how to make a proper test case for this without introducing a large file :/
Let's add this as yet another +1 to the long list of reasons why it would really be great to soon somehow start testing more one real files. 
