### PR TITLE
remove most usages of std::make_pair

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -212,7 +212,7 @@ namespace Exiv2 {
         EXV_WARN_UNUSED_RESULT std::pair<byte*, long> release();
 
         //! Reset value
-        void reset(std::pair<byte*, long> = std::make_pair(nullptr, long(0)));
+        void reset(std::pair<byte*, long> = {nullptr, long(0)});
         //@}
 
         /*!

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -892,7 +892,7 @@ namespace Jzon
 				else
 				{
 					// Store the unknown token, so we can show it to the user
-					data.push(std::make_pair(Value::VT_STRING, valueBuffer));
+					data.emplace(Value::VT_STRING, valueBuffer);
 					tokens.push(T_UNKNOWN);
 				}
 
@@ -946,7 +946,7 @@ namespace Jzon
                     node = new Object;
                 }
 
-                nodeStack.push(std::make_pair(name, node));
+                nodeStack.emplace(name, node);
                 name.clear();
                 break;
             }
@@ -963,7 +963,7 @@ namespace Jzon
                     node = new Array;
                 }
 
-                nodeStack.push(std::make_pair(name, node));
+                nodeStack.emplace(name, node);
                 name.clear();
                 break;
             }
@@ -1040,7 +1040,7 @@ namespace Jzon
                         node = nullptr;
                         name.clear();
                     } else {
-                        nodeStack.push(std::make_pair(name, node));
+                        nodeStack.emplace(name, node);
                         name.clear();
                     }
                 }
@@ -1108,7 +1108,7 @@ namespace Jzon
 			c1 = c2;
 		}
 
-		data.push(std::make_pair(Value::VT_STRING, str));
+		data.emplace(Value::VT_STRING, str);
 	}
 	bool Parser::interpretValue(const std::string &value)
 	{
@@ -1117,17 +1117,17 @@ namespace Jzon
         std::transform(value.begin(), value.end(), upperValue.begin(), toupper);
 
         if (upperValue == "NULL") {
-            data.push(std::make_pair(Value::VT_NULL, std::string("")));
+            data.emplace(Value::VT_NULL, "");
         } else if (upperValue == "TRUE") {
-            data.push(std::make_pair(Value::VT_BOOL, std::string("true")));
+            data.emplace(Value::VT_BOOL, "true");
         } else if (upperValue == "FALSE") {
-            data.push(std::make_pair(Value::VT_BOOL, std::string("false")));
+            data.emplace(Value::VT_BOOL, "false");
         } else {
             bool number = std::all_of(value.begin(), value.end(), IsNumber);
             if (!number) {
                 return false;
             }
-            data.push(std::make_pair(Value::VT_NUMBER, value));
+            data.emplace(Value::VT_NUMBER, value);
         }
         return true;
     }

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -448,11 +448,11 @@ namespace Jzon
 
     void Object::Add(const std::string &name, Node &node)
     {
-        children.push_back(NamedNodePtr(name, node.GetCopy()));
+        children.emplace_back(name, node.GetCopy());
     }
     void Object::Add(const std::string &name, const Value &node)
     {
-        children.push_back(NamedNodePtr(name, new Value(node)));
+        children.emplace_back(name, new Value(node));
     }
     void Object::Remove(const std::string &name)
     {

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -70,8 +70,8 @@ try {
     // Set two rational components from a string
     rv->read("1/2 1/3");
     // Add more elements through the extended interface of rational value
-    rv->value_.push_back(std::make_pair(2,3));
-    rv->value_.push_back(std::make_pair(3,4));
+    rv->value_.emplace_back(2, 3);
+    rv->value_.emplace_back(3, 4);
     // Add the key and value pair to the Exif data
     key = Exiv2::ExifKey("Exif.Image.PrimaryChromaticities");
     exifData.add(key, rv.get());
@@ -101,7 +101,7 @@ try {
         throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
     rv = Exiv2::URationalValue::UniquePtr(prv);
     // Modify the value directly through the interface of URationalValue
-    rv->value_.at(2) = std::make_pair(88,77);
+    rv->value_.at(2) = {88, 77};
     // Copy the modified value back to the metadatum
     pos->setValue(rv.get());
     std::cout << "Modified key \"" << key

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -452,23 +452,23 @@ namespace {
                 posBeginPageSetup = startPos;
             } else if (!inRemovableEmbedding && line == "%Exiv2BeginXMP: Before %%EndPageSetup") {
                 inRemovableEmbedding = true;
-                removableEmbeddings.push_back(std::make_pair(startPos, startPos));
+                removableEmbeddings.emplace_back(startPos, startPos);
                 removableEmbeddingEndLine = "%Exiv2EndXMP";
             } else if (!inRemovableEmbedding && line == "%Exiv2BeginXMP: After %%PageTrailer") {
                 inRemovableEmbedding = true;
-                removableEmbeddings.push_back(std::make_pair(startPos, startPos));
+                removableEmbeddings.emplace_back(startPos, startPos);
                 removableEmbeddingEndLine = "%Exiv2EndXMP";
             } else if (!inRemovableEmbedding && line == "%ADOBeginClientInjection: PageSetup End \"AI11EPS\"") {
                 inRemovableEmbedding = true;
-                removableEmbeddings.push_back(std::make_pair(startPos, startPos));
+                removableEmbeddings.emplace_back(startPos, startPos);
                 removableEmbeddingEndLine = "%ADOEndClientInjection: PageSetup End \"AI11EPS\"";
             } else if (!inRemovableEmbedding && line == "%ADOBeginClientInjection: PageTrailer Start \"AI11EPS\"") {
                 inRemovableEmbedding = true;
-                removableEmbeddings.push_back(std::make_pair(startPos, startPos));
+                removableEmbeddings.emplace_back(startPos, startPos);
                 removableEmbeddingEndLine = "%ADOEndClientInjection: PageTrailer Start \"AI11EPS\"";
             } else if (!inRemovableEmbedding && line == "%begin_xml_code") {
                 inRemovableEmbedding = true;
-                removableEmbeddings.push_back(std::make_pair(startPos, startPos));
+                removableEmbeddings.emplace_back(startPos, startPos);
                 removableEmbeddingEndLine = "%end_xml_code";
                 removableEmbeddingsWithUnmarkedTrailer++;
             } else {
@@ -622,8 +622,8 @@ namespace {
                 if (write) throw Error(kerImageWriteFailed);
                 break;
             }
-            removableEmbeddings.push_back(std::make_pair(posXmpTrailer, posXmpTrailerEnd));
-            #ifdef DEBUG
+            removableEmbeddings.emplace_back(posXmpTrailer, posXmpTrailerEnd);
+#ifdef DEBUG
             EXV_DEBUG << "readWriteEpsMetadata: Recognized unmarked trailer of removable XMP embedding at "
                          "[" << removableEmbeddings.back().first << "," << removableEmbeddings.back().second << ")"
                          "\n";

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -585,7 +585,7 @@ namespace Exiv2 {
         ExifKey exifKey(key);
         auto pos = findKey(exifKey);
         if (pos == end()) {
-            exifMetadata_.push_back(Exifdatum(exifKey));
+            exifMetadata_.emplace_back(exifKey);
             return exifMetadata_.back();
         }
         return *pos;

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -265,7 +265,7 @@ namespace Exiv2 {
         IptcKey iptcKey(key);
         auto pos = findKey(iptcKey);
         if (pos == end()) {
-            iptcMetadata_.push_back(Iptcdatum(iptcKey));
+            iptcMetadata_.emplace_back(iptcKey);
             return iptcMetadata_.back();
         }
         return *pos;

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -472,7 +472,7 @@ namespace Exiv2 {
 #endif
             }
             else if (size != 0) {
-                strips_.push_back(std::make_pair(pStrip, size));
+                strips_.emplace_back(pStrip, size);
             }
         }
     } // TiffImageEntry::setStrips

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -991,14 +991,14 @@ namespace Exiv2 {
                           << " not found. Writing only one strip.\n";
 #endif
                 object->strips_.clear();
-                object->strips_.push_back(std::make_pair(zero, sizeDataArea));
+                object->strips_.emplace_back(zero, sizeDataArea);
             }
             else {
                 uint32_t sizeTotal = 0;
                 object->strips_.clear();
                 for (long i = 0; i < pos->count(); ++i) {
                     uint32_t len = pos->toLong(i);
-                    object->strips_.push_back(std::make_pair(zero, len));
+                    object->strips_.emplace_back(zero, len);
                     sizeTotal += len;
                 }
                 if (sizeTotal != sizeDataArea) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -166,7 +166,7 @@ namespace Exiv2 {
 
     EXV_WARN_UNUSED_RESULT std::pair<byte*, long> DataBuf::release()
     {
-        std::pair<byte*, long> p = std::make_pair(pData_, size_);
+        std::pair<byte*, long> p = {pData_, size_};
         pData_ = nullptr;
         size_ = 0;
         return p;
@@ -230,7 +230,7 @@ namespace Exiv2 {
             if (c != '/')
                 is.setstate(std::ios::failbit);
             if (is)
-                r = std::make_pair(nominator, denominator);
+                r = {nominator, denominator};
         }
         return is;
     }
@@ -258,7 +258,7 @@ namespace Exiv2 {
             if (c != '/')
                 is.setstate(std::ios::failbit);
             if (is)
-                r = std::make_pair(nominator, denominator);
+                r = {nominator, denominator};
         }
         return is;
     }
@@ -294,7 +294,7 @@ namespace Exiv2 {
     {
         uint32_t nominator = getULong(buf, byteOrder);
         uint32_t denominator = getULong(buf + 4, byteOrder);
-        return std::make_pair(nominator, denominator);
+        return {nominator, denominator};
     }
 
     int16_t getShort(const byte* buf, ByteOrder byteOrder)
@@ -317,7 +317,7 @@ namespace Exiv2 {
     {
         int32_t nominator = getLong(buf, byteOrder);
         int32_t denominator = getLong(buf + 4, byteOrder);
-        return std::make_pair(nominator, denominator);
+        return {nominator, denominator};
     }
 
     float getFloat(const byte* buf, ByteOrder byteOrder)


### PR DESCRIPTION
Better alternatives exist with C++11.

Signed-off-by: Rosen Penev <rosenp@gmail.com>