### PR TITLE
Add special build mode for OSS-Fuzz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentatio
 option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
 option( EXIV2_TEAM_WARNINGS_AS_ERRORS "Treat warnings as errors"                              OFF )
 option( EXIV2_TEAM_USE_SANITIZERS     "Enable ASAN and UBSAN when available"                  OFF )
+option( EXIV2_TEAM_OSS_FUZZ           "Build config for OSS-Fuzz"                             OFF )
 option( EXIV2_TEAM_PACKAGING          "Additional stuff for generating packages"              OFF )
 set(EXTRA_COMPILE_FLAGS " ")
 

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -70,7 +70,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
         # This seems to be causing issues in the Fedora_MinGW GitLab job
         #add_compile_options(-fasynchronous-unwind-tables)
 
-        if( EXIV2_BUILD_FUZZ_TESTS )
+        if( EXIV2_BUILD_FUZZ_TESTS AND NOT EXIV2_TEAM_OSS_FUZZ )
             if (NOT COMPILER_IS_CLANG)
                 message(FATAL_ERROR "You need to build with Clang for the fuzzers to work. "
                         "Use Clang")

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,10 +1,16 @@
 
 macro(fuzzer name)
     add_executable(${name} ${name}.cpp)
-    set_target_properties(${name}
-            PROPERTIES
-                COMPILE_FLAGS "-fsanitize=fuzzer"
-                LINK_FLAGS "-fsanitize=fuzzer")
+    if(EXIV2_TEAM_OSS_FUZZ)
+        set_target_properties(${name}
+                PROPERTIES
+                    LINK_FLAGS "${LIB_FUZZING_ENGINE}")
+    else()
+        set_target_properties(${name}
+                PROPERTIES
+                    COMPILE_FLAGS "-fsanitize=fuzzer"
+                    LINK_FLAGS "-fsanitize=fuzzer")
+    endif()
     target_link_libraries(${name}
             PRIVATE
             exiv2lib


### PR DESCRIPTION
This is a follow-up to #1869. It turns out that even the `-fsanitize=fuzzer-no-link` and `-fsanitize=fuzzer` flags don't work with the OSS-Fuzz build. Instead, we have to add `$LIB_FUZZING_ENGINE` as a linker flag when we build the fuzz target. That's because OSS-Fuzz also wants to build for AFL and honggfuzz, not just libFuzzer. Each of those fuzzers uses a different `main` function wrapper around [`LLVMFuzzerTestOneInput`](https://github.com/Exiv2/exiv2/blob/f8bfad1551e1b96a673c2b129bce720d79ddd6a6/fuzz/fuzz-read-print-write.cpp#L7).