### PR TITLE
Add OSS-Fuzz status badge and CIFuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,27 @@
+# OSS-Fuzz continuous integration:
+# https://google.github.io/oss-fuzz/getting-started/continuous-integration/
+
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'exiv2'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'exiv2'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,11 @@ option( EXIV2_BUILD_DOC               "Add 'doc' target to generate documentatio
 option( EXIV2_TEAM_EXTRA_WARNINGS     "Add more sanity checks using compiler flags"           OFF )
 option( EXIV2_TEAM_WARNINGS_AS_ERRORS "Treat warnings as errors"                              OFF )
 option( EXIV2_TEAM_USE_SANITIZERS     "Enable ASAN and UBSAN when available"                  OFF )
+
+# The EXIV2_TEAM_OSS_FUZZ option is used by the OSS-Fuzz build script:
+# https://github.com/google/oss-fuzz/tree/master/projects/exiv2/build.sh
 option( EXIV2_TEAM_OSS_FUZZ           "Build config for OSS-Fuzz"                             OFF )
+
 option( EXIV2_TEAM_PACKAGING          "Additional stuff for generating packages"              OFF )
 set(EXTRA_COMPILE_FLAGS " ")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-|                           Codecov                            |                           Repology                           |                             Chat                             |
-| :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
-| [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/main/graph/badge.svg?token=O9G7Iswx26)](https://codecov.io/gh/Exiv2/exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
+|                           Codecov                            |                           OSS-Fuzz                           |                           Repology                           |                             Chat                             |
+| :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
+| [![codecov](https://codecov.io/gh/Exiv2/exiv2/branch/main/graph/badge.svg?token=O9G7Iswx26)](https://codecov.io/gh/Exiv2/exiv2) | [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/exiv2.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:exiv2) | [![Packaging status](https://repology.org/badge/tiny-repos/exiv2.svg)](https://repology.org/metapackage/exiv2/versions) | [![#exiv2-chat on matrix.org](matrix-standard-vector-logo-xs.png)](https://matrix.to/#/#exiv2-chat:matrix.org) |
 
 CI Status:
 
@@ -65,6 +65,7 @@ The file ReadMe.txt in a build bundle describes how to install the library on th
     4. [Python tests](#4-4)
     5. [Test Summary](#4-5)
     6. [Fuzzing](#4-6)
+        1. [OSS-Fuzz](#4-6-1)
 5. [Platform Notes](#5)
     1. [Linux](#5-1)
     2. [macOS](#5-2)
@@ -1084,6 +1085,15 @@ mkdir corpus
 ```
 
 For more information about fuzzing see [`fuzz/README.md`](fuzz/README.md).
+
+[TOC](#TOC)
+<div id="4-6-1">
+
+### 4.6.1 OSS-Fuzz
+
+Exiv2 is enrolled in [OSS-Fuzz](https://google.github.io/oss-fuzz/), which is a fuzzing service for open-source projects, run by Google.
+
+The build script used by OSS-Fuzz to build Exiv2 can be found [here](https://github.com/google/oss-fuzz/tree/master/projects/exiv2/build.sh). It uses the same fuzz target ([`fuzz-read-print-write`](fuzz/fuzz-read-print-write.cpp)) as mentioned above, but with a slightly different build configuration to integrate with OSS-Fuzz. In particular, it uses the CMake option `-DEXIV2_TEAM_OSS_FUZZ=ON`, which builds the fuzz target without adding the `-fsanitize=fuzzer` flag, so that OSS-Fuzz can control the sanitizer flags itself.
 
 [TOC](#TOC)
 <div id="5">

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -70,6 +70,10 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
         # This seems to be causing issues in the Fedora_MinGW GitLab job
         #add_compile_options(-fasynchronous-unwind-tables)
 
+        # The EXIV2_TEAM_OSS_FUZZ option is used by the OSS-Fuzz build script:
+        # https://github.com/google/oss-fuzz/tree/master/projects/exiv2/build.sh
+        # OSS-Fuzz wants full control of the sanitizer flags, so we don't add
+        # the `-fsanitize=fuzzer-no-link` flag when building for OSS-Fuzz.
         if( EXIV2_BUILD_FUZZ_TESTS AND NOT EXIV2_TEAM_OSS_FUZZ )
             if (NOT COMPILER_IS_CLANG)
                 message(FATAL_ERROR "You need to build with Clang for the fuzzers to work. "

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,6 +1,11 @@
 
 macro(fuzzer name)
     add_executable(${name} ${name}.cpp)
+
+    # The EXIV2_TEAM_OSS_FUZZ option is used by the OSS-Fuzz build script:
+    # https://github.com/google/oss-fuzz/tree/master/projects/exiv2/build.sh
+    # OSS-Fuzz wants full control of the sanitizer flags, and it uses
+    # the LIB_FUZZING_ENGINE option to supply its own main function.
     if(EXIV2_TEAM_OSS_FUZZ)
         set_target_properties(${name}
                 PROPERTIES


### PR DESCRIPTION
* Add the OSS-Fuzz badge to the README.
* Update the documentation to explain the CMake option `EXIV2_TEAM_OSS_FUZZ`.
* Add the [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow.