### PR TITLE
Only build XMLValidator when XMP is enabled.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,8 +173,10 @@ target_include_directories(exiv2lib SYSTEM PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>
 )
 
-target_include_directories(exiv2lib PRIVATE ${EXPAT_INCLUDE_DIR})
-target_link_libraries(exiv2lib PRIVATE EXPAT::EXPAT)
+if (EXIV2_ENABLE_XMP OR EXIV2_ENABLE_EXTERNAL_XMP)
+    target_include_directories(exiv2lib PRIVATE ${EXPAT_INCLUDE_DIR})
+    target_link_libraries(exiv2lib PRIVATE EXPAT::EXPAT)
+endif()
 
 if (EXIV2_ENABLE_XMP)
     target_link_libraries(exiv2lib PRIVATE exiv2-xmp)

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -43,6 +43,7 @@
 # include <XMP.incl_cpp>
 #endif // EXV_HAVE_XMP_TOOLKIT
 
+#ifdef EXV_HAVE_XMP_TOOLKIT
 // This anonymous namespace contains a class named XMLValidator, which uses
 // libexpat to do a basic validation check on an XML document. This is to
 // reduce the chance of hitting a bug in the (third-party) xmpsdk
@@ -203,7 +204,7 @@ namespace {
         }
     };
 }  // namespace
-
+#endif // EXV_HAVE_XMP_TOOLKIT
 
 // *****************************************************************************
 // local declarations


### PR DESCRIPTION
This is a follow-up to #1878. As discussed [here](https://github.com/Exiv2/exiv2/pull/1880#issuecomment-907258149), `XMLValidator` should only be built when XMP is enabled.