### PR TITLE
Make fields of DataBuf private

### DIFF
--- a/fuzz/fuzz-read-print-write.cpp
+++ b/fuzz/fuzz-read-print-write.cpp
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
   try {
     Exiv2::DataBuf data_copy(data, size);
     Exiv2::Image::UniquePtr image =
-      Exiv2::ImageFactory::open(data_copy.pData_, size);
+      Exiv2::ImageFactory::open(data_copy.c_data(0), size);
     assert(image.get() != 0);
 
     image->readMetadata();

--- a/fuzz/fuzz-read-print-write.cpp
+++ b/fuzz/fuzz-read-print-write.cpp
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
   try {
     Exiv2::DataBuf data_copy(data, size);
     Exiv2::Image::UniquePtr image =
-      Exiv2::ImageFactory::open(data_copy.c_data(0), size);
+      Exiv2::ImageFactory::open(data_copy.c_data(), size);
     assert(image.get() != 0);
 
     image->readMetadata();

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -234,7 +234,7 @@ namespace Exiv2 {
          */
         virtual bool iccProfileDefined()
         {
-            return iccProfile_.size_ != 0;
+            return iccProfile_.size() != 0;
         }
 
         /*!

--- a/include/exiv2/preview.hpp
+++ b/include/exiv2/preview.hpp
@@ -70,8 +70,6 @@ namespace Exiv2 {
         //@{
         //! Copy constructor
         PreviewImage(const PreviewImage& rhs);
-        //! Destructor.
-        ~PreviewImage();
         //@}
 
         //! @name Manipulators
@@ -150,8 +148,7 @@ namespace Exiv2 {
         PreviewImage(PreviewProperties properties, DataBuf data);
 
         PreviewProperties properties_;          //!< Preview image properties
-        byte* pData_;                           //!< Pointer to the preview image data
-        uint32_t size_;                         //!< Size of the preview image data
+        DataBuf preview_;                       //!< Preview image data
 
     }; // class PreviewImage
 

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -205,6 +205,10 @@ namespace Exiv2 {
          */
         void alloc(long size);
         /*!
+          @brief Resize the buffer. Existing data is preserved (like std::realloc()).
+         */
+        void resize(long size);
+        /*!
           @brief Release ownership of the buffer to the caller. Returns the
                  buffer as a data pointer and size pair, resets the internal
                  buffer.
@@ -214,6 +218,9 @@ namespace Exiv2 {
         //! Reset value
         void reset(std::pair<byte*, long> = {nullptr, long(0)});
         //@}
+
+        //! Fill the buffer with zeros.
+        void clear();
 
         /*!
           @name Conversions
@@ -228,6 +235,36 @@ namespace Exiv2 {
         operator DataBufRef();
         //@}
 
+        long size() const { return size_; }
+
+        uint8_t read_uint8(size_t offset) const;
+        void write_uint8(size_t offset, uint8_t x);
+
+        uint16_t read_uint16(size_t offset, ByteOrder byteOrder) const;
+        void write_uint16(size_t offset, uint16_t x, ByteOrder byteOrder);
+
+        uint32_t read_uint32(size_t offset, ByteOrder byteOrder) const;
+        void write_uint32(size_t offset, uint32_t x, ByteOrder byteOrder);
+
+        uint64_t read_uint64(size_t offset, ByteOrder byteOrder) const;
+        void write_uint64(size_t offset, uint64_t x, ByteOrder byteOrder);
+
+        //! Copy bytes into the buffer (starting at address &pData_[offset]).
+        void copyBytes(size_t offset, const void* buf, size_t bufsize);
+
+        //! Equivalent to: memcmp(&pData_[offset], buf, bufsize)
+        int cmpBytes(size_t offset, const void* buf, size_t bufsize) const;
+
+        //! Returns a data pointer.
+        byte* data(size_t offset);
+
+        //! Returns a (read-only) data pointer.
+        const byte* c_data(size_t offset) const;
+
+        //! Returns a (read-only) C-style string pointer.
+        const char* c_str(size_t offset) const;
+
+      private:
         // DATA
         //! Pointer to the buffer, 0 if none has been allocated
         byte* pData_;
@@ -302,6 +339,11 @@ namespace Exiv2 {
              return number of bytes written.
      */
     EXIV2API long ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder);
+    /*!
+      @brief Convert an uint64_t to data, write the data to the buffer,
+             return number of bytes written.
+     */
+    EXIV2API long ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder);
     /*!
       @brief Convert an unsigned rational to data, write the data to the buffer,
              return number of bytes written.

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -256,13 +256,13 @@ namespace Exiv2 {
         int cmpBytes(size_t offset, const void* buf, size_t bufsize) const;
 
         //! Returns a data pointer.
-        byte* data(size_t offset);
+        byte* data(size_t offset = 0);
 
         //! Returns a (read-only) data pointer.
-        const byte* c_data(size_t offset) const;
+        const byte* c_data(size_t offset = 0) const;
 
         //! Returns a (read-only) C-style string pointer.
-        const char* c_str(size_t offset) const;
+        const char* c_str(size_t offset = 0) const;
 
       private:
         // DATA

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -88,7 +88,7 @@ namespace Exiv2 {
         void doWriteMetadata(BasicIo& outIo);
         //! @name NOT Implemented
         //@{
-        static long getHeaderOffset(byte* data, long data_size, byte* header, long header_size);
+        static long getHeaderOffset(const byte* data, long data_size, const byte* header, long header_size);
         static bool equalsWebPTag(Exiv2::DataBuf& buf, const char* str);
         void debugPrintHex(byte *data, long size);
         void decodeChunks(long filesize);

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* const argv[])
         }
         Exiv2::DataBuf buf(static_cast<long>(io.size()));
         std::cout << "Reading " << buf.size() << " bytes from " << data << "\n";
-        long readBytes = io.read(buf.data(0), buf.size());
+        long readBytes = io.read(buf.data(), buf.size());
         if (readBytes != buf.size() || io.error() || io.eof()) {
             throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
         }
@@ -59,7 +59,7 @@ int main(int argc, char* const argv[])
 
         // Set Preview field to the content of the data file
         Exiv2::DataValue value;
-        value.read(buf.data(0), buf.size());
+        value.read(buf.data(), buf.size());
         Exiv2::IptcData& iptcData = image->iptcData();
         std::cout << "IPTC fields: " << iptcData.size() << "\n";
         iptcData["Iptc.Application2.Preview"] = value;
@@ -71,7 +71,7 @@ int main(int argc, char* const argv[])
         const Exiv2::byte* record;
         uint32_t sizeHdr = 0;
         uint32_t sizeData = 0;
-        Exiv2::Photoshop::locateIptcIrb(irb.data(0), irb.size(), &record, &sizeHdr, &sizeData);
+        Exiv2::Photoshop::locateIptcIrb(irb.data(), irb.size(), &record, &sizeHdr, &sizeData);
         Exiv2::DataBuf rawIptc = Exiv2::IptcParser::encode(iptcData);
         std::cout << "Comparing IPTC and IRB size... ";
         if (static_cast<uint32_t>(rawIptc.size()) != sizeData) {

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -46,9 +46,9 @@ int main(int argc, char* const argv[])
             throw Exiv2::Error(Exiv2::kerDataSourceOpenFailed, io.path(), Exiv2::strError());
         }
         Exiv2::DataBuf buf(static_cast<long>(io.size()));
-        std::cout << "Reading " << buf.size_ << " bytes from " << data << "\n";
-        long readBytes = io.read(buf.pData_, buf.size_);
-        if (readBytes != buf.size_ || io.error() || io.eof()) {
+        std::cout << "Reading " << buf.size() << " bytes from " << data << "\n";
+        long readBytes = io.read(buf.data(0), buf.size());
+        if (readBytes != buf.size() || io.error() || io.eof()) {
             throw Exiv2::Error(Exiv2::kerFailedToReadImageData);
         }
 
@@ -59,7 +59,7 @@ int main(int argc, char* const argv[])
 
         // Set Preview field to the content of the data file
         Exiv2::DataValue value;
-        value.read(buf.pData_, buf.size_);
+        value.read(buf.data(0), buf.size());
         Exiv2::IptcData& iptcData = image->iptcData();
         std::cout << "IPTC fields: " << iptcData.size() << "\n";
         iptcData["Iptc.Application2.Preview"] = value;
@@ -67,20 +67,20 @@ int main(int argc, char* const argv[])
 
         // Set IRB, compare with IPTC raw data
         Exiv2::DataBuf irb = Exiv2::Photoshop::setIptcIrb(nullptr, 0, iptcData);
-        std::cout << "IRB buffer : " << irb.size_ << "\n";
+        std::cout << "IRB buffer : " << irb.size() << "\n";
         const Exiv2::byte* record;
         uint32_t sizeHdr = 0;
         uint32_t sizeData = 0;
-        Exiv2::Photoshop::locateIptcIrb(irb.pData_, irb.size_, &record, &sizeHdr, &sizeData);
+        Exiv2::Photoshop::locateIptcIrb(irb.data(0), irb.size(), &record, &sizeHdr, &sizeData);
         Exiv2::DataBuf rawIptc = Exiv2::IptcParser::encode(iptcData);
         std::cout << "Comparing IPTC and IRB size... ";
-        if (static_cast<uint32_t>(rawIptc.size_) != sizeData) {
+        if (static_cast<uint32_t>(rawIptc.size()) != sizeData) {
             std::cout << "not ";
         }
         std::cout << "ok\n";
 
         std::cout << "Comparing IPTC and IRB data... ";
-        if (0 != memcmp(rawIptc.pData_, record + sizeHdr, sizeData)) {
+        if (0 != rawIptc.cmpBytes(0, record + sizeHdr, sizeData)) {
             std::cout << "not ";
         }
         std::cout << "ok\n";

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -50,11 +50,11 @@ try {
     long size = static_cast<long>(file.size());
     DataBuf buf(size);
     // Read from the memory mapped region
-    memcpy(buf.pData_, pData, buf.size_);
+    buf.copyBytes(0, pData, buf.size());
     // Reopen file in write mode and write to it
-    file.write(buf.pData_, buf.size_);
+    file.write(buf.c_data(0), buf.size());
     // Read from the mapped region again
-    memcpy(buf.pData_, pData, buf.size_);
+    buf.copyBytes(0, pData, buf.size());
     file.close();
 
     return 0;

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -52,7 +52,7 @@ try {
     // Read from the memory mapped region
     buf.copyBytes(0, pData, buf.size());
     // Reopen file in write mode and write to it
-    file.write(buf.c_data(0), buf.size());
+    file.write(buf.c_data(), buf.size());
     // Read from the mapped region again
     buf.copyBytes(0, pData, buf.size());
     file.close();

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -56,12 +56,12 @@ int main(int argc, char* const argv[])
             Exiv2::DataBuf buf = format->dataArea();
 
             // The first byte of the buffer needs to be patched
-            buf.pData_[0] = 0xff;
+            buf.write_uint8(0, 0xff);
 
             Exiv2::FileIo file("img_thumb.jpg");
 
             file.open("wb");
-            file.write(buf.pData_, buf.size_);
+            file.write(buf.c_data(0), buf.size());
             file.close();
         }
 

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* const argv[])
             Exiv2::FileIo file("img_thumb.jpg");
 
             file.open("wb");
-            file.write(buf.c_data(0), buf.size());
+            file.write(buf.c_data(), buf.size());
             file.close();
         }
 

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -73,7 +73,7 @@ void mini1(const char* path)
 
     // Write nothing, this time with a previous binary image
     DataBuf buf = readFile(path);
-    wm = ExifParser::encode(blob, buf.pData_, buf.size_, bigEndian, exifData);
+    wm = ExifParser::encode(blob, buf.c_data(0), buf.size(), bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     assert(blob.empty());
     std::cout << "Test 2: Writing empty Exif data with original binary data: ok.\n";

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -73,7 +73,7 @@ void mini1(const char* path)
 
     // Write nothing, this time with a previous binary image
     DataBuf buf = readFile(path);
-    wm = ExifParser::encode(blob, buf.c_data(0), buf.size(), bigEndian, exifData);
+    wm = ExifParser::encode(blob, buf.c_data(), buf.size(), bigEndian, exifData);
     enforce(wm == wmIntrusive, Exiv2::kerErrorMessage, "encode returned an unexpected value");
     assert(blob.empty());
     std::cout << "Test 2: Writing empty Exif data with original binary data: ok.\n";

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -39,7 +39,7 @@ try {
     }
     Exiv2::DataBuf buf = Exiv2::readFile(argv[1]);
     std::string xmpPacket;
-    xmpPacket.assign(reinterpret_cast<char*>(buf.pData_), buf.size_);
+    xmpPacket.assign(buf.c_str(0), buf.size());
     Exiv2::XmpData xmpData;
     if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket)) {
         std::string error(argv[1]);

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -39,7 +39,7 @@ try {
     }
     Exiv2::DataBuf buf = Exiv2::readFile(argv[1]);
     std::string xmpPacket;
-    xmpPacket.assign(buf.c_str(0), buf.size());
+    xmpPacket.assign(buf.c_str(), buf.size());
     Exiv2::XmpData xmpData;
     if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket)) {
         std::string error(argv[1]);

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -40,7 +40,7 @@ try {
     std::string filename(argv[1]);
     Exiv2::DataBuf buf = Exiv2::readFile(filename);
     std::string xmpPacket;
-    xmpPacket.assign(buf.c_str(0), buf.size());
+    xmpPacket.assign(buf.c_str(), buf.size());
     std::cerr << "-----> Decoding XMP data read from " << filename << " <-----\n";
     Exiv2::XmpData xmpData;
     if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket)) {

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -40,7 +40,7 @@ try {
     std::string filename(argv[1]);
     Exiv2::DataBuf buf = Exiv2::readFile(filename);
     std::string xmpPacket;
-    xmpPacket.assign(reinterpret_cast<char*>(buf.pData_), buf.size_);
+    xmpPacket.assign(buf.c_str(0), buf.size());
     std::cerr << "-----> Decoding XMP data read from " << filename << " <-----\n";
     Exiv2::XmpData xmpData;
     if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket)) {

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -232,9 +232,9 @@ namespace Action {
                 Exiv2::DataBuf ascii(static_cast<long>(size * 3 + 1));
                 ascii.write_uint8(size * 3, 0);
                 iccProfile.copyBytes(0,output.str().c_str(),size);
-                if (Exiv2::base64encode(iccProfile.c_data(0), size, reinterpret_cast<char*>(ascii.data(0)), size * 3)) {
+                if (Exiv2::base64encode(iccProfile.c_data(), size, reinterpret_cast<char*>(ascii.data()), size * 3)) {
                     long       chunk = 60 ;
-                    std::string code = std::string("data:") + std::string(ascii.c_str(0));
+                    std::string code = std::string("data:") + std::string(ascii.c_str());
                     long length = static_cast<long>(code.size());
                     for ( long start = 0 ; start < length ; start += chunk ) {
                         long   count = (start+chunk) < length ? chunk : length - start ;
@@ -615,8 +615,8 @@ namespace Action {
                 std::cout << std::endl;
             first = false;
             Exiv2::DataBuf buf(md.size());
-            md.copy(buf.data(0), pImage->byteOrder());
-            Exiv2::hexdump(std::cout, buf.c_data(0), buf.size());
+            md.copy(buf.data(), pImage->byteOrder());
+            Exiv2::hexdump(std::cout, buf.c_data(), buf.size());
         }
         std::cout << std::endl;
         return true;
@@ -1025,7 +1025,7 @@ namespace Action {
             } else {
 
                 if ( bStdout ) { // -eC-
-                    std::cout.write(image->iccProfile()->c_str(0),
+                    std::cout.write(image->iccProfile()->c_str(),
                                     image->iccProfile()->size());
                 } else {
                     if (Params::instance().verbose_) {
@@ -1033,7 +1033,7 @@ namespace Action {
                     }
                     Exiv2::FileIo iccFile(target);
                     iccFile.open("wb") ;
-                    iccFile.write(image->iccProfile()->c_data(0),image->iccProfile()->size());
+                    iccFile.write(image->iccProfile()->c_data(),image->iccProfile()->size());
                     iccFile.close();
                 }
             }
@@ -1888,7 +1888,7 @@ namespace {
 
         Exiv2::DataBuf stdIn;
         if ( bStdin )  Params::instance().getStdin(stdIn);
-        Exiv2::BasicIo::UniquePtr ioStdin = Exiv2::BasicIo::UniquePtr(new Exiv2::MemIo(stdIn.c_data(0),stdIn.size()));
+        Exiv2::BasicIo::UniquePtr ioStdin = Exiv2::BasicIo::UniquePtr(new Exiv2::MemIo(stdIn.c_data(),stdIn.size()));
 
         Exiv2::Image::UniquePtr sourceImage = bStdin ? Exiv2::ImageFactory::open(std::move(ioStdin)) : Exiv2::ImageFactory::open(source);
         assert(sourceImage.get() != 0);

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -516,7 +516,7 @@ namespace Exiv2 {
 #else
         // Workaround for platforms without mmap: Read the file into memory
         DataBuf buf(static_cast<long>(p_->mappedLength_));
-        if (read(buf.data(0), buf.size()) != buf.size()) {
+        if (read(buf.data(), buf.size()) != buf.size()) {
 #ifdef EXV_UNICODE_PATH
             if (p_->wpMode_ == Impl::wpUnicode) {
                 throw WError(kerCallFailed, wpath(), strError().c_str(), "FileIo::read");
@@ -671,7 +671,7 @@ namespace Exiv2 {
             if (statOk && S_ISLNK(buf1.st_mode)) {
                 lbuf.alloc(buf1.st_size + 1);
                 lbuf.clear();
-                pf = reinterpret_cast<char*>(lbuf.data(0));
+                pf = reinterpret_cast<char*>(lbuf.data());
                 if (::readlink(path().c_str(), pf, lbuf.size() - 1) == -1) {
                     throw Error(kerCallFailed, path(), strError(), "readlink");
                 }
@@ -990,7 +990,7 @@ namespace Exiv2 {
         if (static_cast<size_t>(rcount) > size())
             throw Error(kerInvalidMalloc);
         DataBuf buf(rcount);
-        long readCount = read(buf.data(0), buf.size());
+        long readCount = read(buf.data(), buf.size());
         if (readCount < 0) {
             throw Error(kerInputDataReadFailed);
         }
@@ -1351,7 +1351,7 @@ namespace Exiv2 {
     DataBuf MemIo::read(long rcount)
     {
         DataBuf buf(rcount);
-        long readCount = read(buf.data(0), buf.size());
+        long readCount = read(buf.data(), buf.size());
         if (readCount < 0) {
             throw Error(kerInputDataReadFailed);
         }
@@ -1831,7 +1831,7 @@ namespace Exiv2 {
     DataBuf RemoteIo::read(long rcount)
     {
         DataBuf buf(rcount);
-        long readCount = read(buf.data(0), buf.size());
+        long readCount = read(buf.data(), buf.size());
         if (readCount < 0) {
             throw Error(kerInputDataReadFailed);
         }
@@ -2442,7 +2442,7 @@ namespace Exiv2 {
             throw Error(kerCallFailed, path, strError(), "::stat");
         }
         DataBuf buf(st.st_size);
-        long len = file.read(buf.data(0), buf.size());
+        long len = file.read(buf.data(), buf.size());
         if (len != buf.size()) {
             throw Error(kerCallFailed, path, strError(), "FileIo::read");
         }
@@ -2461,7 +2461,7 @@ namespace Exiv2 {
             throw WError(kerCallFailed, wpath, strError().c_str(), "::_wstat");
         }
         DataBuf buf(st.st_size);
-        long len = file.read(buf.data(0), buf.size());
+        long len = file.read(buf.data(), buf.size());
         if (len != buf.size()) {
             throw WError(kerCallFailed, wpath, strError().c_str(), "FileIo::read");
         }
@@ -2475,7 +2475,7 @@ namespace Exiv2 {
         if (file.open("wb") != 0) {
             throw Error(kerFileOpenFailed, path, "wb", strError());
         }
-        return file.write(buf.c_data(0), buf.size());
+        return file.write(buf.c_data(), buf.size());
     }
 
 #ifdef EXV_UNICODE_PATH
@@ -2485,7 +2485,7 @@ namespace Exiv2 {
         if (file.open("wb") != 0) {
             throw WError(kerFileOpenFailed, wpath, "wb", strError().c_str());
         }
-        return file.write(buf.c_data(0), buf.size());
+        return file.write(buf.c_data(), buf.size());
     }
 
 #endif

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -516,7 +516,7 @@ namespace Exiv2 {
 #else
         // Workaround for platforms without mmap: Read the file into memory
         DataBuf buf(static_cast<long>(p_->mappedLength_));
-        if (read(buf.pData_, buf.size_) != buf.size_) {
+        if (read(buf.data(0), buf.size()) != buf.size()) {
 #ifdef EXV_UNICODE_PATH
             if (p_->wpMode_ == Impl::wpUnicode) {
                 throw WError(kerCallFailed, wpath(), strError().c_str(), "FileIo::read");
@@ -670,9 +670,9 @@ namespace Exiv2 {
             // In case path() is a symlink, get the path of the linked-to file
             if (statOk && S_ISLNK(buf1.st_mode)) {
                 lbuf.alloc(buf1.st_size + 1);
-                memset(lbuf.pData_, 0x0, lbuf.size_);
-                pf = reinterpret_cast<char*>(lbuf.pData_);
-                if (::readlink(path().c_str(), pf, lbuf.size_ - 1) == -1) {
+                lbuf.clear();
+                pf = reinterpret_cast<char*>(lbuf.data(0));
+                if (::readlink(path().c_str(), pf, lbuf.size() - 1) == -1) {
                     throw Error(kerCallFailed, path(), strError(), "readlink");
                 }
                 // We need the permissions of the file, not the symlink
@@ -990,8 +990,11 @@ namespace Exiv2 {
         if (static_cast<size_t>(rcount) > size())
             throw Error(kerInvalidMalloc);
         DataBuf buf(rcount);
-        long readCount = read(buf.pData_, buf.size_);
-        buf.size_ = readCount;
+        long readCount = read(buf.data(0), buf.size());
+        if (readCount < 0) {
+            throw Error(kerInputDataReadFailed);
+        }
+        buf.resize(readCount);
         return buf;
     }
 
@@ -1348,8 +1351,11 @@ namespace Exiv2 {
     DataBuf MemIo::read(long rcount)
     {
         DataBuf buf(rcount);
-        long readCount = read(buf.pData_, buf.size_);
-        buf.size_ = readCount;
+        long readCount = read(buf.data(0), buf.size());
+        if (readCount < 0) {
+            throw Error(kerInputDataReadFailed);
+        }
+        buf.resize(readCount);
         return buf;
     }
 
@@ -1825,8 +1831,11 @@ namespace Exiv2 {
     DataBuf RemoteIo::read(long rcount)
     {
         DataBuf buf(rcount);
-        long readCount = read(buf.pData_, buf.size_);
-        buf.size_ = readCount;
+        long readCount = read(buf.data(0), buf.size());
+        if (readCount < 0) {
+            throw Error(kerInputDataReadFailed);
+        }
+        buf.resize(readCount);
         return buf;
     }
 
@@ -2433,8 +2442,8 @@ namespace Exiv2 {
             throw Error(kerCallFailed, path, strError(), "::stat");
         }
         DataBuf buf(st.st_size);
-        long len = file.read(buf.pData_, buf.size_);
-        if (len != buf.size_) {
+        long len = file.read(buf.data(0), buf.size());
+        if (len != buf.size()) {
             throw Error(kerCallFailed, path, strError(), "FileIo::read");
         }
         return buf;
@@ -2452,8 +2461,8 @@ namespace Exiv2 {
             throw WError(kerCallFailed, wpath, strError().c_str(), "::_wstat");
         }
         DataBuf buf(st.st_size);
-        long len = file.read(buf.pData_, buf.size_);
-        if (len != buf.size_) {
+        long len = file.read(buf.data(0), buf.size());
+        if (len != buf.size()) {
             throw WError(kerCallFailed, wpath, strError().c_str(), "FileIo::read");
         }
         return buf;
@@ -2466,7 +2475,7 @@ namespace Exiv2 {
         if (file.open("wb") != 0) {
             throw Error(kerFileOpenFailed, path, "wb", strError());
         }
-        return file.write(buf.pData_, buf.size_);
+        return file.write(buf.c_data(0), buf.size());
     }
 
 #ifdef EXV_UNICODE_PATH
@@ -2476,7 +2485,7 @@ namespace Exiv2 {
         if (file.open("wb") != 0) {
             throw WError(kerFileOpenFailed, wpath, "wb", strError().c_str());
         }
-        return file.write(buf.pData_, buf.size_);
+        return file.write(buf.c_data(0), buf.size());
     }
 
 #endif

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -525,7 +525,7 @@ namespace Exiv2
 
             enforce(length < static_cast<unsigned long>(std::numeric_limits<long>::max()), kerCorruptedMetadata);
             DataBuf  xmp(static_cast<long>(length+1));
-            xmp.write_uint8(length, 0); // ensure xmp is null terminated!
+            xmp.write_uint8(static_cast<size_t>(length), 0); // ensure xmp is null terminated!
             if ( io_->read(xmp.data(0), static_cast<long>(length)) != static_cast<long>(length) )
                 throw Error(kerInputDataReadFailed);
             if ( io_->error() )

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -220,7 +220,7 @@ namespace Exiv2
             hdrsize += 8;
             enforce(hdrsize <= static_cast<size_t>(pbox_end - address), Exiv2::kerCorruptedMetadata);
             DataBuf data(8);
-            io_->read(data.data(0), data.size());
+            io_->read(data.data(), data.size());
             box_length = data.read_uint64(0, endian_);
         }
 
@@ -230,7 +230,7 @@ namespace Exiv2
         enforce(box_length - hdrsize <= static_cast<size_t>(pbox_end - restore), Exiv2::kerCorruptedMetadata);
         DataBuf data(static_cast<long>(box_length - hdrsize));
         const long box_end = restore + data.size();
-        io_->read(data.data(0), data.size());
+        io_->read(data.data(), data.size());
         io_->seek(restore, BasicIo::beg);
 
         long skip = 0;  // read position in data.pData_
@@ -407,7 +407,7 @@ namespace Exiv2
                     uint8_t      meth        = data.read_uint8(skip+0);
                     uint8_t      prec        = data.read_uint8(skip+1);
                     uint8_t      approx      = data.read_uint8(skip+2);
-                    std::string colour_type = std::string(data.c_str(0), 4);
+                    std::string colour_type = std::string(data.c_str(), 4);
                     skip+=4;
                     if ( colour_type == "rICC" || colour_type == "prof" ) {
                         DataBuf       profile(data.c_data(skip),data.size()-skip);
@@ -423,7 +423,7 @@ namespace Exiv2
 
             case TAG_uuid: {
                 DataBuf   uuid(16);
-                io_->read(uuid.data(0), uuid.size());
+                io_->read(uuid.data(), uuid.size());
                 std::string name = uuidName(uuid);
                 if ( bTrace ) {
                     out << " uuidName " << name << std::endl;
@@ -476,7 +476,7 @@ namespace Exiv2
         long    restore = io_->tell();
         DataBuf exif(static_cast<long>(length));
         io_->seek(static_cast<long>(start),BasicIo::beg);
-        if ( exif.size() > 8 && io_->read(exif.data(0),exif.size()) == exif.size() ) {
+        if ( exif.size() > 8 && io_->read(exif.data(),exif.size()) == exif.size() ) {
             // hunt for "II" or "MM"
             long  eof  = 0xffffffff; // impossible value for punt
             long  punt = eof;
@@ -500,7 +500,7 @@ namespace Exiv2
             enforce(length - 8 <= io_->size() - io_->tell(), kerCorruptedMetadata);
             enforce(length - 8 <= static_cast<unsigned long>(std::numeric_limits<long>::max()), kerCorruptedMetadata);
             DataBuf data(static_cast<long>(length - 8));
-            long bufRead = io_->read(data.data(0), data.size());
+            long bufRead = io_->read(data.data(), data.size());
 
             if (io_->error())
                 throw Error(kerFailedToReadImageData);
@@ -508,7 +508,7 @@ namespace Exiv2
                 throw Error(kerInputDataReadFailed);
 
             Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(),
-                                               data.c_data(0), data.size(), root_tag,
+                                               data.c_data(), data.size(), root_tag,
                                                Internal::TiffMapping::findDecoder);
         }
     }
@@ -526,12 +526,12 @@ namespace Exiv2
             enforce(length < static_cast<unsigned long>(std::numeric_limits<long>::max()), kerCorruptedMetadata);
             DataBuf  xmp(static_cast<long>(length+1));
             xmp.write_uint8(static_cast<size_t>(length), 0); // ensure xmp is null terminated!
-            if ( io_->read(xmp.data(0), static_cast<long>(length)) != static_cast<long>(length) )
+            if ( io_->read(xmp.data(), static_cast<long>(length)) != static_cast<long>(length) )
                 throw Error(kerInputDataReadFailed);
             if ( io_->error() )
                 throw Error(kerFailedToReadImageData);
             try {
-                Exiv2::XmpParser::decode(xmpData(), std::string(xmp.c_str(0)));
+                Exiv2::XmpParser::decode(xmpData(), std::string(xmp.c_str()));
             } catch (...) {
                 throw Error(kerFailedToReadImageData);
             }
@@ -588,7 +588,7 @@ namespace Exiv2
             default: break; // do nothing
 
             case kpsIccProfile : {
-                out.write(iccProfile_.c_str(0), iccProfile_.size());
+                out.write(iccProfile_.c_str(), iccProfile_.size());
             } break;
 
 #ifdef EXV_HAVE_XMP_TOOLKIT

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1195,8 +1195,8 @@ namespace Exiv2 {
                 auto pos = exifData_->findKey(key);
                 if (pos == exifData_->end()) continue;
                 DataBuf data(pos->size());
-                pos->copy(data.data(0), littleEndian /* FIXME ? */);
-                MD5Update ( &context, data.c_data(0), data.size());
+                pos->copy(data.data(), littleEndian /* FIXME ? */);
+                MD5Update ( &context, data.c_data(), data.size());
             }
         }
         MD5Final(digest, &context);
@@ -1266,7 +1266,7 @@ namespace Exiv2 {
         MD5Init(&context);
 
         DataBuf data = IptcParser::encode(*iptcData_);
-        MD5Update(&context, data.c_data(0), data.size());
+        MD5Update(&context, data.c_data(), data.size());
         MD5Final(digest, &context);
         res << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
         for (auto&& i : digest) {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1195,8 +1195,8 @@ namespace Exiv2 {
                 auto pos = exifData_->findKey(key);
                 if (pos == exifData_->end()) continue;
                 DataBuf data(pos->size());
-                pos->copy(data.pData_, littleEndian /* FIXME ? */);
-                MD5Update ( &context, data.pData_, data.size_);
+                pos->copy(data.data(0), littleEndian /* FIXME ? */);
+                MD5Update ( &context, data.c_data(0), data.size());
             }
         }
         MD5Final(digest, &context);
@@ -1266,7 +1266,7 @@ namespace Exiv2 {
         MD5Init(&context);
 
         DataBuf data = IptcParser::encode(*iptcData_);
-        MD5Update(&context, data.pData_, data.size_);
+        MD5Update(&context, data.c_data(0), data.size());
         MD5Final(digest, &context);
         res << std::setw(2) << std::setfill('0') << std::hex << std::uppercase;
         for (auto&& i : digest) {

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -36,22 +36,22 @@ namespace Exiv2 {
         DataBuf buf(16);
         switch (byteOrder()) {
         case littleEndian:
-            buf.pData_[0] = 'I';
+            buf.write_uint8(0, 'I');
             break;
         case bigEndian:
-            buf.pData_[0] = 'M';
+            buf.write_uint8(0, 'M');
             break;
         case invalidByteOrder:
             assert(false);
             break;
         }
-        buf.pData_[1] = buf.pData_[0];
+        buf.write_uint8(1, buf.read_uint8(0));
 
-        us2Data(buf.pData_ + 2, tag(), byteOrder());
-        ul2Data(buf.pData_ + 4, 0x00000010, byteOrder());
-        memcpy(buf.pData_ + 8, cr2sig_, 4);
+        buf.write_uint16(2, tag(), byteOrder());
+        buf.write_uint32(4, 0x00000010, byteOrder());
+        buf.copyBytes(8, cr2sig_, 4);
         // Write a dummy value for the RAW IFD offset. The offset-writer is used to set this offset in a second pass.
-        ul2Data(buf.pData_ + 12, 0x00000000, byteOrder());
+        buf.write_uint32(12, 0x00000000, byteOrder());
         return buf;
     } // Cr2Header::write
 

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -102,7 +102,7 @@ namespace Exiv2 {
         }
         clearMetadata();
         DataBuf file(static_cast<long>(io().size()));
-        io_->read(file.data(0), file.size());
+        io_->read(file.data(), file.size());
 
         CrwParser::decode(this, io_->mmap(), static_cast<uint32_t>(io_->size()));
 
@@ -121,7 +121,7 @@ namespace Exiv2 {
             if (isCrwType(*io_, false)) {
                 // Read the image into a memory buffer
                 buf.alloc(static_cast<long>(io_->size()));
-                io_->read(buf.data(0), buf.size());
+                io_->read(buf.data(), buf.size());
                 if (io_->error() || io_->eof()) {
                     buf.reset();
                 }
@@ -129,7 +129,7 @@ namespace Exiv2 {
         }
 
         Blob blob;
-        CrwParser::encode(blob, buf.c_data(0), buf.size(), this);
+        CrwParser::encode(blob, buf.c_data(), buf.size(), this);
 
         // Write new buffer to file
         MemIo::UniquePtr tempIo(new MemIo);

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -102,7 +102,7 @@ namespace Exiv2 {
         }
         clearMetadata();
         DataBuf file(static_cast<long>(io().size()));
-        io_->read(file.pData_,file.size_);
+        io_->read(file.data(0), file.size());
 
         CrwParser::decode(this, io_->mmap(), static_cast<uint32_t>(io_->size()));
 
@@ -121,7 +121,7 @@ namespace Exiv2 {
             if (isCrwType(*io_, false)) {
                 // Read the image into a memory buffer
                 buf.alloc(static_cast<long>(io_->size()));
-                io_->read(buf.pData_, buf.size_);
+                io_->read(buf.data(0), buf.size());
                 if (io_->error() || io_->eof()) {
                     buf.reset();
                 }
@@ -129,7 +129,7 @@ namespace Exiv2 {
         }
 
         Blob blob;
-        CrwParser::encode(blob, buf.pData_, buf.size_, this);
+        CrwParser::encode(blob, buf.c_data(0), buf.size(), this);
 
         // Write new buffer to file
         MemIo::UniquePtr tempIo(new MemIo);

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -1028,7 +1028,7 @@ namespace Exiv2 {
         // Set the new value or remove the entry
         if (ed != image.exifData().end()) {
             DataBuf buf(ed->size());
-            ed->copy(buf.data(0), pHead->byteOrder());
+            ed->copy(buf.data(), pHead->byteOrder());
             pHead->add(pCrwMapping->crwTagId_, pCrwMapping->crwDir_, buf);
         }
         else {
@@ -1085,7 +1085,7 @@ namespace Exiv2 {
             DataBuf buf(size);
             long pos = 0;
             if (ed1 != edEnd) {
-                ed1->copy(buf.data(0), pHead->byteOrder());
+                ed1->copy(buf.data(), pHead->byteOrder());
                 pos += ed1->size();
             }
             if (ed2 != edEnd) {
@@ -1187,7 +1187,7 @@ namespace Exiv2 {
             buf.clear();
             if (cc) buf.copyBytes(8, cc->pData() + 8, cc->size() - 8);
             if (edX != edEnd && edX->size() == 4) {
-                edX->copy(buf.data(0), pHead->byteOrder());
+                edX->copy(buf.data(), pHead->byteOrder());
             }
             if (edY != edEnd && edY->size() == 4) {
                 edY->copy(buf.data(4), pHead->byteOrder());

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1165,15 +1165,17 @@ namespace Exiv2
                 bufSize = static_cast<long>(i.size());
             }
         }
+        const long restore = iIo.tell(); // save
         DataBuf buf = iIo.read(bufSize);
-        if (iIo.error() || buf.size_ != bufSize) {
+        if (iIo.error() || buf.size() != bufSize) {
+            iIo.seek(restore, BasicIo::beg);
             return false;
         }
         // check for all possible (DOS) EPS signatures
-        bool matched = (memcmp(buf.pData_, dosEpsSignature.data(), dosEpsSignature.size()) == 0);
+        bool matched = (buf.cmpBytes(0, dosEpsSignature.data(), dosEpsSignature.size()) == 0);
         if (!matched) {
             for (auto&& eps : epsFirstLine) {
-                if (memcmp(buf.pData_, eps.data(), eps.size()) == 0) {
+                if (buf.cmpBytes(0, eps.data(), eps.size()) == 0) {
                     matched = true;
                     break;
                 }
@@ -1181,7 +1183,7 @@ namespace Exiv2
         }
         // seek back if possible and requested
         if (!advance || !matched) {
-            iIo.seek(-buf.size_, BasicIo::cur);
+            iIo.seek(restore, BasicIo::beg);
         }
         return matched;
     }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -468,7 +468,7 @@ namespace Exiv2 {
             return 0;
         std::string name = path + thumbnail->extension();
         DataBuf buf(thumbnail->copy(exifData_));
-        if (buf.size_ == 0) return 0;
+        if (buf.size() == 0) return 0;
         return Exiv2::writeFile(buf, name);
     }
 
@@ -479,7 +479,7 @@ namespace Exiv2 {
         if (thumbnail.get() == 0) return 0;
         std::wstring name = wpath + thumbnail->wextension();
         DataBuf buf(thumbnail->copy(exifData_));
-        if (buf.size_ == 0) return 0;
+        if (buf.size() == 0) return 0;
         return Exiv2::writeFile(buf, name);
     }
 
@@ -522,7 +522,7 @@ namespace Exiv2 {
     )
     {
         DataBuf thumb = readFile(path); // may throw
-        setJpegThumbnail(thumb.pData_, thumb.size_, xres, yres, unit);
+        setJpegThumbnail(thumb.c_data(0), thumb.size(), xres, yres, unit);
     }
 
 #ifdef EXV_UNICODE_PATH
@@ -534,7 +534,7 @@ namespace Exiv2 {
     )
     {
         DataBuf thumb = readFile(wpath); // may throw
-        setJpegThumbnail(thumb.pData_, thumb.size_, xres, yres, unit);
+        setJpegThumbnail(thumb.c_data(0), thumb.size(), xres, yres, unit);
     }
 
 #endif
@@ -555,14 +555,14 @@ namespace Exiv2 {
     void ExifThumb::setJpegThumbnail(const std::string& path)
     {
         DataBuf thumb = readFile(path); // may throw
-        setJpegThumbnail(thumb.pData_, thumb.size_);
+        setJpegThumbnail(thumb.c_data(0), thumb.size());
     }
 
 #ifdef EXV_UNICODE_PATH
     void ExifThumb::setJpegThumbnail(const std::wstring& wpath)
     {
         DataBuf thumb = readFile(wpath); // may throw
-        setJpegThumbnail(thumb.pData_, thumb.size_);
+        setJpegThumbnail(thumb.c_data(0), thumb.size());
     }
 
 #endif

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -522,7 +522,7 @@ namespace Exiv2 {
     )
     {
         DataBuf thumb = readFile(path); // may throw
-        setJpegThumbnail(thumb.c_data(0), thumb.size(), xres, yres, unit);
+        setJpegThumbnail(thumb.c_data(), thumb.size(), xres, yres, unit);
     }
 
 #ifdef EXV_UNICODE_PATH
@@ -534,7 +534,7 @@ namespace Exiv2 {
     )
     {
         DataBuf thumb = readFile(wpath); // may throw
-        setJpegThumbnail(thumb.c_data(0), thumb.size(), xres, yres, unit);
+        setJpegThumbnail(thumb.c_data(), thumb.size(), xres, yres, unit);
     }
 
 #endif
@@ -555,14 +555,14 @@ namespace Exiv2 {
     void ExifThumb::setJpegThumbnail(const std::string& path)
     {
         DataBuf thumb = readFile(path); // may throw
-        setJpegThumbnail(thumb.c_data(0), thumb.size());
+        setJpegThumbnail(thumb.c_data(), thumb.size());
     }
 
 #ifdef EXV_UNICODE_PATH
     void ExifThumb::setJpegThumbnail(const std::wstring& wpath)
     {
         DataBuf thumb = readFile(wpath); // may throw
-        setJpegThumbnail(thumb.c_data(0), thumb.size());
+        setJpegThumbnail(thumb.c_data(), thumb.size());
     }
 
 #endif

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -941,7 +941,7 @@ static int readFileToBuf(FILE* f,Exiv2::DataBuf& buf)
 
     if ( nBytes ) {
         buf.alloc(nBytes);
-        memcpy(buf.pData_, bytes.data(), nBytes);
+        buf.copyBytes(0, bytes.data(), nBytes);
     }
     return nBytes;
 }
@@ -950,7 +950,7 @@ static int readFileToBuf(FILE* f,Exiv2::DataBuf& buf)
 void Params::getStdin(Exiv2::DataBuf& buf)
 {
     // copy stdin to stdinBuf
-    if ( stdinBuf.size_ == 0 ) {
+    if ( stdinBuf.size() == 0 ) {
 #if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__) || defined(_MSC_VER)
         DWORD fdwMode;
         _setmode(fileno(stdin), O_BINARY);
@@ -975,7 +975,7 @@ void Params::getStdin(Exiv2::DataBuf& buf)
         // this is only used to simulate reading from stdin when debugging
         // to simulate exiv2 -pX foo.jpg                | exiv2 -iXX- bar.jpg
         //             exiv2 -pX foo.jpg > ~/temp/stdin ; exiv2 -iXX- bar.jpg
-        if ( stdinBuf.size_ == 0 ) {
+        if ( stdinBuf.size() == 0 ) {
             const char* path = "/Users/rmills/temp/stdin";
             FILE* f = fopen(path,"rb");
             if  ( f ) {
@@ -986,17 +986,17 @@ void Params::getStdin(Exiv2::DataBuf& buf)
         }
 #endif
 #ifdef DEBUG
-            std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size_ << std::endl;
+            std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << std::endl;
 #endif
     }
 
     // copy stdinBuf to buf
-    if ( stdinBuf.size_ ) {
-        buf.alloc(stdinBuf.size_);
-        memcpy(buf.pData_,stdinBuf.pData_,buf.size_);
+    if ( stdinBuf.size() ) {
+        buf.alloc(stdinBuf.size());
+        buf.copyBytes(0,stdinBuf.c_data(0),buf.size());
     }
 #ifdef DEBUG
-    std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size_ << std::endl;
+    std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << std::endl;
 #endif
 
 } // Params::getStdin()

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -993,7 +993,7 @@ void Params::getStdin(Exiv2::DataBuf& buf)
     // copy stdinBuf to buf
     if ( stdinBuf.size() ) {
         buf.alloc(stdinBuf.size());
-        buf.copyBytes(0,stdinBuf.c_data(0),buf.size());
+        buf.copyBytes(0,stdinBuf.c_data(),buf.size());
     }
 #ifdef DEBUG
     std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << std::endl;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -343,7 +343,7 @@ namespace Exiv2 {
         do {
             // Read top of directory
             seekOrThrow(io, start, BasicIo::beg, kerCorruptedMetadata);
-            readOrThrow(io, dir.data(0), 2, kerCorruptedMetadata);
+            readOrThrow(io, dir.data(), 2, kerCorruptedMetadata);
             uint16_t   dirLength = byteSwap2(dir,0,bSwap);
             // Prevent infinite loops. (GHSA-m479-7frc-gqqg)
             enforce(dirLength > 0, kerCorruptedMetadata);
@@ -369,7 +369,7 @@ namespace Exiv2 {
                 }
                 bFirst = false;
 
-                readOrThrow(io, dir.data(0), 12, kerCorruptedMetadata);
+                readOrThrow(io, dir.data(), 12, kerCorruptedMetadata);
                 uint16_t tag    = byteSwap2(dir,0,bSwap);
                 uint16_t type   = byteSwap2(dir,2,bSwap);
                 uint32_t count  = byteSwap4(dir,4,bSwap);
@@ -421,7 +421,7 @@ namespace Exiv2 {
                 if ( bOffsetIsPointer ) {         // read into buffer
                     const long restore = io.tell(); // save
                     seekOrThrow(io, offset, BasicIo::beg, kerCorruptedMetadata); // position
-                    readOrThrow(io, buf.data(0), static_cast<long>(count_x_size), kerCorruptedMetadata); // read
+                    readOrThrow(io, buf.data(), static_cast<long>(count_x_size), kerCorruptedMetadata); // read
                     seekOrThrow(io, restore, BasicIo::beg, kerCorruptedMetadata); // restore
                 }
 
@@ -494,8 +494,8 @@ namespace Exiv2 {
                             // tag is an embedded tiff
                             const long byteslen = count-jump;
                             DataBuf bytes(byteslen);  // allocate a buffer
-                            readOrThrow(io, bytes.data(0), byteslen, kerCorruptedMetadata);  // read
-                            MemIo memIo(bytes.c_data(0), byteslen)    ;  // create a file
+                            readOrThrow(io, bytes.data(), byteslen, kerCorruptedMetadata);  // read
+                            MemIo memIo(bytes.c_data(), byteslen)    ;  // create a file
                             printTiffStructure(memIo,out,option,depth);
                         } else {
                             // tag is an IFD
@@ -509,14 +509,14 @@ namespace Exiv2 {
 
                 if ( isPrintXMP(tag,option) ) {
                     buf.write_uint8(count, 0);
-                    out << buf.c_str(0);
+                    out << buf.c_str();
                 }
                 if ( isPrintICC(tag,option) ) {
-                    out.write(buf.c_str(0), count);
+                    out.write(buf.c_str(), count);
                 }
             }
             if ( start ) {
-                readOrThrow(io, dir.data(0), 4, kerCorruptedMetadata);
+                readOrThrow(io, dir.data(), 4, kerCorruptedMetadata);
                 start = byteSwap4(dir,0,bSwap);
             }
         } while (start) ;
@@ -536,7 +536,7 @@ namespace Exiv2 {
             DataBuf  dir(dirSize);
 
             // read header (we already know for certain that we have a Tiff file)
-            readOrThrow(io, dir.data(0),  8, kerCorruptedMetadata);
+            readOrThrow(io, dir.data(),  8, kerCorruptedMetadata);
             char c = static_cast<char>(dir.read_uint8(0));
             bool bSwap   = ( c == 'M' && isLittleEndianPlatform() )
                         || ( c == 'I' && isBigEndianPlatform()    )

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -507,7 +507,7 @@ namespace Exiv2 {
     DataBuf IptcParser::encode(const IptcData& iptcData)
     {
         DataBuf buf(iptcData.size());
-        byte *pWrite = buf.data(0);
+        byte *pWrite = buf.data();
 
         // Copy the iptc data sets and sort them by record but preserve the order of datasets
         IptcMetadata sortedIptcData;

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -507,7 +507,7 @@ namespace Exiv2 {
     DataBuf IptcParser::encode(const IptcData& iptcData)
     {
         DataBuf buf(iptcData.size());
-        byte *pWrite = buf.pData_;
+        byte *pWrite = buf.data(0);
 
         // Copy the iptc data sets and sort them by record but preserve the order of datasets
         IptcMetadata sortedIptcData;

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -285,7 +285,7 @@ static void boxes_check(size_t b,size_t m)
                                 throw Error(kerCorruptedMetadata);
                             }
                             DataBuf data(static_cast<long>(data_length));
-                            io_->read(data.data(0), data.size());
+                            io_->read(data.data(), data.size());
                             const long    iccLength = data.read_uint32(pad, bigEndian);
                             // subtracting pad from data.size() is safe:
                             // data.size() is at least 8 and pad = 3
@@ -298,7 +298,7 @@ static void boxes_check(size_t b,size_t m)
                             const char* iccPath = "/tmp/libexiv2_jp2.icc";
                             FILE* f = fopen(iccPath,"wb");
                             if ( f ) {
-                                fwrite(icc.c_data(0),icc.size(),1,f);
+                                fwrite(icc.c_data(),icc.size(),1,f);
                                 fclose(f);
                             }
                             std::cout << "Exiv2::Jp2Image::readMetadata: wrote iccProfile " << icc.size() << " bytes to " << iccPath << std::endl ;
@@ -351,7 +351,7 @@ static void boxes_check(size_t b,size_t m)
 #endif
                             enforce(box.length >= sizeof(box) + sizeof(uuid), kerCorruptedMetadata);
                             rawData.alloc(box.length - (sizeof(box) + sizeof(uuid)));
-                            bufRead = io_->read(rawData.data(0), rawData.size());
+                            bufRead = io_->read(rawData.data(), rawData.size());
                             if (io_->error()) throw Error(kerFailedToReadImageData);
                             if (bufRead != rawData.size()) throw Error(kerInputDataReadFailed);
 
@@ -406,11 +406,11 @@ static void boxes_check(size_t b,size_t m)
 #endif
                             enforce(box.length >= sizeof(box) + sizeof(uuid), kerCorruptedMetadata);
                             rawData.alloc(box.length - (sizeof(box) + sizeof(uuid)));
-                            bufRead = io_->read(rawData.data(0), rawData.size());
+                            bufRead = io_->read(rawData.data(), rawData.size());
                             if (io_->error()) throw Error(kerFailedToReadImageData);
                             if (bufRead != rawData.size()) throw Error(kerInputDataReadFailed);
 
-                            if (IptcParser::decode(iptcData_, rawData.c_data(0), rawData.size()))
+                            if (IptcParser::decode(iptcData_, rawData.c_data(), rawData.size()))
                             {
 #ifndef SUPPRESS_WARNINGS
                                 EXV_WARNING << "Failed to decode IPTC metadata." << std::endl;
@@ -426,12 +426,12 @@ static void boxes_check(size_t b,size_t m)
 #endif
                            enforce(box.length >= sizeof(box) + sizeof(uuid), kerCorruptedMetadata);
                            rawData.alloc(box.length - static_cast<uint32_t>(sizeof(box) + sizeof(uuid)));
-                           bufRead = io_->read(rawData.data(0), rawData.size());
+                           bufRead = io_->read(rawData.data(), rawData.size());
                            if (io_->error())
                                throw Error(kerFailedToReadImageData);
                            if (bufRead != rawData.size())
                                throw Error(kerInputDataReadFailed);
-                           xmpPacket_.assign(rawData.c_str(0), rawData.size());
+                           xmpPacket_.assign(rawData.c_str(), rawData.size());
 
                            std::string::size_type idx = xmpPacket_.find_first_of('<');
                            if (idx != std::string::npos && idx > 0) {
@@ -530,7 +530,7 @@ static void boxes_check(size_t b,size_t m)
                             }
 
                             DataBuf data(subBox.length - sizeof(box));
-                            io_->read(data.data(0), data.size());
+                            io_->read(data.data(), data.size());
                             if (bPrint) {
                                 out << Internal::stringFormat("%8ld | %8ld |  sub:", static_cast<size_t>(address),
                                                               static_cast<size_t>(subBox.length))
@@ -585,7 +585,7 @@ static void boxes_check(size_t b,size_t m)
                             DataBuf rawData;
                             enforce(box.length >= sizeof(uuid) + sizeof(box), kerCorruptedMetadata);
                             rawData.alloc(box.length - sizeof(uuid) - sizeof(box));
-                            long bufRead = io_->read(rawData.data(0), rawData.size());
+                            long bufRead = io_->read(rawData.data(), rawData.size());
                             if (io_->error())
                                 throw Error(kerFailedToReadImageData);
                             if (bufRead != rawData.size())
@@ -602,7 +602,7 @@ static void boxes_check(size_t b,size_t m)
                                 const char a = rawData.read_uint8(0);
                                 const char b = rawData.read_uint8(1);
                                 if (a == b && (a == 'I' || a == 'M')) {
-                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(rawData.c_data(0), rawData.size()));
+                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(rawData.c_data(), rawData.size()));
                                     printTiffStructure(*p, out, option, depth);
                                 }
                             }
@@ -612,7 +612,7 @@ static void boxes_check(size_t b,size_t m)
                             }
 
                             if (bIsXMP && bXMP) {
-                                out.write(rawData.c_str(0), rawData.size());
+                                out.write(rawData.c_str(), rawData.size());
                             }
                         }
                     } break;
@@ -659,11 +659,11 @@ static void boxes_check(size_t b,size_t m)
         long    outlen = sizeof(Jp2BoxHeader) ; // now many bytes have we written to output?
         long    inlen = sizeof(Jp2BoxHeader) ; // how many bytes have we read from boxBuf?
         enforce(sizeof(Jp2BoxHeader) <= static_cast<size_t>(output.size()), Exiv2::kerCorruptedMetadata);
-        auto pBox = reinterpret_cast<const Jp2BoxHeader*>(boxBuf.c_data(0));
+        auto pBox = reinterpret_cast<const Jp2BoxHeader*>(boxBuf.c_data());
         uint32_t length = getLong(reinterpret_cast<const byte*>(&pBox->length), bigEndian);
         enforce(length <= static_cast<size_t>(output.size()), Exiv2::kerCorruptedMetadata);
         uint32_t      count  = sizeof (Jp2BoxHeader);
-        auto p = boxBuf.c_str(0);
+        auto p = boxBuf.c_str();
         bool          bWroteColor = false ;
 
         while ( count < length && !bWroteColor ) {
@@ -711,7 +711,7 @@ static void boxes_check(size_t b,size_t m)
                     ul2Data(reinterpret_cast<byte*>(&newBox.type), newBox.type, bigEndian);
                     output.copyBytes(outlen                     ,&newBox            ,sizeof(newBox)  );
                     output.copyBytes(outlen+sizeof(newBox)      , pad               ,psize           );
-                    output.copyBytes(outlen+sizeof(newBox)+psize,iccProfile_.c_data(0),iccProfile_.size());
+                    output.copyBytes(outlen+sizeof(newBox)+psize,iccProfile_.c_data(),iccProfile_.size());
                 }
             } else {
                 enforce(newlen <= static_cast<size_t>(output.size() - outlen), Exiv2::kerCorruptedMetadata);
@@ -724,8 +724,8 @@ static void boxes_check(size_t b,size_t m)
 
         // allocate the correct number of bytes, copy the data and update the box header
         outBuf.alloc(outlen);
-        outBuf.copyBytes(0,output.c_data(0),outlen);
-        auto oBox = reinterpret_cast<Jp2BoxHeader*>(outBuf.data(0));
+        outBuf.copyBytes(0,output.c_data(),outlen);
+        auto oBox = reinterpret_cast<Jp2BoxHeader*>(outBuf.data());
         ul2Data(reinterpret_cast<byte*>(&oBox->type), kJp2BoxTypeJp2Header, bigEndian);
         ul2Data(reinterpret_cast<byte*>(&oBox->length), outlen, bigEndian);
     } // Jp2Image::encodeJp2Header
@@ -771,7 +771,7 @@ static void boxes_check(size_t b,size_t m)
             // Read chunk header.
 
             bheaderBuf.clear();
-            long bufRead = io_->read(bheaderBuf.data(0), bheaderBuf.size());
+            long bufRead = io_->read(bheaderBuf.data(), bheaderBuf.size());
             if (io_->error()) throw Error(kerFailedToReadImageData);
             if (bufRead != bheaderBuf.size()) throw Error(kerInputDataReadFailed);
 
@@ -804,7 +804,7 @@ static void boxes_check(size_t b,size_t m)
 
             // Read whole box : Box header + Box data (not fixed size - can be null).
             DataBuf boxBuf(box.length);                             // Box header (8 bytes) + box data.
-            boxBuf.copyBytes(0, bheaderBuf.c_data(0), 8);        // Copy header.
+            boxBuf.copyBytes(0, bheaderBuf.c_data(), 8);        // Copy header.
             bufRead = io_->read(boxBuf.data(8), box.length - 8); // Extract box data.
             if (io_->error())
             {
@@ -831,7 +831,7 @@ static void boxes_check(size_t b,size_t m)
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write JP2Header box (length: " << box.length << ")" << std::endl;
 #endif
-                    if (outIo.write(newBuf.data(0), newBuf.size()) != newBuf.size()) throw Error(kerImageWriteFailed);
+                    if (outIo.write(newBuf.data(), newBuf.size()) != newBuf.size()) throw Error(kerImageWriteFailed);
 
                     // Write all updated metadata here, just after JP2Header.
 
@@ -851,13 +851,13 @@ static void boxes_check(size_t b,size_t m)
                             boxData.copyBytes(0,      boxDataSize,       4);
                             boxData.copyBytes(4,      boxUUIDtype,       4);
                             boxData.copyBytes(8,      kJp2UuidExif,      16);
-                            boxData.copyBytes(8 + 16, rawExif.c_data(0), rawExif.size());
+                            boxData.copyBytes(8 + 16, rawExif.c_data(), rawExif.size());
 
 #ifdef EXIV2_DEBUG_MESSAGES
                             std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with Exif metadata (length: "
                                       << boxData.size() << std::endl;
 #endif
-                            if (outIo.write(boxData.c_data(0), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
+                            if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
                         }
                     }
 
@@ -874,13 +874,13 @@ static void boxes_check(size_t b,size_t m)
                             boxData.copyBytes(0,      boxDataSize,    4);
                             boxData.copyBytes(4,      boxUUIDtype,    4);
                             boxData.copyBytes(8,      kJp2UuidIptc,   16);
-                            boxData.copyBytes(8 + 16, rawIptc.c_data(0), rawIptc.size());
+                            boxData.copyBytes(8 + 16, rawIptc.c_data(), rawIptc.size());
 
 #ifdef EXIV2_DEBUG_MESSAGES
                             std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with Iptc metadata (length: "
                                       << boxData.size() << std::endl;
 #endif
-                            if (outIo.write(boxData.c_data(0), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
+                            if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
                         }
                     }
 
@@ -902,13 +902,13 @@ static void boxes_check(size_t b,size_t m)
                         boxData.copyBytes(0,      boxDataSize,   4);
                         boxData.copyBytes(4,      boxUUIDtype,   4);
                         boxData.copyBytes(8,      kJp2UuidXmp,   16);
-                        boxData.copyBytes(8 + 16, xmp.c_data(0), xmp.size());
+                        boxData.copyBytes(8 + 16, xmp.c_data(), xmp.size());
 
 #ifdef EXIV2_DEBUG_MESSAGES
                         std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with XMP metadata (length: "
                                   << boxData.size() << ")" << std::endl;
 #endif
-                        if (outIo.write(boxData.c_data(0), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
+                        if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size()) throw Error(kerImageWriteFailed);
                     }
 
                     break;
@@ -940,7 +940,7 @@ static void boxes_check(size_t b,size_t m)
 #ifdef EXIV2_DEBUG_MESSAGES
                         std::cout << "Exiv2::Jp2Image::doWriteMetadata: write Uuid box (length: " << box.length << ")" << std::endl;
 #endif
-                        if (outIo.write(boxBuf.c_data(0), boxBuf.size()) != boxBuf.size()) throw Error(kerImageWriteFailed);
+                        if (outIo.write(boxBuf.c_data(), boxBuf.size()) != boxBuf.size()) throw Error(kerImageWriteFailed);
                     }
                     break;
                 }
@@ -950,7 +950,7 @@ static void boxes_check(size_t b,size_t m)
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cout << "Exiv2::Jp2Image::doWriteMetadata: write box (length: " << box.length << ")" << std::endl;
 #endif
-                    if (outIo.write(boxBuf.c_data(0), boxBuf.size()) != boxBuf.size()) throw Error(kerImageWriteFailed);
+                    if (outIo.write(boxBuf.c_data(), boxBuf.size()) != boxBuf.size()) throw Error(kerImageWriteFailed);
 
                     break;
                 }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -281,7 +281,7 @@ namespace Exiv2 {
             tmpBuf[7] = 0;
             ul2Data(tmpBuf + 8, rawIptc.size(), bigEndian);
             append(psBlob, tmpBuf, 12);
-            append(psBlob, rawIptc.c_data(0), rawIptc.size());
+            append(psBlob, rawIptc.c_data(), rawIptc.size());
             // Data is padded to be even (but not included in size)
             if (rawIptc.size() & 1) psBlob.push_back(0x00);
         }
@@ -307,7 +307,7 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cerr << "IRB block at the end of Photoshop::setIptcIrb\n";
         if (rc.size() == 0) std::cerr << "  None.\n";
-        else hexdump(std::cerr, rc.c_data(0), rc.size());
+        else hexdump(std::cerr, rc.c_data(), rc.size());
 #endif
         return rc;
 
@@ -493,7 +493,7 @@ namespace Exiv2 {
 
                 DataBuf profile(Safe::add(iccProfile_.size(), icc_size));
                 if ( iccProfile_.size() ) {
-                    profile.copyBytes(0, iccProfile_.c_data(0), iccProfile_.size());
+                    profile.copyBytes(0, iccProfile_.c_data(), iccProfile_.size());
                 }
                 profile.copyBytes(iccProfile_.size(), buf.c_data(2+14), icc_size);
                 setIccProfile(profile,chunk==chunks);
@@ -651,7 +651,7 @@ namespace Exiv2 {
                     //    1787 | 0xe1 APP1  |   65460 | http://ns.adobe.com/xmp/extensio
                     if (option == kpsXMP && signature.rfind("http://ns.adobe.com/x", 0) == 0) {
                         // extract XMP
-                        const char* xmp = buf.c_str(0);
+                        const char* xmp = buf.c_str();
                         size_t start = 2;
 
                         // http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf
@@ -724,7 +724,7 @@ namespace Exiv2 {
                         // extract Exif data block which is tiff formatted
                         out << std::endl;
 
-//                        const byte* exif = buf.c_data(0);
+//                        const byte* exif = buf.c_data();
                         uint32_t start = signature == "Exif" ? 8 : 6;
                         uint32_t max = static_cast<uint32_t>(size) - 1;
 
@@ -849,8 +849,8 @@ namespace Exiv2 {
 #endif
                     seekOrThrow(*io_, start, BasicIo::beg, kerFailedToReadImageData);
                     DataBuf buf(length);
-                    readOrThrow(*io_, buf.data(0), buf.size(), kerFailedToReadImageData);
-                    tempIo->write(buf.c_data(0), buf.size());
+                    readOrThrow(*io_, buf.data(), buf.size(), kerFailedToReadImageData);
+                    tempIo->write(buf.c_data(), buf.size());
                 }
             }
 
@@ -1062,8 +1062,8 @@ namespace Exiv2 {
                         bo = littleEndian;
                         setByteOrder(bo);
                     }
-                    WriteMethod wm = ExifParser::encode(blob, rawExif.c_data(0), rawExif.size(), bo, exifData_);
-                    const byte* pExifData = rawExif.c_data(0);
+                    WriteMethod wm = ExifParser::encode(blob, rawExif.c_data(), rawExif.size(), bo, exifData_);
+                    const byte* pExifData = rawExif.c_data();
                     size_t exifSize = rawExif.size();
                     if (wm == wmIntrusive) {
                         pExifData = !blob.empty() ? &blob[0] : nullptr;
@@ -1166,7 +1166,7 @@ namespace Exiv2 {
                     DataBuf newPsData = Photoshop::setIptcIrb(!psBlob.empty() ? &psBlob[0] : nullptr,
                                                               static_cast<long>(psBlob.size()), iptcData_);
                     const long maxChunkSize = 0xffff - 16;
-                    const byte* chunkStart = newPsData.c_data(0);
+                    const byte* chunkStart = newPsData.c_data();
                     const byte* chunkEnd = newPsData.c_data(newPsData.size());
                     while (chunkStart < chunkEnd) {
                         // Determine size of next chunk
@@ -1174,8 +1174,8 @@ namespace Exiv2 {
                         if (chunkSize > maxChunkSize) {
                             chunkSize = maxChunkSize;
                             // Don't break at a valid IRB boundary
-                            const long writtenSize = static_cast<long>(chunkStart - newPsData.c_data(0));
-                            if (Photoshop::valid(newPsData.c_data(0), writtenSize + chunkSize)) {
+                            const long writtenSize = static_cast<long>(chunkStart - newPsData.c_data());
+                            if (Photoshop::valid(newPsData.c_data(), writtenSize + chunkSize)) {
                                 // Since an IRB has minimum size 12,
                                 // (chunkSize - 8) can't be also a IRB boundary
                                 chunkSize -= 8;
@@ -1242,7 +1242,7 @@ namespace Exiv2 {
                 tmpBuf[1] = marker;
                 if (outIo.write(tmpBuf, 2) != 2)
                     throw Error(kerImageWriteFailed);
-                if (outIo.write(buf.c_data(0), size) != size)
+                if (outIo.write(buf.c_data(), size) != size)
                     throw Error(kerImageWriteFailed);
                 if (outIo.error())
                     throw Error(kerImageWriteFailed);
@@ -1266,8 +1266,8 @@ namespace Exiv2 {
 
         DataBuf buf(4096);
         long readSize = 0;
-        while ((readSize = io_->read(buf.data(0), buf.size()))) {
-            if (outIo.write(buf.c_data(0), readSize) != readSize)
+        while ((readSize = io_->read(buf.data(), buf.size()))) {
+            if (outIo.write(buf.c_data(), readSize) != readSize)
                 throw Error(kerImageWriteFailed);
         }
         if (outIo.error())

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -495,12 +495,12 @@ namespace Exiv2 {
     {
         assert(buf_.size() >= 10);
 
-        ioWrapper.write(buf_.c_data(0), 10);
+        ioWrapper.write(buf_.c_data(), 10);
         // Todo: This removes any gap between the header and
         // makernote IFD. The gap should be copied too.
         TiffHeader th(byteOrder);
         DataBuf buf = th.write();
-        ioWrapper.write(buf.c_data(0), buf.size());
+        ioWrapper.write(buf.c_data(), buf.size());
         return 10 + buf.size();
     } // Nikon3MnHeader::write
 

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -267,7 +267,7 @@ namespace Exiv2 {
 
     uint32_t OlympusMnHeader::size() const
     {
-        return header_.size_;
+        return header_.size();
     }
 
     uint32_t OlympusMnHeader::ifdOffset() const
@@ -281,9 +281,9 @@ namespace Exiv2 {
     {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
-        std::memcpy(header_.pData_, pData, header_.size_);
-        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
-                 0 != memcmp(header_.pData_, signature_, 6));
+        header_.copyBytes(0, pData, header_.size());
+        return !(static_cast<uint32_t>(header_.size()) < sizeOfSignature() ||
+                 0 != header_.cmpBytes(0, signature_, 6));
     } // OlympusMnHeader::read
 
     uint32_t OlympusMnHeader::write(IoWrapper& ioWrapper,
@@ -309,7 +309,7 @@ namespace Exiv2 {
 
     uint32_t Olympus2MnHeader::size() const
     {
-        return header_.size_;
+        return header_.size();
     }
 
     uint32_t Olympus2MnHeader::ifdOffset() const
@@ -328,9 +328,9 @@ namespace Exiv2 {
     {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
-        std::memcpy(header_.pData_, pData, header_.size_);
-        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
-                 0 != memcmp(header_.pData_, signature_, 10));
+        header_.copyBytes(0, pData, header_.size());
+        return !(static_cast<uint32_t>(header_.size()) < sizeOfSignature() ||
+                 0 != header_.cmpBytes(0, signature_, 10));
     } // Olympus2MnHeader::read
 
     uint32_t Olympus2MnHeader::write(IoWrapper& ioWrapper,
@@ -357,7 +357,7 @@ namespace Exiv2 {
 
     uint32_t FujiMnHeader::size() const
     {
-        return header_.size_;
+        return header_.size();
     }
 
     uint32_t FujiMnHeader::ifdOffset() const
@@ -381,12 +381,12 @@ namespace Exiv2 {
     {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
-        std::memcpy(header_.pData_, pData, header_.size_);
+        header_.copyBytes(0, pData, header_.size());
         // Read offset to the IFD relative to the start of the makernote
         // from the header. Note that we ignore the byteOrder argument
-        start_ = getULong(header_.pData_ + 8, byteOrder_);
-        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
-                 0 != memcmp(header_.pData_, signature_, 8));
+        start_ = header_.read_uint32(8, byteOrder_);
+        return !(static_cast<uint32_t>(header_.size()) < sizeOfSignature() ||
+                 0 != header_.cmpBytes(0, signature_, 8));
     } // FujiMnHeader::read
 
     uint32_t FujiMnHeader::write(IoWrapper& ioWrapper,
@@ -427,7 +427,7 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         if (0 != memcmp(pData, signature_, 6)) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         start_ = sizeOfSignature();
         return true;
     } // Nikon2MnHeader::read
@@ -452,7 +452,7 @@ namespace Exiv2 {
     Nikon3MnHeader::Nikon3MnHeader() : byteOrder_(invalidByteOrder), start_(sizeOfSignature())
     {
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, signature_, buf_.size_);
+        buf_.copyBytes(0, signature_, buf_.size());
     }
 
     uint32_t Nikon3MnHeader::size() const
@@ -482,9 +482,9 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         if (0 != memcmp(pData, signature_, 6)) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         TiffHeader th;
-        if (!th.read(buf_.pData_ + 10, 8)) return false;
+        if (!th.read(buf_.data(10), 8)) return false;
         byteOrder_ = th.byteOrder();
         start_ = 10 + th.offset();
         return true;
@@ -493,15 +493,15 @@ namespace Exiv2 {
     uint32_t Nikon3MnHeader::write(IoWrapper& ioWrapper,
                                    ByteOrder byteOrder) const
     {
-        assert(buf_.size_ >= 10);
+        assert(buf_.size() >= 10);
 
-        ioWrapper.write(buf_.pData_, 10);
+        ioWrapper.write(buf_.c_data(0), 10);
         // Todo: This removes any gap between the header and
         // makernote IFD. The gap should be copied too.
         TiffHeader th(byteOrder);
         DataBuf buf = th.write();
-        ioWrapper.write(buf.pData_, buf.size_);
-        return 10 + buf.size_;
+        ioWrapper.write(buf.c_data(0), buf.size());
+        return 10 + buf.size();
     } // Nikon3MnHeader::write
 
     void Nikon3MnHeader::setByteOrder(ByteOrder byteOrder)
@@ -540,7 +540,7 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         if (0 != memcmp(pData, signature_, 9)) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         start_ = sizeOfSignature();
         return true;
     } // PanasonicMnHeader::read
@@ -568,7 +568,7 @@ namespace Exiv2 {
 
     uint32_t PentaxDngMnHeader::size() const
     {
-        return header_.size_;
+        return header_.size();
     }
 
     uint32_t PentaxDngMnHeader::baseOffset(uint32_t mnOffset) const
@@ -587,9 +587,9 @@ namespace Exiv2 {
     {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
-        std::memcpy(header_.pData_, pData, header_.size_);
-        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
-                 0 != memcmp(header_.pData_, signature_, 7));
+        header_.copyBytes(0, pData, header_.size());
+        return !(static_cast<uint32_t>(header_.size()) < sizeOfSignature() ||
+                 0 != header_.cmpBytes(0, signature_, 7));
     } // PentaxDngMnHeader::read
 
     uint32_t PentaxDngMnHeader::write(IoWrapper& ioWrapper,
@@ -615,7 +615,7 @@ namespace Exiv2 {
 
     uint32_t PentaxMnHeader::size() const
     {
-        return header_.size_;
+        return header_.size();
     }
 
     uint32_t PentaxMnHeader::ifdOffset() const
@@ -629,9 +629,9 @@ namespace Exiv2 {
     {
         if (!pData || size < sizeOfSignature()) return false;
         header_.alloc(sizeOfSignature());
-        std::memcpy(header_.pData_, pData, header_.size_);
-        return !(static_cast<uint32_t>(header_.size_) < sizeOfSignature() ||
-                 0 != memcmp(header_.pData_, signature_, 3));
+        header_.copyBytes(0, pData, header_.size());
+        return !(static_cast<uint32_t>(header_.size()) < sizeOfSignature() ||
+                 0 != header_.cmpBytes(0, signature_, 3));
     } // PentaxMnHeader::read
 
     uint32_t PentaxMnHeader::write(IoWrapper& ioWrapper,
@@ -705,7 +705,7 @@ namespace Exiv2 {
         if (   0 != memcmp(pData, signature1_, 8)
             && 0 != memcmp(pData, signature2_, 8)) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         start_ = sizeOfSignature();
         return true;
     } // SigmaMnHeader::read
@@ -748,7 +748,7 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         if (0 != memcmp(pData, signature_, sizeOfSignature())) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         start_ = sizeOfSignature();
         return true;
     } // SonyMnHeader::read
@@ -797,7 +797,7 @@ namespace Exiv2 {
         if (!pData || size < sizeOfSignature()) return false;
         if (0 != memcmp(pData, signature_, sizeOfSignature())) return false;
         buf_.alloc(sizeOfSignature());
-        std::memcpy(buf_.pData_, pData, buf_.size_);
+        buf_.copyBytes(0, pData, buf_.size());
         start_ = sizeOfSignature();
         return true;
     } // Casio2MnHeader::read
@@ -1192,8 +1192,8 @@ namespace Exiv2 {
             }
         }
         buf.alloc(size);
-        memcpy(buf.pData_, pData, buf.size_);
-        ncrypt(buf.pData_ + nci->start_, buf.size_ - nci->start_, count, serial);
+        buf.copyBytes(0, pData, buf.size());
+        ncrypt(buf.data(nci->start_), buf.size() - nci->start_, count, serial);
         return buf;
     }
 

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -134,13 +134,13 @@ namespace Exiv2 {
         // will fail if there are fewer than siz bytes left to read.
         enforce(siz <= io_->size(), kerFailedToReadImageData);
         DataBuf buf(siz);
-        io_->read(buf.data(0), buf.size());
+        io_->read(buf.data(), buf.size());
         enforce(!io_->error() && !io_->eof(), kerFailedToReadImageData);
 
         ByteOrder bo = TiffParser::decode(exifData_,
                                           iptcData_,
                                           xmpData_,
-                                          buf.c_data(0),
+                                          buf.c_data(),
                                           buf.size());
         setByteOrder(bo);
     } // MrwImage::readMetadata

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -134,14 +134,14 @@ namespace Exiv2 {
         // will fail if there are fewer than siz bytes left to read.
         enforce(siz <= io_->size(), kerFailedToReadImageData);
         DataBuf buf(siz);
-        io_->read(buf.pData_, buf.size_);
+        io_->read(buf.data(0), buf.size());
         enforce(!io_->error() && !io_->eof(), kerFailedToReadImageData);
 
         ByteOrder bo = TiffParser::decode(exifData_,
                                           iptcData_,
                                           xmpData_,
-                                          buf.pData_,
-                                          buf.size_);
+                                          buf.c_data(0),
+                                          buf.size());
         setByteOrder(bo);
     } // MrwImage::readMetadata
 

--- a/src/orfimage_int.cpp
+++ b/src/orfimage_int.cpp
@@ -55,19 +55,19 @@ namespace Exiv2 {
         DataBuf buf(8);
         switch (byteOrder()) {
         case littleEndian:
-            buf.pData_[0] = 'I';
+            buf.write_uint8(0, 'I');
             break;
         case bigEndian:
-            buf.pData_[0] = 'M';
+            buf.write_uint8(0, 'M');
             break;
         case invalidByteOrder:
             assert(false);
             break;
         }
-        buf.pData_[1] = buf.pData_[0];
+        buf.write_uint8(1, buf.read_uint8(0));
 
-        us2Data(buf.pData_ + 2, sig_, byteOrder());
-        ul2Data(buf.pData_ + 4, 0x00000008, byteOrder());
+        buf.write_uint16(2, sig_, byteOrder());
+        buf.write_uint32(4, 0x00000008, byteOrder());
         return buf;
     }
 

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -67,12 +67,12 @@ namespace Exiv2 {
     static uint32_t byteSwap_(Exiv2::DataBuf& buf,size_t offset,bool bSwap)
     {
         uint32_t v = 0;
-        auto p = reinterpret_cast<char*>(&v);
+        auto p = reinterpret_cast<byte*>(&v);
         int      i;
-        for ( i = 0 ; i < 4 ; i++ ) p[i] = buf.pData_[offset+i];
+        for ( i = 0 ; i < 4 ; i++ ) p[i] = buf.read_uint8(offset+i);
         uint32_t result = byteSwap_(v,bSwap);
-        p = reinterpret_cast<char*>(&result);
-        for ( i = 0 ; i < 4 ; i++ ) buf.pData_[offset+i] = p[i];
+        p = reinterpret_cast<byte*>(&result);
+        for ( i = 0 ; i < 4 ; i++ ) buf.write_uint8(offset+i, p[i]);
         return result;
     }
 
@@ -138,12 +138,12 @@ namespace Exiv2 {
         if (size == 0) return;
 
         DataBuf imgData(size);
-        std::memset(imgData.pData_, 0x0, imgData.size_);
-        long bufRead = io_->read(imgData.pData_, imgData.size_);
+        imgData.clear();
+        long bufRead = io_->read(imgData.data(0), imgData.size());
         if (io_->error()) throw Error(kerFailedToReadImageData);
-        if (bufRead != imgData.size_) throw Error(kerInputDataReadFailed);
+        if (bufRead != imgData.size()) throw Error(kerInputDataReadFailed);
 
-        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.pData_, imgData.size_);
+        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.c_data(0), imgData.size());
         image->readMetadata();
         exifData() = image->exifData();
         iptcData() = image->iptcData();
@@ -214,34 +214,34 @@ namespace Exiv2 {
         if (outIo.putb(mnb) == EOF) throw Error(kerImageWriteFailed);
 
         // Write new Header size.
-        uint32_t newHeaderSize = header.size_ + imgSize;
+        uint32_t newHeaderSize = header.size() + imgSize;
         DataBuf buffer(4);
-        memcpy (buffer.pData_, &newHeaderSize, 4);
+        buffer.copyBytes(0, &newHeaderSize, 4);
         byteSwap_(buffer,0,bSwap_);
-        if (outIo.write(buffer.pData_, 4) != 4) throw Error(kerImageWriteFailed);
+        if (outIo.write(buffer.c_data(0), 4) != 4) throw Error(kerImageWriteFailed);
 
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PgfImage: new PGF header size : " << newHeaderSize << " bytes\n";
 
-        printf("%x\n", buffer.pData_[0]);
-        printf("%x\n", buffer.pData_[1]);
-        printf("%x\n", buffer.pData_[2]);
-        printf("%x\n", buffer.pData_[3]);
+        printf("%x\n", buffer.read_uint8(0));
+        printf("%x\n", buffer.read_uint8(1));
+        printf("%x\n", buffer.read_uint8(2));
+        printf("%x\n", buffer.read_uint8(3));
 #endif
 
         // Write Header data.
-        if (outIo.write(header.pData_, header.size_) != header.size_) throw Error(kerImageWriteFailed);
+        if (outIo.write(header.c_data(0), header.size()) != header.size()) throw Error(kerImageWriteFailed);
 
         // Write new metadata byte array.
-        if (outIo.write(imgBuf.pData_, imgBuf.size_) != imgBuf.size_) throw Error(kerImageWriteFailed);
+        if (outIo.write(imgBuf.c_data(0), imgBuf.size()) != imgBuf.size()) throw Error(kerImageWriteFailed);
 
         // Copy the rest of PGF image data.
 
         DataBuf buf(4096);
         long readSize = 0;
-        while ((readSize=io_->read(buf.pData_, buf.size_)))
+        while ((readSize=io_->read(buf.data(0), buf.size())))
         {
-            if (outIo.write(buf.pData_, readSize) != readSize) throw Error(kerImageWriteFailed);
+            if (outIo.write(buf.c_data(0), readSize) != readSize) throw Error(kerImageWriteFailed);
         }
         if (outIo.error()) throw Error(kerImageWriteFailed);
 
@@ -266,9 +266,9 @@ namespace Exiv2 {
     uint32_t PgfImage::readPgfHeaderSize(BasicIo& iIo) const
     {
         DataBuf buffer(4);
-        long bufRead = iIo.read(buffer.pData_, buffer.size_);
+        long bufRead = iIo.read(buffer.data(0), buffer.size());
         if (iIo.error()) throw Error(kerFailedToReadImageData);
-        if (bufRead != buffer.size_) throw Error(kerInputDataReadFailed);
+        if (bufRead != buffer.size()) throw Error(kerInputDataReadFailed);
 
         int headerSize = static_cast<int>(byteSwap_(buffer, 0, bSwap_));
         if (headerSize <= 0 ) throw Error(kerNoImageInInputData);
@@ -283,12 +283,12 @@ namespace Exiv2 {
     DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const
     {
         DataBuf header(16);
-        long bufRead = iIo.read(header.pData_, header.size_);
+        long bufRead = iIo.read(header.data(0), header.size());
         if (iIo.error()) throw Error(kerFailedToReadImageData);
-        if (bufRead != header.size_) throw Error(kerInputDataReadFailed);
+        if (bufRead != header.size()) throw Error(kerInputDataReadFailed);
 
         DataBuf work(8);  // don't disturb the binary data - doWriteMetadata reuses it
-        memcpy (work.pData_,header.pData_,8);
+        work.copyBytes(0,header.c_data(0),8);
         width   = byteSwap_(work,0,bSwap_);
         height  = byteSwap_(work,4,bSwap_);
 
@@ -298,13 +298,13 @@ namespace Exiv2 {
         byte bpp      = buffer.pData_[10];
         byte channels = buffer.pData_[11];
         */
-        byte mode     = header.pData_[12];
+        byte mode     = header.read_uint8(12);
 
         if (mode == 2)  // Indexed color image. We pass color table (256 * 3 bytes).
         {
             header.alloc(16 + 256*3);
 
-            bufRead = iIo.read(&header.pData_[16], 256*3);
+            bufRead = iIo.read(header.data(16), 256*3);
             if (iIo.error()) throw Error(kerFailedToReadImageData);
             if (bufRead != 256*3) throw Error(kerInputDataReadFailed);
         }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -139,11 +139,11 @@ namespace Exiv2 {
 
         DataBuf imgData(size);
         imgData.clear();
-        long bufRead = io_->read(imgData.data(0), imgData.size());
+        long bufRead = io_->read(imgData.data(), imgData.size());
         if (io_->error()) throw Error(kerFailedToReadImageData);
         if (bufRead != imgData.size()) throw Error(kerInputDataReadFailed);
 
-        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.c_data(0), imgData.size());
+        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.c_data(), imgData.size());
         image->readMetadata();
         exifData() = image->exifData();
         iptcData() = image->iptcData();
@@ -218,7 +218,7 @@ namespace Exiv2 {
         DataBuf buffer(4);
         buffer.copyBytes(0, &newHeaderSize, 4);
         byteSwap_(buffer,0,bSwap_);
-        if (outIo.write(buffer.c_data(0), 4) != 4) throw Error(kerImageWriteFailed);
+        if (outIo.write(buffer.c_data(), 4) != 4) throw Error(kerImageWriteFailed);
 
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PgfImage: new PGF header size : " << newHeaderSize << " bytes\n";
@@ -230,18 +230,18 @@ namespace Exiv2 {
 #endif
 
         // Write Header data.
-        if (outIo.write(header.c_data(0), header.size()) != header.size()) throw Error(kerImageWriteFailed);
+        if (outIo.write(header.c_data(), header.size()) != header.size()) throw Error(kerImageWriteFailed);
 
         // Write new metadata byte array.
-        if (outIo.write(imgBuf.c_data(0), imgBuf.size()) != imgBuf.size()) throw Error(kerImageWriteFailed);
+        if (outIo.write(imgBuf.c_data(), imgBuf.size()) != imgBuf.size()) throw Error(kerImageWriteFailed);
 
         // Copy the rest of PGF image data.
 
         DataBuf buf(4096);
         long readSize = 0;
-        while ((readSize=io_->read(buf.data(0), buf.size())))
+        while ((readSize=io_->read(buf.data(), buf.size())))
         {
-            if (outIo.write(buf.c_data(0), readSize) != readSize) throw Error(kerImageWriteFailed);
+            if (outIo.write(buf.c_data(), readSize) != readSize) throw Error(kerImageWriteFailed);
         }
         if (outIo.error()) throw Error(kerImageWriteFailed);
 
@@ -266,7 +266,7 @@ namespace Exiv2 {
     uint32_t PgfImage::readPgfHeaderSize(BasicIo& iIo) const
     {
         DataBuf buffer(4);
-        long bufRead = iIo.read(buffer.data(0), buffer.size());
+        long bufRead = iIo.read(buffer.data(), buffer.size());
         if (iIo.error()) throw Error(kerFailedToReadImageData);
         if (bufRead != buffer.size()) throw Error(kerInputDataReadFailed);
 
@@ -283,12 +283,12 @@ namespace Exiv2 {
     DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const
     {
         DataBuf header(16);
-        long bufRead = iIo.read(header.data(0), header.size());
+        long bufRead = iIo.read(header.data(), header.size());
         if (iIo.error()) throw Error(kerFailedToReadImageData);
         if (bufRead != header.size()) throw Error(kerInputDataReadFailed);
 
         DataBuf work(8);  // don't disturb the binary data - doWriteMetadata reuses it
-        work.copyBytes(0,header.c_data(0),8);
+        work.copyBytes(0,header.c_data(),8);
         width   = byteSwap_(work,0,bSwap_);
         height  = byteSwap_(work,4,bSwap_);
 

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -82,9 +82,9 @@ namespace Exiv2 {
 
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk data: "
-                  << std::string(arr.c_str(0), arr.size()) << std::endl;
+                  << std::string(arr.c_str(), arr.size()) << std::endl;
 #endif
-        parseChunkContent(pImage, key.c_data(0), key.size(), arr);
+        parseChunkContent(pImage, key.c_data(), key.size(), arr);
 
     } // PngChunk::decodeTXTChunk
 
@@ -95,7 +95,7 @@ namespace Exiv2 {
 
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk key: "
-                  << std::string(key.c_str(0), key.size()) << std::endl;
+                  << std::string(key.c_str(), key.size()) << std::endl;
 #endif
         return parseTXTChunk(data, key.size(), type);
 
@@ -305,7 +305,7 @@ namespace Exiv2 {
                 uint32_t sizeHdr = 0;
 
                 const byte* pEnd = psData.c_data(psData.size());
-                const byte* pCur = psData.c_data(0);
+                const byte* pCur = psData.c_data();
                 while (   pCur < pEnd
                        && 0 == Photoshop::locateIptcIrb(pCur,
                                                         static_cast<long>(pEnd - pCur),
@@ -331,7 +331,7 @@ namespace Exiv2 {
                 // If there is no IRB, try to decode the complete chunk data
                 if (   iptcBlob.empty()
                     && IptcParser::decode(pImage->iptcData(),
-                                          psData.c_data(0),
+                                          psData.c_data(),
                                           psData.size())) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode IPTC metadata.\n";
@@ -353,7 +353,7 @@ namespace Exiv2 {
             if (length > 0)
             {
                 std::string& xmpPacket = pImage->xmpPacket();
-                xmpPacket.assign(xmpBuf.c_str(0), length);
+                xmpPacket.assign(xmpBuf.c_str(), length);
                 std::string::size_type idx = xmpPacket.find_first_of('<');
                 if (idx != std::string::npos && idx > 0)
                 {
@@ -381,7 +381,7 @@ namespace Exiv2 {
             if (arr.size() > 0)
             {
                 std::string& xmpPacket = pImage->xmpPacket();
-                xmpPacket.assign(arr.c_str(0), arr.size());
+                xmpPacket.assign(arr.c_str(), arr.size());
                 std::string::size_type idx = xmpPacket.find_first_of('<');
                 if (idx != std::string::npos && idx > 0)
                 {
@@ -407,7 +407,7 @@ namespace Exiv2 {
             && memcmp("Description", key, 11) == 0
             && pImage->comment().empty())
         {
-            pImage->setComment(std::string(arr.c_str(0), arr.size()));
+            pImage->setComment(std::string(arr.c_str(), arr.size()));
         }
 
     } // PngChunk::parseChunkContent
@@ -453,7 +453,7 @@ namespace Exiv2 {
 
         do {
             arr.alloc(uncompressedLen);
-            zlibResult = uncompress(arr.data(0),
+            zlibResult = uncompress(arr.data(),
                                     &uncompressedLen,
                                     compressedText,
                                     compressedTextSize);
@@ -490,7 +490,7 @@ namespace Exiv2 {
         DataBuf arr;
         do {
             arr.resize(compressedLen);
-            zlibResult = compress2(arr.data(0), &compressedLen, reinterpret_cast<const Bytef*>(text.data()),
+            zlibResult = compress2(arr.data(), &compressedLen, reinterpret_cast<const Bytef*>(text.data()),
                                    static_cast<uLong>(text.size()), Z_BEST_COMPRESSION);
 
             switch (zlibResult) {
@@ -513,7 +513,7 @@ namespace Exiv2 {
             }
         } while (zlibResult == Z_BUF_ERROR);
 
-        return std::string(arr.c_str(0), arr.size());
+        return std::string(arr.c_str(), arr.size());
 
     } // PngChunk::zlibCompress
 
@@ -610,7 +610,7 @@ namespace Exiv2 {
 
         if ( iTXt ) {
             info.alloc(text.size());
-            info.copyBytes(0, text.c_data(0), text.size());
+            info.copyBytes(0, text.c_data(), text.size());
             return  info;
         }
 
@@ -687,7 +687,7 @@ namespace Exiv2 {
 
         // Copy profile, skipping white space and column 1 "=" signs
 
-        unsigned char *dp = info.data(0); // decode pointer
+        unsigned char *dp = info.data(); // decode pointer
         unsigned int nibbles = length * 2;
 
         for (long i = 0; i < static_cast<long>(nibbles); i++) {

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -489,7 +489,7 @@ namespace Exiv2 {
 
         DataBuf arr;
         do {
-            arr.alloc(compressedLen);
+            arr.resize(compressedLen);
             zlibResult = compress2(arr.data(0), &compressedLen, reinterpret_cast<const Bytef*>(text.data()),
                                    static_cast<uLong>(text.size()), Z_BEST_COMPRESSION);
 

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -109,13 +109,13 @@ namespace Exiv2 {
 
         do {
             result.alloc(uncompressedLen);
-            zlibResult = uncompress(result.data(0),&uncompressedLen,bytes,length);
+            zlibResult = uncompress(result.data(),&uncompressedLen,bytes,length);
             // if result buffer is large than necessary, redo to fit perfectly.
             if (zlibResult == Z_OK && static_cast<long>(uncompressedLen) < result.size()) {
                 result.reset();
 
                 result.alloc(uncompressedLen);
-                zlibResult = uncompress(result.data(0),&uncompressedLen,bytes,length);
+                zlibResult = uncompress(result.data(),&uncompressedLen,bytes,length);
             }
             if (zlibResult == Z_BUF_ERROR) {
                 // the uncompressed buffer needs to be larger
@@ -137,7 +137,7 @@ namespace Exiv2 {
 
         do {
             result.alloc(compressedLen);
-            zlibResult = compress(result.data(0),&compressedLen,bytes,length);
+            zlibResult = compress(result.data(),&compressedLen,bytes,length);
             if (zlibResult == Z_BUF_ERROR) {
                 // the compressedArray needs to be larger
                 result.reset();
@@ -145,7 +145,7 @@ namespace Exiv2 {
             } else {
                 result.reset();
                 result.alloc(compressedLen);
-                zlibResult = compress(result.data(0),&compressedLen,bytes,length);
+                zlibResult = compress(result.data(),&compressedLen,bytes,length);
             }
         } while (zlibResult == Z_BUF_ERROR);
 
@@ -189,7 +189,7 @@ namespace Exiv2 {
 
         // hex to binary
         count   = 0 ;
-        byte* r = result.data(0);
+        byte* r = result.data();
         int   n = 0 ; // nibble
         for ( long i = 0 ; i < length ; i++ ) {
             if ( value[p[i]] ) {
@@ -250,7 +250,7 @@ namespace Exiv2 {
                 size_t address = io_->tell();
 
                 cheaderBuf.clear();
-                long bufRead = io_->read(cheaderBuf.data(0), cheaderBuf.size());
+                long bufRead = io_->read(cheaderBuf.data(), cheaderBuf.size());
                 if (io_->error()) throw Error(kerFailedToReadImageData);
                 if (bufRead != cheaderBuf.size()) throw Error(kerInputDataReadFailed);
 
@@ -270,7 +270,7 @@ namespace Exiv2 {
                 }
 
                 DataBuf   buff(dataOffset);
-                bufRead = io_->read(buff.data(0),dataOffset);
+                bufRead = io_->read(buff.data(),dataOffset);
                 enforce(bufRead == static_cast<long>(dataOffset), kerFailedToReadImageData);
                 io_->seek(restore, BasicIo::beg);
 
@@ -324,10 +324,10 @@ namespace Exiv2 {
                     enforce(static_cast<uint64_t>(dataOffset) < static_cast<unsigned long>(std::numeric_limits<long>::max()), kerFailedToReadImageData);
                     DataBuf data(static_cast<long>(dataOffset) + 1);
                     data.write_uint8(dataOffset, 0);
-                    bufRead = io_->read(data.data(0), static_cast<long>(dataOffset));
+                    bufRead = io_->read(data.data(), static_cast<long>(dataOffset));
                     enforce(bufRead == static_cast<long>(dataOffset), kerFailedToReadImageData);
                     io_->seek(restore, BasicIo::beg);
-                    size_t name_l = std::strlen(data.c_str(0)) +
+                    size_t name_l = std::strlen(data.c_str()) +
                                     1; // leading string length
                     enforce(name_l < dataOffset, kerCorruptedMetadata);
 
@@ -359,7 +359,7 @@ namespace Exiv2 {
                         if ( bExif || bIptc ) {
                             DataBuf parsedBuf = PngChunk::readRawProfile(dataBuf,tEXt);
 #if EXIV2_DEBUG_MESSAGES
-                            std::cerr << Exiv2::Internal::binaryToString(makeSlice(parsedBuf.c_data(0), parsedBuf.size()>50?50:parsedBuf.size(),0)) << std::endl;
+                            std::cerr << Exiv2::Internal::binaryToString(makeSlice(parsedBuf.c_data(), parsedBuf.size()>50?50:parsedBuf.size(),0)) << std::endl;
 #endif
                             if ( parsedBuf.size() ) {
                                 if ( bExif ) {
@@ -375,26 +375,26 @@ namespace Exiv2 {
 
                         if ( bSoft && dataBuf.size() > 0) {
                             DataBuf     s(dataBuf.size()+1);               // allocate buffer with an extra byte
-                            s.copyBytes(0,dataBuf.c_data(0),dataBuf.size());// copy in the dataBuf
+                            s.copyBytes(0,dataBuf.c_data(),dataBuf.size());// copy in the dataBuf
                             s.write_uint8(dataBuf.size(), 0);             // nul terminate it
-                            const auto str = s.c_str(0);  // give it name
-                            out << Internal::indent(depth) << buff.c_str(0) << ": " << str;
+                            const auto str = s.c_str();  // give it name
+                            out << Internal::indent(depth) << buff.c_str() << ": " << str;
                             bLF=true;
                         }
 
                         if ( bICC || bComm ) {
-                            out.write(dataBuf.c_str(0), dataBuf.size());
+                            out.write(dataBuf.c_str(), dataBuf.size());
                             bLF = bComm ;
                         }
 
                         if ( bDesc && iTXt ) {
                             DataBuf decoded = PngChunk::decodeTXTChunk(buff,PngChunk::iTXt_Chunk );
-                            out.write(decoded.c_str(0), decoded.size());
+                            out.write(decoded.c_str(), decoded.size());
                             bLF = true;
                         }
                         if ( eXIf && option == kpsRecursive ) {
                             // create memio object with the data, then print the structure
-                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(data.c_data(0), dataOffset));
+                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(data.c_data(), dataOffset));
                             printTiffStructure(*p,out,option,depth);
                         }
 
@@ -412,7 +412,7 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngImage::readMetadata: Position: " << io.tell() << std::endl;
 #endif
-        long bufRead = io.read(buffer.data(0), buffer.size());
+        long bufRead = io.read(buffer.data(), buffer.size());
         if (io.error()) {
             throw Error(kerFailedToReadImageData);
         }
@@ -484,7 +484,7 @@ namespace Exiv2 {
                     ByteOrder bo = TiffParser::decode(exifData(),
                                                       iptcData(),
                                                       xmpData(),
-                                                      chunkData.c_data(0),
+                                                      chunkData.c_data(),
                                                       chunkData.size());
                     setByteOrder(bo);
                 } else if (chunkType == "iCCP") {
@@ -495,7 +495,7 @@ namespace Exiv2 {
                               Exiv2::kerCorruptedMetadata);
                     } while(chunkData.read_uint8(iccOffset++) != 0x00);
 
-                    profileName_ = std::string(chunkData.c_str(0), iccOffset-1);
+                    profileName_ = std::string(chunkData.c_str(), iccOffset-1);
                     ++iccOffset; // +1 = 'compressed' flag
                     enforce(iccOffset <= chunkLength, Exiv2::kerCorruptedMetadata);
 
@@ -564,7 +564,7 @@ namespace Exiv2 {
             // Read chunk header.
 
             cheaderBuf.clear();
-            long bufRead = io_->read(cheaderBuf.data(0), 8);
+            long bufRead = io_->read(cheaderBuf.data(), 8);
             if (io_->error()) throw Error(kerFailedToReadImageData);
             if (bufRead != 8) throw Error(kerInputDataReadFailed);
 
@@ -576,7 +576,7 @@ namespace Exiv2 {
             // Read whole chunk : Chunk header + Chunk data (not fixed size - can be null) + CRC (4 bytes).
 
             DataBuf chunkBuf(8 + dataOffset + 4);  // Chunk header (8 bytes) + Chunk data + CRC (4 bytes).
-            chunkBuf.copyBytes(0, cheaderBuf.c_data(0), 8);           // Copy header.
+            chunkBuf.copyBytes(0, cheaderBuf.c_data(), 8);           // Copy header.
             bufRead = io_->read(chunkBuf.data(8), dataOffset + 4); // Extract chunk data + CRC
             if (io_->error()) throw Error(kerFailedToReadImageData);
             if (bufRead != static_cast<long>(dataOffset) + 4L)
@@ -592,7 +592,7 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Exiv2::PngImage::doWriteMetadata: Write IEND chunk (length: " << dataOffset << ")\n";
 #endif
-                if (outIo.write(chunkBuf.data(0), chunkBuf.size()) != chunkBuf.size())
+                if (outIo.write(chunkBuf.data(), chunkBuf.size()) != chunkBuf.size())
                     throw Error(kerImageWriteFailed);
                 return;
             }
@@ -603,7 +603,7 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Exiv2::PngImage::doWriteMetadata: Write IHDR chunk (length: " << dataOffset << ")\n";
 #endif
-                if (outIo.write(chunkBuf.data(0), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
+                if (outIo.write(chunkBuf.data(), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
 
                 // Write all updated metadata here, just after IHDR.
                 if (!comment_.empty())
@@ -639,7 +639,7 @@ namespace Exiv2 {
                     DataBuf newPsData = Photoshop::setIptcIrb(nullptr, 0, iptcData_);
                     if (newPsData.size() > 0)
                     {
-                        std::string rawIptc(newPsData.c_str(0), newPsData.size());
+                        std::string rawIptc(newPsData.c_str(), newPsData.size());
                         std::string chunk = PngChunk::makeMetadataChunk(rawIptc, mdIptc);
                         if (outIo.write(reinterpret_cast<const byte*>(chunk.data()), static_cast<long>(chunk.size())) !=
                             static_cast<long>(chunk.size())) {
@@ -650,7 +650,7 @@ namespace Exiv2 {
 
                 if ( iccProfileDefined() ) {
                     DataBuf compressed;
-                    if ( zlibToCompressed(iccProfile_.c_data(0),iccProfile_.size(),compressed) ) {
+                    if ( zlibToCompressed(iccProfile_.c_data(),iccProfile_.size(),compressed) ) {
                         const auto nameLength = static_cast<uint32_t>(profileName_.size());
                         const uint32_t chunkLength = nameLength + 2 + compressed.size() ;
                         byte     length[4];
@@ -661,7 +661,7 @@ namespace Exiv2 {
                         tmp         = crc32(tmp, typeICCP, 4);
                         tmp         = crc32(tmp, (const Bytef*)profileName_.data(), nameLength);
                         tmp         = crc32(tmp, nullComp, 2);
-                        tmp = crc32(tmp, compressed.c_data(0), compressed.size());
+                        tmp = crc32(tmp, compressed.c_data(), compressed.size());
                         byte    crc[4];
                         ul2Data(crc, tmp, bigEndian);
 
@@ -669,7 +669,7 @@ namespace Exiv2 {
                         ||  outIo.write(typeICCP, 4) != 4
                         ||  outIo.write(reinterpret_cast<const byte*>(profileName_.data()), nameLength) != nameLength
                         ||  outIo.write(nullComp,2) != 2
-                        ||  outIo.write (compressed.c_data(0),compressed.size()) != compressed.size()
+                        ||  outIo.write (compressed.c_data(),compressed.size()) != compressed.size()
                         ||  outIo.write(crc,4)            != 4
                         ){
                             throw Error(kerImageWriteFailed);
@@ -719,7 +719,7 @@ namespace Exiv2 {
                     std::cout << "Exiv2::PngImage::doWriteMetadata: write " << szChunk
                               << " chunk (length: " << dataOffset << ")" << std::endl;
 #endif
-                    if (outIo.write(chunkBuf.c_data(0), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
+                    if (outIo.write(chunkBuf.c_data(), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
                 }
             } else {
                 // Write all others chunk as well.
@@ -727,7 +727,7 @@ namespace Exiv2 {
                 std::cout << "Exiv2::PngImage::doWriteMetadata:  copy " << szChunk
                           << " chunk (length: " << dataOffset << ")" << std::endl;
 #endif
-                if (outIo.write(chunkBuf.c_data(0), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
+                if (outIo.write(chunkBuf.c_data(), chunkBuf.size()) != chunkBuf.size()) throw Error(kerImageWriteFailed);
             }
         }
 

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -484,7 +484,7 @@ namespace {
             const byte *record;
             uint32_t sizeHdr = 0;
             uint32_t sizeData = 0;
-            if (Photoshop::locatePreviewIrb(psData.c_data(0), psData.size(), &record, &sizeHdr, &sizeData) != 0) {
+            if (Photoshop::locatePreviewIrb(psData.c_data(), psData.size(), &record, &sizeHdr, &sizeData) != 0) {
 #ifndef SUPPRESS_WARNINGS
                 EXV_WARNING << "Missing preview IRB in Photoshop EPS preview.\n";
 #endif
@@ -503,7 +503,7 @@ namespace {
         const DataBuf data = getData();
         if (data.size() == 0) return false;
         try {
-            Image::UniquePtr image = ImageFactory::open(data.c_data(0), data.size());
+            Image::UniquePtr image = ImageFactory::open(data.c_data(), data.size());
             if (image.get() == nullptr) return false;
             image->readMetadata();
 
@@ -651,7 +651,7 @@ namespace {
 
             if (buf.size() == 0) { // direct data
                 buf = DataBuf(pos->size());
-                pos->copy(buf.data(0), invalidByteOrder);
+                pos->copy(buf.data(), invalidByteOrder);
             }
 
             buf.write_uint8(0, 0xff); // fix Minolta thumbnails with invalid jpeg header
@@ -669,7 +669,7 @@ namespace {
         if (buf.size() == 0) return false;
 
         try {
-            Image::UniquePtr image = ImageFactory::open(buf.c_data(0), buf.size());
+            Image::UniquePtr image = ImageFactory::open(buf.c_data(), buf.size());
             if (image.get() == nullptr) return false;
             image->readMetadata();
 
@@ -819,7 +819,7 @@ namespace {
 
                         idxBuf += size;
                     }
-                    dataValue.setDataArea(buf.c_data(0), buf.size());
+                    dataValue.setDataArea(buf.c_data(), buf.size());
                 }
             }
         }
@@ -886,7 +886,7 @@ namespace {
     DataBuf LoaderXmpJpeg::getData() const
     {
         if (!valid()) return DataBuf();
-        return DataBuf(preview_.c_data(0), preview_.size());
+        return DataBuf(preview_.c_data(), preview_.size());
     }
 
     bool LoaderXmpJpeg::readDimensions()
@@ -972,7 +972,7 @@ namespace {
 
     DataBuf decodeAi7Thumbnail(const DataBuf &src)
     {
-        const byte *colorTable = src.c_data(0);
+        const byte *colorTable = src.c_data();
         const long colorTableSize = 256 * 3;
         if (src.size() < colorTableSize) {
 #ifndef SUPPRESS_WARNINGS
@@ -1028,7 +1028,7 @@ namespace {
 
         DataBuf dest(static_cast<long>(header.size() + rgb.size()));
         dest.copyBytes(0, headerBytes, header.size());
-        dest.copyBytes(header.size(), rgb.c_data(0), rgb.size());
+        dest.copyBytes(header.size(), rgb.c_data(), rgb.size());
         return dest;
     }
 
@@ -1078,7 +1078,7 @@ namespace Exiv2 {
 
     const byte* PreviewImage::pData() const
     {
-        return preview_.c_data(0);
+        return preview_.c_data();
     }
 
     uint32_t PreviewImage::size() const

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -247,9 +247,9 @@ namespace Exiv2 {
             case kPhotoshopResourceID_IPTC_NAA:
             {
                 DataBuf rawIPTC(resourceSize);
-                io_->read(rawIPTC.data(0), rawIPTC.size());
+                io_->read(rawIPTC.data(), rawIPTC.size());
                 if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
-                if (IptcParser::decode(iptcData_, rawIPTC.c_data(0), rawIPTC.size())) {
+                if (IptcParser::decode(iptcData_, rawIPTC.c_data(), rawIPTC.size())) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode IPTC metadata.\n";
 #endif
@@ -261,9 +261,9 @@ namespace Exiv2 {
             case kPhotoshopResourceID_ExifInfo:
             {
                 DataBuf rawExif(resourceSize);
-                io_->read(rawExif.data(0), rawExif.size());
+                io_->read(rawExif.data(), rawExif.size());
                 if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
-                ByteOrder bo = ExifParser::decode(exifData_, rawExif.c_data(0), rawExif.size());
+                ByteOrder bo = ExifParser::decode(exifData_, rawExif.c_data(), rawExif.size());
                 setByteOrder(bo);
                 if (rawExif.size() > 0 && byteOrder() == invalidByteOrder) {
 #ifndef SUPPRESS_WARNINGS
@@ -277,9 +277,9 @@ namespace Exiv2 {
             case kPhotoshopResourceID_XMPPacket:
             {
                 DataBuf xmpPacket(resourceSize);
-                io_->read(xmpPacket.data(0), xmpPacket.size());
+                io_->read(xmpPacket.data(), xmpPacket.size());
                 if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
-                xmpPacket_.assign(xmpPacket.c_str(0), xmpPacket.size());
+                xmpPacket_.assign(xmpPacket.c_str(), xmpPacket.size());
                 if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode XMP metadata.\n";
@@ -404,9 +404,9 @@ namespace Exiv2 {
         while (readTotal < colorDataLength) {
             toRead =   static_cast<long>(colorDataLength - readTotal) < lbuf.size()
                      ? static_cast<long>(colorDataLength - readTotal) : lbuf.size();
-            if (io_->read(lbuf.data(0), toRead) != toRead) throw Error(kerNotAnImage, "Photoshop");
+            if (io_->read(lbuf.data(), toRead) != toRead) throw Error(kerNotAnImage, "Photoshop");
             readTotal += toRead;
-            if (outIo.write(lbuf.c_data(0), toRead) != toRead) throw Error(kerImageWriteFailed);
+            if (outIo.write(lbuf.c_data(), toRead) != toRead) throw Error(kerImageWriteFailed);
         }
         if (outIo.error()) throw Error(kerImageWriteFailed);
 
@@ -450,7 +450,7 @@ namespace Exiv2 {
 
             // read rest of resource name, plus any padding
             DataBuf resName(256);
-            if (   io_->read(resName.data(0), adjResourceNameLen)
+            if (   io_->read(resName.data(), adjResourceNameLen)
                 != static_cast<long>(adjResourceNameLen)) throw Error(kerNotAnImage, "Photoshop");
 
             // read resource size (actual length w/o padding!)
@@ -500,7 +500,7 @@ namespace Exiv2 {
                 if (outIo.write(buf, 1) != 1) throw Error(kerImageWriteFailed);
                 buf[0] = resourceNameFirstChar;
                 if (outIo.write(buf, 1) != 1) throw Error(kerImageWriteFailed);
-                if (   outIo.write(resName.c_data(0), adjResourceNameLen)
+                if (   outIo.write(resName.c_data(), adjResourceNameLen)
                     != static_cast<long>(adjResourceNameLen)) throw Error(kerImageWriteFailed);
                 ul2Data(buf, resourceSize, bigEndian);
                 if (outIo.write(buf, 4) != 4) throw Error(kerImageWriteFailed);
@@ -510,11 +510,11 @@ namespace Exiv2 {
                 while (readTotal < pResourceSize) {
                     toRead =   static_cast<long>(pResourceSize - readTotal) < lbuf.size()
                              ? static_cast<long>(pResourceSize - readTotal) : lbuf.size();
-                    if (io_->read(lbuf.data(0), toRead) != toRead) {
+                    if (io_->read(lbuf.data(), toRead) != toRead) {
                         throw Error(kerNotAnImage, "Photoshop");
                     }
                     readTotal += toRead;
-                    if (outIo.write(lbuf.c_data(0), toRead) != toRead) throw Error(kerImageWriteFailed);
+                    if (outIo.write(lbuf.c_data(), toRead) != toRead) throw Error(kerImageWriteFailed);
                 }
                 if (outIo.error()) throw Error(kerImageWriteFailed);
                 newResLength += pResourceSize + adjResourceNameLen + 12;
@@ -548,8 +548,8 @@ namespace Exiv2 {
 
         // Copy remaining data
         long readSize = 0;
-        while ((readSize=io_->read(lbuf.data(0), lbuf.size()))) {
-            if (outIo.write(lbuf.c_data(0), readSize) != readSize) throw Error(kerImageWriteFailed);
+        while ((readSize=io_->read(lbuf.data(), lbuf.size()))) {
+            if (outIo.write(lbuf.c_data(), readSize) != readSize) throw Error(kerImageWriteFailed);
         }
         if (outIo.error()) throw Error(kerImageWriteFailed);
 
@@ -583,7 +583,7 @@ namespace Exiv2 {
                 ul2Data(buf, rawIptc.size(), bigEndian);
                 if (out.write(buf, 4) != 4) throw Error(kerImageWriteFailed);
                 // Write encoded Iptc data
-                if (out.write(rawIptc.c_data(0), rawIptc.size()) != rawIptc.size()) throw Error(kerImageWriteFailed);
+                if (out.write(rawIptc.c_data(), rawIptc.size()) != rawIptc.size()) throw Error(kerImageWriteFailed);
                 resLength += rawIptc.size() + 12;
                 if (rawIptc.size() & 1)    // even padding
                 {

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -160,12 +160,12 @@ namespace Exiv2 {
 
             address = io_->tell();
             DataBuf   unknown(20);
-            io_->read(unknown.pData_,unknown.size_);
+            io_->read(unknown.data(0),unknown.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, 20)
                     << "    unknown : "
-                    << Internal::binaryToString(makeSlice(unknown, 0,unknown.size_))
+                    << Internal::binaryToString(makeSlice(unknown, 0, unknown.size()))
                     << std::endl;
             }
 
@@ -249,34 +249,34 @@ namespace Exiv2 {
             io_->seek(jpg_img_off, BasicIo::beg); // rewind
             address = io_->tell();
             DataBuf payload(16); // header is different from chunks
-            io_->read(payload.pData_, payload.size_);
+            io_->read(payload.data(0), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, jpg_img_len) // , jpg_img_off)
                     << "       JPEG : "
-                    << Internal::binaryToString(makeSlice(payload, 0, payload.size_))
+                    << Internal::binaryToString(makeSlice(payload, 0, payload.size()))
                     << std::endl;
             }
 
             io_->seek(cfa_hdr_off, BasicIo::beg); // rewind
             address = io_->tell();
-            io_->read(payload.pData_, payload.size_);
+            io_->read(payload.data(0), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, cfa_hdr_len, cfa_hdr_off)
                     << "        CFA : "
-                    << Internal::binaryToString(makeSlice(payload, 0, payload.size_))
+                    << Internal::binaryToString(makeSlice(payload, 0, payload.size()))
                     << std::endl;
             }
 
             io_->seek(cfa_off, BasicIo::beg); // rewind
             address = io_->tell();
-            io_->read(payload.pData_, payload.size_);
+            io_->read(payload.data(0), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, cfa_len, cfa_off)
                     << "       TIFF : "
-                    << Internal::binaryToString(makeSlice(payload, 0, payload.size_))
+                    << Internal::binaryToString(makeSlice(payload, 0, payload.size()))
                     << std::endl;
             }
         }
@@ -321,7 +321,7 @@ namespace Exiv2 {
 
         DataBuf buf(jpg_img_len - 12);
         if (io_->seek(jpg_img_off + 12,BasicIo::beg) != 0) throw Error(kerFailedToReadImageData);
-        io_->read(buf.pData_, buf.size_);
+        io_->read(buf.data(0), buf.size());
         if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
 
         io_->seek(0,BasicIo::beg); // rewind
@@ -329,8 +329,8 @@ namespace Exiv2 {
         ByteOrder bo = TiffParser::decode(exifData_,
                                           iptcData_,
                                           xmpData_,
-                                          buf.pData_,
-                                          buf.size_);
+                                          buf.c_data(0),
+                                          buf.size());
 
         exifData_["Exif.Image2.JPEGInterchangeFormat"] = getULong(jpg_img_offset, bigEndian);
         exifData_["Exif.Image2.JPEGInterchangeFormatLength"] = getULong(jpg_img_length, bigEndian);
@@ -360,15 +360,15 @@ namespace Exiv2 {
             memcmp(readBuff, "\x4D\x4D\x00\x2A", 4) == 0)
         {
             DataBuf  tiff(tiffLength);
-            io_->read(tiff.pData_, tiff.size_);
+            io_->read(tiff.data(0), tiff.size());
 
             if (!io_->error() && !io_->eof())
             {
                 TiffParser::decode(exifData_,
                                    iptcData_,
                                    xmpData_,
-                                   tiff.pData_,
-                                   tiff.size_);
+                                   tiff.c_data(0),
+                                   tiff.size());
             }
         }
     } // RafImage::readMetadata

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -160,7 +160,7 @@ namespace Exiv2 {
 
             address = io_->tell();
             DataBuf   unknown(20);
-            io_->read(unknown.data(0),unknown.size());
+            io_->read(unknown.data(),unknown.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, 20)
@@ -249,7 +249,7 @@ namespace Exiv2 {
             io_->seek(jpg_img_off, BasicIo::beg); // rewind
             address = io_->tell();
             DataBuf payload(16); // header is different from chunks
-            io_->read(payload.data(0), payload.size());
+            io_->read(payload.data(), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, jpg_img_len) // , jpg_img_off)
@@ -260,7 +260,7 @@ namespace Exiv2 {
 
             io_->seek(cfa_hdr_off, BasicIo::beg); // rewind
             address = io_->tell();
-            io_->read(payload.data(0), payload.size());
+            io_->read(payload.data(), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, cfa_hdr_len, cfa_hdr_off)
@@ -271,7 +271,7 @@ namespace Exiv2 {
 
             io_->seek(cfa_off, BasicIo::beg); // rewind
             address = io_->tell();
-            io_->read(payload.data(0), payload.size());
+            io_->read(payload.data(), payload.size());
             {
                 out << Internal::indent(depth)
                     << Internal::stringFormat(format,address, cfa_len, cfa_off)
@@ -321,7 +321,7 @@ namespace Exiv2 {
 
         DataBuf buf(jpg_img_len - 12);
         if (io_->seek(jpg_img_off + 12,BasicIo::beg) != 0) throw Error(kerFailedToReadImageData);
-        io_->read(buf.data(0), buf.size());
+        io_->read(buf.data(), buf.size());
         if (io_->error() || io_->eof()) throw Error(kerFailedToReadImageData);
 
         io_->seek(0,BasicIo::beg); // rewind
@@ -329,7 +329,7 @@ namespace Exiv2 {
         ByteOrder bo = TiffParser::decode(exifData_,
                                           iptcData_,
                                           xmpData_,
-                                          buf.c_data(0),
+                                          buf.c_data(),
                                           buf.size());
 
         exifData_["Exif.Image2.JPEGInterchangeFormat"] = getULong(jpg_img_offset, bigEndian);
@@ -360,14 +360,14 @@ namespace Exiv2 {
             memcmp(readBuff, "\x4D\x4D\x00\x2A", 4) == 0)
         {
             DataBuf  tiff(tiffLength);
-            io_->read(tiff.data(0), tiff.size());
+            io_->read(tiff.data(), tiff.size());
 
             if (!io_->error() && !io_->eof())
             {
                 TiffParser::decode(exifData_,
                                    iptcData_,
                                    xmpData_,
-                                   tiff.c_data(0),
+                                   tiff.c_data(),
                                    tiff.size());
             }
         }

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -1348,7 +1348,7 @@ namespace Exiv2 {
 
         // code byte-by-byte
         for ( uint32_t i = 0 ; i < size ; i++ ) {
-            b.pData_[i] = code[bytes[i]];
+            b.write_uint8(i, code[bytes[i]]);
         }
 
         return b;

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2693,20 +2693,22 @@ namespace Exiv2 {
         bool cnv = false;
         if (value.typeId() == unsignedByte && value.size() > 0) {
             DataBuf buf(value.size());
-            value.copy(buf.pData_, invalidByteOrder);
+            value.copy(buf.data(0), invalidByteOrder);
             // Strip trailing odd byte due to failing UCS-2 conversion
-            if (buf.size_ % 2 == 1)  buf.size_ -=1;
+            if (buf.size() % 2 == 1) {
+                buf.resize(buf.size() - 1);
+            }
 
             // Strip trailing UCS-2 0-characters
-            while (buf.size_ >= 2) {
-                if (buf.pData_[buf.size_ - 1] == 0 && buf.pData_[buf.size_ - 2] == 0) {
-                    buf.size_ -= 2;
+            while (buf.size() >= 2) {
+                if (buf.read_uint8(buf.size() - 1) == 0 && buf.read_uint8(buf.size() - 2) == 0) {
+                    buf.resize(buf.size() - 2);
                 } else {
                     break;
                 }
             }
 
-            std::string str(reinterpret_cast<const char*>(buf.pData_), buf.size_);
+            std::string str(buf.c_str(0), buf.size());
             cnv = convertStringCharset(str, "UCS-2LE", "UTF-8");
             if (cnv) os << str;
         }

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2693,7 +2693,7 @@ namespace Exiv2 {
         bool cnv = false;
         if (value.typeId() == unsignedByte && value.size() > 0) {
             DataBuf buf(value.size());
-            value.copy(buf.data(0), invalidByteOrder);
+            value.copy(buf.data(), invalidByteOrder);
             // Strip trailing odd byte due to failing UCS-2 conversion
             if (buf.size() % 2 == 1) {
                 buf.resize(buf.size() - 1);
@@ -2708,7 +2708,7 @@ namespace Exiv2 {
                 }
             }
 
-            std::string str(buf.c_str(0), buf.size());
+            std::string str(buf.c_str(), buf.size());
             cnv = convertStringCharset(str, "UCS-2LE", "UTF-8");
             if (cnv) os << str;
         }

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -1231,8 +1231,8 @@ namespace Exiv2 {
         if (!pValue_) return 0;
 
         DataBuf buf(pValue_->size());
-        pValue_->copy(buf.data(0), byteOrder);
-        ioWrapper.write(buf.c_data(0), buf.size());
+        pValue_->copy(buf.data(), byteOrder);
+        ioWrapper.write(buf.c_data(), buf.size());
         return buf.size();
     } // TiffEntryBase::doWrite
 
@@ -1279,7 +1279,7 @@ namespace Exiv2 {
                                tiffType(),
                                byteOrder);
         }
-        ioWrapper.write(buf.c_data(0), buf.size());
+        ioWrapper.write(buf.c_data(), buf.size());
         return buf.size();
     } // TiffDataEntry::doWrite
 
@@ -1311,7 +1311,7 @@ namespace Exiv2 {
                 imageIdx += strip.second & 1;  // Align strip data to word boundary
             }
         }
-        ioWrapper.write(buf.c_data(0), buf.size());
+        ioWrapper.write(buf.c_data(), buf.size());
         return buf.size();
     } // TiffImageEntry::doWrite
 
@@ -1330,7 +1330,7 @@ namespace Exiv2 {
             idx += writeOffset(buf.data(idx), offset + dataIdx, tiffType(), byteOrder);
             dataIdx += ifd->size();
         }
-        ioWrapper.write(buf.c_data(0), buf.size());
+        ioWrapper.write(buf.c_data(), buf.size());
         return buf.size();
     } // TiffSubIfd::doWrite
 
@@ -1419,7 +1419,7 @@ namespace Exiv2 {
             DataBuf buf = cryptFct(tag(), mio.mmap(), static_cast<uint32_t>(mio.size()), pRoot_);
             if (    buf.size()) {
                 mio.seek(0,Exiv2::FileIo::beg);
-                mio.write(buf.c_data(0), buf.size());
+                mio.write(buf.c_data(), buf.size());
             }
         }
         ioWrapper.write(mio.mmap(), static_cast<uint32_t>(mio.size()));
@@ -1437,8 +1437,8 @@ namespace Exiv2 {
         Value const* pv = pValue();
         if (!pv || pv->count() == 0) return 0;
         DataBuf buf(pv->size());
-        pv->copy(buf.data(0), byteOrder);
-        ioWrapper.write(buf.c_data(0), buf.size());
+        pv->copy(buf.data(), byteOrder);
+        ioWrapper.write(buf.c_data(), buf.size());
         return buf.size();
     } // TiffBinaryElement::doWrite
 
@@ -1496,7 +1496,7 @@ namespace Exiv2 {
         if (!pValue()) return 0;
 
         DataBuf buf = pValue()->dataArea();
-        ioWrapper.write(buf.c_data(0), buf.size());
+        ioWrapper.write(buf.c_data(), buf.size());
         // Align data to word boundary
         uint32_t align = (buf.size() & 1);
         if (align) ioWrapper.putb(0x0);
@@ -1604,7 +1604,7 @@ namespace Exiv2 {
                       << ": Writing data area, size = " << len;
 #endif
             DataBuf buf = pValue()->dataArea();
-            ioWrapper.write(buf.c_data(0), buf.size());
+            ioWrapper.write(buf.c_data(), buf.size());
             uint32_t align = len & 1;       // Align image data to word boundary
             if (align) ioWrapper.putb(0x0);
             len += align;
@@ -1912,7 +1912,7 @@ namespace {
         if (curr < tobe) {
             Exiv2::DataBuf buf(tobe - curr);
             buf.clear();
-            ioWrapper.write(buf.c_data(0), buf.size());
+            ioWrapper.write(buf.c_data(), buf.size());
             return tobe - curr;
         }
         return 0;

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -199,7 +199,7 @@ namespace Exiv2 {
                 throw Error(kerFailedToReadImageData);
             }
             iccProfile_.alloc(size);
-            pos->copy(iccProfile_.pData_,bo);
+            pos->copy(iccProfile_.data(0),bo);
         }
 
     }
@@ -234,7 +234,7 @@ namespace Exiv2 {
         auto pos   = exifData_.findKey(key);
         bool                      found = pos != exifData_.end();
         if ( iccProfileDefined() ) {
-            Exiv2::DataValue value(iccProfile_.pData_,iccProfile_.size_);
+            Exiv2::DataValue value(iccProfile_.c_data(0), iccProfile_.size());
             if ( found ) pos->setValue(&value);
             else     exifData_.add(key,&value);
         } else {

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -199,7 +199,7 @@ namespace Exiv2 {
                 throw Error(kerFailedToReadImageData);
             }
             iccProfile_.alloc(size);
-            pos->copy(iccProfile_.data(0),bo);
+            pos->copy(iccProfile_.data(),bo);
         }
 
     }
@@ -234,7 +234,7 @@ namespace Exiv2 {
         auto pos   = exifData_.findKey(key);
         bool                      found = pos != exifData_.end();
         if ( iccProfileDefined() ) {
-            Exiv2::DataValue value(iccProfile_.c_data(0), iccProfile_.size());
+            Exiv2::DataValue value(iccProfile_.c_data(), iccProfile_.size());
             if ( found ) pos->setValue(&value);
             else     exifData_.add(key,&value);
         } else {

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1929,7 +1929,7 @@ namespace Exiv2 {
             DataBuf header = pHeader->write();
             BasicIo::UniquePtr tempIo(new MemIo);
             assert(tempIo.get() != 0);
-            IoWrapper ioWrapper(*tempIo, header.c_data(0), header.size(), pOffsetWriter);
+            IoWrapper ioWrapper(*tempIo, header.c_data(), header.size(), pOffsetWriter);
             auto imageIdx(uint32_t(-1));
             createdTree->write(ioWrapper,
                                pHeader->byteOrder(),

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1929,11 +1929,11 @@ namespace Exiv2 {
             DataBuf header = pHeader->write();
             BasicIo::UniquePtr tempIo(new MemIo);
             assert(tempIo.get() != 0);
-            IoWrapper ioWrapper(*tempIo, header.pData_, header.size_, pOffsetWriter);
+            IoWrapper ioWrapper(*tempIo, header.c_data(0), header.size(), pOffsetWriter);
             auto imageIdx(uint32_t(-1));
             createdTree->write(ioWrapper,
                                pHeader->byteOrder(),
-                               header.size_,
+                               header.size(),
                                uint32_t(-1),
                                uint32_t(-1),
                                imageIdx);
@@ -2043,18 +2043,18 @@ namespace Exiv2 {
         DataBuf buf(8);
         switch (byteOrder_) {
         case littleEndian:
-            buf.pData_[0] = 'I';
+            buf.write_uint8(0, 'I');
             break;
         case bigEndian:
-            buf.pData_[0] = 'M';
+            buf.write_uint8(0, 'M');
             break;
         case invalidByteOrder:
             assert(false);
             break;
         }
-        buf.pData_[1]=buf.pData_[0];
-        us2Data(buf.pData_ + 2, tag_, byteOrder_);
-        ul2Data(buf.pData_ + 4, 0x00000008, byteOrder_);
+        buf.write_uint8(1, buf.read_uint8(0));
+        buf.write_uint16(2, tag_, byteOrder_);
+        buf.write_uint32(4, 0x00000008, byteOrder_);
         return buf;
     }
 

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -624,12 +624,12 @@ namespace Exiv2 {
                 // Pad the last unsignedLong value with 0s
                 buf.alloc((rawIptc.size() / 4) * 4 + 4);
                 buf.clear();
-                buf.copyBytes(0, rawIptc.c_data(0), rawIptc.size());
+                buf.copyBytes(0, rawIptc.c_data(), rawIptc.size());
             }
             else {
                 buf = rawIptc; // Note: This resets rawIptc
             }
-            value->read(buf.data(0), buf.size(), byteOrder_);
+            value->read(buf.data(), buf.size(), byteOrder_);
             Exifdatum iptcDatum(iptcNaaKey, value.get());
             exifData_.add(iptcDatum);
             pos = exifData_.findKey(irbKey); // needed after add()
@@ -638,12 +638,12 @@ namespace Exiv2 {
         // but don't create it if not.
         if (pos != exifData_.end()) {
             DataBuf irbBuf(pos->value().size());
-            pos->value().copy(irbBuf.data(0), invalidByteOrder);
-            irbBuf = Photoshop::setIptcIrb(irbBuf.c_data(0), irbBuf.size(), iptcData_);
+            pos->value().copy(irbBuf.data(), invalidByteOrder);
+            irbBuf = Photoshop::setIptcIrb(irbBuf.c_data(), irbBuf.size(), iptcData_);
             exifData_.erase(pos);
             if (irbBuf.size() != 0) {
                 Value::UniquePtr value = Value::create(unsignedByte);
-                value->read(irbBuf.data(0), irbBuf.size(), invalidByteOrder);
+                value->read(irbBuf.data(), irbBuf.size(), invalidByteOrder);
                 Exifdatum iptcDatum(irbKey, value.get());
                 exifData_.add(iptcDatum);
             }
@@ -833,7 +833,7 @@ namespace Exiv2 {
             const byte* pData = object->pData();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
             if (buf.size() > 0) {
-                pData = buf.c_data(0);
+                pData = buf.c_data();
                 size = buf.size();
             }
             if (!object->updOrigDataBuf(pData, size)) {
@@ -948,7 +948,7 @@ namespace Exiv2 {
 #endif
                 DataBuf buf = object->pValue()->dataArea();
                 if ( buf.size() > 0 ) {
-                    memcpy(object->pDataArea_, buf.c_data(0), buf.size());
+                    memcpy(object->pDataArea_, buf.c_data(), buf.size());
                     if (object->sizeDataArea_ > static_cast<size_t>(buf.size())) {
                         memset(object->pDataArea_ + buf.size(),
                            0x0, object->sizeDataArea_ - buf.size());

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -617,19 +617,19 @@ namespace Exiv2 {
         if (pos != exifData_.end()) {
             irbKey.setIdx(pos->idx());
         }
-        if (rawIptc.size_ != 0 && (del || pos == exifData_.end())) {
+        if (rawIptc.size() != 0 && (del || pos == exifData_.end())) {
             Value::UniquePtr value = Value::create(unsignedLong);
             DataBuf buf;
-            if (rawIptc.size_ % 4 != 0) {
+            if (rawIptc.size() % 4 != 0) {
                 // Pad the last unsignedLong value with 0s
-                buf.alloc((rawIptc.size_ / 4) * 4 + 4);
-                memset(buf.pData_, 0x0, buf.size_);
-                memcpy(buf.pData_, rawIptc.pData_, rawIptc.size_);
+                buf.alloc((rawIptc.size() / 4) * 4 + 4);
+                buf.clear();
+                buf.copyBytes(0, rawIptc.c_data(0), rawIptc.size());
             }
             else {
                 buf = rawIptc; // Note: This resets rawIptc
             }
-            value->read(buf.pData_, buf.size_, byteOrder_);
+            value->read(buf.data(0), buf.size(), byteOrder_);
             Exifdatum iptcDatum(iptcNaaKey, value.get());
             exifData_.add(iptcDatum);
             pos = exifData_.findKey(irbKey); // needed after add()
@@ -638,12 +638,12 @@ namespace Exiv2 {
         // but don't create it if not.
         if (pos != exifData_.end()) {
             DataBuf irbBuf(pos->value().size());
-            pos->value().copy(irbBuf.pData_, invalidByteOrder);
-            irbBuf = Photoshop::setIptcIrb(irbBuf.pData_, irbBuf.size_, iptcData_);
+            pos->value().copy(irbBuf.data(0), invalidByteOrder);
+            irbBuf = Photoshop::setIptcIrb(irbBuf.c_data(0), irbBuf.size(), iptcData_);
             exifData_.erase(pos);
-            if (irbBuf.size_ != 0) {
+            if (irbBuf.size() != 0) {
                 Value::UniquePtr value = Value::create(unsignedByte);
-                value->read(irbBuf.pData_, irbBuf.size_, invalidByteOrder);
+                value->read(irbBuf.data(0), irbBuf.size(), invalidByteOrder);
                 Exifdatum iptcDatum(irbKey, value.get());
                 exifData_.add(iptcDatum);
             }
@@ -832,9 +832,9 @@ namespace Exiv2 {
         if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
-            if (buf.size_ > 0) {
-                pData = buf.pData_;
-                size = buf.size_;
+            if (buf.size() > 0) {
+                pData = buf.c_data(0);
+                size = buf.size();
             }
             if (!object->updOrigDataBuf(pData, size)) {
                 setDirty();
@@ -947,11 +947,11 @@ namespace Exiv2 {
                 std::cerr << "Writing data area for " << key << "\n";
 #endif
                 DataBuf buf = object->pValue()->dataArea();
-                if ( buf.pData_ ) {
-                    memcpy(object->pDataArea_, buf.pData_, buf.size_);
-                    if (object->sizeDataArea_ > static_cast<uint32_t>(buf.size_)) {
-                        memset(object->pDataArea_ + buf.size_,
-                           0x0, object->sizeDataArea_ - buf.size_);
+                if ( buf.size() > 0 ) {
+                    memcpy(object->pDataArea_, buf.c_data(0), buf.size());
+                    if (object->sizeDataArea_ > static_cast<size_t>(buf.size())) {
+                        memset(object->pDataArea_ + buf.size(),
+                           0x0, object->sizeDataArea_ - buf.size());
                     }
                 }
             }
@@ -1654,7 +1654,7 @@ namespace Exiv2 {
             const byte* pData = object->pData();
             int32_t size = object->TiffEntryBase::doSize();
             DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
-            if (buf.size_ > 0) object->setData(buf);
+            if (buf.size() > 0) object->setData(buf);
         }
 
         const ArrayDef* defs = object->def();

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -304,13 +304,13 @@ namespace Exiv2 {
     Slice<byte*> makeSlice(DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return {buf.data(0), begin, end};
+        return {buf.data(), begin, end};
     }
 
     Slice<const byte*> makeSlice(const DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return {buf.c_data(0), begin, end};
+        return {buf.c_data(), begin, end};
     }
 
     std::ostream& operator<<(std::ostream& os, const Rational& r)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -164,6 +164,19 @@ namespace Exiv2 {
         }
     }
 
+    void DataBuf::resize(long size)
+    {
+        if (size > size_) {
+            byte* newbuf = new byte[size];
+            if (size_ > 0) {
+                memcpy(newbuf, pData_, size_);
+            }
+            delete[] pData_;
+            pData_ = newbuf;
+        }
+        size_ = size;
+    }
+
     EXV_WARN_UNUSED_RESULT std::pair<byte*, long> DataBuf::release()
     {
         std::pair<byte*, long> p = {pData_, size_};
@@ -181,11 +194,103 @@ namespace Exiv2 {
         size_ = p.second;
     }
 
+    void DataBuf::clear() {
+        memset(pData_, 0, size_);
+    }
+
     DataBuf::DataBuf(const DataBufRef &rhs) : pData_(rhs.p.first), size_(rhs.p.second) {}
 
     DataBuf &DataBuf::operator=(DataBufRef rhs) { reset(rhs.p); return *this; }
 
     Exiv2::DataBuf::operator DataBufRef() { return DataBufRef(release()); }
+
+    uint8_t Exiv2::DataBuf::read_uint8(size_t offset) const {
+        if (offset >= static_cast<size_t>(size_)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::read_uint8");
+        }
+        return pData_[offset];
+    }
+
+    void Exiv2::DataBuf::write_uint8(size_t offset, uint8_t x) {
+        if (offset >= static_cast<size_t>(size_)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::write_uint8");
+        }
+        pData_[offset] = x;
+    }
+
+    uint16_t Exiv2::DataBuf::read_uint16(size_t offset, ByteOrder byteOrder) const {
+        if (size_ < 2 || offset > static_cast<size_t>(size_ - 2)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::read_uint16");
+        }
+        return getUShort(&pData_[offset], byteOrder);
+    }
+
+    void Exiv2::DataBuf::write_uint16(size_t offset, uint16_t x, ByteOrder byteOrder) {
+        if (size_ < 2 || offset > static_cast<size_t>(size_ - 2)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::write_uint16");
+        }
+        us2Data(&pData_[offset], x, byteOrder);
+    }
+
+    uint32_t Exiv2::DataBuf::read_uint32(size_t offset, ByteOrder byteOrder) const {
+        if (size_ < 4 || offset > static_cast<size_t>(size_ - 4)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::read_uint32");
+        }
+        return getULong(&pData_[offset], byteOrder);
+    }
+
+    void Exiv2::DataBuf::write_uint32(size_t offset, uint32_t x, ByteOrder byteOrder) {
+        if (size_ < 4 || offset > static_cast<size_t>(size_ - 4)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::write_uint32");
+        }
+        ul2Data(&pData_[offset], x, byteOrder);
+    }
+
+    uint64_t Exiv2::DataBuf::read_uint64(size_t offset, ByteOrder byteOrder) const {
+        if (size_ < 8 || offset > static_cast<size_t>(size_ - 8)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::read_uint64");
+        }
+        return getULongLong(&pData_[offset], byteOrder);
+    }
+
+    void Exiv2::DataBuf::write_uint64(size_t offset, uint64_t x, ByteOrder byteOrder) {
+        if (size_ < 8 || offset > static_cast<size_t>(size_ - 8)) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::write_uint64");
+        }
+        ull2Data(&pData_[offset], x, byteOrder);
+    }
+
+    void Exiv2::DataBuf::copyBytes(size_t offset, const void* buf, size_t bufsize) {
+        if (static_cast<size_t>(size_) < bufsize || offset > size_ - bufsize) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::copyBytes");
+        }
+        memcpy(&pData_[offset], buf, bufsize);
+    }
+
+    int Exiv2::DataBuf::cmpBytes(size_t offset, const void* buf, size_t bufsize) const {
+        if (static_cast<size_t>(size_) < bufsize || offset > size_ - bufsize) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::cmpBytes");
+        }
+        return memcmp(&pData_[offset], buf, bufsize);
+    }
+
+    byte* Exiv2::DataBuf::data(size_t offset) {
+        if (static_cast<size_t>(size_) < offset) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::c_data");
+        }
+        return &pData_[offset];
+    }
+
+    const byte* Exiv2::DataBuf::c_data(size_t offset) const {
+        if (static_cast<size_t>(size_) < offset) {
+            throw std::overflow_error("Overflow in Exiv2::DataBuf::c_data");
+        }
+        return &pData_[offset];
+    }
+
+    const char* Exiv2::DataBuf::c_str(size_t offset) const {
+        return reinterpret_cast<const char*>(c_data(offset));
+    }
 
     // *************************************************************************
     // free functions
@@ -193,19 +298,19 @@ namespace Exiv2 {
     static void checkDataBufBounds(const DataBuf& buf, size_t end) {
         enforce<std::invalid_argument>(end <= static_cast<size_t>(std::numeric_limits<long>::max()),
                                        "end of slice too large to be compared with DataBuf bounds.");
-        enforce<std::out_of_range>(static_cast<long>(end) <= buf.size_, "Invalid slice bounds specified");
+        enforce<std::out_of_range>(static_cast<long>(end) <= buf.size(), "Invalid slice bounds specified");
     }
 
     Slice<byte*> makeSlice(DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return {buf.pData_, begin, end};
+        return {buf.data(0), begin, end};
     }
 
     Slice<const byte*> makeSlice(const DataBuf& buf, size_t begin, size_t end)
     {
         checkDataBufBounds(buf, end);
-        return {buf.pData_, begin, end};
+        return {buf.c_data(0), begin, end};
     }
 
     std::ostream& operator<<(std::ostream& os, const Rational& r)
@@ -396,6 +501,23 @@ namespace Exiv2 {
             buf[3] = static_cast<byte>(l & 0x000000ff);
         }
         return 4;
+    }
+
+    long ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder)
+    {
+        if (byteOrder == littleEndian) {
+            for (size_t i = 0; i < 8; i++) {
+                buf[i] = static_cast<byte>(l & 0xff);
+                l >>= 8;
+            }
+        }
+        else {
+            for (size_t i = 0; i < 8; i++) {
+                buf[8-i-1] = static_cast<byte>(l & 0xff);
+                l >>= 8;
+            }
+        }
+        return 8;
     }
 
     long ur2Data(byte* buf, URational l, ByteOrder byteOrder)

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -180,7 +180,7 @@ namespace Exiv2 {
          case we have any exif or xmp data, also check
          for any chunks with alpha frame/layer set */
         while (!io_->eof() && static_cast<uint64_t>(io_->tell()) < filesize) {
-            readOrThrow(*io_, chunkId.data(0), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            readOrThrow(*io_, chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
             readOrThrow(*io_, size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
@@ -189,7 +189,7 @@ namespace Exiv2 {
                     Exiv2::kerCorruptedMetadata);
             const long size = static_cast<long>(size_u32);
             DataBuf payload(size);
-            readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+            readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
             if ( payload.size() % 2 ) {
               byte c = 0;
               readOrThrow(*io_, &c, 1, Exiv2::kerCorruptedMetadata);
@@ -317,7 +317,7 @@ namespace Exiv2 {
 
         io_->seek(12, BasicIo::beg);
         while (!io_->eof() && static_cast<uint64_t>(io_->tell()) < filesize) {
-            readOrThrow(*io_, chunkId.data(0), 4, Exiv2::kerCorruptedMetadata);
+            readOrThrow(*io_, chunkId.data(), 4, Exiv2::kerCorruptedMetadata);
             readOrThrow(*io_, size_buff, 4, Exiv2::kerCorruptedMetadata);
 
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
@@ -328,7 +328,7 @@ namespace Exiv2 {
             const long size = static_cast<long>(size_u32);
 
             DataBuf payload(size);
-            readOrThrow(*io_, payload.data(0), size, Exiv2::kerCorruptedMetadata);
+            readOrThrow(*io_, payload.data(), size, Exiv2::kerCorruptedMetadata);
             if ( io_->tell() % 2 ) io_->seek(+1,BasicIo::cur); // skip pad
 
             if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8X)) {
@@ -357,11 +357,11 @@ namespace Exiv2 {
                     payload.write_uint8(0, x & ~WEBP_VP8X_EXIF_BIT);
                 }
 
-                if (outIo.write(chunkId.c_data(0), WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
+                if (outIo.write(chunkId.c_data(), WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
                     throw Error(kerImageWriteFailed);
                 if (outIo.write(size_buff, WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
                     throw Error(kerImageWriteFailed);
-                if (outIo.write(payload.c_data(0), payload.size()) != payload.size())
+                if (outIo.write(payload.c_data(), payload.size()) != payload.size())
                     throw Error(kerImageWriteFailed);
                 if (outIo.tell() % 2) {
                     if (outIo.write(&WEBP_PAD_ODD, 1) != 1) throw Error(kerImageWriteFailed);
@@ -373,7 +373,7 @@ namespace Exiv2 {
                         throw Error(kerImageWriteFailed);
                     ul2Data(data, static_cast<uint32_t>(iccProfile_.size()), littleEndian);
                     if (outIo.write(data, WEBP_TAG_SIZE) != WEBP_TAG_SIZE) throw Error(kerImageWriteFailed);
-                    if (outIo.write(iccProfile_.c_data(0), iccProfile_.size()) != iccProfile_.size()) {
+                    if (outIo.write(iccProfile_.c_data(), iccProfile_.size()) != iccProfile_.size()) {
                         throw Error(kerImageWriteFailed);
                     }
                     has_icc = false;
@@ -385,11 +385,11 @@ namespace Exiv2 {
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP)) {
                 // Skip and add new data afterwards
             } else {
-                if (outIo.write(chunkId.c_data(0), WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
+                if (outIo.write(chunkId.c_data(), WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
                     throw Error(kerImageWriteFailed);
                 if (outIo.write(size_buff, WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
                     throw Error(kerImageWriteFailed);
-                if (outIo.write(payload.c_data(0), payload.size()) != payload.size())
+                if (outIo.write(payload.c_data(), payload.size()) != payload.size())
                     throw Error(kerImageWriteFailed);
             }
 
@@ -471,15 +471,15 @@ namespace Exiv2 {
             while (!io_->eof() && static_cast<uint64_t>(io_->tell()) < filesize) {
                 auto offset = static_cast<uint64_t>(io_->tell());
                 byte     size_buff[WEBP_TAG_SIZE];
-                io_->read(chunkId.data(0), WEBP_TAG_SIZE);
+                io_->read(chunkId.data(), WEBP_TAG_SIZE);
                 io_->read(size_buff, WEBP_TAG_SIZE);
                 long size = Exiv2::getULong(size_buff, littleEndian);
                 DataBuf payload(offset?size:WEBP_TAG_SIZE); // header is different from chunks
-                io_->read(payload.data(0), payload.size());
+                io_->read(payload.data(), payload.size());
 
                 if ( bPrint ) {
                     out << Internal::indent(depth)
-                        << Internal::stringFormat("  %s | %8u | %8u | ", chunkId.c_str(0),
+                        << Internal::stringFormat("  %s | %8u | %8u | ", chunkId.c_str(),
                                                   static_cast<uint32_t>(size), static_cast<uint32_t>(offset))
                         << Internal::binaryToString(makeSlice(payload, 0, payload.size() > 32 ? 32 : payload.size()))
                         << std::endl;
@@ -487,7 +487,7 @@ namespace Exiv2 {
 
                 if ( equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
                     // create memio object with the payload, then print the structure
-                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.c_data(0),payload.size()));
+                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.c_data(),payload.size()));
                     printTiffStructure(*p,out,option,depth);
                 }
 
@@ -495,7 +495,7 @@ namespace Exiv2 {
                                   || (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_ICCP) && option==kpsIccProfile)
                                    ;
                 if ( bPrintPayload ) {
-                    out.write(payload.c_str(0), payload.size());
+                    out.write(payload.c_str(), payload.size());
                 }
 
                 if ( offset && io_->tell() % 2 ) io_->seek(+1, BasicIo::cur); // skip padding byte on sub-chunks
@@ -546,7 +546,7 @@ namespace Exiv2 {
 
         chunkId.write_uint8(4, '\0');
         while (!io_->eof() && io_->tell() < filesize) {
-            readOrThrow(*io_, chunkId.data(0), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            readOrThrow(*io_, chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
             readOrThrow(*io_, size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
 
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
@@ -568,7 +568,7 @@ namespace Exiv2 {
                 has_canvas_data = true;
                 byte size_buf[WEBP_TAG_SIZE];
 
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf, payload.c_data(4), 3);
@@ -583,7 +583,7 @@ namespace Exiv2 {
                 enforce(size >= 10, Exiv2::kerCorruptedMetadata);
 
                 has_canvas_data = true;
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
                 byte size_buf[WEBP_TAG_SIZE];
 
                 // Fetch width""
@@ -604,7 +604,7 @@ namespace Exiv2 {
                 byte size_buf_w[2];
                 byte size_buf_h[3];
 
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf_w, payload.c_data(1), 2);
@@ -622,7 +622,7 @@ namespace Exiv2 {
                 has_canvas_data = true;
                 byte size_buf[WEBP_TAG_SIZE];
 
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf, payload.c_data(6), 3);
@@ -634,10 +634,10 @@ namespace Exiv2 {
                 size_buf[3] = 0;
                 pixelHeight_ = Exiv2::getULong(size_buf, littleEndian) + 1;
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_ICCP)) {
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
                 this->setIccProfile(payload);
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF)) {
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 byte  size_buff2[2];
                 // 4 meaningful bytes + 2 padding bytes
@@ -649,22 +649,22 @@ namespace Exiv2 {
                 bool  s_header = false;
                 bool  le_header = false;
                 bool  be_header = false;
-                long pos = getHeaderOffset(payload.c_data(0), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 4);
+                long pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 4);
 
                 if (pos == -1) {
-                    pos = getHeaderOffset(payload.c_data(0), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 6);
+                    pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 6);
                     if (pos != -1) {
                         s_header = true;
                     }
                 }
                 if (pos == -1) {
-                    pos = getHeaderOffset(payload.c_data(0), payload.size(), reinterpret_cast<byte*>(&exifTiffLEHeader), 3);
+                    pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifTiffLEHeader), 3);
                     if (pos != -1) {
                         le_header = true;
                     }
                 }
                 if (pos == -1) {
-                    pos = getHeaderOffset(payload.c_data(0), payload.size(), reinterpret_cast<byte*>(&exifTiffBEHeader), 4);
+                    pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifTiffBEHeader), 4);
                     if (pos != -1) {
                         be_header = true;
                     }
@@ -693,11 +693,11 @@ namespace Exiv2 {
                     rawExifData.copyBytes(6, reinterpret_cast<char*>(&exifShortHeader), 6);
                 }
 
-                rawExifData.copyBytes(offset, payload.c_data(0), payload.size());
+                rawExifData.copyBytes(offset, payload.c_data(), payload.size());
 
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Display Hex Dump [size:" << static_cast<unsigned long>(sizePayload) << "]" << std::endl;
-                std::cout << Internal::binaryToHex(rawExifData.c_data(0), sizePayload);
+                std::cout << Internal::binaryToHex(rawExifData.c_data(), sizePayload);
 #endif
 
                 if (pos != -1) {
@@ -715,8 +715,8 @@ namespace Exiv2 {
                     exifData_.clear();
                 }
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP)) {
-                readOrThrow(*io_, payload.data(0), payload.size(), Exiv2::kerCorruptedMetadata);
-                xmpPacket_.assign(payload.c_str(0), payload.size());
+                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                xmpPacket_.assign(payload.c_str(), payload.size());
                 if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
                     EXV_WARNING << "Failed to decode XMP metadata." << std::endl;
@@ -725,7 +725,7 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cout << "Display Hex Dump [size:" << static_cast<unsigned long>(payload.size()) << "]"
                               << std::endl;
-                    std::cout << Internal::binaryToHex(payload.c_data(0), payload.size());
+                    std::cout << Internal::binaryToHex(payload.c_data(), payload.size());
 #endif
                 }
             } else {
@@ -837,7 +837,7 @@ namespace Exiv2 {
                 throw Error(kerImageWriteFailed);
             if (iIo.write(size_buff, WEBP_TAG_SIZE) != WEBP_TAG_SIZE)
                 throw Error(kerImageWriteFailed);
-            if (iIo.write(iccProfile_.c_data(0), iccProfile_.size()) != iccProfile_.size())
+            if (iIo.write(iccProfile_.c_data(), iccProfile_.size()) != iccProfile_.size())
                 throw Error(kerImageWriteFailed);
             if (iIo.tell() % 2) {
                 if (iIo.write(&WEBP_PAD_ODD, 1) != 1) throw Error(kerImageWriteFailed);

--- a/unitTests/test_cr2header_int.cpp
+++ b/unitTests/test_cr2header_int.cpp
@@ -38,8 +38,8 @@ TEST(ACr2Header, sizeIs16Bytes)
 {
     Internal::Cr2Header header;
     DataBuf buffer = header.write();
-    ASSERT_EQ(header.size(), buffer.size_);
-    ASSERT_EQ(0, memcmp(cr2LittleEndian, buffer.pData_, 16));
+    ASSERT_EQ(header.size(), buffer.size());
+    ASSERT_EQ(0, buffer.cmpBytes(0, cr2LittleEndian, 16));
 }
 
 

--- a/unitTests/test_tiffheader.cpp
+++ b/unitTests/test_tiffheader.cpp
@@ -43,7 +43,7 @@ TEST_F(ATiffHeader, hasExpectedValuesAfterCreation)
 TEST_F(ATiffHeader, canBeWrittenAndItsSizeIs8Bytes)
 {
     DataBuf buffer = header.write();
-    ASSERT_EQ(header.size(), buffer.size_);
+    ASSERT_EQ(header.size(), buffer.size());
     ASSERT_EQ(8U, header.size());
 }
 

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -47,15 +47,15 @@ TEST(ExivTime, doesNotGetTimeWithBadFormedString)
 TEST(DataBuf, pointsToNullByDefault)
 {
     DataBuf instance;
-    ASSERT_EQ(nullptr, instance.pData_);
-    ASSERT_EQ(0,    instance.size_);
+    ASSERT_EQ(nullptr, instance.c_data(0));
+    ASSERT_EQ(0,    instance.size());
 }
 
 TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
 {
     DataBuf instance (5);
-    ASSERT_NE(static_cast<byte *>(nullptr), instance.pData_);  /// \todo use nullptr once we move to c++11
-    ASSERT_EQ(5,    instance.size_);
+    ASSERT_NE(static_cast<byte *>(nullptr), instance.c_data(0));  /// \todo use nullptr once we move to c++11
+    ASSERT_EQ(5,    instance.size());
 }
 
 TEST(Rational, floatToRationalCast)

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -58,6 +58,39 @@ TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
     ASSERT_EQ(5,    instance.size());
 }
 
+// Test methods like DataBuf::read_uint32 and DataBuf::write_uint32.
+TEST(DataBuf, read_write_endianess)
+{
+    DataBuf buf(4 + 1 + 2 + 4 + 8);
+    buf.clear();
+
+    // Big endian.
+    buf.write_uint8(4, 0x01);
+    buf.write_uint16(4 + 1, 0x0203, bigEndian);
+    buf.write_uint32(4 + 1 + 2, 0x04050607, bigEndian);
+    buf.write_uint64(4 + 1 + 2 + 4, 0x08090a0b0c0d0e0fULL, bigEndian);
+    static const uint8_t expected_le[4 + 1 + 2 + 4 + 8] =
+        {0, 0, 0, 0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
+    ASSERT_EQ(0, buf.cmpBytes(0, expected_le, buf.size()));
+    ASSERT_EQ(buf.read_uint8(4), 0x01);
+    ASSERT_EQ(buf.read_uint16(4 + 1, bigEndian), 0x0203);
+    ASSERT_EQ(buf.read_uint32(4 + 1 + 2, bigEndian), 0x04050607);
+    ASSERT_EQ(buf.read_uint64(4 + 1 + 2 + 4, bigEndian), 0x08090a0b0c0d0e0fULL);
+
+    // Little endian.
+    buf.write_uint8(4, 0x01);
+    buf.write_uint16(4 + 1, 0x0203, littleEndian);
+    buf.write_uint32(4 + 1 + 2, 0x04050607, littleEndian);
+    buf.write_uint64(4 + 1 + 2 + 4, 0x08090a0b0c0d0e0fULL, littleEndian);
+    static const uint8_t expected_be[4 + 1 + 2 + 4 + 8] =
+        {0, 0, 0, 0, 0x1, 0x3, 0x2, 0x7, 0x6, 0x5, 0x4, 0xf, 0xe, 0xd, 0xc, 0xb, 0xa, 0x9, 0x8};
+    ASSERT_EQ(0, buf.cmpBytes(0, expected_be, buf.size()));
+    ASSERT_EQ(buf.read_uint8(4), 0x01);
+    ASSERT_EQ(buf.read_uint16(4 + 1, littleEndian), 0x0203);
+    ASSERT_EQ(buf.read_uint32(4 + 1 + 2, littleEndian), 0x04050607);
+    ASSERT_EQ(buf.read_uint64(4 + 1 + 2 + 4, littleEndian), 0x08090a0b0c0d0e0fULL);
+}
+
 TEST(Rational, floatToRationalCast)
 {
     static const float floats[] = {0.5F, 0.015F, 0.0000625F};

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -47,14 +47,14 @@ TEST(ExivTime, doesNotGetTimeWithBadFormedString)
 TEST(DataBuf, pointsToNullByDefault)
 {
     DataBuf instance;
-    ASSERT_EQ(nullptr, instance.c_data(0));
+    ASSERT_EQ(nullptr, instance.c_data());
     ASSERT_EQ(0,    instance.size());
 }
 
 TEST(DataBuf, allocatesDataWithNonEmptyConstructor)
 {
     DataBuf instance (5);
-    ASSERT_NE(static_cast<byte *>(nullptr), instance.c_data(0));  /// \todo use nullptr once we move to c++11
+    ASSERT_NE(static_cast<byte *>(nullptr), instance.c_data());  /// \todo use nullptr once we move to c++11
     ASSERT_EQ(5,    instance.size());
 }
 


### PR DESCRIPTION
This a refactoring change to tidy the `DataBuf` class. I made the `pData_` and `size_` fields private and added a few new methods which you can use to read and write the data.