### PR TITLE
Lock conan version on Windows.

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind ninja-build
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |
@@ -140,7 +140,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind doxygen graphviz gettext
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install conan
+          pip.exe install "conan==1.39.0"
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default
           conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install conan
+          pip.exe install "conan==1.39.0"
           conan profile new --detect default
           conan profile show default
 
@@ -64,7 +64,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan
         run: |

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install gettext
           sudo apt-get install doxygen
           sudo apt-get install graphviz
-          pip3 install conan==1.36.0
+          pip3 install conan==1.39.0
 
       - name: Conan common config
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install conan
+          pip.exe install "conan==1.39.0"
           conan profile new --detect default
           conan profile update settings.build_type=Release default
           conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache


### PR DESCRIPTION
The recent release of [Conan version 1.40](https://github.com/conan-io/conan/releases/tag/1.40.0) broke our Windows builds. I believe [this change](https://github.com/conan-io/conan/pull/9401) is responsible. As a short term fix, I think the best solution is to use Conan version 1.39.0. It turns out we were already locking the conan version to 1.36.0 on every platform except Windows, which is why the build only broke on Windows. This PR locks the version to 1.39.0 on all platforms.