### PR TITLE
Remove unused constructor that was causing a build failure in OSS-Fuzz

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -685,13 +685,6 @@ namespace Exiv2 {
          */
         static XmpArrayType xmpArrayType(TypeId typeId);
 
-    protected:
-        /*!
-          @brief Assignment operator. Protected so that it can only be used
-                 by subclasses but not directly.
-         */
-        XmpValue& operator=(const XmpValue& rhs) = default;
-
     private:
         // DATA
         XmpArrayType xmpArrayType_;             //!< Type of XMP array


### PR DESCRIPTION
This fixes a [build failure in OSS-Fuzz](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38491):

```
Step #3 - "compile-afl-address-x86_64": In file included from /src/exiv2/src/value.cpp:22:
--
  | Step #3 - "compile-afl-address-x86_64": /src/exiv2/include/exiv2/value.hpp:693:19: error: definition of implicit copy constructor for 'XmpValue' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
  | Step #3 - "compile-afl-address-x86_64":         XmpValue& operator=(const XmpValue& rhs) = default;
  | Step #3 - "compile-afl-address-x86_64":                   ^
  | Step #3 - "compile-afl-address-x86_64": /src/exiv2/include/exiv2/value.hpp:709:20: note: in implicit copy constructor for 'Exiv2::XmpValue' first required here
  | Step #3 - "compile-afl-address-x86_64":     class EXIV2API XmpTextValue : public XmpValue {
  | Step #3 - "compile-afl-address-x86_64":                    ^
  | Step #3 - "compile-afl-address-x86_64": /src/exiv2/src/value.cpp:707:20: note: in implicit copy constructor for 'Exiv2::XmpTextValue' first required here
  | Step #3 - "compile-afl-address-x86_64":         return new XmpTextValue(*this);
  | Step #3 - "compile-afl-address-x86_64":                    ^
  | Step #3 - "compile-afl-address-x86_64": [ 48%] Building CXX object src/CMakeFiles/exiv2lib.dir/pngimage.cpp.o
  | Step #3 - "compile-afl-address-x86_64": 1 error generated.
  | Step #3 - "compile-afl-address-x86_64": make[2]: *** [src/CMakeFiles/exiv2lib.dir/build.make:524: src/CMakeFiles/exiv2lib.dir/value.cpp.o] Error 1
  | Step #3 - "compile-afl-address-x86_64": make[2]: *** Waiting for unfinished jobs....
  | Step #3 - "compile-afl-address-x86_64": make[1]: *** [CMakeFiles/Makefile2:1089: src/CMakeFiles/exiv2lib.dir/all] Error 2
  | Step #3 - "compile-afl-address-x86_64": make: *** [Makefile:146: all] Error 2
```

I am not able to reproduce this myself. I guess OSS-Fuzz are using  a new version of the compiler with stricter warnings.

This constructor declaration is unused, so we can just remove it.

I checked that this constructor declaration is unused with this query:

```
/**
 * @kind problem
 */

// OSS-Fuzz build failure.
// https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38491
// Check that the constructor declaration isn't used anywhere.
import cpp

from ConstructorCall call, Constructor c, Constructor d
where
  c.getName() = "XmpValue" and
  c.getParameter(0).getType() instanceof ReferenceType and
  d.overrides*(c) and
  d = call.getTarget()
select call, "contructor call"
```

Results of the query are [here](https://lgtm.com/query/7537427231751372770/).