### PR TITLE
Annotate some strings with xgettext:no-c-format

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -2080,6 +2080,7 @@ namespace Exiv2 {
                                                 N_("A decimal representation of the precision of the coordinates given in the decimalLatitude and decimalLongitude.")
             },
             { "pointRadiusSpatialFit",          N_("Point Radius Spatial Fit"),              "Real",      xmpText,   xmpExternal,
+                                                /* xgettext:no-c-format */
                                                 N_("The ratio of the area of the point-radius (decimalLatitude, decimalLongitude, coordinateUncertaintyInMeters) to the area of the true (original, or most specific) spatial representation of the Location. Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given point-radius does not completely contain the original representation. The pointRadiusSpatialFit is undefined (and should be left blank) if the original representation is a point without uncertainty and the given georeference is not that same point (without uncertainty). If both the original and the given georeference are the same point, the pointRadiusSpatialFit is 1.")
             },
             { "footprintWKT",                   N_("Footprint WKT"),                         "Text",      xmpText,    xmpExternal,
@@ -2089,6 +2090,7 @@ namespace Exiv2 {
                                                 N_("A Well-Known Text (WKT) representation of the Spatial Reference System (SRS) for the footprintWKT of the Location. Do not use this term to describe the SRS of the decimalLatitude and decimalLongitude, even if it is the same as for the footprintWKT - use the geodeticDatum instead.")
             },
             { "footprintSpatialFit",            N_("Footprint Spatial Fit"),                "Real",      xmpText,    xmpExternal,
+                                                /* xgettext:no-c-format */
                                                 N_("The ratio of the area of the footprint (footprintWKT) to the area of the true (original, or most specific) spatial representation of the Location. Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given footprint does not completely contain the original representation. The footprintSpatialFit is undefined (and should be left blank) if the original representation is a point and the given georeference is not that same point. If both the original and the given georeference are the same point, the footprintSpatialFit is 1.")
             },
             { "georeferencedBy",                N_("Georeferenced By"),                     "bag Text",     xmpBag,   xmpExternal,

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -716,6 +716,7 @@ namespace Exiv2 {
                 N_("The number of inks. Usually equal to SamplesPerPixel, unless there are extra samples."),
                 ifd0Id, imgStruct, unsignedShort, 1, printValue}, // TIFF tag
         {0x0150, "DotRange", N_("Dot Range"),
+                /* xgettext:no-c-format */
                 N_("The component values that correspond to a 0% dot and 100% dot."),
                 ifd0Id, imgStruct, unsignedByte, -1, printValue}, // TIFF tag
         {0x0151, "TargetPrinter", N_("Target Printer"),


### PR DESCRIPTION
Some descriptions of location properties contain the text "100%
overlap".  When extracting text for translation, `xgettext`
misidentifies this as containing the C format string "% o", and tags it
as `c-format`.  Translation tools that are sensitive to this will
require that translations contain matching format strings; since in this
case the format string is nonsensical, that is often not reasonably
possible.  See:

  https://answers.launchpad.net/launchpad/+question/698762

The description of the DotRange tag contains the text "0% dot and 100%
dot", which is similarly misidentified.

To fix this, inform `xgettext` that the messages do not contain C format
strings, as documented here (towards the end):

  https://www.gnu.org/software/gettext/manual/html_node/c_002dformat-Flag.html