### PR TITLE
Pass `-fstack-protector-strong` to linker

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -48,6 +48,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
             endif()
             if(BUILD_WITH_STACK_PROTECTOR AND HAS_FSTACK_PROTECTOR_STRONG)
                 add_compile_options(-fstack-protector-strong)
+                add_link_options(-fstack-protector-strong)
             endif()
         endif()
 


### PR DESCRIPTION
Fixes some older compiler / platform combinations (e.g. GCC7 on PPC Mac)