### PR TITLE
Explicitly test for libproc.h

### DIFF
--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -41,6 +41,9 @@
 // Define if you have the munmap function.
 #cmakedefine EXV_HAVE_MUNMAP
 
+/* Define if you have the <libproc.h> header file. */
+#cmakedefine EXV_HAVE_LIBPROC_H
+
 /* Define if you have the <unistd.h> header file. */
 #cmakedefine EXV_HAVE_UNISTD_H
 

--- a/cmake/generateConfigFile.cmake
+++ b/cmake/generateConfigFile.cmake
@@ -36,6 +36,7 @@ int main() {
     return 0;
 }" EXV_STRERROR_R_CHAR_P )
 
+check_include_file_cxx( "libproc.h"     EXV_HAVE_LIBPROC_H )
 check_include_file_cxx( "unistd.h"      EXV_HAVE_UNISTD_H )
 check_include_file_cxx( "sys/mman.h"    EXV_HAVE_SYS_MMAN_H )
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -48,8 +48,7 @@
 #if defined(_MSC_VER)
 #define S_ISREG(m)      (((m) & S_IFMT) == S_IFREG)
 #elif defined(__APPLE__)
-#include <Targetconditionals.h>
-#ifndef TARGET_OS_IPHONE
+#if defined(EXV_HAVE_LIBPROC_H)
 #include <libproc.h>
 #endif
 #endif
@@ -458,7 +457,7 @@ namespace Exiv2 {
             CloseHandle(processHandle);
         }
     #elif defined(__APPLE__)
-    #ifndef TARGET_OS_IPHONE
+    #ifdef EXV_HAVE_LIBPROC_H
         const int pid = getpid();
         char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
         if (proc_pidpath (pid, pathbuf, sizeof(pathbuf)) > 0) {


### PR DESCRIPTION
This change adds support for ancient macOS lacking libproc. It also eliminates a bug where exiv2 could not be built on case-sensitive file systems (the header file is properly `TargetConditionals.h`, not `Targetconditionals.h`).