### PR TITLE
Add SonyMisc(2b|3c) Groups for Sony TIFF files

### DIFF
--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1231,8 +1231,16 @@ namespace Exiv2 {
     {
         // From Exiftool: https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/Sony.pm
         // >  First byte must be 9 or 12 or 13 or 15 or 16 and 4th byte must be 2 (deciphered)
-        const auto value = getExifValue(pRoot, 0x9404, Exiv2::Internal::sony1Id);
-        if (!value || value->count() < 4)
+
+        // Get the value from the image format that is being used
+        auto value = getExifValue(pRoot, 0x9404, Exiv2::Internal::sony1Id);
+        if (!value) {
+            value = getExifValue(pRoot, 0x9404, Exiv2::Internal::sony2Id);
+            if (!value)
+                return -1;
+        }
+
+        if (value->count() < 4)
             return -1;
 
         switch (value->toLong(0)) {                // Using encrypted values
@@ -1251,8 +1259,16 @@ namespace Exiv2 {
     {
         // From Exiftool (Tag 9400c): https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/Sony.pm
         // >  first byte decoded: 62, 48, 215, 28, 106 respectively
-        const auto value = getExifValue(pRoot, 0x9400, Exiv2::Internal::sony1Id);
-        if (!value || value->count() < 1)
+
+        // Get the value from the image format that is being used
+        auto value = getExifValue(pRoot, 0x9400, Exiv2::Internal::sony1Id);
+        if (!value) {
+            value = getExifValue(pRoot, 0x9400, Exiv2::Internal::sony2Id);
+            if (!value)
+                return -1;
+        }
+
+        if (value->count() < 1)
             return -1;
 
         switch (value->toLong()) {    // Using encrypted values

--- a/tests/bugfixes/github/test_pr_1792.py
+++ b/tests/bugfixes/github/test_pr_1792.py
@@ -4,17 +4,24 @@ from system_tests import CaseMeta, path
 
 class SonyMisc2bTestSupported(metaclass=CaseMeta):
 
-    filename = path("$data_path/test_issue_1464.exv")
-    commands = ["$exiv2 -pa --grep SonyMisc2b $filename"]
+# Check that JPEG and TIFF based formats work
+    filenames = [path("$data_path/test_issue_1464.exv"),  # JPEG
+                 path("$data_path/exiv2-bug1153Aa.exv")]  # TIFF
+    commands = ["$exiv2 -pa --grep SonyMisc2b {!s}".format(fname) for fname in filenames]
 
     stdout = ["""Exif.SonyMisc2b.ExposureProgram              Byte        1  Shutter speed priority AE
 Exif.SonyMisc2b.IntelligentAuto              Byte        1  Off
 Exif.SonyMisc2b.LensZoomPosition             Short       1  100%
 Exif.SonyMisc2b.FocusPosition2               Byte        1  0
+""",
+"""Exif.SonyMisc2b.ExposureProgram              Byte        1  Aperture-priority AE
+Exif.SonyMisc2b.IntelligentAuto              Byte        1  Off
+Exif.SonyMisc2b.LensZoomPosition             Short       1  0%
+Exif.SonyMisc2b.FocusPosition2               Byte        1  0
 """
     ]
-    stderr = [""]
-    retval = [0]
+    stderr = [""] *2
+    retval = [0] *2
 
 # An example of a Sony camera model that does NOT support SonyMisc2b
 class SonyMisc2bTestUnsupported(metaclass=CaseMeta):
@@ -22,7 +29,6 @@ class SonyMisc2bTestUnsupported(metaclass=CaseMeta):
     filename = path("$data_path/exiv2-pr906.exv")
     commands = ["$exiv2 -pa --grep SonyMisc2b $filename"]
 
-    stdout = [""""""
-    ]
+    stdout = [""]
     stderr = [""]
     retval = [1]

--- a/tests/bugfixes/github/test_pr_1800.py
+++ b/tests/bugfixes/github/test_pr_1800.py
@@ -5,8 +5,10 @@ from system_tests import CaseMeta, path
 #Full support for SonyMisc3c tags using this model
 class SonyMisc3cSupportedTest(metaclass=CaseMeta):
 
-    filename = path("$data_path/exiv2-SonyDSC-HX60V.exv")
-    commands = ["$exiv2 -pa --grep SonyMisc3c $filename"]
+# Check that JPEG and TIFF based formats work
+    filenames = [path("$data_path/exiv2-SonyDSC-HX60V.exv"),  # JPEG
+                 path("$data_path/exiv2-bug1153Aa.exv")]      # TIFF
+    commands = ["$exiv2 -pa --grep SonyMisc3c {!s}".format(fname) for fname in filenames]
 
     stdout = ["""Exif.SonyMisc3c.ReleaseMode2                 Byte        1  Normal
 Exif.SonyMisc3c.ShotNumberSincePowerUp       Long        1  4
@@ -18,10 +20,21 @@ Exif.SonyMisc3c.CameraOrientation            Byte        1  Horizontal (normal)
 Exif.SonyMisc3c.Quality2                     Byte        1  JPEG
 Exif.SonyMisc3c.SonyImageHeight              Short       1  3888
 Exif.SonyMisc3c.ModelReleaseYear             Byte        1  2014
+""",
+"""Exif.SonyMisc3c.ReleaseMode2                 Byte        1  Normal
+Exif.SonyMisc3c.ShotNumberSincePowerUp       Long        1  2
+Exif.SonyMisc3c.SequenceImageNumber          Long        1  1
+Exif.SonyMisc3c.SequenceLength1              Byte        1  1 shot
+Exif.SonyMisc3c.SequenceFileNumber           Long        1  1
+Exif.SonyMisc3c.SequenceLength2              Byte        1  1 file
+Exif.SonyMisc3c.CameraOrientation            Byte        1  Horizontal (normal)
+Exif.SonyMisc3c.Quality2                     Byte        1  Raw + JPEG
+Exif.SonyMisc3c.SonyImageHeight              Short       1  4000
+Exif.SonyMisc3c.ModelReleaseYear             Byte        1  2014
 """
     ]
-    stderr = [""]
-    retval = [0]
+    stderr = [""] *2
+    retval = [0] *2 
 
 #Partial support for SonyMisc3c tags using this model
 class SonyMisc3cPartiallySupportedTest(metaclass=CaseMeta):

--- a/tests/bugfixes/redmine/test_issue_1153.py
+++ b/tests/bugfixes/redmine/test_issue_1153.py
@@ -16,7 +16,7 @@ class CheckSony6000WithoutLensModels(metaclass=system_tests.CaseMeta):
     ]
 
     commands = [
-        "$exiv2 -pa -g Lens {!s}".format(fname) for fname in filenames
+        "$exiv2 -pa -g LensSpecification -g LensModel -g LensID {!s}".format(fname) for fname in filenames
     ]
 
     stdout = [


### PR DESCRIPTION
- Groups now support JPEG and TIFF formats
- Add regression testing
