### PR TITLE
Add conditions to 2 Sony temperature tags

### DIFF
--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -838,7 +838,7 @@ namespace Exiv2 {
 
     //! Sony Tag 9402 Sony2Fp (FocusPosition)
     constexpr TagInfo SonyMakerNote::tagInfoFp_[] = {
-        {  0x04, "AmbientTemperature", N_("Ambient temperature"), N_("Temperature of the surroundings (in degrees Celsius)"), sony2FpId, makerTags, signedByte, 1, printTemperatureInDegC},
+        {  0x04, "AmbientTemperature", N_("Ambient temperature"), N_("Temperature of the surroundings (in degrees Celsius)"), sony2FpId, makerTags, signedByte, 1, printSony2FpAmbientTemperature},
         {  0x16, "FocusMode"         , N_("Focus mode")         , N_("Focus mode")          , sony2FpId, makerTags, unsignedByte, 1, printSony2FpFocusMode},
         {  0x17, "AFAreaMode"        , N_("AF area mode")       , N_("Auto focus area mode"), sony2FpId, makerTags, unsignedByte, 1, EXV_PRINT_TAG(sony2FpAFAreaMode)},
         {  0x2d, "FocusPosition2"    , N_("Focus position 2")   , N_("Focus position 2")    , sony2FpId, makerTags, unsignedByte, 1, printSony2FpFocusPosition2},
@@ -849,6 +849,18 @@ namespace Exiv2 {
     const TagInfo* SonyMakerNote::tagListFp()
     {
         return tagInfoFp_;
+    }
+
+    std::ostream& SonyMakerNote::printSony2FpAmbientTemperature(std::ostream& os, const Value& value, const ExifData* metadata)
+    {
+        if (value.count() != 1)
+            return os << "(" << value << ")";
+
+        auto pos = metadata->findKey(ExifKey("Exif.Sony2Fp.0x0002"));
+        if (pos != metadata->end() && pos-> count() == 1 && pos->toLong() == 255)
+            return os << value << " °C";
+
+        return os << N_("n/a");
     }
 
     std::ostream& SonyMakerNote::printSony2FpFocusMode(std::ostream& os, const Value& value, const ExifData*)
@@ -914,7 +926,7 @@ namespace Exiv2 {
     constexpr TagInfo SonyMakerNote::tagInfoSonyMisc1_[] = {
         {0x05,  "CameraTemperature", N_("Camera temperature"),
         		N_("Internal camera temperature (in degrees Celsius)"),
-				sonyMisc1Id, makerTags, signedByte, -1, printTemperatureInDegC},
+				sonyMisc1Id, makerTags, signedByte, -1, printSonyMisc1CameraTemperature},
         // End of list marker
         {0xffff, "(UnknownSonyMisc1Tag)", "(UnknownSonyMisc1Tag)",
         		 "(UnknownSonyMisc1Tag)",
@@ -926,14 +938,16 @@ namespace Exiv2 {
         return tagInfoSonyMisc1_;
     }
 
-    std::ostream& SonyMakerNote::printTemperatureInDegC(std::ostream& os, const Value& value, const ExifData*)
+    std::ostream& SonyMakerNote::printSonyMisc1CameraTemperature(std::ostream& os, const Value& value, const ExifData* metadata)
     {
         if (value.count() != 1)
-            os << "(" << value << ")";
-        else
-            os << value << " °C";
+            return os << "(" << value << ")";
 
-        return os;
+        auto pos = metadata->findKey(ExifKey("Exif.SonyMisc1.0x0004"));
+        if (pos != metadata->end() && pos->count() == 1 && pos->toLong() != 0 && pos->toLong() < 100)
+            return os << value << " °C";
+
+        return os << N_("n/a");
     }
 
     //! Lookup table to translate Sony Exposure Program 3 values to readable labels

--- a/src/sonymn_int.hpp
+++ b/src/sonymn_int.hpp
@@ -62,12 +62,14 @@ namespace Exiv2 {
 
         //! @name Print functions for Sony %MakerNote tags
         //@{
+        //! Print Sony SonyMisc1 CameraTemperature values (in degrees Celsius)
+        static std::ostream& printSonyMisc1CameraTemperature(std::ostream&, const Value&, const ExifData*);
         //! Print Sony2Fp Focus Mode value
         static std::ostream& printSony2FpFocusMode(std::ostream&, const Value&, const ExifData*);
         //! Print Sony2Fp Focus Position 2 value
         static std::ostream& printSony2FpFocusPosition2(std::ostream&, const Value&, const ExifData* metadata);
-        //! Print Sony temperature values (in degrees Celsius)
-        static std::ostream& printTemperatureInDegC(std::ostream&, const Value&, const ExifData*);
+        //! Print Sony 2Fp AmbientTemperature values (in degrees Celsius)
+        static std::ostream& printSony2FpAmbientTemperature(std::ostream&, const Value&, const ExifData*);
         //! Print SonyMisc2b Lens Zoom Position value
         static std::ostream& printSonyMisc2bLensZoomPosition(std::ostream&, const Value&, const ExifData* metadata);
         //! Print SonyMisc2b Focus Position 2 value

--- a/tests/bugfixes/github/test_pr_1926.py
+++ b/tests/bugfixes/github/test_pr_1926.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+class Sony2FpAmbientTemperatureUnsupportedTagTest(metaclass=CaseMeta):
+
+    filename = path("$data_path/exiv2-bug1153Ja.exv")
+    commands = ["$exiv2 -pa --grep AmbientTemperature $filename"]
+
+    stdout = ["""Exif.Sony2Fp.AmbientTemperature              SByte       1  n/a
+"""
+    ]
+    stderr = [""]
+    retval = [0]
+
+class SonyMisc1CameraTemperatureUnsupportedTagTest(metaclass=CaseMeta):
+
+    filename = path("$data_path/exiv2-bug1145a.exv")
+    commands = ["$exiv2 -pa --grep SonyMisc1 $filename"]
+
+    stdout = ["""Exif.SonyMisc1.CameraTemperature             SByte       1  n/a
+"""
+    ]
+    stderr = [""]
+    retval = [0]


### PR DESCRIPTION
Only certain camera models are supported.

Changes:
- Add conditions to `Exif.Sony2Fp.AmbientTemperature` and `Exif.SonyMisc1.CameraTemperature`
- Add Python tests

Source: https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/Sony.pm