### PR TITLE
Update canonmn_int.cpp to correct lens "Canon EF 80-200mm f/4.5-5.6 II"

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -1667,7 +1667,7 @@ namespace Exiv2 {
         {   37, "Tamron AF 28-300mm f/3.5-6.3 XR Di VC LD Aspherical [IF] Macro"}, // 2
         {   37, "Tamron SP AF 17-50mm f/2.8 XR Di II VC LD Aspherical [IF]" }, // 3
         {   37, "Tamron AF 18-270mm f/3.5-6.3 Di II VC LD Aspherical [IF] Macro"}, // 4
-        {   38, "Canon EF 80-200mm f/4.5-5.6"                               },
+        {   38, "Canon EF 80-200mm f/4.5-5.6 II"                            },
         {   39, "Canon EF 75-300mm f/4-5.6"                                 },
         {   40, "Canon EF 28-80mm f/3.5-5.6"                                },
         {   41, "Canon EF 28-90mm f/4-5.6"                                  },


### PR DESCRIPTION
This PR corrects exiv2 lens identification for "Canon EF 80-200mm f/4.5-5.6 II" 
Canon Exif.CanonCs.LensType IDs 28 and 38 both get reported as Canon EF 80-200mm f/4.5-5.6

See: https://github.com/Exiv2/exiv2/issues/1906

I have raised an issue with lensfun to correct their database and consider how they determine the lens from the metadata which Exiv2 parses correctly.
https://github.com/lensfun/lensfun/issues/1484

