### PR TITLE
Add workaround for conan outage.

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default
           conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 
@@ -68,6 +69,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 
@@ -106,6 +108,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 
@@ -144,6 +147,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install Conan & Common config
         run: |
           pip.exe install "conan==1.39.0"
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default
           conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install Conan & Common config
         run: |
           pip.exe install "conan==1.39.0"
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile show default
 
@@ -69,6 +70,7 @@ jobs:
       - name: Conan
         run: |
           mkdir build && cd build
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
           conan profile show default

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.compiler.libcxx=libstdc++11 default
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Conan common config
         run: |
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=Release default
           conan profile update settings.compiler.libcxx=libstdc++11 default
@@ -115,6 +116,7 @@ jobs:
       - name: Install Conan & Common config
         run: |
           pip.exe install "conan==1.39.0"
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=Release default
           conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ install:
     - cd %APPVEYOR_BUILD_FOLDER%
 
 before_build:
+    - cmd: conan config install https://github.com/conan-io/conanclientcert.git
     - cmd: conan remote list
     - cmd: conan config set storage.path=c:\Users\appveyor\conanCache
     - cmd: conan profile new --detect default

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -32,6 +32,7 @@ else
 fi
 
 conan --version
+conan config install https://github.com/conan-io/conanclientcert.git
 conan config set storage.path=~/conanData
 conan profile new default --detect
 


### PR DESCRIPTION
Our CI [stopped working](https://github.com/Exiv2/exiv2/issues/1935#issuecomment-931532052) due to a [conan outage](https://github.com/conan-io/conan/issues/9695). According to [this comment](https://github.com/conan-io/conan/issues/9695#issuecomment-931406912), the workaround is to add this to the CI scripts:

```bash
conan config install https://github.com/conan-io/conanclientcert.git
```