### PR TITLE
Hide "static constexpr auto" from SWIG

### DIFF
--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -332,8 +332,9 @@ namespace Exiv2 {
         IptcKey* clone_() const override;
 
         // DATA
+#ifndef SWIG
         static constexpr auto familyName_ = "Iptc";
-
+#endif
         uint16_t tag_;                 //!< Tag value
         uint16_t record_;              //!< Record value
         std::string key_;              //!< Key


### PR DESCRIPTION
I'm using SWIG to generate a Python interface to libexiv2 (https://github.com/jim-easterbrook/python-exiv2). SWIG can't parse "static constexpr auto" at present (https://github.com/swig/swig/issues/1125). This patch hides the "static constexpr auto" expression from SWIG. It should have no unpleasant side effects.