### PR TITLE
Fix integer overflow in leap year calculation

### DIFF
--- a/test/data/issue_1954_poc.xmp
+++ b/test/data/issue_1954_poc.xmp
@@ -1,0 +1,1 @@
+<x:xmpmeta xmlns:x=" "><rdf:RDF xmlns:rdf=" "><rdf:Description xmlns:xmp="x"><xmp:CreateDate>-9223372036854775807-3</xmp:CreateDate></rdf:Description></rdf:RDF></x:xmpmeta>

--- a/tests/bugfixes/github/test_issue_1954.py
+++ b/tests/bugfixes/github/test_issue_1954.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+class XMPUtilsLeapYearOverflow(metaclass=CaseMeta):
+    """
+    Regression test for the bug described in:
+    https://github.com/Exiv2/exiv2/issues/1954
+    """
+    url = "https://github.com/Exiv2/exiv2/issues/1954"
+
+    filename = path("$data_path/issue_1954_poc.xmp")
+    commands = ["$exiv2 -q $filename"]
+    stderr = ["""$filename: No Exif data found in the file
+"""]
+    stdout = ["""File name       : $filename
+File size       : 172 Bytes
+MIME type       : application/rdf+xml
+Image size      : 0 x 0
+"""]
+    retval = [253]

--- a/xmpsdk/src/XMPUtils.cpp
+++ b/xmpsdk/src/XMPUtils.cpp
@@ -174,8 +174,8 @@ XMP_VarString * sExtendedDigest = 0;
 static bool
 IsLeapYear ( long year )
 {
-
-	if ( year < 0 ) year = -year + 1;		// Fold the negative years, assuming there is a year 0.
+	// This code uses the Gregorian calendar algorithm:
+	// https://en.wikipedia.org/wiki/Leap_year#Algorithm
 
 	if ( (year % 4) != 0 ) return false;	// Not a multiple of 4.
 	if ( (year % 100) != 0 ) return true;	// A multiple of 4 but not a multiple of 100.


### PR DESCRIPTION
Fixes: #1954

Credit to OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39555

This code looks completely bogus to me. I can't find any reference online that says that negative years should be treated different in a leap year calculation. So the simplest solution to the integer overflow bug is to comment this code out.