### PR TITLE
Fix macOS build failure

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -31,12 +31,10 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
 
 
     if (COMPILER_IS_GCC OR COMPILER_IS_CLANG)
-        # This fails under Fedora - MinGW - Gcc 8.3 and macOS/M1
+        # This fails under Fedora - MinGW - Gcc 8.3
         if (NOT (MINGW OR CYGWIN OR CMAKE_HOST_SOLARIS))
-            # macOS M1 will set ARCHITECTURE == arm64
-            EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
-            if ( NOT ${ARCHITECTURE} STREQUAL arm64 )
-                check_cxx_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
+            if (NOT APPLE) # Don't know why this isn't working correctly on Apple with M1 processor
+            check_cxx_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
             endif()
             check_cxx_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
             check_cxx_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -34,7 +34,7 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
         # This fails under Fedora - MinGW - Gcc 8.3
         if (NOT (MINGW OR CYGWIN OR CMAKE_HOST_SOLARIS))
             if (NOT APPLE) # Don't know why this isn't working correctly on Apple with M1 processor
-            check_cxx_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
+                check_cxx_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
             endif()
             check_cxx_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
             check_cxx_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)


### PR DESCRIPTION
Builds have started failing on macOS. See for example #1958.

This problem originally only affected Macs with the M1 chip, but I guess it has now spread to the Intel machines too.

This commit reverts #1857, which limited the workaround to just M1 machines. I think we need to go back to applying the workaround to all Macs.