### PR TITLE
Add readOrThrow and seekOrThrow to BasicIo

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -27,6 +27,7 @@
 #include "exiv2lib_export.h"
 
 // included header files
+#include "error.hpp"
 #include "types.hpp"
 
 // + standard includes
@@ -143,6 +144,17 @@ namespace Exiv2 {
          */
         virtual long read(byte* buf, long rcount) = 0;
         /*!
+          @brief Safe version of `read()` that checks for errors and throws
+              an exception if the read was unsuccessful.
+          @param buf Pointer to a block of memory into which the read data
+              is stored. The memory block must be at least \em rcount bytes
+              long.
+          @param rcount Maximum number of bytes to read. Fewer bytes may be
+              read if \em rcount bytes are not available.
+          @param err Error code to use if an exception is thrown.
+         */
+        void readOrThrow(byte* buf, long rcount, ErrorCode err);
+        /*!
           @brief Read one byte from the IO source. Current IO position is
               advanced by one byte.
           @return The byte read from the IO source if successful;<BR>
@@ -175,6 +187,19 @@ namespace Exiv2 {
         virtual int seek(int64_t offset, Position pos) = 0;
 #else
         virtual int seek(long offset, Position pos) = 0;
+#endif
+        /*!
+          @brief Safe version of `seek()` that checks for errors and throws
+              an exception if the seek was unsuccessful.
+          @param offset Number of bytes to move the position relative
+              to the starting position specified by \em pos
+          @param pos Position from which the seek should start
+          @param err Error code to use if an exception is thrown.
+         */
+#if defined(_MSC_VER)
+        void seekOrThrow(int64_t offset, Position pos, ErrorCode err);
+#else
+        void seekOrThrow(long offset, Position pos, ErrorCode err);
 #endif
 
         /*!

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -28,6 +28,7 @@
 #include "futils.hpp"
 #include "types.hpp"
 #include "error.hpp"
+#include "enforce.hpp"
 #include "http.hpp"
 #include "properties.hpp"
 #include "image_int.hpp"
@@ -77,6 +78,21 @@ using nlink_t = short;
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
+    void BasicIo::readOrThrow(byte* buf, long rcount, ErrorCode err) {
+        const long nread = read(buf, rcount);
+        enforce(nread == rcount, err);
+        enforce(!error(), err);
+    }
+
+#if defined(_MSC_VER)
+    void BasicIo::seekOrThrow(int64_t offset, Position pos, ErrorCode err) {
+#else
+    void BasicIo::seekOrThrow(long offset, Position pos, ErrorCode err) {
+#endif
+        const int r = seek(offset, pos);
+        enforce(r == 0, err);
+    }
+
     //! Internal Pimpl structure of class FileIo.
     class FileIo::Impl {
     public:

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -138,16 +138,6 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-    // BasicIo::read() with error checking
-    static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-        iIo.readOrThrow(buf, rcount, err);
-    }
-
-    // BasicIo::seek() with error checking
-    static void seekOrThrow(BasicIo& iIo, long offset, BasicIo::Position pos, ErrorCode err) {
-        iIo.seekOrThrow(offset, pos, err);
-    }
-
     Image::Image(int imageType, uint16_t supportedMetadata, BasicIo::UniquePtr io)
         : io_(std::move(io)),
           pixelWidth_(0),
@@ -339,8 +329,8 @@ namespace Exiv2 {
 
         do {
             // Read top of directory
-            seekOrThrow(io, start, BasicIo::beg, kerCorruptedMetadata);
-            readOrThrow(io, dir.data(), 2, kerCorruptedMetadata);
+            io.seekOrThrow(start, BasicIo::beg, kerCorruptedMetadata);
+            io.readOrThrow(dir.data(), 2, kerCorruptedMetadata);
             uint16_t   dirLength = byteSwap2(dir,0,bSwap);
             // Prevent infinite loops. (GHSA-m479-7frc-gqqg)
             enforce(dirLength > 0, kerCorruptedMetadata);
@@ -366,7 +356,7 @@ namespace Exiv2 {
                 }
                 bFirst = false;
 
-                readOrThrow(io, dir.data(), 12, kerCorruptedMetadata);
+                io.readOrThrow(dir.data(), 12, kerCorruptedMetadata);
                 uint16_t tag    = byteSwap2(dir,0,bSwap);
                 uint16_t type   = byteSwap2(dir,2,bSwap);
                 uint32_t count  = byteSwap4(dir,4,bSwap);
@@ -417,9 +407,9 @@ namespace Exiv2 {
 
                 if ( bOffsetIsPointer ) {         // read into buffer
                     const long restore = io.tell(); // save
-                    seekOrThrow(io, offset, BasicIo::beg, kerCorruptedMetadata); // position
-                    readOrThrow(io, buf.data(), static_cast<long>(count_x_size), kerCorruptedMetadata); // read
-                    seekOrThrow(io, restore, BasicIo::beg, kerCorruptedMetadata); // restore
+                    io.seekOrThrow(offset, BasicIo::beg, kerCorruptedMetadata); // position
+                    io.readOrThrow(buf.data(), static_cast<long>(count_x_size), kerCorruptedMetadata); // read
+                    io.seekOrThrow(restore, BasicIo::beg, kerCorruptedMetadata); // restore
                 }
 
                 if ( bPrint ) {
@@ -461,7 +451,7 @@ namespace Exiv2 {
                             const long restore = io.tell();
                             offset = byteSwap4(buf,k*size,bSwap);
                             printIFDStructure(io,out,option,offset,bSwap,c,depth);
-                            seekOrThrow(io, restore, BasicIo::beg, kerCorruptedMetadata);
+                            io.seekOrThrow(restore, BasicIo::beg, kerCorruptedMetadata);
                         }
                     } else if ( option == kpsRecursive && tag == 0x83bb /* IPTCNAA */ ) {
                         if (count > 0) {
@@ -470,11 +460,11 @@ namespace Exiv2 {
                             }
 
                             const long restore = io.tell();
-                            seekOrThrow(io, offset, BasicIo::beg, kerCorruptedMetadata);  // position
+                            io.seekOrThrow(offset, BasicIo::beg, kerCorruptedMetadata);  // position
                             std::vector<byte> bytes(count) ;  // allocate memory
                             // TODO: once we have C++11 use bytes.data()
-                            readOrThrow(io, &bytes[0], count, kerCorruptedMetadata);
-                            seekOrThrow(io, restore, BasicIo::beg, kerCorruptedMetadata);
+                            io.readOrThrow(&bytes[0], count, kerCorruptedMetadata);
+                            io.seekOrThrow(restore, BasicIo::beg, kerCorruptedMetadata);
                             // TODO: once we have C++11 use bytes.data()
                             IptcData::printStructure(out, makeSliceUntil(&bytes[0], count), depth);
                         }
@@ -484,23 +474,23 @@ namespace Exiv2 {
                         uint32_t jump= 10           ;
                         byte     bytes[20]          ;
                         const auto chars = reinterpret_cast<const char*>(&bytes[0]);
-                        seekOrThrow(io, offset, BasicIo::beg, kerCorruptedMetadata);  // position
-                        readOrThrow(io, bytes, jump, kerCorruptedMetadata)     ;  // read
+                        io.seekOrThrow(offset, BasicIo::beg, kerCorruptedMetadata);  // position
+                        io.readOrThrow(bytes, jump, kerCorruptedMetadata)     ;  // read
                         bytes[jump]=0               ;
                         if ( ::strcmp("Nikon",chars) == 0 ) {
                             // tag is an embedded tiff
                             const long byteslen = count-jump;
                             DataBuf bytes(byteslen);  // allocate a buffer
-                            readOrThrow(io, bytes.data(), byteslen, kerCorruptedMetadata);  // read
+                            io.readOrThrow(bytes.data(), byteslen, kerCorruptedMetadata);  // read
                             MemIo memIo(bytes.c_data(), byteslen)    ;  // create a file
                             printTiffStructure(memIo,out,option,depth);
                         } else {
                             // tag is an IFD
-                            seekOrThrow(io, 0, BasicIo::beg, kerCorruptedMetadata);  // position
+                            io.seekOrThrow(0, BasicIo::beg, kerCorruptedMetadata);  // position
                             printIFDStructure(io,out,option,offset,bSwap,c,depth);
                         }
 
-                        seekOrThrow(io, restore, BasicIo::beg, kerCorruptedMetadata); // restore
+                        io.seekOrThrow(restore, BasicIo::beg, kerCorruptedMetadata); // restore
                     }
                 }
 
@@ -513,7 +503,7 @@ namespace Exiv2 {
                 }
             }
             if ( start ) {
-                readOrThrow(io, dir.data(), 4, kerCorruptedMetadata);
+                io.readOrThrow(dir.data(), 4, kerCorruptedMetadata);
                 start = byteSwap4(dir,0,bSwap);
             }
         } while (start) ;
@@ -533,7 +523,7 @@ namespace Exiv2 {
             DataBuf  dir(dirSize);
 
             // read header (we already know for certain that we have a Tiff file)
-            readOrThrow(io, dir.data(),  8, kerCorruptedMetadata);
+            io.readOrThrow(dir.data(),  8, kerCorruptedMetadata);
             char c = static_cast<char>(dir.read_uint8(0));
             bool bSwap   = ( c == 'M' && isLittleEndianPlatform() )
                         || ( c == 'I' && isBigEndianPlatform()    )

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -140,15 +140,12 @@ namespace {
 namespace Exiv2 {
     // BasicIo::read() with error checking
     static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-      const long nread = iIo.read(buf, rcount);
-      enforce(nread == rcount, err);
-      enforce(!iIo.error(), err);
+        iIo.readOrThrow(buf, rcount, err);
     }
 
     // BasicIo::seek() with error checking
     static void seekOrThrow(BasicIo& iIo, long offset, BasicIo::Position pos, ErrorCode err) {
-      const int r = iIo.seek(offset, pos);
-      enforce(r == 0, err);
+        iIo.seekOrThrow(offset, pos, err);
     }
 
     Image::Image(int imageType, uint16_t supportedMetadata, BasicIo::UniquePtr io)

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -96,15 +96,12 @@ namespace Exiv2 {
 
     // BasicIo::read() with error checking
     static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-      const long nread = iIo.read(buf, rcount);
-      enforce(nread == rcount, err);
-      enforce(!iIo.error(), err);
+        iIo.readOrThrow(buf, rcount, err);
     }
 
     // BasicIo::seek() with error checking
     static void seekOrThrow(BasicIo& iIo, long offset, BasicIo::Position pos, ErrorCode err) {
-      const int r = iIo.seek(offset, pos);
-      enforce(r == 0, err);
+        iIo.seekOrThrow(offset, pos, err);
     }
 
     static inline bool inRange(int lo,int value, int hi)

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -94,16 +94,6 @@ namespace Exiv2 {
     constexpr uint16_t Photoshop::iptc_ = 0x0404;
     constexpr uint16_t Photoshop::preview_ = 0x040c;
 
-    // BasicIo::read() with error checking
-    static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-        iIo.readOrThrow(buf, rcount, err);
-    }
-
-    // BasicIo::seek() with error checking
-    static void seekOrThrow(BasicIo& iIo, long offset, BasicIo::Position pos, ErrorCode err) {
-        iIo.seekOrThrow(offset, pos, err);
-    }
-
     static inline bool inRange(int lo,int value, int hi)
     {
         return lo<=value && value <= hi;
@@ -386,7 +376,7 @@ namespace Exiv2 {
             byte sizebuf[2];
             uint16_t size = 0;
             if (markerHasLength(marker)) {
-                readOrThrow(*io_, sizebuf, 2, kerFailedToReadImageData);
+                io_->readOrThrow(sizebuf, 2, kerFailedToReadImageData);
                 size = getUShort(sizebuf, bigEndian);
                 // `size` is the size of the segment, including the 2-byte size field
                 // that we just read.
@@ -396,7 +386,7 @@ namespace Exiv2 {
             // Read the rest of the segment.
             DataBuf buf(size);
             if (size > 0) {
-                readOrThrow(*io_, buf.data(2), size - 2, kerFailedToReadImageData);
+                io_->readOrThrow(buf.data(2), size - 2, kerFailedToReadImageData);
                 buf.copyBytes(0, sizebuf, 2);
             }
 
@@ -613,7 +603,7 @@ namespace Exiv2 {
                 byte sizebuf[2];
                 uint16_t size = 0;
                 if (markerHasLength(marker)) {
-                    readOrThrow(*io_, sizebuf, 2, kerFailedToReadImageData);
+                    io_->readOrThrow(sizebuf, 2, kerFailedToReadImageData);
                     size = getUShort(sizebuf, bigEndian);
                     // `size` is the size of the segment, including the 2-byte size field
                     // that we just read.
@@ -624,7 +614,7 @@ namespace Exiv2 {
                 DataBuf buf(size);
                 if (size > 0) {
                     assert(size >= 2); // enforced above
-                    readOrThrow(*io_, buf.data(2), size - 2, kerFailedToReadImageData);
+                    io_->readOrThrow(buf.data(2), size - 2, kerFailedToReadImageData);
                     buf.copyBytes(0, sizebuf, 2);
                 }
 
@@ -844,16 +834,16 @@ namespace Exiv2 {
 #ifdef EXIV2_DEBUG_MESSAGES
                     std::cout << start << ":" << length << std::endl;
 #endif
-                    seekOrThrow(*io_, start, BasicIo::beg, kerFailedToReadImageData);
+                    io_->seekOrThrow(start, BasicIo::beg, kerFailedToReadImageData);
                     DataBuf buf(length);
-                    readOrThrow(*io_, buf.data(), buf.size(), kerFailedToReadImageData);
+                    io_->readOrThrow(buf.data(), buf.size(), kerFailedToReadImageData);
                     tempIo->write(buf.c_data(), buf.size());
                 }
             }
 
-            seekOrThrow(*io_, 0, BasicIo::beg, kerFailedToReadImageData);
+            io_->seekOrThrow(0, BasicIo::beg, kerFailedToReadImageData);
             io_->transfer(*tempIo);  // may throw
-            seekOrThrow(*io_, 0, BasicIo::beg, kerFailedToReadImageData);
+            io_->seekOrThrow(0, BasicIo::beg, kerFailedToReadImageData);
             readMetadata();
         }
     }  // JpegBase::printStructure
@@ -920,7 +910,7 @@ namespace Exiv2 {
             byte sizebuf[2];
             uint16_t size = 0;
             if (markerHasLength(marker)) {
-                readOrThrow(*io_, sizebuf, 2, kerFailedToReadImageData);
+                io_->readOrThrow(sizebuf, 2, kerFailedToReadImageData);
                 size = getUShort(sizebuf, bigEndian);
                 // `size` is the size of the segment, including the 2-byte size field
                 // that we just read.
@@ -931,7 +921,7 @@ namespace Exiv2 {
             DataBuf buf(size);
             if (size > 0) {
                 assert(size >= 2); // enforced above
-                readOrThrow(*io_, buf.data(2), size - 2, kerFailedToReadImageData);
+                io_->readOrThrow(buf.data(2), size - 2, kerFailedToReadImageData);
                 buf.copyBytes(0, sizebuf, 2);
             }
 
@@ -1021,7 +1011,7 @@ namespace Exiv2 {
         if (!comment_.empty())
             ++search;
 
-        seekOrThrow(*io_, seek, BasicIo::beg, kerNoImageInInputData);
+        io_->seekOrThrow(seek, BasicIo::beg, kerNoImageInInputData);
         count = 0;
         marker = advanceToMarker(kerNoImageInInputData);
 
@@ -1034,7 +1024,7 @@ namespace Exiv2 {
             byte sizebuf[2];
             uint16_t size = 0;
             if (markerHasLength(marker)) {
-                readOrThrow(*io_, sizebuf, 2, kerFailedToReadImageData);
+                io_->readOrThrow(sizebuf, 2, kerFailedToReadImageData);
                 size = getUShort(sizebuf, bigEndian);
                 // `size` is the size of the segment, including the 2-byte size field
                 // that we just read.
@@ -1045,7 +1035,7 @@ namespace Exiv2 {
             DataBuf buf(size);
             if (size > 0) {
                 assert(size >= 2); // enforced above
-                readOrThrow(*io_, buf.data(2), size - 2, kerFailedToReadImageData);
+                io_->readOrThrow(buf.data(2), size - 2, kerFailedToReadImageData);
                 buf.copyBytes(0, sizebuf, 2);
             }
 

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -58,9 +58,7 @@ namespace Exiv2 {
     // This static function is a temporary fix in v0.27. In the next version,
     // it will be added as a method of BasicIo.
     static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-      const long nread = iIo.read(buf, rcount);
-      enforce(nread == rcount, err);
-      enforce(!iIo.error(), err);
+        iIo.readOrThrow(buf, rcount, err);
     }
 
     WebPImage::WebPImage(BasicIo::UniquePtr io)

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -55,12 +55,6 @@
 namespace Exiv2 {
     using namespace Exiv2::Internal;
 
-    // This static function is a temporary fix in v0.27. In the next version,
-    // it will be added as a method of BasicIo.
-    static void readOrThrow(BasicIo& iIo, byte* buf, long rcount, ErrorCode err) {
-        iIo.readOrThrow(buf, rcount, err);
-    }
-
     WebPImage::WebPImage(BasicIo::UniquePtr io)
     : Image(ImageType::webp, mdNone, std::move(io))
     {
@@ -138,7 +132,7 @@ namespace Exiv2 {
         DataBuf chunkId(WEBP_TAG_SIZE+1);
         chunkId.write_uint8(WEBP_TAG_SIZE, '\0');
 
-        readOrThrow(*io_, data, WEBP_TAG_SIZE * 3, Exiv2::kerCorruptedMetadata);
+        io_->readOrThrow(data, WEBP_TAG_SIZE * 3, Exiv2::kerCorruptedMetadata);
         uint64_t filesize = Exiv2::getULong(data + WEBP_TAG_SIZE, littleEndian);
 
         /* Set up header */
@@ -178,8 +172,8 @@ namespace Exiv2 {
          case we have any exif or xmp data, also check
          for any chunks with alpha frame/layer set */
         while (!io_->eof() && static_cast<uint64_t>(io_->tell()) < filesize) {
-            readOrThrow(*io_, chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
-            readOrThrow(*io_, size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
             // Check that `size_u32` is safe to cast to `long`.
@@ -187,10 +181,10 @@ namespace Exiv2 {
                     Exiv2::kerCorruptedMetadata);
             const long size = static_cast<long>(size_u32);
             DataBuf payload(size);
-            readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
             if ( payload.size() % 2 ) {
               byte c = 0;
-              readOrThrow(*io_, &c, 1, Exiv2::kerCorruptedMetadata);
+              io_->readOrThrow(&c, 1, Exiv2::kerCorruptedMetadata);
             }
 
             /* Chunk with information about features
@@ -315,8 +309,8 @@ namespace Exiv2 {
 
         io_->seek(12, BasicIo::beg);
         while (!io_->eof() && static_cast<uint64_t>(io_->tell()) < filesize) {
-            readOrThrow(*io_, chunkId.data(), 4, Exiv2::kerCorruptedMetadata);
-            readOrThrow(*io_, size_buff, 4, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(chunkId.data(), 4, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(size_buff, 4, Exiv2::kerCorruptedMetadata);
 
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
@@ -326,7 +320,7 @@ namespace Exiv2 {
             const long size = static_cast<long>(size_u32);
 
             DataBuf payload(size);
-            readOrThrow(*io_, payload.data(), size, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(payload.data(), size, Exiv2::kerCorruptedMetadata);
             if ( io_->tell() % 2 ) io_->seek(+1,BasicIo::cur); // skip pad
 
             if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8X)) {
@@ -518,7 +512,7 @@ namespace Exiv2 {
         DataBuf chunkId(5);
         chunkId.write_uint8(4, '\0');
 
-        readOrThrow(*io_, data, WEBP_TAG_SIZE * 3, Exiv2::kerCorruptedMetadata);
+        io_->readOrThrow(data, WEBP_TAG_SIZE * 3, Exiv2::kerCorruptedMetadata);
 
         const uint32_t filesize_u32 =
             Safe::add(Exiv2::getULong(data + WEBP_TAG_SIZE, littleEndian), 8U);
@@ -544,8 +538,8 @@ namespace Exiv2 {
 
         chunkId.write_uint8(4, '\0');
         while (!io_->eof() && io_->tell() < filesize) {
-            readOrThrow(*io_, chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
-            readOrThrow(*io_, size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(chunkId.data(), WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
+            io_->readOrThrow(size_buff, WEBP_TAG_SIZE, Exiv2::kerCorruptedMetadata);
 
             const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
@@ -566,7 +560,7 @@ namespace Exiv2 {
                 has_canvas_data = true;
                 byte size_buf[WEBP_TAG_SIZE];
 
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf, payload.c_data(4), 3);
@@ -581,7 +575,7 @@ namespace Exiv2 {
                 enforce(size >= 10, Exiv2::kerCorruptedMetadata);
 
                 has_canvas_data = true;
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
                 byte size_buf[WEBP_TAG_SIZE];
 
                 // Fetch width""
@@ -602,7 +596,7 @@ namespace Exiv2 {
                 byte size_buf_w[2];
                 byte size_buf_h[3];
 
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf_w, payload.c_data(1), 2);
@@ -620,7 +614,7 @@ namespace Exiv2 {
                 has_canvas_data = true;
                 byte size_buf[WEBP_TAG_SIZE];
 
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 // Fetch width
                 memcpy(&size_buf, payload.c_data(6), 3);
@@ -632,10 +626,10 @@ namespace Exiv2 {
                 size_buf[3] = 0;
                 pixelHeight_ = Exiv2::getULong(size_buf, littleEndian) + 1;
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_ICCP)) {
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
                 this->setIccProfile(std::move(payload));
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF)) {
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
 
                 byte  size_buff2[2];
                 // 4 meaningful bytes + 2 padding bytes
@@ -713,7 +707,7 @@ namespace Exiv2 {
                     exifData_.clear();
                 }
             } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP)) {
-                readOrThrow(*io_, payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
+                io_->readOrThrow(payload.data(), payload.size(), Exiv2::kerCorruptedMetadata);
                 xmpPacket_.assign(payload.c_str(), payload.size());
                 if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
@@ -756,9 +750,9 @@ namespace Exiv2 {
         byte webp[len];
         byte data[len];
         byte riff[len];
-        readOrThrow(iIo, riff, len, Exiv2::kerCorruptedMetadata);
-        readOrThrow(iIo, data, len, Exiv2::kerCorruptedMetadata);
-        readOrThrow(iIo, webp, len, Exiv2::kerCorruptedMetadata);
+        iIo.readOrThrow(riff, len, Exiv2::kerCorruptedMetadata);
+        iIo.readOrThrow(data, len, Exiv2::kerCorruptedMetadata);
+        iIo.readOrThrow(webp, len, Exiv2::kerCorruptedMetadata);
         bool matched_riff = (memcmp(riff, RiffImageId, len) == 0);
         bool matched_webp = (memcmp(webp, WebPImageId, len) == 0);
         iIo.seek(-12, BasicIo::cur);


### PR DESCRIPTION
`readOrThrow` and `seekOrThrow` were previously added as static functions in several sources files because we didn't want to change the header files on the 0.27-maintenance branch. I would like to add them to the API in 1.00.