### PR TITLE
Only include expat.h when XMP is enabled.

### DIFF
--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -30,10 +30,10 @@
 #include <algorithm>
 #include <cassert>
 #include <string>
-#include <expat.h>
 
 // Adobe XMP Toolkit
 #ifdef   EXV_HAVE_XMP_TOOLKIT
+# include <expat.h>
 # define TXMP_STRING_TYPE std::string
 # ifdef  EXV_ADOBE_XMPSDK
 # include <XMP.hpp>


### PR DESCRIPTION
Fixes: #1971