### PR TITLE
Update libcurl version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,7 @@ class Exiv2Conan(ConanFile):
 
     def requirements(self):
         self.requires('zlib/1.2.11')
-        self.requires('libcurl/7.75.0')
+        self.requires('libcurl/7.79.1')
 
         if os_info.is_windows and self.options.iconv:
             self.requires('libiconv/1.16')


### PR DESCRIPTION
macOS builds are now [failing](https://github.com/Exiv2/exiv2/pull/1967/checks?check_run_id=3961972812) with this error message:

```
dyld: Symbol not found: _z_errmsg
  Referenced from: /Users/runner/work/exiv2/exiv2/build/bin/exiv2
  Expected in: /usr/lib/libcurl.4.dylib
 in /Users/runner/work/exiv2/exiv2/build/bin/exiv2
```

Maybe bumping the libcurl version number will help.