### PR TITLE
Remove Conan from MacOS build

### DIFF
--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -19,21 +19,18 @@ jobs:
       - name: install dependencies
         run: |
           brew install ninja
-          pip3 install conan==1.41.0
-
-      - name: Run Conan
-        run: |
-          mkdir build && cd build
-          conan config install https://github.com/conan-io/conanclientcert.git
-          conan profile new --detect default
-          conan profile show default
-          conan install .. -o webready=True --build missing
-          # Hack: Delete cmake_find_package generated files to fix compilation on mac.
-          rm Find*
+          pushd /tmp
+          curl -LO https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+          tar xzf   release-1.8.0.tar.gz
+          mkdir -p  googletest-release-1.8.0/build
+          pushd     googletest-release-1.8.0/build
+          cmake .. ; make ; make install
+          popd
+          popd
 
       - name: Build
         run: |
-          cd build
+          mkdir build && cd build
           cmake -GNinja -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}} -DEXIV2_ENABLE_PNG=ON -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_INSTALL_PREFIX=install -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build .
 

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -97,21 +97,18 @@ jobs:
       - name: install dependencies
         run: |
           brew install ninja
-          pip3 install conan==1.39.0
-
-      - name: Conan
-        run: |
-          mkdir build && cd build
-          conan config install https://github.com/conan-io/conanclientcert.git
-          conan profile new --detect default
-          conan profile show default
-          conan install .. -o webready=True --build missing
-          # Hack: Delete cmake_find_package generated files to fix compilation on mac.
-          rm Find*
+          pushd /tmp
+          curl -LO https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+          tar xzf   release-1.8.0.tar.gz
+          mkdir -p  googletest-release-1.8.0/build
+          pushd     googletest-release-1.8.0/build
+          cmake .. ; make ; make install
+          popd
+          popd
 
       - name: build and compile
         run: |
-          cd build
+          mkdir build && cd build
           cmake -GNinja -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=ON -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,23 +67,12 @@ jobs:
           brew install ninja
           brew install tree
           brew install gettext
-          pip3 install conan==1.39.0
           brew install doxygen
           brew install graphviz
 
-      - name: Run Conan
-        run: |
-          mkdir build && cd build
-          conan config install https://github.com/conan-io/conanclientcert.git
-          conan profile new --detect default
-          conan profile show default
-          conan install .. -o webready=False --build missing
-          # Hack: Delete cmake_find_package generated files to fix compilation on mac.
-          rm Find*
-
       - name: Build packaged release
         run: |
-          cd build
+          mkdir build && cd build
           cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DEXIV2_BUILD_DOC=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
           cmake --build . -t doc
           cmake --build . -t package


### PR DESCRIPTION
Conan on macOS is not working (see #1976, #1980). It's probably related to the [switch to macOS-11 in GitHub Actions](https://github.com/actions/virtual-environments/issues/4060), but I have no idea how to fix it. On the 0.27-maintenance branch, we don't use Conan on macOS, so maybe it would be easier to do the same on main.