### PR TITLE
Remove opensuse/tumbleweed

### DIFF
--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # arch suffering this issue: https://github.com/abseil/abseil-cpp/issues/709
         # centos:8 had linking issues with gtest
-        container_image: ["fedora:latest", "debian:10", "archlinux:base", "ubuntu:20.04", "centos:8", "opensuse/tumbleweed", "alpine:3.13"]
+        container_image: ["fedora:latest", "debian:10", "archlinux:base", "ubuntu:20.04", "centos:8", "alpine:3.13"]
         compiler: [g++, clang++]
         build_type: [Release, Debug]
         shared_libraries: [ON, OFF]
@@ -25,12 +25,6 @@ jobs:
         CMAKE_FLAGS: -DEXIV2_TEAM_EXTRA_WARNINGS=OFF -DEXIV2_ENABLE_WEBREADY=ON -DEXIV2_ENABLE_CURL=ON -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=OFF -DEXIV2_ENABLE_PNG=ON -DCMAKE_INSTALL_PREFIX=install
 
     steps:
-    - name: install tar in opensuse
-      run: |
-        distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
-        echo $distro_id
-        if [[ "$distro_id" == "opensuse-tumbleweed" ]]; then zypper --non-interactive install tar gzip; fi
-
     - uses: actions/checkout@v2
     - name: install dependencies
       run: ./ci/install_dependencies.sh


### PR DESCRIPTION
This workflow is [failing](https://github.com/Exiv2/exiv2/runs/3987217205?check_suite_focus=true) because the opensuse/tumbleweed docker image is currently broken. It's a [known issue](https://stackoverflow.com/questions/69314156/zypper-not-working-in-a-fresh-opensuse-tumbleweed-container) that isn't getting fixed quickly, so I think it's better to just drop tumbleweed for now.