### PR TITLE
Add/Update git templates from `old-master`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+
+1. Provide the image with which you observed the issue (commonly named PoC)
+2. Provide exact command to reproduce the issue
+3. Mention the branch/commit in which you observed the issue (i.e: `master` or `0.27-maintenance`)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Linux, iOS, Windows]
+ - Compiler & Version [Gcc 7.3, Clang-6, MSVC 2017]
+ - Compilation mode and/or compiler flags
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,23 +7,22 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+##### **Describe the bug**
+A clear and concise description of the bug.
 
-**To Reproduce**
-Steps to reproduce the behaviour:
+##### **To Reproduce**
+Steps to reproduce the behavior:
+1. Provide the file with which you observed the issue (commonly named PoC)
+2. List the exact commands/functions to reproduce the issue and include any related output
+3. Mention the branch/commit in which you observed the issue (e.g., `main`, `0.27-maintenance`, `commit 9f721b40`)
 
-1. Provide the image with which you observed the issue (commonly named PoC)
-2. Provide exact command to reproduce the issue
-3. Mention the branch/commit in which you observed the issue (i.e: `master` or `0.27-maintenance`)
+##### **Expected behavior**
+A short description of what you expected to happen.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+##### **Desktop (please complete the following information):**
+- OS and version: (e.g., Linux (Fedora 34), macOS 12, Windows 11)
+- Compiler and version: (e.g., Gcc 11.2, Clang 13.0.0, MSVC 2019)
+- Compilation mode and/or compiler flags:
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Linux, iOS, Windows]
- - Compiler & Version [Gcc 7.3, Clang-6, MSVC 2017]
- - Compilation mode and/or compiler flags
-
-**Additional context**
+##### **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: FeatureRequest
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Examples: I'm always frustrated when [...]; Exiv2 does not support XXX format [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: FeatureRequest
+labels: request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Examples: I'm always frustrated when [...]; Exiv2 does not support XXX format [...]
+##### **Is your feature request related to a problem?**
+A clear and concise description of the problem (e.g., I'm always frustrated when [...]; Exiv2 does not support XXX format [...])
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+##### **Describe the solution you would like**
+A short description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+##### **Describe alternatives you have considered**
+A simple explanation of any alternative solutions or features you have considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+##### **Additional context**
+Add any other information about the feature request here (e.g. screenshots, URLs).


### PR DESCRIPTION
The Exiv2 GitHub templates were lost during the transition from the `master` branch to `main` branch.