### PR TITLE
Restore modified tags after TZ manipulation

### DIFF
--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -144,11 +144,6 @@ namespace Exiv2 {
             copyExifToXmp(exifData_, xmpData_);
             copyIptcToXmp(iptcData_, xmpData_);
 
-            // #589 - restore tags which were modified by the convertors
-            for (auto&& it : copy) {
-                xmpData_[it.key()] = it.value();
-            }
-
             // #1112 - restore dates if they lost their TZ info
             for (auto&& date : dates_) {
                 std::string sKey = date.first;
@@ -161,6 +156,11 @@ namespace Exiv2 {
                         xmpData_[sKey] = value_orig ;
                     }
                 }
+            }
+
+            // #589 - restore tags which were modified by the convertors
+            for (auto&& it : copy) {
+                xmpData_[it.key()] = it.value();
             }
 
             if (XmpParser::encode(xmpPacket_, xmpData_,

--- a/test/data/issue_1998.xmp
+++ b/test/data/issue_1998.xmp
@@ -1,0 +1,9 @@
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 4.4.0-Exiv2">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+   xmp:CreateDate="2021-02-03T12:34:56+02:00"/>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/tests/bugfixes/github/test_pr_1999.py
+++ b/tests/bugfixes/github/test_pr_1999.py
@@ -10,16 +10,16 @@ class TestXmpDateTimeSetting(metaclass=CaseMeta):
 
     infile = path("$data_path/issue_1998.xmp")
     commands = [
-        "$exiv2 -M'set Xmp.xmp.CreateDate XmpText 2021-02-03T12:00:00+01:00' $infile",
+        "$exiv2 -M\"set Xmp.xmp.CreateDate XmpText 2021-02-03T12:00:00+01:00\" $infile",
         "$exiv2 -K Xmp.xmp.CreateDate $infile",
-        "$exiv2 -M'set Xmp.xmp.CreateDate XmpText 2021-02-03T12:34:56+02:00' $infile",
+        "$exiv2 -M\"set Xmp.xmp.CreateDate XmpText 2021-02-03T12:34:56+02:00\" $infile",
         "$exiv2 -K Xmp.xmp.CreateDate $infile",
         ]
     stdout = [
-        """""",
+        "",
         """Xmp.xmp.CreateDate                           XmpText    25  2021-02-03T12:00:00+01:00
 """,
-        """""",
+        "",
         """Xmp.xmp.CreateDate                           XmpText    25  2021-02-03T12:34:56+02:00
 """,
               ]

--- a/tests/bugfixes/github/test_pr_1999.py
+++ b/tests/bugfixes/github/test_pr_1999.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import system_tests
+from system_tests import CaseMeta, path
+
+class TestXmpDateTimeSetting(metaclass=CaseMeta):
+    """
+    Test fix for issue 1998.
+    """
+
+    infile = path("$data_path/issue_1998.xmp")
+    commands = [
+        "$exiv2 -M'set Xmp.xmp.CreateDate XmpText 2021-02-03T12:00:00+01:00' $infile",
+        "$exiv2 -K Xmp.xmp.CreateDate $infile",
+        "$exiv2 -M'set Xmp.xmp.CreateDate XmpText 2021-02-03T12:34:56+02:00' $infile",
+        "$exiv2 -K Xmp.xmp.CreateDate $infile",
+        ]
+    stdout = [
+        """""",
+        """Xmp.xmp.CreateDate                           XmpText    25  2021-02-03T12:00:00+01:00
+""",
+        """""",
+        """Xmp.xmp.CreateDate                           XmpText    25  2021-02-03T12:34:56+02:00
+""",
+              ]
+    stderr = [""]*4
+    retval = [0]*4
+


### PR DESCRIPTION
This ensures that Xmp date/times that have been set by the user aren't
over written by the TZ restoration efforts. This fixes bug #1998