### PR TITLE
Treat Exif.Sony1.PreviewImage as undefined tag

### DIFF
--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1534,7 +1534,6 @@ namespace Exiv2 {
             return;
         }
         p += 4;
-        uint32_t isize= 0; // size of Exif.Sony1.PreviewImage
 
         if (count > std::numeric_limits<uint32_t>::max() / typeSize) {
             throw Error(kerArithmeticOverflow);
@@ -1547,7 +1546,19 @@ namespace Exiv2 {
                 || static_cast<int32_t>(baseOffset()) + offset <= 0)) {
                 // #1143
                 if ( object->tag() == 0x2001 && std::string(groupName(object->group())) == "Sony1" ) {
-                    isize=size;
+                    // This tag is Exif.Sony1.PreviewImage, which refers to a preview image which is
+                    // not stored in the metadata. Instead it is stored at the end of the file, after
+                    // the main image. The value of `size` refers to the size of the preview image, not
+                    // the size of the tag's payload, so we set it to zero here so that we don't attempt
+                    // to read those bytes from the metadata. We currently leave this tag as "undefined",
+                    // although we may attempt to handle it better in the future. More discussion of
+                    // this issue can be found here:
+                    //
+                    //   https://github.com/Exiv2/exiv2/issues/2001
+                    //   https://github.com/Exiv2/exiv2/pull/2008
+                    //   https://github.com/Exiv2/exiv2/pull/2013
+                    typeId = undefined;
+                    size = 0;
                 } else {
 #ifndef SUPPRESS_WARNINGS
             EXV_ERROR << "Offset of directory " << groupName(object->group())
@@ -1595,18 +1606,7 @@ namespace Exiv2 {
         }
         Value::UniquePtr v = Value::create(typeId);
         enforce(v.get() != nullptr, kerCorruptedMetadata);
-        if ( !isize ) {
-            v->read(pData, size, byteOrder());
-        } else {
-            // Prevent large memory allocations: https://github.com/Exiv2/exiv2/issues/1881
-            enforce(isize <= 1024 * 1024, kerCorruptedMetadata);
-
-            // #1143 Write a "hollow" buffer for the preview image
-            //       Sadly: we don't know the exact location of the image in the source (it's near offset)
-            //       And neither TiffReader nor TiffEntryBase have access to the BasicIo object being processed
-            std::vector<byte> buffer(isize);
-            v->read(buffer.data() ,isize, byteOrder());
-        }
+        v->read(pData, size, byteOrder());
 
         object->setValue(std::move(v));
         object->setData(pData, size);

--- a/tests/bugfixes/github/test_issue_1881.py
+++ b/tests/bugfixes/github/test_issue_1881.py
@@ -14,9 +14,5 @@ class SonyPreviewImageLargeAllocation(metaclass=CaseMeta):
     filename2 = path("$tmp_path/issue_1881_coverage.jpg")
     commands = ["$exiv2 -q -d I rm $filename1", "$exiv2 -q -d I rm $filename2"]
     stdout = ["",""]
-    stderr = [
-"""Exiv2 exception in erase action for file $filename1:
-$kerCorruptedMetadata
-""",
-""]
-    retval = [1,0]
+    stderr = ["",""]
+    retval = [0,0]


### PR DESCRIPTION
Fixes: #2001

We should treat Exif.Sony1.PreviewImage as an undefined tag, as suggested by @clanmills in [this comment](https://github.com/Exiv2/exiv2/pull/2013#issuecomment-984875697).

In the future, we may be able to do something more sophisticated with Exif.Sony1.PreviewImage. For example, something like what I tried in #2008 might enable us to correctly update the offset that's stored in the tag when modifying the metadata causes us to change the size of the file.