### PR TITLE
Add more DNG 1.6 tags

### DIFF
--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -1701,6 +1701,10 @@ namespace Exiv2 {
                 "for the third illuminant. Otherwise, this tag is ignored. The "
                 "format of the data is the same as IlluminantData1."),
                 ifd0Id, dngTags, undefined, -1, printValue}, // DNG 1.6 tag
+        {0xcd38, "MaskSubArea", N_("Mask Subarea"),
+                N_("This tag identifies the crop rectangle of this IFD's mask, "
+                "relative to the main image."),
+                ifd0Id, dngTags, unsignedLong, 4, printValue}, // DNG 1.6 tag
         {0xcd39, "ProfileHueSatMapData3", N_("Profile Hue Sat Map Data 3"),
                 N_("This tag contains the data for the third hue/saturation/value mapping "
                 "table. Each entry of the table contains three 32-bit IEEE floating-point "
@@ -1718,6 +1722,14 @@ namespace Exiv2 {
                 "used if ColorPlanes is greater than 3. The matrix is stored in row "
                 "scan order."),
                 ifd0Id, dngTags, signedRational, -1, printValue}, // DNG 1.6 tag
+        {0xcd3b, "RGBTables", N_("RGB Tables"),
+                N_("This tag specifies color transforms that can be applied to masked image "
+                "regions. Color transforms are specified using RGB-to-RGB color lookup tables. "
+                "These tables are associated with Semantic Masks to limit the color transform "
+                "to a sub-region of the image. The overall color transform is a linear "
+                "combination of the color tables, weighted by their corresponding Semantic "
+                "Masks."),
+                ifd0Id, dngTags, undefined, -1, printValue}, // DNG 1.6 tag
 
         ////////////////////////////////////////
         // End of list marker

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -980,6 +980,8 @@ namespace Exiv2 {
         {0xc4a5, "PrintImageMatching", N_("Print Image Matching"),
                 N_("Print Image Matching, description needed."),
                 ifd0Id, otherTags, undefined, -1, printValue},
+        ////////////////////////////////////////
+        // https://wwwimages.adobe.com/content/dam/Adobe/en/products/photoshop/pdfs/dng_spec_1.5.0.0.pdf
         {0xc612, "DNGVersion", N_("DNG version"),
                 N_("This tag encodes the DNG four-tier version number. For files "
                    "compliant with version 1.1.0.0 of the DNG specification, this "
@@ -1515,9 +1517,8 @@ namespace Exiv2 {
                 "independent, ignoring fixed pattern effects and other sources of noise (e.g., "
                 "pixel response non-uniformity, spatially-dependent thermal effects, etc.)."),
                 ifd0Id, dngTags, tiffDouble, -1, printValue}, // DNG tag
-
         ////////////////////////////////////////
-        // http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/cinemadng/pdfs/CinemaDNG_Format_Specification_v1_1.pdf
+        // https://www.adobe.com/content/dam/acom/en/devnet/CinemaDNG/pdf/CinemaDNG_Format_Specification_v1_1.pdf
         {0xc763, "TimeCodes", N_("TimeCodes"),
                 N_("The optional TimeCodes tag shall contain an ordered array of time codes. "
                 "All time codes shall be 8 bytes long and in binary format. The tag may "
@@ -1643,6 +1644,8 @@ namespace Exiv2 {
         {0xc7ee, "EnhanceParams", N_("Enhance Params"),
                 N_("A string that documents how the enhanced image data was processed."),
                 ifd0Id, dngTags, asciiString, 0, printValue}, // DNG 1.5 tag
+        ////////////////////////////////////////
+        // https://helpx.adobe.com/photoshop/kb/dng-specification-tags.html
         {0xcd2d, "ProfileGainTableMap", N_("Profile Gain Table Map"),
                 N_("Contains spatially varying gain tables that can be applied while processing the "
                 "image as a starting point for user adjustments."),

--- a/tests/bugfixes/github/test_pr_1905.py
+++ b/tests/bugfixes/github/test_pr_1905.py
@@ -254,8 +254,10 @@ Exif.Image.ForwardMatrix3
 Exif.Image.IlluminantData1
 Exif.Image.IlluminantData2
 Exif.Image.IlluminantData3
+Exif.Image.MaskSubArea
 Exif.Image.ProfileHueSatMapData3
 Exif.Image.ReductionMatrix3
+Exif.Image.RGBTables
 Exif.Photo.ExposureTime
 Exif.Photo.FNumber
 Exif.Photo.ExposureProgram


### PR DESCRIPTION
Add a couple of more DNG 1.6 tags since the last update from https://helpx.adobe.com/photoshop/kb/dng-specification-tags.html (seems like it's a living, not yet finalized/published spec)