### PR TITLE
Use std::shared_ptr for storage in TiffEntryBase

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -205,13 +205,6 @@ namespace Exiv2 {
          */
         void resize(long size);
 
-        /*!
-          @brief Release ownership of the buffer to the caller. Returns the
-                 buffer as a data pointer and size pair, resets the internal
-                 buffer.
-         */
-        EXV_WARN_UNUSED_RESULT std::pair<byte*, long> release();
-
         //! Reset value
         void reset();
         //@}

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -97,7 +97,6 @@ namespace Exiv2 {
           offset_(0),
           size_(0),
           pData_(nullptr),
-          isMalloced_(false),
           idx_(0),
           pValue_(nullptr)
     {
@@ -188,9 +187,6 @@ namespace Exiv2 {
 
     TiffEntryBase::~TiffEntryBase()
     {
-        if (isMalloced_) {
-            delete[] pData_;
-        }
         delete pValue_;
     }
 
@@ -218,14 +214,10 @@ namespace Exiv2 {
           offset_(rhs.offset_),
           size_(rhs.size_),
           pData_(rhs.pData_),
-          isMalloced_(rhs.isMalloced_),
           idx_(rhs.idx_),
-          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : nullptr)
+          pValue_(rhs.pValue_ ? rhs.pValue_->clone().release() : nullptr),
+          storage_(rhs.storage_)
     {
-        if (rhs.isMalloced_) {
-            pData_ = new byte[rhs.size_];
-            memcpy(pData_, rhs.pData_, rhs.size_);
-        }
     }
 
     TiffDirectory::TiffDirectory(const TiffDirectory& rhs) : TiffComponent(rhs), hasNext_(rhs.hasNext_), pNext_(nullptr)
@@ -320,18 +312,15 @@ namespace Exiv2 {
         return idx_;
     }
 
-    void TiffEntryBase::setData(DataBuf buf)
+    void TiffEntryBase::setData(const std::shared_ptr<DataBuf>& buf)
     {
-        std::pair<byte*, long> p = buf.release();
-        setData(p.first, p.second);
-        isMalloced_ = true;
+        storage_ = buf;
+        pData_ = buf->data();
+        size_ = buf->size();
     }
 
     void TiffEntryBase::setData(byte* pData, int32_t size)
     {
-        if (isMalloced_) {
-            delete[] pData_;
-        }
         pData_ = pData;
         size_  = size;
         if (pData_ == nullptr)
@@ -344,7 +333,7 @@ namespace Exiv2 {
             return;
         uint32_t newSize = value->size();
         if (newSize > size_) {
-            setData(DataBuf(newSize));
+            setData(std::make_shared<DataBuf>(newSize));
         }
         if (pData_ != nullptr) {
             memset(pData_, 0x0, size_);

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -319,10 +319,12 @@ namespace Exiv2 {
         size_ = buf->size();
     }
 
-    void TiffEntryBase::setData(byte* pData, int32_t size)
+    void TiffEntryBase::setData(byte* pData, int32_t size,
+                                const std::shared_ptr<DataBuf>& storage)
     {
         pData_ = pData;
         size_  = size;
+        storage_ = storage;
         if (pData_ == nullptr)
             size_ = 0;
     }
@@ -579,7 +581,7 @@ namespace Exiv2 {
         // the TIFF structure table (TiffCreator::tiffTreeStruct_)
         assert(tp);
         tp->setStart(pData() + idx);
-        tp->setData(const_cast<byte*>(pData() + idx), sz);
+        tp->setData(const_cast<byte*>(pData() + idx), sz, storage());
         tp->setElDef(def);
         tp->setElByteOrder(cfg()->byteOrder_);
         addChild(std::move(tc));

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -437,7 +437,7 @@ namespace Exiv2 {
         //! Set the offset
         void setOffset(int32_t offset) { offset_ = offset; }
         //! Set pointer and size of the entry's data (not taking ownership of the data).
-        void setData(byte* pData, int32_t size);
+        void setData(byte* pData, int32_t size, const std::shared_ptr<DataBuf>& storage);
         /*!
           @brief Set the entry's data buffer. A shared_ptr is used to manage the DataBuf
                  because TiffEntryBase has a clone method so it is possible (in theory) for
@@ -532,6 +532,8 @@ namespace Exiv2 {
                                     int32_t   offset,
                                     TiffType  tiffType,
                                     ByteOrder byteOrder);
+
+        const std::shared_ptr<DataBuf>& storage() { return storage_; }
 
     private:
         //! @name NOT implemented

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -436,7 +436,21 @@ namespace Exiv2 {
         void encode(TiffEncoder& encoder, const Exifdatum* datum);
         //! Set the offset
         void setOffset(int32_t offset) { offset_ = offset; }
-        //! Set pointer and size of the entry's data (not taking ownership of the data).
+        /*!
+          @brief Set pointer and size of the entry's data (not taking ownership of the data).
+
+          @param storage Usually, pData is a pointer into a copy of the image file, which
+                         means that it points to memory which is guaranteed to live longer
+                         than this class. However, sometimes pData is pointer into a
+                         DataBuf that was allocated by another node in the component tree.
+                         If so, we need to make sure that the DataBuf doesn't get freed too
+                         early. We use a std::shared_ptr to hold a reference to the DataBuf
+                         to ensure that it will be kept alive. The storage parameter is
+                         assigned to the storage_ field. In the more common scenario where
+                         pData points to a copy of the image, rather than a DataBuf, then
+                         you should pass std::shared_ptr<DataBuf>(), which is essentially
+                         a nullptr.
+         */
         void setData(byte* pData, int32_t size, const std::shared_ptr<DataBuf>& storage);
         /*!
           @brief Set the entry's data buffer. A shared_ptr is used to manage the DataBuf
@@ -533,6 +547,7 @@ namespace Exiv2 {
                                     TiffType  tiffType,
                                     ByteOrder byteOrder);
 
+        //! Used (internally) to create another reference to the DataBuf reference by storage_.
         const std::shared_ptr<DataBuf>& storage() { return storage_; }
 
     private:

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1653,8 +1653,10 @@ namespace Exiv2 {
         if (cryptFct != nullptr) {
             const byte* pData = object->pData();
             int32_t size = object->TiffEntryBase::doSize();
-            DataBuf buf = cryptFct(object->tag(), pData, size, pRoot_);
-            if (buf.size() > 0) object->setData(std::move(buf));
+            std::shared_ptr<DataBuf> buf = std::make_shared<DataBuf>(
+              cryptFct(object->tag(), pData, size, pRoot_)
+            );
+            if (buf->size() > 0) object->setData(buf);
         }
 
         const ArrayDef* defs = object->def();

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1609,7 +1609,7 @@ namespace Exiv2 {
         v->read(pData, size, byteOrder());
 
         object->setValue(std::move(v));
-        object->setData(pData, size);
+        object->setData(pData, size, std::shared_ptr<DataBuf>());
         object->setOffset(offset);
         object->setIdx(nextIdx(object->group()));
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -183,14 +183,6 @@ namespace Exiv2 {
         size_ = size;
     }
 
-    EXV_WARN_UNUSED_RESULT std::pair<byte*, long> DataBuf::release()
-    {
-        std::pair<byte*, long> p = {pData_, size_};
-        pData_ = nullptr;
-        size_ = 0;
-        return p;
-    }
-
     void DataBuf::reset()
     {
         delete[] pData_;


### PR DESCRIPTION
The `isMalloced_` field in `TiffEntryBase` makes me nervous. I'm not convinced that the memory management is always correct. This pull request replaces it with a `shared_ptr<DataBuf>` so that reference counting is used. I think this should make it safer.

To summarize why I am worried about the memory management in the old version of the code:

In `TiffEntryBase::setData()`, the original `pData_` is replaced with a pointer to a newly allocated `DataBuf`.

https://github.com/Exiv2/exiv2/blob/c28e501b91f55202dd6c99081b022582a399657a/src/tiffcomposite_int.cpp#L323-L328

In [`TiffBinaryArray::addElement`](https://github.com/Exiv2/exiv2/blob/c28e501b91f55202dd6c99081b022582a399657a/src/tiffcomposite_int.cpp#L583), a pointer to the current `pData_` is passed to a newly created child component:

https://github.com/Exiv2/exiv2/blob/c28e501b91f55202dd6c99081b022582a399657a/src/tiffcomposite_int.cpp#L593

That should be fine if `pData_` is a pointer to a long-lived allocation, such as a memory-mapped copy of the image file (which I believe is the most common scenario), but is it safe if `pData_` to a locally stored `DataBuf`?

In `TiffEntryBase`'s copy constructor, the data is cloned if the `isMalloced_` flag is set:

https://github.com/Exiv2/exiv2/blob/c28e501b91f55202dd6c99081b022582a399657a/src/tiffcomposite_int.cpp#L214-L229

But if `rhs.pData_` points to a `DataBuf` that was allocated by one of its parent components, then `isMalloced_` will be false, but there is no guarantee that the parent component won't be deleted, since we are in the middle of a cloning operation.