### PR TITLE
Revisiting cmake code for generating coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test/tmp/*
 doc/html
 contrib/vms/.vagrant
 /.vscode
+.vs/

--- a/cmake/gcovr.cmake
+++ b/cmake/gcovr.cmake
@@ -1,8 +1,8 @@
-# Intentd usage
-#   cmake -DBUILD_WITH_COVERAGE=yes ../
-#   make -j
-#   make tests
-#   make coverage
+# Intended usage
+#   cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_WITH_COVERAGE=yes ../
+#   cmake --build . --config Debug 
+#   ctest
+#   cmake --build . --config Debug --target coverage
 
 if(BUILD_WITH_COVERAGE)
     find_program (GCOVR gcovr)
@@ -12,6 +12,9 @@ if(BUILD_WITH_COVERAGE)
         add_custom_command(OUTPUT _run_gcovr_parser
             POST_BUILD
             COMMAND ${GCOVR} --root ${CMAKE_SOURCE_DIR} --object-dir=${CMAKE_BINARY_DIR} --html --html-details -o coverage_output/coverage.html
+              --exclude-directories xmpsdk --exclude-directories unitTests --exclude-directories samples
+              --exclude '.*xmpsdk.*' --exclude '.*unitTests.*' --exclude '.*samples.*'
+
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
         add_custom_target (coverage DEPENDS _run_gcovr_parser)

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -263,7 +263,7 @@ namespace Exiv2 {
           @note This method should be only called after the concerned data (metadata)
                 are all downloaded from the remote file to memory.
          */
-        virtual void populateFakeData() {}
+        virtual void populateFakeData() = 0;
 
         /*!
           @brief this is allocated and populated by mmap()

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -662,7 +662,7 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-        virtual int seek(int64_t offset, Position pos);
+        virtual int seek(int64_t offset, Position pos) override;
 
         /*!
           @brief Allow direct access to the underlying data buffer. The buffer
@@ -944,7 +944,7 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-       virtual int seek(int64_t offset, Position pos);
+       virtual int seek(int64_t offset, Position pos) override;
 
        /*!
          @brief Not support

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -435,14 +435,7 @@ namespace Exiv2 {
           @throw Error In case of failure
          */
         void transfer(BasicIo& src) override;
-        /*!
-          @brief Move the current file position.
-          @param offset Number of bytes to move the file position
-              relative to the starting position specified by \em pos
-          @param pos Position from which the seek should start
-          @return 0 if successful;<BR>
-                 Nonzero if failure;
-         */
+
         int seek(int64_t offset, Position pos) override;
 
         /*!
@@ -654,15 +647,8 @@ namespace Exiv2 {
           @throw Error In case of failure
          */
         void transfer(BasicIo& src) override;
-        /*!
-          @brief Move the current IO position.
-          @param offset Number of bytes to move the IO position
-              relative to the starting position specified by \em pos
-          @param pos Position from which the seek should start
-          @return 0 if successful;<BR>
-                 Nonzero if failure;
-         */
-        virtual int seek(int64_t offset, Position pos) override;
+
+        int seek(int64_t offset, Position pos) override;
 
         /*!
           @brief Allow direct access to the underlying data buffer. The buffer
@@ -936,15 +922,8 @@ namespace Exiv2 {
           @note The write access is only supported by http, https, ssh.
          */
         void transfer(BasicIo& src) override;
-        /*!
-          @brief Move the current IO position.
-          @param offset Number of bytes to move the IO position
-              relative to the starting position specified by \em pos
-          @param pos Position from which the seek should start
-          @return 0 if successful;<BR>
-                 Nonzero if failure;
-         */
-       virtual int seek(int64_t offset, Position pos) override;
+
+       int seek(int64_t offset, Position pos) override;
 
        /*!
          @brief Not support

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -183,11 +183,8 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
               Nonzero if failure;
          */
-#if defined(_MSC_VER)
         virtual int seek(int64_t offset, Position pos) = 0;
-#else
-        virtual int seek(long offset, Position pos) = 0;
-#endif
+
         /*!
           @brief Safe version of `seek()` that checks for errors and throws
               an exception if the seek was unsuccessful.
@@ -196,11 +193,7 @@ namespace Exiv2 {
           @param pos Position from which the seek should start
           @param err Error code to use if an exception is thrown.
          */
-#if defined(_MSC_VER)
         void seekOrThrow(int64_t offset, Position pos, ErrorCode err);
-#else
-        void seekOrThrow(long offset, Position pos, ErrorCode err);
-#endif
 
         /*!
           @brief Direct access to the IO data. For files, this is done by
@@ -450,11 +443,8 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-#if defined(_MSC_VER)
         int seek(int64_t offset, Position pos) override;
-#else
-        int seek(long offset, Position pos) override;
-#endif
+
         /*!
           @brief Map the file into the process's address space. The file must be
                  open before mmap() is called. If the mapped area is writeable,
@@ -672,11 +662,8 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-#if defined(_MSC_VER)
         virtual int seek(int64_t offset, Position pos);
-#else
-        int seek(long offset, Position pos) override;
-#endif
+
         /*!
           @brief Allow direct access to the underlying data buffer. The buffer
                  is not protected against write access in any way, the argument
@@ -957,11 +944,8 @@ namespace Exiv2 {
           @return 0 if successful;<BR>
                  Nonzero if failure;
          */
-#if defined(_MSC_VER)
        virtual int seek(int64_t offset, Position pos);
-#else
-        int seek(long offset, Position pos) override;
-#endif
+
        /*!
          @brief Not support
          @return NULL

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -628,6 +628,7 @@ namespace Exiv2 {
             fileIo->close();
             // Check if the file can be written to, if it already exists
             if (open("a+b") != 0) {
+                /// \todo Use std::filesystem once C++17 can be used
                 // Remove the (temporary) file
 #ifdef EXV_UNICODE_PATH
                 if (fileIo->p_->wpMode_ == Impl::wpUnicode) {

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1321,22 +1321,21 @@ namespace Exiv2 {
     {
         DataBuf buf(rcount);
         long readCount = read(buf.data(), buf.size());
-        if (readCount < 0) {
-            throw Error(kerInputDataReadFailed);
-        }
         buf.resize(readCount);
         return buf;
     }
 
     long MemIo::read(byte* buf, long rcount)
     {
-        long avail = std::max(p_->size_ - p_->idx_, 0L);
-        long allow = std::min(rcount, avail);
+        const long avail = std::max(p_->size_ - p_->idx_, 0L);
+        const long allow = std::min(rcount, avail);
         if (allow > 0) {
             std::memcpy(buf, &p_->data_[p_->idx_], allow);
         }
         p_->idx_ += allow;
-        if (rcount > avail) p_->eof_ = true;
+        if (rcount > avail) {
+          p_->eof_ = true;
+        }
         return allow;
     }
 
@@ -1872,10 +1871,10 @@ namespace Exiv2 {
         src.close();
     }
 
-    int RemoteIo::seek( int64_t offset, Position pos )
+    int RemoteIo::seek( int64_t offset, Position pos)
     {
         assert(p_->isMalloced_);
-        uint64_t newIdx = 0;
+        int64_t newIdx = 0;
 
         switch (pos) {
             case BasicIo::cur: newIdx = p_->idx_ + offset; break;
@@ -1883,12 +1882,12 @@ namespace Exiv2 {
             case BasicIo::end: newIdx = p_->size_ + offset; break;
         }
 
-        /// \todo in previous ::seek() overload there was the following comment:
-        ///  #1198.  Don't return 1 when asked to seek past EOF.  Stay calm and set eof_
-        /// And the following line was commented. Check out this part of the code
-        if ( /*newIdx < 0 || */ newIdx > static_cast<uint64_t>(p_->size_) ) return 1;
-        p_->idx_ = static_cast<long>(newIdx);   //not very sure about this. need more test!!    - note by Shawn  fly2xj@gmail.com //TODO
-        p_->eof_ = false;
+        // #1198.  Don't return 1 when asked to seek past EOF.  Stay calm and set eof_
+        // if (newIdx < 0 || newIdx > (long) p_->size_) return 1;
+        p_->idx_ = static_cast<long>(newIdx);
+        p_->eof_ = newIdx > static_cast<long>(p_->size_);
+        if (p_->idx_ > static_cast<long>(p_->size_))
+            p_->idx_ = static_cast<long>(p_->size_);
         return 0;
     }
 

--- a/unitTests/test_FileIo.cpp
+++ b/unitTests/test_FileIo.cpp
@@ -26,6 +26,7 @@ namespace
 {
     const std::string testData(TESTDATA_PATH);
     const std::string imagePath(testData + "/DSC_3079.jpg");
+    const std::string nonExistingImagePath(testData + "/nonExisting.jpg");
 }  // namespace
 
 TEST(AFileIO, canBeInstantiatedWithFilePath)
@@ -43,9 +44,26 @@ TEST(AFileIO, isOpenDoItsJob)
 {
     FileIo file(imagePath);
     ASSERT_FALSE(file.isopen());
-    file.open();
+    ASSERT_EQ(0, file.open());
     ASSERT_TRUE(file.isopen());
 }
+
+TEST(AFileIO, failsToOpenANonExistingFile)
+{
+    FileIo file(nonExistingImagePath);
+    ASSERT_FALSE(file.isopen());
+    ASSERT_EQ(1, file.open());
+    ASSERT_FALSE(file.isopen());
+}
+
+TEST(AFileIO, canChangeItsPathWithSetPath)
+{
+    FileIo file(nonExistingImagePath);
+    ASSERT_EQ(nonExistingImagePath, file.path());
+    file.setPath(imagePath);
+    ASSERT_EQ(imagePath, file.path());
+}
+
 
 TEST(AFileIO, returnsFileSizeIfItsOpened)
 {

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -21,80 +21,148 @@
 #include <exiv2/basicio.hpp>
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace Exiv2;
 
-TEST(MemIo, seek_out_of_bounds_00)
+TEST(MemIo, isNotAtEofInitially)
 {
-    byte buf[1024];
-    memset(buf, 0, sizeof(buf));
+    std::array<byte, 64> buf;
+    buf.fill(0);
 
-    MemIo io(buf, sizeof(buf));
+    MemIo io(buf.data(), buf.size());
     ASSERT_FALSE(io.eof());
-
-    // Regression test for bug reported in https://github.com/Exiv2/exiv2/pull/945
-    // The problem is that MemIo::seek() does not check that the new offset is
-    // in bounds.
-    byte tmp[16];
-    ASSERT_EQ(io.seek(0x10000000, BasicIo::beg), 1);
-    ASSERT_TRUE(io.eof());
-
-    // The seek was invalid, so the offset didn't change and this read still works.
-    const long sizeTmp = static_cast<long>(sizeof(sizeTmp));
-    ASSERT_EQ(io.read(tmp, sizeTmp), sizeTmp);
 }
 
-TEST(MemIo, seek_out_of_bounds_01)
+TEST(MemIo, seekBeyondBufferSizeReturns1AndSetsEofToTrue)
 {
-    byte buf[1024];
-    memset(buf, 0, sizeof(buf));
+    std::array<byte, 64> buf;
+    buf.fill(0);
 
-    MemIo io(buf, sizeof(buf));
-    ASSERT_FALSE(io.eof());
-
-    byte tmp[16];
-
-    // Seek to the end of the file.
-    ASSERT_EQ(io.seek(0, BasicIo::end), 0);
-    ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
-
-    // Try to seek past the end of the file.
-    ASSERT_EQ(io.seek(0x10000000, BasicIo::end), 1);
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(1, io.seek(65, BasicIo::beg));
     ASSERT_TRUE(io.eof());
-    ASSERT_EQ(io.read(tmp, sizeof(tmp)), 0);
 }
 
-TEST(MemIo, seek_out_of_bounds_02)
+TEST(MemIo, seekBefore0Returns1ButItDoesNotSetEofToTrue)
 {
-    byte buf[1024];
-    memset(buf, 0, sizeof(buf));
+    std::array<byte, 64> buf;
+    buf.fill(0);
 
-    MemIo io(buf, sizeof(buf));
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(1, io.seek(-1, BasicIo::beg));
     ASSERT_FALSE(io.eof());
-
-    byte tmp[16];
-
-    // Try to seek past the end of the file.
-    ASSERT_EQ(io.seek(0x10000000, BasicIo::cur), 1);
-    ASSERT_TRUE(io.eof());
-    // The seek was invalid, so the offset didn't change and this read still works.
-    const long sizeTmp = static_cast<long>(sizeof(sizeTmp));
-    ASSERT_EQ(io.read(tmp, sizeTmp), sizeTmp);
 }
 
-TEST(MemIo, seek_out_of_bounds_03)
+TEST(MemIo, seekBeyondBoundsDoesNotMoveThePosition)
 {
-    byte buf[1024];
-    memset(buf, 0, sizeof(buf));
+    std::array<byte, 64> buf;
+    buf.fill(0);
 
-    MemIo io(buf, sizeof(buf));
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(0, io.tell());
+    ASSERT_EQ(1, io.seek(65, BasicIo::beg));
+    ASSERT_EQ(0, io.tell());
+}
+
+TEST(MemIo, seekInsideBoundsMoveThePosition)
+{
+    std::array<byte, 64> buf;
+    buf.fill(0);
+
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(0, io.tell());
+    ASSERT_EQ(0, io.seek(32, BasicIo::beg));
+    ASSERT_EQ(32, io.tell());
+}
+
+TEST(MemIo, seekInsideBoundsUsingBeg_resetsThePosition)
+{
+    std::array<byte, 64> buf;
+    buf.fill(0);
+
+    MemIo io(buf.data(), buf.size());
+    std::vector<std::int64_t> positions {0, 8, 16, 32, 64};
+    for(auto pos: positions) {
+      ASSERT_EQ(0, io.seek(pos, BasicIo::beg));
+      ASSERT_EQ(pos, io.tell());
+    }
+}
+
+TEST(MemIo, seekInsideBoundsUsingCur_shiftThePosition)
+{
+    std::array<byte, 64> buf;
+    buf.fill(0);
+
+    MemIo io(buf.data(), buf.size());
+    std::vector<std::int64_t> shifts {4, 4, 8, 16, 32};
+    std::vector<std::int64_t> positions {4, 8, 16, 32, 64};
+    for (size_t i = 0; i < shifts.size(); ++i) {
+      ASSERT_EQ(0, io.seek(shifts[i], BasicIo::cur));
+      ASSERT_EQ(positions[i], io.tell());
+    }
+}
+
+TEST(MemIo, seekToEndPosition_doesNotTriggerEof)
+{
+    std::array<byte, 64> buf;
+    buf.fill(0);
+
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(0, io.tell());
+    ASSERT_EQ(0, io.seek(0, BasicIo::end));
+    ASSERT_EQ(64, io.tell());
     ASSERT_FALSE(io.eof());
+}
 
-    byte tmp[16];
+TEST(MemIo, seekToEndPositionAndReadTriggersEof)
+{
+    std::array<byte, 64> buf;
+    buf.fill(0);
 
-    // Try to seek past the beginning of the file.
-    ASSERT_EQ(io.seek(-0x10000000, BasicIo::cur), 1);
-    ASSERT_FALSE(io.eof());
-    // The seek was invalid, so the offset didn't change and this read still works.
-    const long sizeTmp = static_cast<long>(sizeof(sizeTmp));
-    ASSERT_EQ(io.read(tmp, sizeTmp), sizeTmp);
+    MemIo io(buf.data(), buf.size());
+    ASSERT_EQ(0, io.seek(0, BasicIo::end));
+    ASSERT_EQ(64, io.tell());
+
+    std::array<byte, 64> buf2;
+    buf2.fill(0);
+    ASSERT_EQ(0, io.read(buf2.data(), 1)); // Note that we cannot even read 1 byte being at the end
+    ASSERT_TRUE(io.eof());
+}
+
+TEST(MemIo, readEmptyIoReturns0)
+{
+    std::array<byte, 10> buf;
+    MemIo io;
+    ASSERT_EQ(0, io.read(buf.data(), buf.size()));
+}
+
+TEST(MemIo, readLessBytesThanAvailableReturnsRequestedBytes)
+{
+    std::array<byte, 10> buf1, buf2;
+    buf1.fill(1);
+    buf2.fill(0);
+
+    MemIo io(buf1.data(), buf1.size());
+    ASSERT_EQ(5, io.read(buf2.data(), 5));
+}
+
+TEST(MemIo, readSameBytesThanAvailableReturnsRequetedBytes)
+{
+    std::array<byte, 10> buf1, buf2;
+    buf1.fill(1);
+    buf2.fill(0);
+
+    MemIo io(buf1.data(), buf1.size());
+    ASSERT_EQ(10, io.read(buf2.data(), 10));
+}
+
+TEST(MemIo, readMoreBytesThanAvailableReturnsAvailableBytes)
+{
+    std::array<byte, 10> buf1, buf2;
+    buf1.fill(1);
+    buf2.fill(0);
+
+    MemIo io(buf1.data(), buf1.size());
+    ASSERT_EQ(10, io.read(buf2.data(), 15));
 }

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -30,7 +30,7 @@ TEST(MemIo, isNotAtEofInitially)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_FALSE(io.eof());
 }
 
@@ -39,7 +39,7 @@ TEST(MemIo, seekBeyondBufferSizeReturns1AndSetsEofToTrue)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(1, io.seek(65, BasicIo::beg));
     ASSERT_TRUE(io.eof());
 }
@@ -49,7 +49,7 @@ TEST(MemIo, seekBefore0Returns1ButItDoesNotSetEofToTrue)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(1, io.seek(-1, BasicIo::beg));
     ASSERT_FALSE(io.eof());
 }
@@ -59,7 +59,7 @@ TEST(MemIo, seekBeyondBoundsDoesNotMoveThePosition)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(0, io.tell());
     ASSERT_EQ(1, io.seek(65, BasicIo::beg));
     ASSERT_EQ(0, io.tell());
@@ -70,7 +70,7 @@ TEST(MemIo, seekInsideBoundsMoveThePosition)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(0, io.tell());
     ASSERT_EQ(0, io.seek(32, BasicIo::beg));
     ASSERT_EQ(32, io.tell());
@@ -81,7 +81,7 @@ TEST(MemIo, seekInsideBoundsUsingBeg_resetsThePosition)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     std::vector<std::int64_t> positions {0, 8, 16, 32, 64};
     for(auto pos: positions) {
       ASSERT_EQ(0, io.seek(pos, BasicIo::beg));
@@ -94,7 +94,7 @@ TEST(MemIo, seekInsideBoundsUsingCur_shiftThePosition)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     std::vector<std::int64_t> shifts {4, 4, 8, 16, 32};
     std::vector<std::int64_t> positions {4, 8, 16, 32, 64};
     for (size_t i = 0; i < shifts.size(); ++i) {
@@ -108,7 +108,7 @@ TEST(MemIo, seekToEndPosition_doesNotTriggerEof)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(0, io.tell());
     ASSERT_EQ(0, io.seek(0, BasicIo::end));
     ASSERT_EQ(64, io.tell());
@@ -120,7 +120,7 @@ TEST(MemIo, seekToEndPositionAndReadTriggersEof)
     std::array<byte, 64> buf;
     buf.fill(0);
 
-    MemIo io(buf.data(), buf.size());
+    MemIo io(buf.data(), static_cast<long>(buf.size()));
     ASSERT_EQ(0, io.seek(0, BasicIo::end));
     ASSERT_EQ(64, io.tell());
 
@@ -134,7 +134,7 @@ TEST(MemIo, readEmptyIoReturns0)
 {
     std::array<byte, 10> buf;
     MemIo io;
-    ASSERT_EQ(0, io.read(buf.data(), buf.size()));
+    ASSERT_EQ(0, io.read(buf.data(), static_cast<long>(buf.size())));
 }
 
 TEST(MemIo, readLessBytesThanAvailableReturnsRequestedBytes)
@@ -143,7 +143,7 @@ TEST(MemIo, readLessBytesThanAvailableReturnsRequestedBytes)
     buf1.fill(1);
     buf2.fill(0);
 
-    MemIo io(buf1.data(), buf1.size());
+    MemIo io(buf1.data(), static_cast<long>(buf1.size()));
     ASSERT_EQ(5, io.read(buf2.data(), 5));
 }
 
@@ -153,7 +153,7 @@ TEST(MemIo, readSameBytesThanAvailableReturnsRequetedBytes)
     buf1.fill(1);
     buf2.fill(0);
 
-    MemIo io(buf1.data(), buf1.size());
+    MemIo io(buf1.data(), static_cast<long>(buf1.size()));
     ASSERT_EQ(10, io.read(buf2.data(), 10));
 }
 
@@ -163,6 +163,6 @@ TEST(MemIo, readMoreBytesThanAvailableReturnsAvailableBytes)
     buf1.fill(1);
     buf2.fill(0);
 
-    MemIo io(buf1.data(), buf1.size());
+    MemIo io(buf1.data(), static_cast<long>(buf1.size()));
     ASSERT_EQ(10, io.read(buf2.data(), 15));
 }


### PR DESCRIPTION
I started taking a look to the existing CMake code we have to generate Code Coverage reports with **gcovr**. Since we started using ctest, I decided to update the notes we had in the file `cmake/gcovr.cmake`. I also made some changes there to exclude the folders that are not interesting for the coverage report.

Afterwards I also added an additional "unrelated" change which came to my mind after reviewing the code coverage report. I noticed that the `BasicIO::seek` function had an overload that could be easily simplified. I removed the overload and the compilation and tests seem to stay green.

What I have in mind at the moment for the beginning of 2022 is to increase the code coverage by adding more unit tests, so that I can learn more about the code base. Hopefully this will also lead me to find more refactoring opportunities. 