### PR TITLE
Rename GHA workflows for having more intuitive navigation

### DIFF
--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -4,7 +4,7 @@ on:
   schedule:
   - cron: 0 4 * * *
 
-name: CI for different Linux distributions
+name: Nightly - Linux distributions
 
 jobs:
   distros:

--- a/.github/workflows/on_PR_linux_fuzz.yml
+++ b/.github/workflows/on_PR_linux_fuzz.yml
@@ -2,7 +2,7 @@
 # mainly to protect the fuzz target from bitrot, but hopefully will
 # also help to quickly catch some bugs before the PR is merged.
 
-name: Linux-Ubuntu Quick Fuzz on PRs
+name: On PRs - Linux-Ubuntu Quick Fuzz
 
 on:
   pull_request:

--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -1,4 +1,4 @@
-name: Linux-Ubuntu Matrix on PRs
+name: On PRs - Linux-Ubuntu Matrix
 
 on: [pull_request]
 

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -1,4 +1,4 @@
-name: Linux Special Builds on PRs
+name: On PRs - Linux Special Builds
 
 on: [pull_request]
 

--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -1,4 +1,4 @@
-name: Mac Matrix on PRs
+name: On PRs - Mac Matrix
 
 on: [pull_request]
 

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -1,4 +1,4 @@
-name: Win Matrix on PRs
+name: On PRs - Windows Matrix
 
 on:
   pull_request:

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -4,7 +4,7 @@
 # - Only running UnitTests and not regression tests
 
 on: [push]
-name: Basic CI for all platforms on push
+name: On PUSH - Basic CI for main platforms
 
 jobs:
   windows:

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -1,4 +1,4 @@
-name: Linux Special Builds for main branch on push
+name: On PUSH - Linux Special Builds for main branch
 
 on:
   push:


### PR DESCRIPTION
GHA are great, and I am very pleased to see that all our CI pipelines are now only running in one single place.

However, I found a bit confusing finding the jobs I was looking for in the "Actions" page:
![WorkflowNames](https://user-images.githubusercontent.com/102645/148396325-7bc3a4b9-5f95-4d25-a320-a23c6ca25410.png)

I am opening this PR to propose a new naming schema for all the workflows, so that it makes easier to find the different workflows. What do you think? Do you have other ideas to make the names even more intuitive? 

In the past I noticed that once you make changes in the workflow names, the old names remain for some time. But I think it is possible to manually discard the old data. 