### PR TITLE
Fix pr#2053 for native Windows builds

### DIFF
--- a/tests/bugfixes/github/test_issue_1959.py
+++ b/tests/bugfixes/github/test_issue_1959.py
@@ -9,12 +9,13 @@ class XmpIptcStandardsTest(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1959"
 
-    filename      = path("$data_path/issue_1959_poc.xmp")
-    filename_save = path("$tmp_path/issue_1959_poc.xmp_save.out")
-    filename_out  = path("$data_path/issue_1959_poc.xmp.out")
+    def setUp(self):
+        self.stdout = [open(self.expand_variables("$filename_ref"),'r').read()]
     
-    commands = ["$exiv2 -Pkvt $filename > $filename_save", "diff --strip-trailing-cr $filename_save $filename_out"]
+    filename      = path("$data_path/issue_1959_poc.xmp")
+    filename_ref  = path("$data_path/issue_1959_poc.xmp.out")
+    
+    commands = ["$exiv2 -Pkvt $filename"]
 
-    stderr = [""]*2
-    retval = [0]*2
-    compare_stdout = check_no_ASAN_UBSAN_errors
+    stderr = [""]
+    retval = [0]

--- a/tests/bugfixes/github/test_issue_1959.py
+++ b/tests/bugfixes/github/test_issue_1959.py
@@ -13,7 +13,7 @@ class XmpIptcStandardsTest(metaclass=CaseMeta):
     filename_save = path("$tmp_path/issue_1959_poc.xmp_save.out")
     filename_out  = path("$data_path/issue_1959_poc.xmp.out")
     
-    commands = ["$exiv2 -Pkvt $filename > $filename_save", "cmp $filename_save $filename_out"]
+    commands = ["$exiv2 -Pkvt $filename > $filename_save", "diff --strip-trailing-cr $filename_save $filename_out"]
 
     stderr = [""]*2
     retval = [0]*2

--- a/tests/bugfixes/github/test_pr_1979.py
+++ b/tests/bugfixes/github/test_pr_1979.py
@@ -3,7 +3,6 @@
 import system_tests
 from system_tests import CaseMeta, path, CopyTmpFiles, check_no_ASAN_UBSAN_errors
 
-@CopyTmpFiles("$data_path/issue_1934_poc1.exv")
 class TestExiv2ExtractThumbnailToStdout(metaclass=CaseMeta):
     """
     Regression test for 'extracting a thumbnail to stdout' bug described in:

--- a/tests/bugfixes/github/test_pr_1979.py
+++ b/tests/bugfixes/github/test_pr_1979.py
@@ -11,14 +11,16 @@ class TestExiv2ExtractThumbnailToStdout(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1934"
 
-    filename1 = path("$tmp_path/issue_1934_poc1.exv")
-    filename2 = path("$tmp_path/issue_1934_poc1-thumb.jpg")
-    filename3 = path("$data_path/issue_1934_poc1-thumb.jpg")
-    commands = ["$exiv2 --force --extract t- $filename1 > $filename2",
-                "cmp $filename2 $filename3"
-               ]
-    stderr = [""]*2
-    retval = [0]*2
+    encodings = [bytes]
 
-    compare_stdout = check_no_ASAN_UBSAN_errors
+    def setUp(self):
+        self.stdout = [bytes(open(self.expand_variables("$filename_ref"),'rb').read())]
+    
+    filename      = path("$data_path/issue_1934_poc1.exv")
+    filename_ref  = path("$data_path/issue_1934_poc1-thumb.jpg")
+    
+    commands = ["$exiv2 --force --extract t- $filename"]
+
+    stderr = [bytes([])]
+    retval = [0]
 

--- a/tests/bugfixes/github/test_pr_2000.py
+++ b/tests/bugfixes/github/test_pr_2000.py
@@ -144,17 +144,18 @@ class TestVerboseExtractRawMetadataToStdout(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1934"
 
-    filenameJPG     = path("$data_path/issue_1934_poc4.jpg")
-    filenameEXV     = path("$tmp_path/issue_1934_poc4.exv")
-    filenameRefEXV  = path("$data_path/issue_1934_poc4_ref.exv")
+    encodings = [bytes]
+
+    def setUp(self):
+        self.stdout = [bytes(open(self.expand_variables("$filename_ref"),'rb').read())]
+
+    filename     = path("$data_path/issue_1934_poc4.jpg")
+    filename_ref = path("$data_path/issue_1934_poc4_ref.exv")
     
-    commands = ["$exiv2 --verbose --extract XXeix- $filenameJPG > $filenameEXV",	
-                "cmp $filenameEXV $filenameRefEXV"]
+    commands = ["$exiv2 --verbose --extract XXeix- $filename"]
 
-    stderr = [""]*2
-    retval = [0]*2
-
-    compare_stdout = check_no_ASAN_UBSAN_errors
+    stderr = [bytes([])]
+    retval = [0]
 
 class TestVerboseExtractThumbnailToStdout(metaclass=CaseMeta):
     """
@@ -163,17 +164,18 @@ class TestVerboseExtractThumbnailToStdout(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1934"
 
-    filenameJPG           = path("$data_path/issue_1934_poc4.jpg")
-    filenameThumbnail     = path("$tmp_path/issue_1934_poc4-thumb.jpg")
-    filenameRefThumbnail  = path("$data_path/issue_1934_poc4-thumb_ref.jpg")
+    encodings = [bytes]
+
+    def setUp(self):
+        self.stdout = [bytes(open(self.expand_variables("$filename_ref"),'rb').read())]
+
+    filename     = path("$data_path/issue_1934_poc4.jpg")
+    filename_ref = path("$data_path/issue_1934_poc4-thumb_ref.jpg")
     
-    commands = ["$exiv2 --verbose --extract t- $filenameJPG > $filenameThumbnail",
-                "cmp $filenameThumbnail $filenameRefThumbnail"]
+    commands = ["$exiv2 --verbose --extract t- $filename"]
 
-    stderr = [""]*2
-    retval = [0]*2
-
-    compare_stdout = check_no_ASAN_UBSAN_errors
+    stderr = [bytes([])]
+    retval = [0]
 
 class TestVerboseExtractICCProfileToStdout(metaclass=CaseMeta):
     """
@@ -182,15 +184,18 @@ class TestVerboseExtractICCProfileToStdout(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1934"
 
-    filenameJPG     = path("$data_path/issue_1934_poc4.jpg")
-    filenameICC     = path("$tmp_path/issue_1934_poc4.icc")
-    filenameRefICC  = path("$data_path/issue_1934_poc4_ref.icc")
-    
-    commands = ["$exiv2 --verbose --extract C- $filenameJPG > $filenameICC",
-                "cmp $filenameICC $filenameRefICC"]
+    encodings = [bytes]
 
-    stderr = [""]*2
-    retval = [0]*2
+    def setUp(self):
+        self.stdout = [bytes(open(self.expand_variables("$filename_ref"),'rb').read())]
+
+    filename     = path("$data_path/issue_1934_poc4.jpg")
+    filename_ref = path("$data_path/issue_1934_poc4_ref.icc")
+    
+    commands = ["$exiv2 --verbose --extract C- $filename"]
+
+    stderr = [bytes([])]
+    retval = [0]
 
     compare_stdout = check_no_ASAN_UBSAN_errors
 
@@ -201,14 +206,15 @@ class TestVerboseExtractCommentToStdout(metaclass=CaseMeta):
     """
     url = "https://github.com/Exiv2/exiv2/issues/1934"
 
-    filenameJPG         = path("$data_path/issue_1934_poc4.jpg")
-    filenameComment     = path("$tmp_path/issue_1934_poc4_comment.txt")
-    filenameRefComment  = path("$data_path/issue_1934_poc4_comment_ref.txt")
+    encodings = [bytes]
 
-    commands = ["$exiv2 --verbose --extract c- $filenameJPG > $filenameComment",
-                "cmp $filenameComment $filenameRefComment"]
+    def setUp(self):
+        self.stdout = [bytes(open(self.expand_variables("$filename_ref"),'rb').read())]
 
-    stderr = [""]*2
-    retval = [0]*2
+    filename     = path("$data_path/issue_1934_poc4.jpg")
+    filename_ref = path("$data_path/issue_1934_poc4_comment_ref.txt")
 
-    compare_stdout = check_no_ASAN_UBSAN_errors
+    commands = ["$exiv2 --verbose --extract c- $filename"]
+
+    stderr = [bytes([])]
+    retval = [0]


### PR DESCRIPTION
Fixes:
1. Fix Windows native build error introduced in pr#2053. Correct problem of mismatched Windows/Linux newline characters.
2. Remove dependency on command line tools being available.
