### PR TITLE
Modernise code around iterators & smart pointers

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -46,14 +46,6 @@
  */
 #define EXV_CALL_MEMBER_FN(object,ptrToMember)  ((object).*(ptrToMember))
 
-#if defined(__GNUC__) && (__GNUC__ >= 4) || defined(__clang__)
-#define EXV_WARN_UNUSED_RESULT __attribute__ ((warn_unused_result))
-#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
-#define EXV_WARN_UNUSED_RESULT _Check_return_
-#else
-#define EXV_WARN_UNUSED_RESULT
-#endif
-
 #ifndef _MSC_VER
 #define EXV_UNUSED [[gnu::unused]]
 #else

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -853,16 +853,12 @@ namespace Exiv2 {
                        : str1.size() > str2.size() ? -1
                        : 0
                        ;
-            std::string::const_iterator c1 = str1.begin();
-            std::string::const_iterator c2 = str2.begin();
-            if (  result==0 ) for (
-                ; result==0 && c1 != str1.end()
-                ; ++c1, ++c2
-                ) {
-                result = tolower(*c1) < tolower(*c2) ?  1
-                       : tolower(*c1) > tolower(*c2) ? -1
-                       : 0
-                       ;
+            if (  result==0 ) {
+                for (auto c1 = str1.begin(), c2 = str2.begin() ; result==0 && c1 != str1.end() ; ++c1, ++c2 ) {
+                   result = tolower(*c1) < tolower(*c2) ?  1
+                          : tolower(*c1) > tolower(*c2) ? -1
+                          : 0 ;
+                }
             }
             return result < 0 ;
         }
@@ -1543,8 +1539,7 @@ namespace Exiv2 {
     long ValueType<T>::copy(byte* buf, ByteOrder byteOrder) const
     {
         long offset = 0;
-        typename ValueList::const_iterator end = value_.end();
-        for (typename ValueList::const_iterator i = value_.begin(); i != end; ++i) {
+        for (auto i = value_.begin(); i != value_.end(); ++i) {
             offset += toData(buf + offset, *i, byteOrder);
         }
         return offset;
@@ -1571,11 +1566,12 @@ namespace Exiv2 {
     template<typename T>
     std::ostream& ValueType<T>::write(std::ostream& os) const
     {
-        typename ValueList::const_iterator end = value_.end();
-        typename ValueList::const_iterator i = value_.begin();
+        auto end = value_.end();
+        auto i = value_.begin();
         while (i != end) {
             os << std::setprecision(15) << *i;
-            if (++i != end) os << " ";
+            if (++i != end)
+                os << " ";
         }
         return os;
     }

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -169,43 +169,35 @@ namespace Action {
 
     void TaskFactory::cleanup()
     {
-         for (auto&& i : registry_) {
-            delete i.second;
-         }
+        registry_.clear();
     }
 
     void TaskFactory::registerTask(TaskType type, Task::UniquePtr task)
     {
-        auto i = registry_.find(type);
-        if (i != registry_.end()) {
-            delete i->second;
-        }
-        registry_[type] = task.release();
+        registry_[type] = std::move(task);
     }
 
     TaskFactory::TaskFactory()
     {
-        // Register a prototype of each known task
-        registerTask(adjust,  std::make_unique<Adjust>());
-        registerTask(print,   std::make_unique<Print>());
-        registerTask(rename,  std::make_unique<Rename>());
-        registerTask(erase,   std::make_unique<Erase>());
-        registerTask(extract, std::make_unique<Extract>());
-        registerTask(insert,  std::make_unique<Insert>());
-        registerTask(modify,  std::make_unique<Modify>());
-        registerTask(fixiso,  std::make_unique<FixIso>());
-        registerTask(fixcom,  std::make_unique<FixCom>());
-    } // TaskFactory c'tor
+        registry_.emplace(adjust, std::make_unique<Adjust>());
+        registry_.emplace(print, std::make_unique<Print>());
+        registry_.emplace(rename, std::make_unique<Rename>());
+        registry_.emplace(erase, std::make_unique<Erase>());
+        registry_.emplace(extract, std::make_unique<Extract>());
+        registry_.emplace(insert, std::make_unique<Insert>());
+        registry_.emplace(modify, std::make_unique<Modify>());
+        registry_.emplace(fixiso, std::make_unique<FixIso>());
+        registry_.emplace(fixcom, std::make_unique<FixCom>());
+    }
 
     Task::UniquePtr TaskFactory::create(TaskType type)
     {
         auto i = registry_.find(type);
-        if (i != registry_.end() && i->second != 0) {
-            Task* t = i->second;
-            return t->clone();
+        if (i != registry_.end() && i->second) {
+            return i->second->clone();
         }
         return nullptr;
-    } // TaskFactory::create
+    }
 
     int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::string& path,bool binary)
     {

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1451,21 +1451,21 @@ namespace Action {
         Exiv2::XmpData&  xmpData  = pImage->xmpData();
         if (modifyCmd.metadataId_ == exif) {
             Exiv2::ExifData::iterator pos;
-            Exiv2::ExifKey exifKey = Exiv2::ExifKey(modifyCmd.key_);
+            const Exiv2::ExifKey exifKey(modifyCmd.key_);
             while((pos = exifData.findKey(exifKey)) != exifData.end()) {
                 exifData.erase(pos);
             }
         }
         if (modifyCmd.metadataId_ == iptc) {
             Exiv2::IptcData::iterator pos;
-            Exiv2::IptcKey iptcKey = Exiv2::IptcKey(modifyCmd.key_);
+            const Exiv2::IptcKey iptcKey(modifyCmd.key_);
             while((pos = iptcData.findKey(iptcKey)) != iptcData.end()) {
                 iptcData.erase(pos);
             }
         }
         if (modifyCmd.metadataId_ == xmp) {
             Exiv2::XmpData::iterator pos;
-            Exiv2::XmpKey xmpKey = Exiv2::XmpKey(modifyCmd.key_);
+            const Exiv2::XmpKey xmpKey (modifyCmd.key_);
             if((pos = xmpData.findKey(xmpKey)) != xmpData.end()) {
                 xmpData.eraseFamily(pos);
             }

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -170,6 +170,7 @@ namespace Action {
 
     TaskFactory& TaskFactory::instance()
     {
+        /// \todo move the static instance here. It is the "modern" way to implement a singleton
         if (nullptr == instance_) {
             instance_ = new TaskFactory;
         }

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -161,27 +161,18 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Action {
-    TaskFactory* TaskFactory::instance_ = nullptr;
-
     TaskFactory& TaskFactory::instance()
     {
-        /// \todo move the static instance here. It is the "modern" way to implement a singleton
-        if (nullptr == instance_) {
-            instance_ = new TaskFactory;
-        }
-        return *instance_;
-    } // TaskFactory::instance
+        static TaskFactory instance_;
+        return instance_;
+    }
 
     void TaskFactory::cleanup()
     {
-        if (instance_ != nullptr) {
-            for (auto&& i : registry_) {
-                delete i.second;
-            }
-            delete instance_;
-            instance_ = nullptr;
-        }
-    } //TaskFactory::cleanup
+         for (auto&& i : registry_) {
+            delete i.second;
+         }
+    }
 
     void TaskFactory::registerTask(TaskType type, Task::UniquePtr task)
     {
@@ -190,7 +181,7 @@ namespace Action {
             delete i->second;
         }
         registry_[type] = task.release();
-    } // TaskFactory::registerTask
+    }
 
     TaskFactory::TaskFactory()
     {

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -161,11 +161,6 @@ namespace {
 // *****************************************************************************
 // class member definitions
 namespace Action {
-    Task::UniquePtr Task::clone() const
-    {
-        return UniquePtr(clone_());
-    }
-
     TaskFactory* TaskFactory::instance_ = nullptr;
 
     TaskFactory& TaskFactory::instance()
@@ -668,14 +663,9 @@ namespace Action {
         return 0;
     } // Print::printPreviewList
 
-    Print::UniquePtr Print::clone() const
+    Task::UniquePtr Print::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Print* Print::clone_() const
-    {
-        return new Print(*this);
+        return std::make_unique<Print>(*this);
     }
 
     int Rename::run(const std::string& path)
@@ -753,14 +743,9 @@ namespace Action {
     }
     }
 
-    Rename::UniquePtr Rename::clone() const
+    Task::UniquePtr Rename::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Rename* Rename::clone_() const
-    {
-        return new Rename(*this);
+        return std::make_unique<Rename>(*this);
     }
 
     int Erase::run(const std::string& path)
@@ -877,14 +862,9 @@ namespace Action {
         return 0;
     }
 
-    Erase::UniquePtr Erase::clone() const
+    Task::UniquePtr Erase::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Erase* Erase::clone_() const
-    {
-        return new Erase(*this);
+        return std::make_unique<Erase>(*this);
     }
 
     int Extract::run(const std::string& path)
@@ -1072,14 +1052,9 @@ namespace Action {
         }
     } // Extract::writePreviewFile
 
-    Extract::UniquePtr Extract::clone() const
+    Task::UniquePtr Extract::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Extract* Extract::clone_() const
-    {
-        return new Extract(*this);
+        return std::make_unique<Extract>(*this);
     }
 
     int Insert::run(const std::string& path)
@@ -1250,14 +1225,9 @@ namespace Action {
         return 0;
     } // Insert::insertThumbnail
 
-    Insert::UniquePtr Insert::clone() const
+    Task::UniquePtr Insert::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Insert* Insert::clone_() const
-    {
-        return new Insert(*this);
+        return std::make_unique<Insert>(*this);
     }
 
     int Modify::run(const std::string& path)
@@ -1483,14 +1453,9 @@ namespace Action {
         Exiv2::XmpProperties::registerNs(modifyCmd.value_, modifyCmd.key_);
     }
 
-    Modify::UniquePtr Modify::clone() const
+    Task::UniquePtr Modify::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Modify* Modify::clone_() const
-    {
-        return new Modify(*this);
+        return std::make_unique<Modify>(*this);
     }
 
     int Adjust::run(const std::string& path)
@@ -1535,14 +1500,9 @@ namespace Action {
         return 1;
     } // Adjust::run
 
-    Adjust::UniquePtr Adjust::clone() const
+    Task::UniquePtr Adjust::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    Adjust* Adjust::clone_() const
-    {
-        return new Adjust(*this);
+        return std::make_unique<Adjust>(*this);
     }
 
     int Adjust::adjustDateTime(Exiv2::ExifData& exifData,
@@ -1677,14 +1637,9 @@ namespace Action {
     }
     } // FixIso::run
 
-    FixIso::UniquePtr FixIso::clone() const
+    Task::UniquePtr FixIso::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    FixIso* FixIso::clone_() const
-    {
-        return new FixIso(*this);
+        return std::make_unique<FixIso>(*this);
     }
 
     int FixCom::run(const std::string& path)
@@ -1748,14 +1703,9 @@ namespace Action {
     }
     } // FixCom::run
 
-    FixCom::UniquePtr FixCom::clone() const
+    Task::UniquePtr FixCom::clone() const
     {
-        return UniquePtr(clone_());
-    }
-
-    FixCom* FixCom::clone_() const
-    {
-        return new FixCom(*this);
+        return std::make_unique<FixCom>(*this);
     }
 
 }                                       // namespace Action

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -140,12 +140,8 @@ namespace Action {
         //! Prevent construction other than through instance().
         TaskFactory();
 
-        //! Pointer to the one and only instance of this class.
-        static TaskFactory* instance_;
-        //! Type used to store Task prototype classes
-        using Registry = std::map<TaskType, Task*>;
         //! List of task types and corresponding prototypes.
-        Registry registry_;
+        std::map<TaskType, Task*> registry_;
     };
 
     //! %Print the Exif (or other metadata) of a file to stdout

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -31,6 +31,7 @@
 // *****************************************************************************
 // included header files
 #include "exiv2app.hpp"
+#include <unordered_map>
 
 // *****************************************************************************
 // class declarations
@@ -141,7 +142,7 @@ namespace Action {
         TaskFactory();
 
         //! List of task types and corresponding prototypes.
-        std::map<TaskType, Task*> registry_;
+        std::unordered_map<TaskType, Task::UniquePtr> registry_;
     };
 
     //! %Print the Exif (or other metadata) of a file to stdout

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -44,9 +44,7 @@ namespace Exiv2 {
 
 // *****************************************************************************
 // namespace extensions
-/*!
-  @brief Contains all action classes (task subclasses).
- */
+/// @brief Contains all action classes (task subclasses).
 namespace Action {
 
     //! Enumerates all tasks
@@ -68,32 +66,27 @@ namespace Action {
         using UniquePtr = std::unique_ptr<Task>;
         //! Virtual destructor.
         virtual ~Task() = default;
-        //! Virtual copy construction.
-        UniquePtr clone() const;
-        /*!
-          @brief Application interface to perform a task.
 
-          @param path Path of the file to process.
-          @return 0 if successful.
-         */
+        //! Virtual copy construction.
+        virtual UniquePtr clone() const = 0;
+
+        /// @brief Application interface to perform a task.
+        /// @param path Path of the file to process.
+        /// @return 0 if successful.
         virtual int run(const std::string& path) =0;
         
-        /*!
-          @brief Application interface to perform a task.
+        bool setBinary(bool b)
+        {
+            bool bResult = binary_;
+            binary_ = b;
+            return bResult ;
+        }
 
-          @param path Path of the file to process.
-          @return 0 if successful.
-         */
-        bool setBinary(bool b) { bool bResult = binary_ ; binary_ = b ; return bResult ;}
         bool binary() { return binary_ ; }
 
     private:
-        //! Internal virtual copy constructor.
-        virtual Task* clone_() const =0;
-        
         //! copy binary_ from command-line params to task
         bool binary_ {false} ;
-
     }; // class Task
 
     /*!
@@ -107,9 +100,7 @@ namespace Action {
     public:
         /*!
           @brief Get access to the task factory.
-
-          Clients access the task factory exclusively through
-          this method.
+          Clients access the task factory exclusively through this method. (SINGLETON)
         */
         static TaskFactory& instance();
 
@@ -155,16 +146,14 @@ namespace Action {
         using Registry = std::map<TaskType, Task*>;
         //! List of task types and corresponding prototypes.
         Registry registry_;
-
-    }; // class TaskFactory
+    };
 
     //! %Print the Exif (or other metadata) of a file to stdout
     class Print : public Task {
     public:
         ~Print() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Print>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
         //! Print the Jpeg comment
         int printComment();
@@ -205,25 +194,16 @@ namespace Action {
                      EasyAccessFct easyAccessFctFallback =NULL) const;
 
     private:
-        Print* clone_() const override;
-
         std::string path_;
         int align_{0};                // for the alignment of the summary output
-    }; // class Print
+    };
 
-    /*!
-      @brief %Rename a file to its metadata creation timestamp,
-             in the specified format.
-     */
+    /// @brief %Rename a file to its metadata creation timestamp, in the specified format.
     class Rename : public Task {
     public:
         ~Rename() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Rename>;
-        UniquePtr clone() const;
-
-    private:
-        Rename* clone_() const override;
+        Task::UniquePtr clone() const override;
     }; // class Rename
 
     //! %Adjust the Exif (or other metadata) timestamps
@@ -231,11 +211,9 @@ namespace Action {
     public:
         ~Adjust() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Adjust>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
     private:
-        Adjust* clone_() const override;
         int adjustDateTime(Exiv2::ExifData& exifData,
                            const std::string& key,
                            const std::string& path) const;
@@ -247,56 +225,41 @@ namespace Action {
 
     }; // class Adjust
 
-    /*!
-      @brief %Erase the entire exif data or only the thumbnail section.
-     */
+    /// @brief %Erase the entire exif data or only the thumbnail section.
     class Erase : public Task {
     public:
         ~Erase() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Erase>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
-        /*!
-          @brief Delete the thumbnail image, incl IFD1 metadata from the file.
-         */
+        /// @brief Delete the thumbnail image, incl IFD1 metadata from the file.
         static int eraseThumbnail(Exiv2::Image* image);
-        /*!
-          @brief Erase the complete Exif data block from the file.
-         */
+
+        /// @brief Erase the complete Exif data block from the file.
         static int eraseExifData(Exiv2::Image* image);
-        /*!
-          @brief Erase all Iptc data from the file.
-         */
+
+        /// @brief Erase all Iptc data from the file.
         static int eraseIptcData(Exiv2::Image* image);
-        /*!
-          @brief Erase Jpeg comment from the file.
-         */
+
+        /// @brief Erase Jpeg comment from the file.
         static int eraseComment(Exiv2::Image* image);
-        /*!
-          @brief Erase XMP packet from the file.
-         */
+
+        /// @brief Erase XMP packet from the file.
         static int eraseXmpData(Exiv2::Image* image);
-        /*!
-          @brief Erase ICCProfile from the file.
-         */
+
+        /// @brief Erase ICCProfile from the file.
         static int eraseIccProfile(Exiv2::Image* image);
 
     private:
-        Erase* clone_() const override;
         std::string path_;
+    };
 
-    }; // class Erase
-
-    /*!
-      @brief %Extract the entire exif data or only the thumbnail section.
-     */
+    /// @brief %Extract the entire exif data or only the thumbnail section.
     class Extract : public Task {
     public:
         ~Extract() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Extract>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
         /*!
           @brief Write the thumbnail image to a file. The filename is composed by
@@ -305,37 +268,28 @@ namespace Action {
                  on the format of the Exif thumbnail image.
          */
         int writeThumbnail() const;
-        /*!
-          @brief Write preview images to files.
-         */
+
+        /// @brief Write preview images to files.
         int writePreviews() const;
-        /*!
-          @brief Write one preview image to a file. The filename is composed by
-                 removing the suffix from the image filename and appending
-                 "-preview<num>" and the appropriate suffix (".jpg" or ".tif"),
-                 depending on the format of the Exif thumbnail image.
-         */
+
+        /// @brief Write one preview image to a file. The filename is composed by removing the suffix from the image
+        /// filename and appending "-preview<num>" and the appropriate suffix (".jpg" or ".tif"), depending on the
+        /// format of the Exif thumbnail image.
         void writePreviewFile(const Exiv2::PreviewImage& pvImg, int num) const;
-        /*!
-          @brief Write embedded iccProfile files.
-         */
+
+        /// @brief Write embedded iccProfile files.
         int writeIccProfile(const std::string& target) const;
 
     private:
-        Extract* clone_() const override;
         std::string path_;
+    };
 
-    }; // class Extract
-
-    /*!
-      @brief %Insert the Exif data from corresponding *.exv files.
-     */
+    /// @brief %Insert the Exif data from corresponding *.exv files.
     class Insert : public Task {
     public:
         ~Insert() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Insert>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
         /*!
           @brief Insert a Jpeg thumbnail image from a file into file \em path.
@@ -344,96 +298,62 @@ namespace Action {
          */
         static int insertThumbnail(const std::string& path);
 
-        /*!
-          @brief Insert an XMP packet from a xmpPath into file \em path.
-         */
+        /// @brief Insert an XMP packet from a xmpPath into file \em path.
         static int insertXmpPacket(const std::string& path,const std::string& xmpPath) ;
-        /*!
-          @brief Insert xmp from a DataBuf into file \em path.
-         */
+
+        /// @brief Insert xmp from a DataBuf into file \em path.
         static int insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket = false);
 
-        /*!
-          @brief Insert an ICC profile from iccPath into file \em path.
-         */
+        /// @brief Insert an ICC profile from iccPath into file \em path.
         static int insertIccProfile(const std::string& path,const std::string& iccPath) ;
-        /*!
-          @brief Insert an ICC profile from binary DataBuf into file \em path.
-         */
+
+        /// @brief Insert an ICC profile from binary DataBuf into file \em path.
         static int insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfileBlob);
+    };
 
-    private:
-        Insert* clone_() const override;
-
-    }; // class Insert
-
-    /*!
-      @brief %Modify the Exif data according to the commands in the
-             modification table.
-     */
+    /// @brief %Modify the Exif data according to the commands in the modification table.
     class Modify : public Task {
     public:
+        Modify() {}
         ~Modify() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<Modify>;
-        UniquePtr clone() const;
-        Modify() {}
+        Task::UniquePtr clone() const override;
         //! Apply modification commands to the \em pImage, return 0 if successful.
         static int applyCommands(Exiv2::Image* pImage);
 
     private:
-        Modify* clone_() const override;
-        //! Copy constructor needed because of UniquePtr member
-        Modify(const Modify& /*src*/) = default;
-
         //! Add a metadatum to \em pImage according to \em modifyCmd
-        static int addMetadatum(Exiv2::Image* pImage,
-                                const ModifyCmd& modifyCmd);
+        static int addMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd);
         //! Set a metadatum in \em pImage according to \em modifyCmd
-        static int setMetadatum(Exiv2::Image* pImage,
-                                const ModifyCmd& modifyCmd);
+        static int setMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd);
         //! Delete a metadatum from \em pImage according to \em modifyCmd
-        static void delMetadatum(Exiv2::Image* pImage,
-                                 const ModifyCmd& modifyCmd);
+        static void delMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd);
         //! Register an XMP namespace according to \em modifyCmd
         static void regNamespace(const ModifyCmd& modifyCmd);
+    };
 
-    }; // class Modify
-
-    /*!
-      @brief %Copy ISO settings from any of the Nikon makernotes to the
-             regular Exif tag, Exif.Photo.ISOSpeedRatings.
-     */
+    /// @brief %Copy ISO settings from any of the Nikon makernotes to the regular Exif tag, Exif.Photo.ISOSpeedRatings.
     class FixIso : public Task {
     public:
         ~FixIso() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<FixIso>;
-        UniquePtr clone() const;
+        Task::UniquePtr clone() const override;
 
     private:
-        FixIso* clone_() const override;
         std::string path_;
+    };
 
-    }; // class FixIso
-
-    /*!
-      @brief Fix the character encoding of Exif UNICODE user comments.
-             Decodes the comment using the auto-detected or specified
-             character encoding and writes it back in UCS-2.
-     */
+    /// @brief Fix the character encoding of Exif UNICODE user comments.
+    ///
+    /// Decodes the comment using the auto-detected or specified character encoding and writes it back in UCS-2.
     class FixCom : public Task {
     public:
         ~FixCom() override = default;
         int run(const std::string& path) override;
-        using UniquePtr = std::unique_ptr<FixCom>;
-        UniquePtr clone() const;
-
+        Task::UniquePtr clone() const override;
     private:
-        FixCom* clone_() const override;
         std::string path_;
-
-    }; // class FixCom
+    };
 
 }                                       // namespace Action
 

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -712,7 +712,7 @@ namespace Exiv2
     // free functions
     Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new BmffImage(std::move(io), create));
+        auto image = std::make_unique<BmffImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -122,7 +122,7 @@ namespace Exiv2
     // free functions
     Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new BmpImage(std::move(io)));
+        auto image = std::make_unique<BmpImage>(std::move(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1283,6 +1283,7 @@ namespace Exiv2 {
     // free functions
     void copyExifToXmp(const ExifData& exifData, XmpData& xmpData)
     {
+        /// \todo the const_cast is "lying". We are modifying the input data. Check if this might have any bad side effect
         Converter converter(const_cast<ExifData&>(exifData), xmpData);
         converter.cnvToXmp();
     }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -196,7 +196,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new Cr2Image(std::move(io), create));
+        auto image = std::make_unique<Cr2Image>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -316,10 +316,10 @@ namespace Exiv2 {
 
         for (uint16_t i = 0; i < count; ++i) {
             uint16_t tag = getUShort(pData + o, byteOrder);
-            CiffComponent::UniquePtr m;
+            std::unique_ptr<CiffComponent> m;
             switch (CiffComponent::typeId(tag)) {
-            case directory: m = CiffComponent::UniquePtr(new CiffDirectory); break;
-            default: m = CiffComponent::UniquePtr(new CiffEntry); break;
+            case directory: m = std::make_unique<CiffDirectory>(); break;
+            default: m = std::make_unique<CiffEntry>(); break;
             }
             m->setDir(this->tag());
             m->read(pData, size, o, byteOrder);
@@ -533,9 +533,8 @@ namespace Exiv2 {
            << ", " << _("size") << " = " << std::dec << size_
            << ", " << _("offset") << " = " << offset_ << "\n";
 
-        Value::UniquePtr value;
         if (typeId() != directory) {
-            value = Value::create(typeId());
+            auto value = Value::create(typeId());
             value->read(pData_, size_, byteOrder);
             if (value->size() < 100) {
                 os << prefix << *value << "\n";
@@ -679,7 +678,7 @@ namespace Exiv2 {
             }
             if (cc_ == nullptr) {
                 // Directory doesn't exist yet, add it
-                m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
+                m_ = std::make_unique<CiffDirectory>(csd.crwDir_, csd.parent_);
                 cc_ = m_.get();
                 add(std::move(m_));
             }
@@ -809,7 +808,7 @@ namespace Exiv2 {
 
         // Make
         ExifKey key1("Exif.Image.Make");
-        Value::UniquePtr value1 = Value::create(ciffComponent.typeId());
+        auto value1 = Value::create(ciffComponent.typeId());
         uint32_t i = 0;
         while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
             // empty
@@ -819,7 +818,7 @@ namespace Exiv2 {
 
         // Model
         ExifKey key2("Exif.Image.Model");
-        Value::UniquePtr value2 = Value::create(ciffComponent.typeId());
+        auto value2 = Value::create(ciffComponent.typeId());
         uint32_t j = i;
         while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
             // empty
@@ -951,7 +950,7 @@ namespace Exiv2 {
         assert(pCrwMapping != 0);
         // create a key and value pair
         ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
-        Value::UniquePtr value;
+        std::unique_ptr<Value> value;
         if (ciffComponent.typeId() != directory) {
             value = Value::create(ciffComponent.typeId());
             uint32_t size = 0;

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -729,15 +729,11 @@ namespace Exiv2 {
 
     void CiffDirectory::doRemove(CrwDirs& crwDirs, uint16_t crwTagId)
     {
-        const Components::iterator b = components_.begin();
-        const Components::iterator e = components_.end();
-        Components::iterator i;
-
         if (!crwDirs.empty()) {
             CrwSubDir csd = crwDirs.top();
             crwDirs.pop();
             // Find the directory
-            for (i = b; i != e; ++i) {
+            for (auto i = components_.begin(); i != components_.end(); ++i) {
                 if ((*i)->tag() == csd.crwDir_) {
                     // Recursive call to next lower level directory
                     (*i)->remove(crwDirs, crwTagId);
@@ -748,7 +744,7 @@ namespace Exiv2 {
         }
         else {
             // Find the tag
-            for (i = b; i != e; ++i) {
+            for (auto i = components_.begin(); i != components_.end(); ++i) {
                 if ((*i)->tagId() == crwTagId) {
                     // Remove the entry and abort the loop
                     delete *i;

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -455,28 +455,32 @@ namespace Exiv2 {
 
     DataBuf ExifThumbC::copy() const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == nullptr)
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail)
             return DataBuf();
         return thumbnail->copy(exifData_);
     }
 
     long ExifThumbC::writeFile(const std::string& path) const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == nullptr)
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail.get())
             return 0;
+
         std::string name = path + thumbnail->extension();
         DataBuf buf(thumbnail->copy(exifData_));
-        if (buf.size() == 0) return 0;
+        if (buf.size() == 0)
+            return 0;
+
         return Exiv2::writeFile(buf, name);
     }
 
 #ifdef EXV_UNICODE_PATH
     long ExifThumbC::writeFile(const std::wstring& wpath) const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return 0;
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail)
+            return 0;
         std::wstring name = wpath + thumbnail->wextension();
         DataBuf buf(thumbnail->copy(exifData_));
         if (buf.size() == 0) return 0;
@@ -486,16 +490,16 @@ namespace Exiv2 {
 #endif
     const char* ExifThumbC::mimeType() const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == nullptr)
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail.get())
             return "";
         return thumbnail->mimeType();
     }
 
     const char* ExifThumbC::extension() const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == nullptr)
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail)
             return "";
         return thumbnail->extension();
     }
@@ -503,8 +507,9 @@ namespace Exiv2 {
 #ifdef EXV_UNICODE_PATH
     const wchar_t* ExifThumbC::wextension() const
     {
-        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
-        if (thumbnail.get() == 0) return EXV_WIDEN("");
+        auto thumbnail = Thumbnail::create(exifData_);
+        if (!thumbnail)
+            return EXV_WIDEN("");
         return thumbnail->wextension();
     }
 
@@ -870,24 +875,25 @@ namespace {
     //! @cond IGNORE
     Thumbnail::UniquePtr Thumbnail::create(const Exiv2::ExifData& exifData)
     {
-        Thumbnail::UniquePtr thumbnail;
+        std::unique_ptr<Thumbnail> thumbnail;
         const Exiv2::ExifKey k1("Exif.Thumbnail.Compression");
         auto pos = exifData.findKey(k1);
         if (pos != exifData.end()) {
-            if (pos->count() == 0) return thumbnail;
+            if (pos->count() == 0)
+                return thumbnail;
             long compression = pos->toLong();
             if (compression == 6) {
-                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
+                thumbnail = std::make_unique<JpegThumbnail>();
             }
             else {
-                thumbnail = Thumbnail::UniquePtr(new TiffThumbnail);
+                thumbnail = std::make_unique<TiffThumbnail>();
             }
         }
         else {
             const Exiv2::ExifKey k2("Exif.Thumbnail.JPEGInterchangeFormat");
             pos = exifData.findKey(k2);
             if (pos != exifData.end()) {
-                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
+                thumbnail = std::make_unique<JpegThumbnail>();
             }
         }
         return thumbnail;

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -791,12 +791,12 @@ namespace Exiv2 {
             { pttIfd, "Thumbnail"                                     }
         };
         bool delTags = false;
-        ExifData::iterator pos;
         for (auto&& filteredPvTag : filteredPvTags) {
             switch (filteredPvTag.ptt_) {
                 case pttLen:
+                {
                     delTags = false;
-                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
+                    auto pos = ed.findKey(ExifKey(filteredPvTag.key_));
                     if (pos != ed.end() && sumToLong(*pos) > 32768) {
                         delTags = true;
 #ifndef SUPPRESS_WARNINGS
@@ -805,9 +805,11 @@ namespace Exiv2 {
                     ed.erase(pos);
                     }
                 break;
+                }
             case pttTag:
+                {
                 if (delTags) {
-                    pos = ed.findKey(ExifKey(filteredPvTag.key_));
+                    auto pos = ed.findKey(ExifKey(filteredPvTag.key_));
                     if (pos != ed.end()) {
 #ifndef SUPPRESS_WARNINGS
                         EXV_WARNING << "Exif tag " << pos->key() << " not encoded\n";
@@ -816,6 +818,7 @@ namespace Exiv2 {
                     }
                 }
                 break;
+                }
             case pttIfd:
                 if (delTags) {
 #ifndef SUPPRESS_WARNINGS

--- a/src/exiv2.cpp
+++ b/src/exiv2.cpp
@@ -153,8 +153,8 @@ int main(int argc, char* const argv[])
     try {
         // Create the required action class
         Action::TaskFactory& taskFactory = Action::TaskFactory::instance();
-        Action::Task::UniquePtr task = taskFactory.create(Action::TaskType(params.action_));
-        assert(task.get());
+        auto task = taskFactory.create(Action::TaskType(params.action_));
+        assert(task);
 
         // Process all files
         int n = 1;

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -100,7 +100,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new GifImage(std::move(io)));
+        auto image = std::make_unique<GifImage>(std::move(io));
         if (!image->good())
         {
             image.reset();

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -31,7 +31,6 @@
 // + standard includes
 #include <iostream>
 #include <algorithm>
-#include <iterator>
 #include <fstream>      // write the temporary file
 
 // *****************************************************************************
@@ -514,9 +513,7 @@ namespace Exiv2 {
         std::copy(iptcData.begin(), iptcData.end(), std::back_inserter(sortedIptcData));
         std::stable_sort(sortedIptcData.begin(), sortedIptcData.end(), cmpIptcdataByRecord);
 
-        IptcData::const_iterator iter = sortedIptcData.begin();
-        IptcData::const_iterator end = sortedIptcData.end();
-        for ( ; iter != end; ++iter) {
+        for (auto iter = sortedIptcData.cbegin() ; iter != sortedIptcData.cend(); ++iter) {
             // marker, record Id, dataset num
             *pWrite++ = marker_;
             *pWrite++ = static_cast<byte>(iter->record());

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -226,7 +226,7 @@ namespace Exiv2 {
 
     Iptcdatum& Iptcdatum::operator=(const uint16_t& value)
     {
-        UShortValue::UniquePtr v(new UShortValue);
+        auto v = std::make_unique<UShortValue>();
         v->value_.push_back(value);
         value_ = std::move(v);
         return *this;
@@ -553,9 +553,8 @@ namespace {
               uint32_t         sizeData
     )
     {
-        Exiv2::Value::UniquePtr value;
         Exiv2::TypeId type = Exiv2::IptcDataSets::dataSetType(dataSet, record);
-        value = Exiv2::Value::create(type);
+        auto value = Exiv2::Value::create(type);
         int rc = value->read(data, sizeData, Exiv2::bigEndian);
         if (0 == rc) {
             Exiv2::IptcKey key(dataSet, record);

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -602,8 +602,8 @@ static void boxes_check(size_t b,size_t m)
                                 const char a = rawData.read_uint8(0);
                                 const char b = rawData.read_uint8(1);
                                 if (a == b && (a == 'I' || a == 'M')) {
-                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(rawData.c_data(), rawData.size()));
-                                    printTiffStructure(*p, out, option, depth);
+                                    MemIo p (rawData.c_data(), rawData.size());
+                                    printTiffStructure(p, out, option, depth);
                                 }
                             }
 
@@ -638,8 +638,7 @@ static void boxes_check(size_t b,size_t m)
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        auto tempIo = std::make_unique<MemIo>();
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -967,7 +966,7 @@ static void boxes_check(size_t b,size_t m)
     // free functions
     Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new Jp2Image(std::move(io), create));
+        auto image = std::make_unique<Jp2Image>(std::move(io), create);
         if (!image->good())
         {
             image.reset();

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -744,10 +744,11 @@ namespace Exiv2 {
                         if (bPS) {
                             IptcData::printStructure(out, makeSlice(buf, 0, size), depth);
                         } else {
-                            // create a copy on write memio object with the data, then print the structure
-                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(buf.c_data(start), size - start));
-                            if (start < max)
-                                printTiffStructure(*p, out, option, depth);
+                            if (start < max) {
+                                // create a copy on write memio object with the data, then print the structure
+                                MemIo p (buf.c_data(start), size - start);
+                                printTiffStructure(p, out, option, depth);
+                            }
                         }
 
                         // restore and clean up
@@ -817,9 +818,7 @@ namespace Exiv2 {
             // exiv2 -pS E.jpg
 
             // binary copy io_ to a temporary file
-            BasicIo::UniquePtr tempIo(new MemIo);
-
-            assert(tempIo.get() != 0);
+            auto tempIo = std::make_unique<MemIo>();
             for (size_t i = 0; i < (count / 2) + 1; i++) {
                 long start = pos[2 * i] + 2;  // step JPG 2 byte marker
                 if (start == 2)
@@ -1304,7 +1303,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new JpegImage(std::move(io), create));
+        auto image = std::make_unique<JpegImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }
@@ -1357,9 +1356,9 @@ namespace Exiv2 {
 
     Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image;
-        image = Image::UniquePtr(new ExvImage(std::move(io), create));
-        if (!image->good()) image.reset();
+        auto image = std::make_unique<ExvImage>(std::move(io), create);
+        if (!image->good())
+            image.reset();
         return image;
     }
 

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -155,7 +155,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new MrwImage(std::move(io), create));
+        auto image = std::make_unique<MrwImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -192,7 +192,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new OrfImage(std::move(io), create));
+        auto image = std::make_unique<OrfImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1158,16 +1158,16 @@ namespace Exiv2 {
     {
         if ( ! metadata ) return os << "undefined" ;
 
-        auto dateIt = metadata->findKey(
-                ExifKey("Exif.PentaxDng.Date"));
+        auto dateIt = metadata->findKey(ExifKey("Exif.PentaxDng.Date"));
         if (dateIt == metadata->end()) {
             dateIt = metadata->findKey(ExifKey("Exif.Pentax.Date"));
         }
-        auto timeIt = metadata->findKey(
-                ExifKey("Exif.PentaxDng.Time"));
+
+        auto timeIt = metadata->findKey(ExifKey("Exif.PentaxDng.Time"));
         if (timeIt == metadata->end()) {
             timeIt = metadata->findKey(ExifKey("Exif.Pentax.Time"));
         }
+
         if (    dateIt == metadata->end() || dateIt->size() != 4 ||
                 timeIt == metadata->end() || timeIt->size() != 3 ||
                 value.size() != 4) {
@@ -1219,11 +1219,11 @@ namespace Exiv2 {
 
     // Throws std::exception if the LensInfo can't be found.
     static ExifData::const_iterator findLensInfo(const ExifData* metadata) {
-      const ExifData::const_iterator dngLensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo"));
+      const auto dngLensInfo = metadata->findKey(ExifKey("Exif.PentaxDng.LensInfo"));
       if (dngLensInfo != metadata->end()) {
         return dngLensInfo;
       }
-      const ExifData::const_iterator lensInfo = metadata->findKey(ExifKey("Exif.Pentax.LensInfo"));
+      const auto lensInfo = metadata->findKey(ExifKey("Exif.Pentax.LensInfo"));
       if (lensInfo != metadata->end()) {
         return lensInfo;
       }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -143,13 +143,12 @@ namespace Exiv2 {
         if (io_->error()) throw Error(kerFailedToReadImageData);
         if (bufRead != imgData.size()) throw Error(kerInputDataReadFailed);
 
-        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.c_data(), imgData.size());
+        auto image = Exiv2::ImageFactory::open(imgData.c_data(), imgData.size());
         image->readMetadata();
         exifData() = image->exifData();
         iptcData() = image->iptcData();
         xmpData()  = image->xmpData();
-
-    } // PgfImage::readMetadata
+    }
 
     void PgfImage::writeMetadata()
     {
@@ -158,8 +157,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        auto tempIo = std::make_unique<MemIo>();
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -192,7 +190,7 @@ namespace Exiv2 {
         int w = 0, h = 0;
         DataBuf header      = readPgfHeaderStructure(*io_, w, h);
 
-        Image::UniquePtr img  = ImageFactory::create(ImageType::png);
+        auto img = ImageFactory::create(ImageType::png);
 
         img->setExifData(exifData_);
         img->setIptcData(iptcData_);
@@ -316,7 +314,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new PgfImage(std::move(io), create));
+        auto image = std::make_unique<PgfImage>(std::move(io), create);
         if (!image->good())
         {
             image.reset();

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -306,6 +306,8 @@ namespace Exiv2 {
                 bool eXIf  = std::strcmp(chType,"eXIf")== 0;
 
                 // for XMP, ICC etc: read and format data
+                /// \todo inside findi we are transforming the dataString to uppercase. Therefore we are transforming it several times
+                /// when we could do it just once and reuse it.
                 bool bXMP  = option == kpsXMP        && findi(dataString,xmpKey)==0;
                 bool bICC  = option == kpsIccProfile && findi(dataString,iccKey)==0;
                 bool bExif = option == kpsRecursive  &&(findi(dataString,exifKey)==0 || findi(dataString,app1Key)==0);

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -362,8 +362,8 @@ namespace Exiv2 {
                             if ( parsedBuf.size() ) {
                                 if ( bExif ) {
                                     // create memio object with the data, then print the structure
-                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(parsedBuf.c_data(6),parsedBuf.size()-6));
-                                    printTiffStructure(*p,out,option,depth);
+                                    MemIo p(parsedBuf.c_data(6),parsedBuf.size()-6);
+                                    printTiffStructure(p,out,option,depth);
                                 }
                                 if ( bIptc ) {
                                     IptcData::printStructure(out, makeSlice(parsedBuf, 0, parsedBuf.size()), depth);
@@ -392,8 +392,8 @@ namespace Exiv2 {
                         }
                         if ( eXIf && option == kpsRecursive ) {
                             // create memio object with the data, then print the structure
-                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(data.c_data(), dataOffset));
-                            printTiffStructure(*p,out,option,depth);
+                            MemIo p(data.c_data(), dataOffset);
+                            printTiffStructure(p,out,option,depth);
                         }
 
                         if ( bLF ) out << std::endl;
@@ -529,8 +529,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        auto tempIo = std::make_unique<MemIo>();
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -735,7 +734,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new PngImage(std::move(io), create));
+        auto image = std::make_unique<PngImage>(std::move(io), create);
         if (!image->good())
         {
             image.reset();

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -37,7 +37,6 @@
 // + standard includes
 #include <array>
 #include <string>
-#include <iterator>
 #include <cstring>
 #include <iostream>
 #include <cassert>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -4010,6 +4010,7 @@ namespace Exiv2 {
     void XmpProperties::unregisterNs()
     {
         std::lock_guard<std::mutex> scoped_write_lock(mutex_);
+        /// \todo check if we are not unregistering the first NS
         auto i = nsRegistry_.begin();
         while (i != nsRegistry_.end()) {
             auto kill = i++;
@@ -4021,16 +4022,18 @@ namespace Exiv2 {
     {
         std::lock_guard<std::mutex> scoped_read_lock(mutex_);
         std::string ns2 = ns;
-        if (   ns2.substr(ns2.size() - 1, 1) != "/"
-            && ns2.substr(ns2.size() - 1, 1) != "#") ns2 += "/";
-        NsRegistry::const_iterator i = nsRegistry_.find(ns2);
+        if (ns2.substr(ns2.size() - 1, 1) != "/" && ns2.substr(ns2.size() - 1, 1) != "#")
+            ns2 += "/";
+
+        auto i = nsRegistry_.find(ns2);
         std::string p;
         if (i != nsRegistry_.end()) {
             p = i->second.prefix_;
         }
         else {
             const XmpNsInfo* xn = find(xmpNsInfo, XmpNsInfo::Ns(ns2));
-            if (xn) p = std::string(xn->prefix_);
+            if (xn)
+                p = std::string(xn->prefix_);
         }
         return p;
     }

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -350,8 +350,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        auto tempIo = std::make_unique<MemIo>();
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -685,7 +684,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new PsdImage(std::move(io)));
+        auto image = std::make_unique<PsdImage>(std::move(io));
         if (!image->good())
         {
             image.reset();

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -383,7 +383,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new RafImage(std::move(io), create));
+        auto image = std::make_unique<RafImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -136,8 +136,8 @@ namespace Exiv2 {
         if (list.size() != 1) return;
         ExifData exifData;
         PreviewImage preview = loader.getPreviewImage(*list.begin());
-        Image::UniquePtr image = ImageFactory::open(preview.pData(), preview.size());
-        if (image.get() == nullptr) {
+        auto image = ImageFactory::open(preview.pData(), preview.size());
+        if (!image) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to open RW2 preview image.\n";
 #endif
@@ -238,7 +238,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new Rw2Image(std::move(io)));
+        auto image = std::make_unique<Rw2Image>(std::move(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -122,7 +122,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new TgaImage(std::move(io)));
+        auto image = std::make_unique<TgaImage>(std::move(io));
         if (!image->good())
         {
             image.reset();

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -575,7 +575,7 @@ namespace Exiv2 {
     {
         auto tag = static_cast<uint16_t>(idx / cfg()->tagStep());
         int32_t sz = std::min(def.size(tag, cfg()->group_), TiffEntryBase::doSize() - idx);
-        TiffComponent::UniquePtr tc = TiffCreator::create(tag, cfg()->group_);
+        auto tc = TiffCreator::create(tag, cfg()->group_);
         auto tp = dynamic_cast<TiffBinaryElement*>(tc.get());
         // The assertion typically fails if a component is not configured in
         // the TIFF structure table (TiffCreator::tiffTreeStruct_)
@@ -633,7 +633,7 @@ namespace Exiv2 {
             }
         }
         if (tc == nullptr) {
-            TiffComponent::UniquePtr atc;
+            std::unique_ptr<TiffComponent> atc;
             if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
             } else {
@@ -682,7 +682,7 @@ namespace Exiv2 {
             if (tiffPath.size() == 1 && object.get() != nullptr) {
                 tc = addChild(std::move(object));
             } else {
-                TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
+                auto atc = std::make_unique<TiffDirectory>(tpi1.tag(), tpi2.group());
                 tc = addChild(std::move(atc));
             }
             setCount(static_cast<uint32_t>(ifds_.size()));
@@ -747,7 +747,7 @@ namespace Exiv2 {
             }
         }
         if (tc == nullptr) {
-            TiffComponent::UniquePtr atc;
+            std::unique_ptr<TiffComponent> atc;
             if (tiffPath.size() == 1 && object.get() != nullptr) {
                 atc = std::move(object);
             } else {
@@ -1879,17 +1879,17 @@ namespace Exiv2 {
 
     TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group)
     {
-        return TiffComponent::UniquePtr(new TiffEntry(tag, group));
+        return std::make_unique<TiffEntry>(tag, group);
     }
 
     TiffComponent::UniquePtr newTiffMnEntry(uint16_t tag, IfdId group)
     {
-        return TiffComponent::UniquePtr(new TiffMnEntry(tag, group, mnId));
+        return std::make_unique<TiffMnEntry>(tag, group, mnId);
     }
 
     TiffComponent::UniquePtr newTiffBinaryElement(uint16_t tag, IfdId group)
     {
-        return TiffComponent::UniquePtr(new TiffBinaryElement(tag, group));
+        return std::make_unique<TiffBinaryElement>(tag, group);
     }
 
     }  // namespace Internal

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -201,7 +201,7 @@ namespace Exiv2 {
         TiffComponent* addPath(uint16_t tag,
                                TiffPath& tiffPath,
                                TiffComponent* const pRoot,
-                               UniquePtr object =UniquePtr(nullptr));
+                               UniquePtr object =nullptr);
         /*!
           @brief Add a child to the component. Default is to do nothing.
           @param tiffComponent Auto pointer to the component to add.

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -307,7 +307,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new TiffImage(std::move(io), create));
+        auto image = std::make_unique<TiffImage>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1268,7 +1268,7 @@ namespace Exiv2 {
 
     bool TiffReader::circularReference(const byte* start, IfdId group)
     {
-        DirList::const_iterator pos = dirList_.find(start);
+        auto pos = dirList_.find(start);
         if (pos != dirList_.end()) {
 #ifndef SUPPRESS_WARNINGS
             EXV_ERROR << groupName(group) << " pointer references previously read "

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -196,7 +196,7 @@ namespace Exiv2 {
         assert(object != 0);
 
         if (pHeader_->isImageTag(object->tag(), object->group(), pPrimaryGroups_)) {
-            TiffComponent::UniquePtr clone = object->clone();
+            auto clone = object->clone();
             // Assumption is that the corresponding TIFF entry doesn't exist
             TiffPath tiffPath;
             TiffCreator::getPath(tiffPath, object->tag(), object->group(), root_);
@@ -618,7 +618,7 @@ namespace Exiv2 {
             irbKey.setIdx(pos->idx());
         }
         if (rawIptc.size() != 0 && (del || pos == exifData_.end())) {
-            Value::UniquePtr value = Value::create(unsignedLong);
+            auto value = Value::create(unsignedLong);
             DataBuf buf;
             if (rawIptc.size() % 4 != 0) {
                 // Pad the last unsignedLong value with 0s
@@ -642,7 +642,7 @@ namespace Exiv2 {
             irbBuf = Photoshop::setIptcIrb(irbBuf.c_data(), irbBuf.size(), iptcData_);
             exifData_.erase(pos);
             if (irbBuf.size() != 0) {
-                Value::UniquePtr value = Value::create(unsignedByte);
+                auto value = Value::create(unsignedByte);
                 value->read(irbBuf.data(), irbBuf.size(), invalidByteOrder);
                 Exifdatum iptcDatum(irbKey, value.get());
                 exifData_.add(iptcDatum);
@@ -672,7 +672,7 @@ namespace Exiv2 {
         }
         if (!xmpPacket.empty()) {
             // Set the XMP Exif tag to the new value
-            Value::UniquePtr value = Value::create(unsignedByte);
+            auto value = Value::create(unsignedByte);
             value->read(reinterpret_cast<const byte*>(&xmpPacket[0]),
                         static_cast<long>(xmpPacket.size()),
                         invalidByteOrder);
@@ -1332,8 +1332,8 @@ namespace Exiv2 {
                 return;
             }
             uint16_t tag = getUShort(p, byteOrder());
-            TiffComponent::UniquePtr tc = TiffCreator::create(tag, object->group());
-            if (tc.get()) {
+            auto tc = TiffCreator::create(tag, object->group());
+            if (tc) {
                 tc->setStart(p);
                 object->addChild(std::move(tc));
             } else {
@@ -1411,8 +1411,8 @@ namespace Exiv2 {
                     break;
                 }
                 // If there are multiple dirs, group is incremented for each
-                TiffComponent::UniquePtr td(new TiffDirectory(object->tag(),
-                                                            static_cast<IfdId>(object->newGroup_ + i)));
+                auto td = std::make_unique<TiffDirectory>(object->tag(),
+                                                            static_cast<IfdId>(object->newGroup_ + i));
                 td->setStart(pData_ + baseOffset() + offset);
                 object->addChild(std::move(td));
             }
@@ -1604,7 +1604,7 @@ namespace Exiv2 {
                 size = 0;
             }
         }
-        Value::UniquePtr v = Value::create(typeId);
+        auto v = Value::create(typeId);
         enforce(v.get() != nullptr, kerCorruptedMetadata);
         v->read(pData, size, byteOrder());
 
@@ -1705,7 +1705,7 @@ namespace Exiv2 {
         ByteOrder bo = object->elByteOrder();
         if (bo == invalidByteOrder) bo = byteOrder();
         TypeId typeId = toTypeId(object->elDef()->tiffType_, object->tag(), object->group());
-        Value::UniquePtr v = Value::create(typeId);
+        auto v = Value::create(typeId);
         enforce(v.get() != nullptr, kerCorruptedMetadata);
         v->read(pData, size, bo);
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -50,69 +50,69 @@ namespace Exiv2 {
 
     Value::UniquePtr Value::create(TypeId typeId)
     {
-        UniquePtr value;
+        std::unique_ptr<Value> value;
         switch (typeId) {
         case invalidTypeId:
         case signedByte:
         case unsignedByte:
-            value = UniquePtr(new DataValue(typeId));
+            value = std::make_unique<DataValue>(typeId);
             break;
         case asciiString:
-            value = UniquePtr(new AsciiValue);
+            value = std::make_unique<AsciiValue>();
             break;
         case unsignedShort:
-            value = UniquePtr(new ValueType<uint16_t>);
+            value = std::make_unique<ValueType<uint16_t>>();
             break;
         case unsignedLong:
         case tiffIfd:
-            value = UniquePtr(new ValueType<uint32_t>(typeId));
+            value = std::make_unique<ValueType<uint32_t>>(typeId);
             break;
         case unsignedRational:
-            value = UniquePtr(new ValueType<URational>);
+            value = std::make_unique<ValueType<URational>>();
             break;
         case undefined:
-            value = UniquePtr(new DataValue);
+            value = std::make_unique<DataValue>();
             break;
         case signedShort:
-            value = UniquePtr(new ValueType<int16_t>);
+            value = std::make_unique<ValueType<int16_t>>();
             break;
         case signedLong:
-            value = UniquePtr(new ValueType<int32_t>);
+            value = std::make_unique<ValueType<int32_t>>();
             break;
         case signedRational:
-            value = UniquePtr(new ValueType<Rational>);
+            value = std::make_unique<ValueType<Rational>>();
             break;
         case tiffFloat:
-            value = UniquePtr(new ValueType<float>);
+            value = std::make_unique<ValueType<float>>();
             break;
         case tiffDouble:
-            value = UniquePtr(new ValueType<double>);
+            value = std::make_unique<ValueType<double>>();
             break;
         case string:
-            value = UniquePtr(new StringValue);
+            value = std::make_unique<StringValue>();
             break;
         case date:
-            value = UniquePtr(new DateValue);
+            value = std::make_unique<DateValue>();
             break;
         case time:
-            value = UniquePtr(new TimeValue);
+            value = std::make_unique<TimeValue>();
             break;
         case comment:
-            value = UniquePtr(new CommentValue);
+            value = std::make_unique<CommentValue>();
             break;
         case xmpText:
-            value = UniquePtr(new XmpTextValue);
+            value = std::make_unique<XmpTextValue>();
             break;
         case xmpBag:
         case xmpSeq:
         case xmpAlt:
-            value = UniquePtr(new XmpArrayValue(typeId));
+            value = std::make_unique<XmpArrayValue>(typeId);
             break;
         case langAlt:
-            value = UniquePtr(new LangAltValue);
+            value = std::make_unique<LangAltValue>();
             break;
         default:
-            value = UniquePtr(new DataValue(typeId));
+            value = std::make_unique<DataValue>(typeId);
             break;
         }
         return value;

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -110,8 +110,7 @@ namespace Exiv2 {
             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
         }
         IoCloser closer(*io_);
-        BasicIo::UniquePtr tempIo(new MemIo);
-        assert (tempIo.get() != 0);
+        auto tempIo = std::make_unique<MemIo>();
 
         doWriteMetadata(*tempIo); // may throw
         io_->close();
@@ -479,8 +478,8 @@ namespace Exiv2 {
 
                 if ( equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
                     // create memio object with the payload, then print the structure
-                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.c_data(),payload.size()));
-                    printTiffStructure(*p,out,option,depth);
+                    MemIo p (payload.c_data(),payload.size());
+                    printTiffStructure(p,out,option,depth);
                 }
 
                 bool bPrintPayload = (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP) && option==kpsXMP)
@@ -732,7 +731,7 @@ namespace Exiv2 {
 
     Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool /*create*/)
     {
-        Image::UniquePtr image(new WebPImage(std::move(io)));
+        auto image = std::make_unique<WebPImage>(std::move(io));
         if (!image->good()) {
             image.reset();
         }

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -655,7 +655,7 @@ namespace Exiv2 {
         std::string out(buffer,bufferSize);
 
         // remove blanks: http://stackoverflow.com/questions/83439/remove-spaces-from-stdstring-in-c
-        out.erase(std::remove_if(out.begin(), out.end(), std::isspace), out.end());
+        out.erase(std::remove_if(out.begin(), out.end(), isspace), out.end());
 
         bool bURI = out.find("http://") != std::string::npos   ;
         bool bNS  = out.find(':') != std::string::npos && !bURI;

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -654,10 +654,8 @@ namespace Exiv2 {
         XMP_Status result = 0 ;
         std::string out(buffer,bufferSize);
 
-        // remove blanks
-        // http://stackoverflow.com/questions/83439/remove-spaces-from-stdstring-in-c
-        std::string::iterator end_pos = std::remove(out.begin(), out.end(), ' ');
-        out.erase(end_pos, out.end());
+        // remove blanks: http://stackoverflow.com/questions/83439/remove-spaces-from-stdstring-in-c
+        out.erase(std::remove_if(out.begin(), out.end(), std::isspace), out.end());
 
         bool bURI = out.find("http://") != std::string::npos   ;
         bool bNS  = out.find(':') != std::string::npos && !bURI;

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -786,10 +786,10 @@ namespace Exiv2 {
                 }
                 continue;
             }
-            XmpKey::UniquePtr key = makeXmpKey(schemaNs, propPath);
+            auto key = makeXmpKey(schemaNs, propPath);
             if (XMP_ArrayIsAltText(opt)) {
                 // Read Lang Alt property
-                LangAltValue::UniquePtr val(new LangAltValue);
+                auto val = std::make_unique<LangAltValue>();
                 XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
                 while (count-- > 0) {
                     // Get the text
@@ -836,7 +836,7 @@ namespace Exiv2 {
                 }
                 if (simpleArray) {
                     // Read the array into an XmpArrayValue
-                    XmpArrayValue::UniquePtr val(new XmpArrayValue(arrayValueTypeId(opt)));
+                    auto val = std::make_unique<XmpArrayValue>(arrayValueTypeId(opt));
                     XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
                     while (count-- > 0) {
                         iter.Next(&schemaNs, &propPath, &propValue, &opt);
@@ -847,17 +847,16 @@ namespace Exiv2 {
                     continue;
                 }
             }
-            XmpTextValue::UniquePtr val(new XmpTextValue);
-            if (   XMP_PropIsStruct(opt)
-                || XMP_PropIsArray(opt)) {
+
+            auto val = std::make_unique<XmpTextValue>();
+            if (XMP_PropIsStruct(opt) || XMP_PropIsArray(opt)) {
                 // Create a metadatum with only XMP options
                 val->setXmpArrayType(xmpArrayType(opt));
                 val->setXmpStruct(xmpStruct(opt));
                 xmpData.add(*key.get(), val.get());
                 continue;
             }
-            if (   XMP_PropIsSimple(opt)
-                || XMP_PropIsQualifier(opt)) {
+            if (XMP_PropIsSimple(opt) || XMP_PropIsQualifier(opt)) {
                 val->read(propValue);
                 xmpData.add(*key.get(), val.get());
                 continue;
@@ -1146,7 +1145,7 @@ namespace {
         if (prefix.empty()) {
             throw Exiv2::Error(Exiv2::kerNoPrefixForNamespace, propPath, schemaNs);
         }
-        return Exiv2::XmpKey::UniquePtr(new Exiv2::XmpKey(prefix, property));
+        return std::make_unique<Exiv2::XmpKey>(prefix, property);
     } // makeXmpKey
 #endif // EXV_HAVE_XMP_TOOLKIT
 

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -112,6 +112,7 @@ namespace Exiv2 {
     } // XmpSidecar::readMetadata
 
     // lower case string
+    /// \todo very similar function in pngimage (upper). We should move those things to a string utilities file
     static std::string toLowerCase(const std::string& a)
     {
         std::string b = a;

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -175,8 +175,8 @@ namespace Exiv2 {
             if (xmpPacket_.substr(0, 5)  != "<?xml") {
                 xmpPacket_ = xmlHeader + xmpPacket_ + xmlFooter;
             }
-            BasicIo::UniquePtr tempIo(new MemIo);
-            assert(tempIo.get() != 0);
+            auto tempIo = std::make_unique<MemIo>();
+
             // Write XMP packet
             if (   tempIo->write(reinterpret_cast<const byte*>(xmpPacket_.data()),
                                  static_cast<long>(xmpPacket_.size()))
@@ -191,7 +191,7 @@ namespace Exiv2 {
     // free functions
     Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create)
     {
-        Image::UniquePtr image(new XmpSidecar(std::move(io), create));
+        auto image = std::make_unique<XmpSidecar>(std::move(io), create);
         if (!image->good()) {
             image.reset();
         }

--- a/unitTests/test_XmpKey.cpp
+++ b/unitTests/test_XmpKey.cpp
@@ -90,7 +90,7 @@ TEST_F(AXmpKey, canBeCopied)
 TEST_F(AXmpKey, canBeCloned)
 {
     XmpKey key(expectedPrefix, expectedProperty);
-    XmpKey::UniquePtr clonedKey = key.clone();
+    auto clonedKey = key.clone();
     checkValidity(*clonedKey);
 }
 

--- a/unitTests/test_slice.cpp
+++ b/unitTests/test_slice.cpp
@@ -390,7 +390,7 @@ TEST_F(stringSlice, mutateString)
 {
     Slice<std::string> is_a_mutable = makeSlice(this->sentence, 5, 10);
 
-    for (Slice<std::string>::iterator it = is_a_mutable.begin(); it < is_a_mutable.end(); ++it) {
+    for (auto it = is_a_mutable.begin(); it < is_a_mutable.end(); ++it) {
         *it = ' ';
     }
 


### PR DESCRIPTION
In this PR my main objective was to cleanup some code around the iterators & smart pointers:
* Try to use `auto` when we are dealing with iterators since it makes the code much less verbose and without lossing clarity.
* Use `std::make_unique` whenever possible when dealing with smart pointers. It reduces the amount of code and specially it avoids the usage of `new` and `delete`.  This follows one of the [rules](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es60-avoid-new-and-delete-outside-resource-management-functions) in the C++ Core guidelines.
* I also took the oportunity to simplify other parts of the code as I saw improvements opportunities. I tried to scope each change in a independent & atomic commit. 