### PR TITLE
Upgrade centos:8 to centos-stream

### DIFF
--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -14,8 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # arch suffering this issue: https://github.com/abseil/abseil-cpp/issues/709
-        # centos:8 had linking issues with gtest
-        container_image: ["fedora:latest", "debian:10", "archlinux:base", "ubuntu:20.04", "centos:8", "alpine:3.13"]
+        container_image: ["fedora:latest", "debian:10", "archlinux:base", "ubuntu:20.04", "tgagor/centos-stream:2.0.11", "alpine:3.13"]
         compiler: [g++, clang++]
         build_type: [Release, Debug]
         shared_libraries: [ON, OFF]

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -30,39 +30,39 @@ distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
 
 case "$distro_id" in
     'fedora')
-        dnf -y --refresh install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which dos2unix glibc-langpack-en diffutils
+        dnf -y --refresh install gcc-c++ clang cmake make expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which dos2unix glibc-langpack-en diffutils
         ;;
 
     'debian')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev libxml2-utils
+        apt-get install -y cmake g++ clang make libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev libxml2-utils
         debian_build_gtest
         ;;
 
     'arch')
         pacman --noconfirm -Syu
-        pacman --noconfirm -S gcc clang cmake make ccache expat zlib libssh curl gtest python dos2unix which diffutils
+        pacman --noconfirm -S gcc clang cmake make expat zlib libssh curl gtest dos2unix which diffutils
         ;;
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake g++ clang make ccache python3 libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libxml2-utils
+        apt-get install -y cmake g++ clang make libexpat1-dev zlib1g-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libxml2-utils
         debian_build_gtest
         ;;
 
     'alpine')
         apk update
-        apk add gcc g++ clang cmake make ccache expat-dev zlib-dev libssh-dev curl-dev gtest gtest-dev gmock libintl gettext-dev which dos2unix bash libxml2-utils diffutils python3
+        apk add gcc g++ clang cmake make expat-dev zlib-dev libssh-dev curl-dev gtest gtest-dev gmock libintl gettext-dev which dos2unix bash libxml2-utils diffutils 
         ;;
 
     'centos'|'rhel')
         dnf clean all
-        dnf -y install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel which python3 dos2unix
+        dnf -y install gcc-c++ clang cmake make expat-devel zlib-devel libssh-devel libcurl-devel which dos2unix
         ;;
 
     'opensuse-tumbleweed')
         zypper --non-interactive refresh
-        zypper --non-interactive install gcc-c++ clang cmake make ccache libexpat-devel zlib-devel libssh-devel curl libcurl-devel git which dos2unix libxml2-tools
+        zypper --non-interactive install gcc-c++ clang cmake make libexpat-devel zlib-devel libssh-devel curl libcurl-devel git which dos2unix libxml2-tools
         pushd /tmp
           curl -LO https://github.com/google/googletest/archive/release-1.8.0.tar.gz
           tar xzf   release-1.8.0.tar.gz

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -56,12 +56,8 @@ case "$distro_id" in
         ;;
 
     'centos'|'rhel')
-        yum -y update libarchive # workaround for https://bugs.centos.org/view.php?id=18212
-        yum -y install epel-release
-        # enable copr for gtest
-        curl https://copr.fedorainfracloud.org/coprs/defolos/devel/repo/epel-7/defolos-devel-epel-7.repo > /etc/yum.repos.d/_copr_defolos-devel.repo
-        yum clean all
-        yum -y install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel gtest-devel which python3 dos2unix
+        dnf clean all
+        dnf -y install gcc-c++ clang cmake make ccache expat-devel zlib-devel libssh-devel libcurl-devel which python3 dos2unix
         ;;
 
     'opensuse-tumbleweed')


### PR DESCRIPTION
I was about to completely drop the centos build (see #2065) when I realized that there is a non-official image for the new centos-stream.

It looks like with minor modifications we can keep this build around. This is the last manual execution of the nightly pipeline over this branch:
https://github.com/Exiv2/exiv2/actions/runs/1785076279

I also took the opportunity to drop the installation of some useless dependencies such as ccache & python. In the nightly builds we are always building from scratch (no need for ccache) and not running the tests (no need for python). 