### PR TITLE
Remove date from testData file

### DIFF
--- a/test/data/issue_1959_poc.xmp
+++ b/test/data/issue_1959_poc.xmp
@@ -33,7 +33,6 @@
    exif:ExifVersion="0232"
    exif:FlashpixVersion="0100"
    exif:ColorSpace="65535"
-   photoshop:DateCreated="2022-01-04T09:41:01+00:00"
    photoshop:Instructions="Test Instructions"
    photoshop:AuthorsPosition="Test Creator's Job Title"
    photoshop:City="Test City"

--- a/test/data/issue_1959_poc.xmp.out
+++ b/test/data/issue_1959_poc.xmp.out
@@ -9,13 +9,11 @@ Exif.Photo.ExifVersion                        48 50 51 50  2.32
 Exif.Photo.FlashpixVersion                    48 49 48 48  1.00
 Exif.Photo.ColorSpace                         65535  Uncalibrated
 Exif.Photo.ComponentsConfiguration            1  Y
-Exif.Photo.DateTimeOriginal                   2022:01:04 09:41:01  2022:01:04 09:41:01
 Iptc.Application2.ObjectName                  Test IPTC XMP file  Test IPTC XMP file
 Iptc.Envelope.CharacterSet                    %G  %G
 Iptc.Application2.Keywords                    Test  Test
 Iptc.Application2.SubLocation                 Test Sublocation  Test Sublocation
 Iptc.Application2.SpecialInstructions         Test Instructions  Test Instructions
-Iptc.Application2.DateCreated                 2022-01-04  2022-01-04
 Iptc.Application2.Byline                      postscript-dev  postscript-dev
 Iptc.Application2.BylineTitle                 Test Creator's Job Title  Test Creator's Job Title
 Iptc.Application2.City                        Test City  Test City
@@ -211,7 +209,6 @@ Xmp.exif.ExifVersion                          0232  2.32
 Xmp.exif.FlashpixVersion                      0100  1.00
 Xmp.exif.ColorSpace                           65535  Uncalibrated
 Xmp.exif.ComponentsConfiguration              1  Y
-Xmp.photoshop.DateCreated                     2022-01-04T09:41:01+00:00  2022-01-04T09:41:01+00:00
 Xmp.photoshop.Instructions                    Test Instructions  Test Instructions
 Xmp.photoshop.AuthorsPosition                 Test Creator's Job Title  Test Creator's Job Title
 Xmp.photoshop.City                            Test City  Test City


### PR DESCRIPTION
In #2053 a new test was added and since then I was obtaining failures when running the tests locally. 

When running the tests locally, the `DateTimeOriginal` key is printed like this:
```
Exif.Photo.DateTimeOriginal 2022:01:04 10:41:01  2022:01:04 10:41:01
```
While the expectation was:
```
Exif.Photo.DateTimeOriginal 2022:01:04 09:41:01 2022:01:04 09:41:01
```

It seems that such time is printed in local time. Since that field is not relevant for the test added in #2053, I think we can just remove it.