### PR TITLE
Address issue #2083, fixing a time-zone bug in a unit test

### DIFF
--- a/tests/bugfixes/github/test_issue_1959.py
+++ b/tests/bugfixes/github/test_issue_1959.py
@@ -15,7 +15,7 @@ class XmpIptcStandardsTest(metaclass=CaseMeta):
     filename      = path("$data_path/issue_1959_poc.xmp")
     filename_ref  = path("$data_path/issue_1959_poc.xmp.out")
     
-    commands = ["$exiv2 -Pkvt $filename"]
+    commands = ["TZ=UTC $exiv2 -Pkvt $filename"]
 
     stderr = [""]
     retval = [0]

--- a/tests/bugfixes/github/test_issue_1959.py
+++ b/tests/bugfixes/github/test_issue_1959.py
@@ -15,7 +15,11 @@ class XmpIptcStandardsTest(metaclass=CaseMeta):
     filename      = path("$data_path/issue_1959_poc.xmp")
     filename_ref  = path("$data_path/issue_1959_poc.xmp.out")
     
-    commands = ["TZ=UTC $exiv2 -Pkvt $filename"]
+    # fix the timezone to avoid failing tests if a user's timezone is different than the reference
+    env = {
+        'TZ': 'UTC'
+    }
+    commands = ["$exiv2 -Pkvt $filename"]
 
     stderr = [""]
     retval = [0]


### PR DESCRIPTION
Address issue #2083, fixing a time-zone related bug in test_issue_1959.py.

Note, I'm following the documentation in the [exiv2.md](https://github.com/Exiv2/exiv2/blob/46c329081f147d68ba38e7256481d8e432cac64c/exiv2.md#TZ) in setting the TZ variable.