### PR TITLE
ci-conan: be more explicit about desired compiler in conan profile

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
           pip3 install gcovr
 
       - name: Conan common config
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind ninja-build
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan common config
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan common config
         run: |
@@ -162,7 +162,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind doxygen graphviz gettext
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan common config
         run: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
           sudo add-apt-repository ppa:ubuntu-lxc/daily -y
           wget -q -O - https://files.pvs-studio.com/etc/pubkey.txt |sudo apt-key add -
           sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/etc/viva64.list

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.43.0"
+          pip.exe install "conan==1.45.0"
           conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   windows:
     name: 'Win10 Arch: ${{matrix.platform}} BuildType:${{matrix.build_type}} - SHARED:${{matrix.shared_libraries}}'
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
@@ -50,6 +50,8 @@ jobs:
           conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default
+          conan profile update settings.compiler="Visual Studio" default
+          conan profile update settings.compiler.version=17 default
           conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
           conan config get storage.path
           tree /f ./conanCache

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -9,7 +9,7 @@ name: On PUSH - Basic CI for main platforms
 jobs:
   windows:
     name: 'Win10 Arch:x64 BuildType:Release - SHARED'
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +34,8 @@ jobs:
           pip.exe install "conan==1.43.0"
           conan profile new --detect default
           conan profile show default
+          conan profile update settings.compiler="Visual Studio" default
+          conan profile update settings.compiler.version=17 default
 
       - name: Run Conan
         run: |

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.43.0"
+          pip.exe install "conan==1.45.0"
           conan profile new --detect default
           conan profile show default
           conan profile update settings.compiler="Visual Studio" default
@@ -77,7 +77,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan
         run: |

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip3 install conan==1.43.0
+          pip3 install conan==1.45.0
 
       - name: Conan common config
         run: |


### PR DESCRIPTION
The windows builds suddenly broke in the last hours. It seems to be a conan related problem:

```
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=msvc
compiler.runtime_type=Release
compiler.version=193
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

ERROR: : 'settings.compiler.cppstd' value not defined
```

I recently noticed that the conan profile autodetection started to find as compiler `msvc` instead of `Visual Studio`. I had some problems with that in other projects and I decided to keep using old profiles like this one:

```
[settings]
os=Windows
os_build=Windows
arch=x86_64
arch_build=x86_64
compiler=Visual Studio
compiler.version=17
build_type=Release
[options]
[build_requires]
[env]
```

So that is what I am proposing here. To use a profile that we know it works for sure. I'll try to find out in the meantime why this change happened in conan and if we should migrate to `msvc`. 