### PR TITLE
fix(canon): cleanup canonAf2 and canonAf3 related code

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -597,6 +597,9 @@ namespace Exiv2 {
         {0x00c1, "0x00c1", "0x00c1", N_("Unknown"), canonId, makerTags, unsignedShort, -1, printValue},
         {0x00d0, "VRDOffset", N_("VRD Offset"), N_("VRD offset"), canonId, makerTags, unsignedLong, -1, printValue},
         {0x00e0, "SensorInfo", N_("Sensor Info"), N_("Sensor info"), canonId, makerTags, unsignedShort, -1, printValue},
+        // AFInfo2 structure has a special decoder, see decodeCanonAFInfo in
+        // tiffvisitor_int.cpp that decoder useses the below tags from
+        // 0x2600 to 0x2611
         {0x2600, "AFInfoSize", N_("AF InfoSize"), N_("AF InfoSize"), canonId, makerTags, signedShort, -1, printValue},
         {0x2601, "AFAreaMode", N_("AF Area Mode"), N_("AF Area Mode"), canonId, makerTags, signedShort, -1, EXV_PRINT_TAG(canonAFAreaMode)},
         {0x2602, "AFNumPoints", N_("AF NumPoints"), N_("AF NumPoints"), canonId, makerTags, signedShort, -1, printValue},
@@ -766,61 +769,6 @@ namespace Exiv2 {
     {
         return tagInfoFcd3_;
     }
-
-
-    // Canon AFInfo2 Info Tag
-    constexpr TagInfo CanonMakerNote::tagInfoAf2_[] = {
-        {0x0000, "AFInfoSize", N_("AF InfoSize"), N_("AF InfoSize"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0001, "AFAreaMode", N_("AF Area Mode"), N_("AF Area Mode"), canonAf2Id, makerTags, signedShort, -1, EXV_PRINT_TAG(canonAFAreaMode)},
-        {0x0002, "AFNumPoints", N_("AF NumPoints"), N_("AF NumPoints"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0003, "AFValidPoints", N_("AF ValidPoints"), N_("AF ValidPoints"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0004, "AFCanonImageWidth", N_("AF ImageWidth"), N_("AF ImageWidth"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0005, "AFCanonImageHeight", N_("AF ImageHeight"), N_("AF ImageHeight"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0006, "AFImageWidth", N_("AF Width"), N_("AF Width"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0007, "AFImageHeight", N_("AF Height"), N_("AF Height"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0008, "AFAreaWidths", N_("AF Area Widths"), N_("AF Area Widths"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x0009, "AFAreaHeights", N_("AF Area Heights"), N_("AF Area Heights"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x000a, "AFXPositions", N_("AF X Positions"), N_("AF X Positions"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x000b, "AFYPositions", N_("AF Y Positions"), N_("AF Y Positions"), canonAf2Id, makerTags, signedShort, -1, printValue},
-        {0x000c, "AFPointsInFocus", N_("AF Points in Focus"), N_("AF Points in Focus"), canonAf2Id, makerTags, signedShort, -1,printBitmask},
-        {0x000d, "AFPointsSelected", N_("AF Points Selected"), N_("AF Points Selected"), canonAf2Id, makerTags, signedShort, -1, printBitmask},
-        {0x000e, "AFPrimaryPoint", N_("AF Primary Point"), N_("AF Primary Point"), canonAf2Id, makerTags, signedShort, -1, printBitmask},
-        {0x000f, "0x000f", "0x000f", N_("0x000f"), canonAf2Id, makerTags, unsignedShort, -1, printValue},
-        {0x0010, "0x0010", "0x0010", N_("0x0010"), canonAf2Id, makerTags, unsignedShort, -1, printValue},
-        {0x0011, "AFFineRotation", N_("AFFineRotation"), N_("AFFineRotation"), canonAf2Id, makerTags, unsignedShort, -1, printValue},
-        {0xffff, "(UnknowAFInfo2Tag)", "(UnknowAFInfo2Tag)", N_("UnknowAFInfo2Tag  Tag"), canonAf2Id, makerTags, unsignedShort, 1, printValue} // important to add end of tag
-    };
-
-    const TagInfo* CanonMakerNote::tagListAf2()
-    {
-        return tagInfoAf2_;
-    }
-
-
-    // Canon AFInfo3 Info Tag
-    constexpr TagInfo CanonMakerNote::tagInfoAf3_[] = {
-        {0x0000, "AFInfoSize", N_("AF InfoSize"), N_("AF InfoSize"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0001, "AFAreaMode", N_("AF Area Mode"), N_("AF Area Mode"), canonAf3Id, makerTags, signedShort, -1, EXV_PRINT_TAG(canonAFAreaMode)},
-        {0x0002, "AFNumPoints", N_("AF NumPoints"), N_("AF NumPoints"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0003, "AFValidPoints", N_("AF ValidPoints"), N_("AF ValidPoints"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0004, "AFCanonImageWidth", N_("AF ImageWidth"), N_("AF ImageWidth"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0005, "AFCanonImageHeight", N_("AF ImageHeight"), N_("AF ImageHeight"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0006, "AFImageWidth", N_("AF Width"), N_("AF Width"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0007, "AFImageHeight", N_("AF Height"), N_("AF Height"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0008, "AFAreaWidths", N_("AF Area Widths"), N_("AF Area Widths"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x0009, "AFAreaHeights", N_("AF Area Heights"), N_("AF Area Heights"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x000a, "AFXPositions", N_("AF X Positions"), N_("AF X Positions"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x000b, "AFYPositions", N_("AF Y Positions"), N_("AF Y Positions"), canonAf3Id, makerTags, signedShort, -1, printValue},
-        {0x000c, "AFPointsInFocus", N_("AF Points in Focus"), N_("AF Points in Focus"), canonAf3Id, makerTags, signedShort, -1,printBitmask},
-        {0x000d, "AFPointsSelected", N_("AF Points Selected"), N_("AF Points Selected"), canonAf3Id, makerTags, signedShort, -1, printBitmask},
-        {0x000e, "AFPrimaryPoint", N_("AF Primary Point"), N_("AF Primary Point"), canonAf3Id, makerTags, signedShort, -1, printBitmask},
-    };
-
-    const TagInfo* CanonMakerNote::tagListAf3()
-    {
-        return tagInfoAf3_;
-    }
-
 
     /*
     // Canon Aspect Info, tag 0x001d

--- a/src/canonmn_int.hpp
+++ b/src/canonmn_int.hpp
@@ -77,8 +77,6 @@ namespace Exiv2 {
         static const TagInfo* tagListMv();
         //! Return read-only list of built-in Canon My Colors Info tags
         static const TagInfo* tagListMc();
-        //! Return read-only list of built-in Canon AFInfo3 Info tags
-        static const TagInfo* tagListAf3();
         //! Return read-only list of built-in Canon Face detection Info tags
         static const TagInfo* tagListFcd3();
         //! Return read-only list of built-in Canon White balance Info tags
@@ -123,8 +121,6 @@ namespace Exiv2 {
         static const TagInfo* tagListAfC();
         //! Return read-only list of built-in Canon RawBurstInfo Info tags
         static const TagInfo* tagListRawB();
-        //! Return read-only list of built-in Canon AFInfo2 Info tags
-        static const TagInfo* tagListAf2();     
        
 
         //! @name Print functions for Canon %MakerNote tags
@@ -176,8 +172,6 @@ namespace Exiv2 {
 
         //! Tag information
         static const TagInfo tagInfo_[];
-        static const TagInfo tagInfoAf2_[];
-        static const TagInfo tagInfoAf3_[];
         static const TagInfo tagInfoAfC_[];
         static const TagInfo tagInfoAfMiAdj_[];        
         static const TagInfo tagInfoAm_[];

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -90,7 +90,6 @@ namespace Exiv2 {
         { canonFiId,       "Makernote", "CanonFi",      CanonMakerNote::tagListFi      },
         { canonPaId,       "Makernote", "CanonPa",      CanonMakerNote::tagListPa      },
         { canonPrId,       "Makernote", "CanonPr",      CanonMakerNote::tagListPr      },
-        { canonAf2Id,      "Makernote", "CanonAf2Id",   CanonMakerNote::tagListAf2 },
         { canonVigCor2Id,  "Makernote", "CanonVigCor2", CanonMakerNote::tagListVigCor2 }, 
         { canonLiOpId,     "Makernote", "CanonLiOp",    CanonMakerNote::tagListLiOp    }, 
         { canonAfMiAdjId,  "Makernote", "CanonAfMiAdj", CanonMakerNote::tagListAfMiAdj },

--- a/src/tags_int.hpp
+++ b/src/tags_int.hpp
@@ -66,8 +66,6 @@ namespace Exiv2 {
         panaRawId,
         mnId,
         canonId,
-        canonAf2Id,
-        canonAf3Id,
         canonAfCId,
         canonAfMiAdjId,
         canonAmId,

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -115,18 +115,6 @@ namespace Exiv2 {
     };
 
 
-         //! Canon canonAfMiAdj Info binary array - configuration
-    extern const ArrayCfg canonAf2Cfg = {
-        canonAf2Id,        // Group for the elements
-        invalidByteOrder, // Use byte order from parent
-        ttSignedLong,  // Type for array entry and size element
-        notEncrypted,     // Not encrypted
-        true,             // Has a size element
-        false,            // No fillers
-        false,            // Don't concatenate gaps
-        { 0, ttSignedLong, 1 }
-    };
-
     //! Canon File Info binary array - configuration
     constexpr ArrayCfg canonFiCfg = {
         canonFiId,        // Group for the elements
@@ -1313,7 +1301,6 @@ namespace Exiv2 {
         { Tag::root, canonId,          exifId,           0x927c    },
         { Tag::root, canonCsId,        canonId,          0x0001    },
         { Tag::root, canonSiId,        canonId,          0x0004    },        
-        { Tag::root, canonAf2Id,       canonId,          0x0026    },
         { Tag::root, canonPaId,        canonId,          0x0005    },
         { Tag::root, canonCfId,        canonId,          0x000f    },
         { Tag::root, canonPiId,        canonId,          0x0012    },
@@ -1684,7 +1671,6 @@ namespace Exiv2 {
         {    0x0005, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonPaCfg)       },
         {    0x000f, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonCfCfg)       },
         {    0x0012, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonPiCfg)       },
-    //  {    0x0026, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonAf2Cfg)      }, // allow TiffDecoder::decodeCanonAFInfo to deal with this
         {    0x0035, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonTiCfg)       },
         {    0x0093, canonId,          EXV_BINARY_ARRAY(canonFiCfg, canonFiDef)  },
         {    0x00a0, canonId,          EXV_SIMPLE_BINARY_ARRAY(canonPrCfg)       },        
@@ -1705,7 +1691,6 @@ namespace Exiv2 {
         // Canon makernote composite tags
         {  Tag::all, canonCsId,        newTiffBinaryElement                      },
         {  Tag::all, canonSiId,        newTiffBinaryElement                      },
-        {  Tag::all, canonAf2Id,       newTiffBinaryElement                      },
         {  Tag::all, canonPaId,        newTiffBinaryElement                      },
         {  Tag::all, canonCfId,        newTiffBinaryElement                      },
         {  Tag::all, canonPiId,        newTiffBinaryElement                      },


### PR DESCRIPTION
this PR is targeting @alexvanderberkel's canon tags PR. 

@alexvanderberkel there is a lot of unused code in `canonmn_int.cpp` but I've tried to only focus on the `Af2` and `Af3` fields here. 
I think we should include this to make it more obvious that e.g. `tagListAf2()` just never gets called.