### PR TITLE
fix(testing): fix codecov.yml

### DIFF
--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -55,7 +55,8 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure
-          gcovr --root .. --object-dir . --exclude-directories xmpsdk --exclude-directories unitTests --exclude-directories samples --exclude '.*xmpsdk.*' --exclude '.*unitTests.*' --exclude '.*samples.*' --exclude-unreachable-branches --exclude-throw-branches --xml -o coverage.xml
+          # this needs to match th ecommand in on_push_ExtraJobsForMain.yml!
+          gcovr --root .. --object-dir . --exclude-unreachable-branches --exclude-throw-branches --xml -o coverage.xml
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -18,6 +18,7 @@ jobs:
       - name: install dependencies
         run: |
           pip3 install conan==1.45.0
+          pip install gcovr
 
       - name: Conan common config
         run: |
@@ -52,8 +53,8 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure
-          pip install gcovr
-          gcovr -r ./../ -x --exclude-unreachable-branches --exclude-throw-branches -o coverage.xml .
+          # this needs to match th ecommand in on_PR_linux_secial_builds.yml!
+          gcovr --root .. --object-dir . --exclude-unreachable-branches --exclude-throw-branches --xml -o coverage.xml .
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,25 @@
-codecov:
-  branch: main
+coverage:
   precision: 2
+  round: down
   range: "60..100"
-  ignore:
-    - "xmpsdk"  # Not interested about the coverage of XMKSDK
-    - "unitTests"
-    - "samples"
+
+  status:
+    project:
+      default:
+        threshold: 1 # decrease by up to 1% doesn't result in failure
+        paths:
+          - "src"
+          - "include"
+        branches:
+          - main
+
+    # check only the diff of the PR
+    patch:
+      default:
+        threshold: 1
+        paths:
+          - "src"
+          - "include"
+        branches:
+          - main
+        only_pulls: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,13 +3,16 @@ coverage:
   round: down
   range: "60..100"
 
+  # we don't care about the coverage of files in these folders
+  ignore:
+    - "xmpsdk"
+    - "unitTests"
+    - "samples"
+
   status:
     project:
       default:
         threshold: 1 # decrease by up to 1% doesn't result in failure
-        paths:
-          - "src"
-          - "include"
         branches:
           - main
 
@@ -17,9 +20,6 @@ coverage:
     patch:
       default:
         threshold: 1
-        paths:
-          - "src"
-          - "include"
         branches:
           - main
         only_pulls: true


### PR DESCRIPTION
I noticed [that you can validate the `codecov.yml`](https://docs.codecov.com/docs/codecovyml-reference) by using 

`curl -X POST --data-binary @codecov.yml https://codecov.io/validate`  

Which our `codecov.yml` was failing :see_no_evil:   
So I've tried to massage it a bit, and now it passes the validation.   
But I'd probably continue to play with it a bit to see if I can get our weird coverage reports fixed...