### PR TITLE
Remove PR-Status badges from README

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,10 @@
 # https://google.github.io/oss-fuzz/getting-started/continuous-integration/
 
 name: CIFuzz
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,9 +8,13 @@ name: "CodeQL"
 on:
   push:
     branches: [0.27-maintenance, main]
+    paths-ignore:
+      - "*.md"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [0.27-maintenance, main]
+    paths-ignore:
+      - "*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/on_PR_linux_fuzz.yml
+++ b/.github/workflows/on_PR_linux_fuzz.yml
@@ -6,6 +6,8 @@ name: On PRs - Linux-Ubuntu Quick Fuzz
 
 on:
   pull_request:
+    paths-ignore:
+      - "*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -1,6 +1,9 @@
 name: On PRs - Linux-Ubuntu Matrix
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
 
 jobs:
   Linux:

--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -3,6 +3,8 @@ name: On PRs - Linux Special Builds
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "*.md"
 
 jobs:
   special_debugRelease:

--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -1,6 +1,9 @@
 name: On PRs - Mac Matrix
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
 
 jobs:
   MacOS:

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -2,11 +2,15 @@ name: On PRs - Windows Matrix
 
 on:
   pull_request:
+    paths-ignore:
+      - "*.md"
   push:
     branches:
     - main
     tags:
     - '!*'
+    paths-ignore:
+      - "*.md"
 
 jobs:
   windows:

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -3,7 +3,11 @@
 # PRs, we will test things more intensively :)
 # - Only running UnitTests and not regression tests
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - "*.md"
+
 name: On PUSH - Basic CI for main platforms
 
 jobs:

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -6,6 +6,8 @@ on:
     - main
     tags:
     - '!*'
+    paths-ignore:
+      - "*.md"
 
 jobs:
   special_debugRelease:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 | **CI Status:**    |      |      |
 |:--                |:--   |:--   |
-| [![Basic CI for all platforms on push](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![CI for different Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) |  [![Linux Special Builds on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_special_builds.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_special_builds.yml) |
-| [![Linux-Ubuntu Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_linux_matrix.yml) | [![Mac Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_mac_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_mac_matrix.yml) | [![Win Matrix on PRs](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_windows_matrix.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_PR_windows_matrix.yml) |
+| [![Basic jobs for all platforms](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![Nightly jobs for Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) | [![On PUSH - Linux Special Builds for main branch](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml) |
 
 <div id="Welcome">
 


### PR DESCRIPTION
I noticed that in the main documentation page we were showing some badges about the CI status in Pull Requests. 
![image](https://user-images.githubusercontent.com/102645/153908680-2e26a795-23d2-435b-a3e8-e47fd11c5ad7.png)

This might send a wrong message to users regarding the status of the project.

I also took the opportunity to try to reduce the CI workload when only modifying `*.md` files. 