### PR TITLE
Make Exif.NikonAf22.ContrastDetectAFInFocus print as a Short

### DIFF
--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -294,6 +294,7 @@ namespace Exiv2 {
         { 76, ttUnsignedShort, 1 }, // AFAreaYPosition
         { 78, ttUnsignedShort, 1 }, // AFAreaWidth
         { 80, ttUnsignedShort, 1 }, // AFAreaHeight
+        { 82, ttUnsignedShort, 1 }, // ContrastDetectAFInFocus
     };
 
     //! Nikon AF2 configuration and definitions

--- a/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
+++ b/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  5057  5057
 Exif.NikonAf22.AFAreaYPosition               Short       1  2304  2304
 Exif.NikonAf22.AFAreaWidth                   Short       1  870  870
 Exif.NikonAf22.AFAreaHeight                  Short       1  729  729
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  112  112
 Exif.NikonFi.FileNumber                      Short       1  4925  4925

--- a/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
+++ b/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  246  246

--- a/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
@@ -145,7 +145,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  129  129
 Exif.NikonFi.FileNumber                      Short       1  495  495

--- a/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
@@ -141,7 +141,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  104  104
 Exif.NikonFi.FileNumber                      Short       1  476  476

--- a/test/data/test_reference_files/_DSC8437.exv.out
+++ b/test/data/test_reference_files/_DSC8437.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  1 0  1 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  1  1
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  8437  8437

--- a/test/data/test_reference_files/exiv2-issue1208.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1208.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  110  110
 Exif.NikonFi.FileNumber                      Short       1  6176  6176

--- a/test/data/test_reference_files/exiv2-issue1941-1.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-1.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0  0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  6115  6115

--- a/tests/bugfixes/github/test_issue_646.py
+++ b/tests/bugfixes/github/test_issue_646.py
@@ -22,7 +22,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  1 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  1
 """
     ]
     stderr = [ "" ] * len(commands)


### PR DESCRIPTION
To motivate this change, I was trying to interpret the output of `Exif.NikonAf22.ContrastDetectAFInFocus`. I would see things like

```
Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0
```

This had me befuddled, especially as according to the documentation at https://exiv2.org/tags-nikon.html, the value for `Exif.NikonAf2.ContrastDetectAFInFocus` is a short. After some digging, I decided this is almost certainly a bug. I believe the correct output should like something like

```
Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  0
```

or

```
Exif.NikonAf22.ContrastDetectAFInFocus       Short       1  1
```

This PR adds an entry for the `ContrastDetectAFInFocus` tag to the `nikonAf22Def` array in tiffimage_int.cpp. This entry corresponds to the entry for byte offset 82 in the `TagInfo Nikon3MakerNote::tagInfoAf22_` array in nikonmn_int.cpp, which states it's a single unsigned short entry:

https://github.com/Exiv2/exiv2/blob/0a135ff37ab05bd29a40baa23a9ab2064edfce53/src/nikonmn_int.cpp#L931

Additionally, this brings the data structure to parity with the `nikonAf21Def` array:

https://github.com/Exiv2/exiv2/blob/0a135ff37ab05bd29a40baa23a9ab2064edfce53/src/tiffimage_int.cpp#L270

