### PR TITLE
Replace Metadatum::toLong() with Metadatum::toInt64().

### DIFF
--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -134,8 +134,8 @@ namespace Exiv2
         //! @name Accessors
         //@{
         std::string mimeType() const override /* override */;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
         
         Exiv2::ByteOrder endian_{Exiv2::bigEndian};

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -87,8 +87,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -87,8 +87,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
 
         //! @name NOT Implemented

--- a/include/exiv2/exif.hpp
+++ b/include/exiv2/exif.hpp
@@ -189,7 +189,7 @@ namespace Exiv2 {
         //! Return the value as a string.
         std::string toString() const override;
         std::string toString(long n) const override;
-        long toLong(long n = 0) const override;
+        int64_t toInt64(long n = 0) const override;
         float toFloat(long n = 0) const override;
         Rational toRational(long n = 0) const override;
         Value::UniquePtr getValue() const override;

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -381,11 +381,11 @@ namespace Exiv2 {
         /*!
           @brief Return the pixel width of the image.
          */
-        virtual int pixelWidth() const;
+        virtual uint32_t pixelWidth() const;
         /*!
           @brief Return the pixel height of the image.
          */
-        virtual int pixelHeight() const;
+        virtual uint32_t pixelHeight() const;
         /*!
           @brief Returns an ExifData instance containing currently buffered
               Exif data.
@@ -490,8 +490,8 @@ namespace Exiv2 {
         DataBuf           iccProfile_;        //!< ICC buffer (binary data)
         std::string       comment_;           //!< User comment
         std::string       xmpPacket_;         //!< XMP packet
-        int               pixelWidth_;        //!< image pixel width
-        int               pixelHeight_;       //!< image pixel height
+        uint32_t          pixelWidth_;        //!< image pixel width
+        uint32_t          pixelHeight_;       //!< image pixel height
         NativePreviewList nativePreviews_;    //!< list of native previews
 
         //! Return tag name for given tag id.

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -140,7 +140,7 @@ namespace Exiv2 {
         long size() const override;
         std::string toString() const override;
         std::string toString(long n) const override;
-        long toLong(long n = 0) const override;
+        int64_t toInt64(long n = 0) const override;
         float toFloat(long n = 0) const override;
         Rational toRational(long n = 0) const override;
         Value::UniquePtr getValue() const override;

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -222,7 +222,7 @@ namespace Exiv2 {
                  The return value is -1 if the value is not set and the behaviour
                  of the method is undefined if there is no <EM>n</EM>-th component.
          */
-        virtual long toLong(long n =0) const =0;
+        virtual int64_t toInt64(long n =0) const =0;
         /*!
           @brief Return the <EM>n</EM>-th component of the value converted to float.
                  The return value is -1 if the value is not set and the behaviour

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -226,9 +226,7 @@ namespace Exiv2 {
         /*!
           @brief Return the <EM>n</EM>-th component of the value converted to uint32_t.
          */
-        uint32_t toUint32(long n =0) const {
-            return static_cast<uint32_t>(toInt64(n));
-        }
+        uint32_t toUint32(long n =0) const;
         /*!
           @brief Return the <EM>n</EM>-th component of the value converted to float.
                  The return value is -1 if the value is not set and the behaviour

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -218,11 +218,17 @@ namespace Exiv2 {
          */
         virtual std::string toString(long n) const =0;
         /*!
-          @brief Return the <EM>n</EM>-th component of the value converted to long.
+          @brief Return the <EM>n</EM>-th component of the value converted to int64_t.
                  The return value is -1 if the value is not set and the behaviour
                  of the method is undefined if there is no <EM>n</EM>-th component.
          */
         virtual int64_t toInt64(long n =0) const =0;
+        /*!
+          @brief Return the <EM>n</EM>-th component of the value converted to uint32_t.
+         */
+        uint32_t toUint32(long n =0) const {
+            return static_cast<uint32_t>(toInt64(n));
+        }
         /*!
           @brief Return the <EM>n</EM>-th component of the value converted to float.
                  The return value is -1 if the value is not set and the behaviour

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -95,8 +95,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
     }; // class MrwImage
 

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -82,8 +82,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
     }; // class OrfImage
 

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -96,7 +96,7 @@ namespace Exiv2
         //! Read PGF Header size encoded in 32 bits integer.
         uint32_t readPgfHeaderSize(BasicIo& iIo) const;
         //! Read header structure.
-        DataBuf readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const;
+        DataBuf readPgfHeaderStructure(BasicIo& iIo, uint32_t& width, uint32_t& height) const;
         //@}
 
     }; // class PgfImage

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -93,8 +93,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -86,8 +86,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
 
         //! @name NOT implemented

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -105,8 +105,8 @@ namespace Exiv2 {
         // DATA
         mutable std::string primaryGroup_;     //!< The primary group
         mutable std::string mimeType_;         //!< The MIME type
-        mutable int pixelWidthPrimary_;        //!< Width of the primary image in pixels
-        mutable int pixelHeightPrimary_;       //!< Height of the primary image in pixels
+        mutable int64_t pixelWidthPrimary_;    //!< Width of the primary image in pixels
+        mutable int64_t pixelHeightPrimary_;   //!< Height of the primary image in pixels
 
     }; // class TiffImage
 

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -83,8 +83,8 @@ namespace Exiv2 {
         //! @name Accessors
         //@{
         std::string mimeType() const override;
-        int pixelWidth() const override;
-        int pixelHeight() const override;
+        uint32_t pixelWidth() const override;
+        uint32_t pixelHeight() const override;
         //@}
 
         //! @name NOT Implemented
@@ -105,8 +105,8 @@ namespace Exiv2 {
         // DATA
         mutable std::string primaryGroup_;     //!< The primary group
         mutable std::string mimeType_;         //!< The MIME type
-        mutable int64_t pixelWidthPrimary_;    //!< Width of the primary image in pixels
-        mutable int64_t pixelHeightPrimary_;   //!< Height of the primary image in pixels
+        mutable uint32_t pixelWidthPrimary_;   //!< Width of the primary image in pixels
+        mutable uint32_t pixelHeightPrimary_;  //!< Height of the primary image in pixels
 
     }; // class TiffImage
 

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -135,7 +135,7 @@ namespace Exiv2 {
         long size() const override;
         std::string toString() const override;
         std::string toString(long n) const override;
-        long toLong(long n = 0) const override;
+        int64_t toInt64(long n = 0) const override;
         float toFloat(long n = 0) const override;
         Rational toRational(long n = 0) const override;
         Value::UniquePtr getValue() const override;

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -74,7 +74,7 @@ try {
     xmpData["Xmp.dc.eight"]   = true;
 
     // Extracting values
-    assert(xmpData["Xmp.dc.one"].toLong() == -1);
+    assert(xmpData["Xmp.dc.one"].toInt64() == -1);
     assert(xmpData["Xmp.dc.one"].value().ok());
 
     const Exiv2::Value &getv1 = xmpData["Xmp.dc.one"].value();

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -161,7 +161,7 @@ namespace Exiv2
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toLong();
+            return imageWidth->toInt64();
         }
         return pixelWidth_;
     }
@@ -170,7 +170,7 @@ namespace Exiv2
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toLong();
+            return imageHeight->toInt64();
         }
         return pixelHeight_;
     }

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -157,20 +157,20 @@ namespace Exiv2
         }
     }
 
-    int BmffImage::pixelWidth() const
+    uint32_t BmffImage::pixelWidth() const
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toInt64();
+            return imageWidth->toUint32();
         }
         return pixelWidth_;
     }
 
-    int BmffImage::pixelHeight() const
+    uint32_t BmffImage::pixelHeight() const
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toInt64();
+            return imageHeight->toUint32();
         }
         return pixelHeight_;
     }
@@ -406,9 +406,9 @@ namespace Exiv2
             case TAG_ispe: {
                 enforce(data.size() - skip >= 12, Exiv2::kerCorruptedMetadata);
                 skip += 4;
-                int width = data.read_uint32(skip, endian_);
+                uint32_t width = data.read_uint32(skip, endian_);
                 skip += 4;
-                int height = data.read_uint32(skip, endian_);
+                uint32_t height = data.read_uint32(skip, endian_);
                 skip += 4;
                 if ( bTrace ) {
                     out << "pixelWidth_, pixelHeight_ = " << Internal::stringFormat("%d, %d", width, height);

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -698,7 +698,7 @@ namespace Exiv2 {
         if (!prepareXmpTarget(to)) return;
         std::ostringstream value;
         for (long i = 0; i < pos->count(); ++i) {
-            value << static_cast<char>(pos->toLong(i));
+            value << static_cast<char>(pos->toInt64(i));
         }
         (*xmpData_)[to] = value.str();
         if (erase_) exifData_->erase(pos);
@@ -712,7 +712,7 @@ namespace Exiv2 {
         std::ostringstream value;
         for (long i = 0; i < pos->count(); ++i) {
             if (i > 0) value << '.';
-            value << pos->toLong(i);
+            value << pos->toInt64(i);
         }
         (*xmpData_)[to] = value.str();
         if (erase_) exifData_->erase(pos);
@@ -723,7 +723,7 @@ namespace Exiv2 {
         auto pos = exifData_->findKey(ExifKey(from));
         if (pos == exifData_->end() || pos->count() == 0) return;
         if (!prepareXmpTarget(to)) return;
-        int value = pos->toLong();
+        auto value = pos->toInt64();
         if (!pos->value().ok()) {
 #ifndef SUPPRESS_WARNINGS
             EXV_WARNING << "Failed to convert " << from << " to " << to << "\n";
@@ -991,7 +991,7 @@ namespace Exiv2 {
         unsigned short value = 0;
 
         if (pos != xmpData_->end() && pos->count() > 0) {
-            int fired = pos->toLong();
+            auto fired = pos->toInt64();
             if (pos->value().ok())
                 value |= fired & 1;
 #ifndef SUPPRESS_WARNINGS
@@ -1001,7 +1001,7 @@ namespace Exiv2 {
         }
         pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:Return"));
         if (pos != xmpData_->end() && pos->count() > 0) {
-            int ret = pos->toLong();
+            auto ret = pos->toInt64();
             if (pos->value().ok())
                 value |= (ret & 3) << 1;
 #ifndef SUPPRESS_WARNINGS
@@ -1011,7 +1011,7 @@ namespace Exiv2 {
         }
         pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:Mode"));
         if (pos != xmpData_->end() && pos->count() > 0) {
-            int mode = pos->toLong();
+            auto mode = pos->toInt64();
             if (pos->value().ok())
                 value |= (mode & 3) << 3;
 #ifndef SUPPRESS_WARNINGS
@@ -1021,7 +1021,7 @@ namespace Exiv2 {
         }
         pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:Function"));
         if (pos != xmpData_->end() && pos->count() > 0) {
-            int function = pos->toLong();
+            auto function = pos->toInt64();
             if (pos->value().ok())
                 value |= (function & 1) << 5;
 #ifndef SUPPRESS_WARNINGS
@@ -1032,7 +1032,7 @@ namespace Exiv2 {
         pos = xmpData_->findKey(XmpKey(std::string(from) + "/exif:RedEyeMode"));
         if (pos != xmpData_->end()) {
             if (pos->count() > 0) {
-                int red = pos->toLong();
+                auto red = pos->toInt64();
                 if (pos->value().ok())
                     value |= (red & 1) << 6;
 #ifndef SUPPRESS_WARNINGS

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -56,20 +56,20 @@ namespace Exiv2 {
         return "image/x-canon-cr2";
     }
 
-    int Cr2Image::pixelWidth() const
+    uint32_t Cr2Image::pixelWidth() const
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toInt64();
+            return imageWidth->toUint32();
         }
         return 0;
     }
 
-    int Cr2Image::pixelHeight() const
+    uint32_t Cr2Image::pixelHeight() const
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toInt64();
+            return imageHeight->toUint32();
         }
         return 0;
     }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -60,7 +60,7 @@ namespace Exiv2 {
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toLong();
+            return imageWidth->toInt64();
         }
         return 0;
     }
@@ -69,7 +69,7 @@ namespace Exiv2 {
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toLong();
+            return imageHeight->toInt64();
         }
         return 0;
     }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -66,7 +66,7 @@ namespace Exiv2 {
     {
         auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
-            return widthIter->toLong();
+            return widthIter->toInt64();
         }
         return 0;
     }
@@ -75,7 +75,7 @@ namespace Exiv2 {
     {
         auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
-            return heightIter->toLong();
+            return heightIter->toInt64();
         }
         return 0;
     }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -62,20 +62,20 @@ namespace Exiv2 {
         return "image/x-canon-crw";
     }
 
-    int CrwImage::pixelWidth() const
+    uint32_t CrwImage::pixelWidth() const
     {
         auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
-            return widthIter->toInt64();
+            return widthIter->toUint32();
         }
         return 0;
     }
 
-    int CrwImage::pixelHeight() const
+    uint32_t CrwImage::pixelHeight() const
     {
         auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
-            return heightIter->toInt64();
+            return heightIter->toUint32();
         }
         return 0;
     }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -1175,7 +1175,7 @@ namespace Exiv2 {
             }
             int32_t d = 0;
             if (edO != edEnd && edO->count() > 0 && edO->typeId() == unsignedShort) {
-                d = RotationMap::degrees(static_cast<uint16_t>(edO->toLong()));
+                d = RotationMap::degrees(static_cast<uint16_t>(edO->toInt64()));
             }
             buf.write_uint32(12, d, pHead->byteOrder());
             pHead->add(pCrwMapping->crwTagId_, pCrwMapping->crwDir_, std::move(buf));

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -157,7 +157,7 @@ namespace {
     }; // class JpegThumbnail
 
     //! Helper function to sum all components of the value of a metadatum
-    long sumToLong(const Exiv2::Exifdatum& md);
+    int64_t sumToLong(const Exiv2::Exifdatum& md);
 
     //! Helper function to delete all tags of a specific IFD from the metadata.
     void eraseIfd(Exiv2::ExifData& ed, Exiv2::Internal::IfdId ifdId);
@@ -405,9 +405,9 @@ namespace Exiv2 {
         return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
-    long Exifdatum::toLong(long n) const
+    int64_t Exifdatum::toInt64(long n) const
     {
-        return value_.get() == nullptr ? -1 : static_cast<long>(value_->toInt64(n));
+        return value_.get() == nullptr ? -1 : value_->toInt64(n);
     }
 
     float Exifdatum::toFloat(long n) const
@@ -825,7 +825,7 @@ namespace {
         if (pos != exifData.end()) {
             if (pos->count() == 0)
                 return thumbnail;
-            long compression = pos->toLong();
+            auto compression = pos->toInt64();
             if (compression == 6) {
                 thumbnail = std::make_unique<JpegThumbnail>();
             }
@@ -889,11 +889,11 @@ namespace {
         return format->dataArea();
     }
 
-    long sumToLong(const Exiv2::Exifdatum& md)
+    int64_t sumToLong(const Exiv2::Exifdatum& md)
     {
-        long sum = 0;
+        int64_t sum = 0;
         for (long i = 0; i < md.count(); ++i) {
-            sum += md.toLong(i);
+            sum += md.toInt64(i);
         }
         return sum;
     }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -691,12 +691,12 @@ namespace Exiv2 {
         return byteOrder_;
     }
 
-    int Image::pixelWidth() const
+    uint32_t Image::pixelWidth() const
     {
         return pixelWidth_;
     }
 
-    int Image::pixelHeight() const
+    uint32_t Image::pixelHeight() const
     {
         return pixelHeight_;
     }

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -181,9 +181,9 @@ namespace Exiv2 {
         return value_.get() == nullptr ? "" : value_->toString(n);
     }
 
-    long Iptcdatum::toLong(long n) const
+    int64_t Iptcdatum::toInt64(long n) const
     {
-        return value_.get() == nullptr ? -1 : static_cast<long>(value_->toInt64(n));
+        return value_.get() == nullptr ? -1 : value_->toInt64(n);
     }
 
     float Iptcdatum::toFloat(long n) const

--- a/src/metadatum.cpp
+++ b/src/metadatum.cpp
@@ -42,6 +42,10 @@ namespace Exiv2 {
         return os.str();
     }
 
+    uint32_t Metadatum::toUint32(long n) const {
+        return static_cast<uint32_t>(toInt64(n));
+    }
+
     bool cmpMetadataByTag(const Metadatum& lhs, const Metadatum& rhs)
     {
         return lhs.tag() < rhs.tag();

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toLong();
+            return imageWidth->toInt64();
         }
         return 0;
     }
@@ -62,7 +62,7 @@ namespace Exiv2 {
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toLong();
+            return imageHeight->toInt64();
         }
         return 0;
     }

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -49,20 +49,20 @@ namespace Exiv2 {
         return "image/x-minolta-mrw";
     }
 
-    int MrwImage::pixelWidth() const
+    uint32_t MrwImage::pixelWidth() const
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toInt64();
+            return imageWidth->toUint32();
         }
         return 0;
     }
 
-    int MrwImage::pixelHeight() const
+    uint32_t MrwImage::pixelHeight() const
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toInt64();
+            return imageHeight->toUint32();
         }
         return 0;
     }

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -2665,14 +2665,14 @@ fmountlens[] = {
             if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
                 return os << value;
             }
-            raw[i] = static_cast<byte>(md->toLong());
+            raw[i] = static_cast<byte>(md->toInt64());
         }
 
         auto md = metadata->findKey(ExifKey("Exif.Nikon3.LensType"));
         if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
             return os << value;
         }
-        raw[7] = static_cast<byte>(md->toLong());
+        raw[7] = static_cast<byte>(md->toInt64());
 
         for (int i = 0; fmountlens[i].lensname != nullptr; ++i) {
             if (   raw[0] == fmountlens[i].lid ) {
@@ -2990,7 +2990,7 @@ fmountlens[] = {
             os << "(" << value << ")";
         }
         else {
-            if (pos->toLong() < 0x06) {
+            if (pos->toInt64() < 0x06) {
                 // FlashGroupACompensation value
                 if (temp == 0)
                     os << 0;
@@ -3031,7 +3031,7 @@ fmountlens[] = {
             os << "(" << value << ")";
         }
         else {
-            if (pos->toLong() < 0x06) {
+            if (pos->toInt64() < 0x06) {
                 // FlashGroupBCompensation value
                 if (temp == 0)
                     os << 0;
@@ -3072,7 +3072,7 @@ fmountlens[] = {
             os << "(" << value << ")";
         }
         else {
-            if (pos->toLong() < 0x06) {
+            if (pos->toInt64() < 0x06) {
                 // FlashGroupCCompensation value
                 if (temp == 0)
                     os << 0;

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -54,20 +54,20 @@ namespace Exiv2 {
         return "image/x-olympus-orf";
     }
 
-    int OrfImage::pixelWidth() const
+    uint32_t OrfImage::pixelWidth() const
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toInt64();
+            return imageWidth->toUint32();
         }
         return 0;
     }
 
-    int OrfImage::pixelHeight() const
+    uint32_t OrfImage::pixelHeight() const
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toInt64();
+            return imageHeight->toUint32();
         }
         return 0;
     }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -58,7 +58,7 @@ namespace Exiv2 {
     {
         auto imageWidth = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toLong();
+            return imageWidth->toInt64();
         }
         return 0;
     }
@@ -67,7 +67,7 @@ namespace Exiv2 {
     {
         auto imageHeight = exifData_.findKey(Exiv2::ExifKey("Exif.Image.ImageLength"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toLong();
+            return imageHeight->toInt64();
         }
         return 0;
     }

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1175,11 +1175,11 @@ namespace Exiv2 {
             return os;
         }
         const uint32_t date =
-            (dateIt->toInt64(0) << 24) + (dateIt->toInt64(1) << 16) +
-            (dateIt->toInt64(2) <<  8) + (dateIt->toInt64(3) <<  0);
+            (dateIt->toUint32(0) << 24) + (dateIt->toUint32(1) << 16) +
+            (dateIt->toUint32(2) <<  8) + (dateIt->toUint32(3) <<  0);
         const uint32_t time =
-            (timeIt->toInt64(0) << 24) + (timeIt->toInt64(1) << 16) +
-            (timeIt->toInt64(2) <<  8);
+            (timeIt->toUint32(0) << 24) + (timeIt->toUint32(1) << 16) +
+            (timeIt->toUint32(2) <<  8);
         const uint32_t countEnc =
             (value.toUint32(0) << 24) + (value.toUint32(1) << 16) +
             (value.toUint32(2) <<  8) + (value.toUint32(3) <<  0);
@@ -1276,13 +1276,13 @@ namespace Exiv2 {
                 // 0x0207 Pentax       LensInfo  Undefined  36 3 255 0 0 40 148 71 152 80 6 241 65 237 153 88 36 1 76 107 251 255 255 255 0 0 80 6 241 0 0 0 0 0 0 0 0
                 unsigned long base   = 1;
 
-                unsigned int  autoAperture     = lensInfo->toInt64(base+1) & 0x01 ;
-                unsigned int  minAperture      = lensInfo->toInt64(base+2) & 0x06 ;
-                unsigned int  minFocusDistance = lensInfo->toInt64(base+3) & 0xf8 ;
+                unsigned int  autoAperture     = lensInfo->toUint32(base+1) & 0x01 ;
+                unsigned int  minAperture      = lensInfo->toUint32(base+2) & 0x06 ;
+                unsigned int  minFocusDistance = lensInfo->toUint32(base+3) & 0xf8 ;
 
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+4) == 148) index = 8;
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+5) == 110) index = 7;
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+4) == 110) index = 7;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toUint32(base+4) == 148) index = 8;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toUint32(base+5) == 110) index = 7;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toUint32(base+4) == 110) index = 7;
 
             } else if ( value.count() == 3 ) {
                 // http://dev.exiv2.org/attachments/download/858/_IGP9032.DNG
@@ -1290,15 +1290,15 @@ namespace Exiv2 {
                 // 0x003f PentaxDng    LensType  Byte        3    3 255   0
                 // 0x0207 PentaxDng    LensInfo  Undefined  69  131   0   0 255 0  40 148  68 244 ...
                 //                                                0   1   2   3 4   5   6
-                if ( lensInfo->toInt64(4) == 0 && lensInfo->toInt64(5) == 40 && lensInfo->toInt64(6) == 148 ) index = 8;
+                if ( lensInfo->toUint32(4) == 0 && lensInfo->toUint32(5) == 40 && lensInfo->toUint32(6) == 148 ) index = 8;
 
             } else if ( value.count() == 4 ) {
                 // http://dev.exiv2.org/attachments/download/868/IMGP2221.JPG
                 // 0x0207 PentaxDng    LensInfo  Undefined 128    0 131 128   0 0 255   1 184   0 0 0 0 0
                 //                                                0   1   2   3 4   5   6
-                if ( lensInfo->count() == 128 && lensInfo->toInt64(1) == 131 && lensInfo->toInt64(2) == 128 ) index = 8;
+                if ( lensInfo->count() == 128 && lensInfo->toUint32(1) == 131 && lensInfo->toUint32(2) == 128 ) index = 8;
                 // #1155
-                if ( lensInfo->toInt64(6) == 5 )  index = 7;
+                if ( lensInfo->toUint32(6) == 5 )  index = 7;
             }
 
             if ( index > 0 )  {
@@ -1323,7 +1323,7 @@ namespace Exiv2 {
             const auto lensInfo = findLensInfo(metadata);
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toInt64(1) == 168 && lensInfo->toInt64(2) == 144 ) index = 7;
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toUint32(1) == 168 && lensInfo->toUint32(2) == 144 ) index = 7;
             }
 
             if ( index > 0 )  {
@@ -1348,7 +1348,7 @@ namespace Exiv2 {
             const auto lensInfo = findLensInfo(metadata);
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toInt64(1) == 131 && lensInfo->toInt64(2) == 128 )
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toUint32(1) == 131 && lensInfo->toUint32(2) == 128 )
                     index = 6;
             }
             if ( value.count() == 2 ) {

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1175,11 +1175,11 @@ namespace Exiv2 {
             return os;
         }
         const uint32_t date =
-            (dateIt->toLong(0) << 24) + (dateIt->toLong(1) << 16) +
-            (dateIt->toLong(2) <<  8) + (dateIt->toLong(3) <<  0);
+            (dateIt->toInt64(0) << 24) + (dateIt->toInt64(1) << 16) +
+            (dateIt->toInt64(2) <<  8) + (dateIt->toInt64(3) <<  0);
         const uint32_t time =
-            (timeIt->toLong(0) << 24) + (timeIt->toLong(1) << 16) +
-            (timeIt->toLong(2) <<  8);
+            (timeIt->toInt64(0) << 24) + (timeIt->toInt64(1) << 16) +
+            (timeIt->toInt64(2) <<  8);
         const uint32_t countEnc =
             (value.toUint32(0) << 24) + (value.toUint32(1) << 16) +
             (value.toUint32(2) <<  8) + (value.toUint32(3) <<  0);
@@ -1276,13 +1276,13 @@ namespace Exiv2 {
                 // 0x0207 Pentax       LensInfo  Undefined  36 3 255 0 0 40 148 71 152 80 6 241 65 237 153 88 36 1 76 107 251 255 255 255 0 0 80 6 241 0 0 0 0 0 0 0 0
                 unsigned long base   = 1;
 
-                unsigned int  autoAperture     = lensInfo->toLong(base+1) & 0x01 ;
-                unsigned int  minAperture      = lensInfo->toLong(base+2) & 0x06 ;
-                unsigned int  minFocusDistance = lensInfo->toLong(base+3) & 0xf8 ;
+                unsigned int  autoAperture     = lensInfo->toInt64(base+1) & 0x01 ;
+                unsigned int  minAperture      = lensInfo->toInt64(base+2) & 0x06 ;
+                unsigned int  minFocusDistance = lensInfo->toInt64(base+3) & 0xf8 ;
 
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toLong(base+4) == 148) index = 8;
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toLong(base+5) == 110) index = 7;
-                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toLong(base+4) == 110) index = 7;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+4) == 148) index = 8;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+5) == 110) index = 7;
+                if ( autoAperture == 0x0 && minAperture == 0x0 && minFocusDistance == 0x28 && lensInfo->toInt64(base+4) == 110) index = 7;
 
             } else if ( value.count() == 3 ) {
                 // http://dev.exiv2.org/attachments/download/858/_IGP9032.DNG
@@ -1290,15 +1290,15 @@ namespace Exiv2 {
                 // 0x003f PentaxDng    LensType  Byte        3    3 255   0
                 // 0x0207 PentaxDng    LensInfo  Undefined  69  131   0   0 255 0  40 148  68 244 ...
                 //                                                0   1   2   3 4   5   6
-                if ( lensInfo->toLong(4) == 0 && lensInfo->toLong(5) == 40 && lensInfo->toLong(6) == 148 ) index = 8;
+                if ( lensInfo->toInt64(4) == 0 && lensInfo->toInt64(5) == 40 && lensInfo->toInt64(6) == 148 ) index = 8;
 
             } else if ( value.count() == 4 ) {
                 // http://dev.exiv2.org/attachments/download/868/IMGP2221.JPG
                 // 0x0207 PentaxDng    LensInfo  Undefined 128    0 131 128   0 0 255   1 184   0 0 0 0 0
                 //                                                0   1   2   3 4   5   6
-                if ( lensInfo->count() == 128 && lensInfo->toLong(1) == 131 && lensInfo->toLong(2) == 128 ) index = 8;
+                if ( lensInfo->count() == 128 && lensInfo->toInt64(1) == 131 && lensInfo->toInt64(2) == 128 ) index = 8;
                 // #1155
-                if ( lensInfo->toLong(6) == 5 )  index = 7;
+                if ( lensInfo->toInt64(6) == 5 )  index = 7;
             }
 
             if ( index > 0 )  {
@@ -1323,7 +1323,7 @@ namespace Exiv2 {
             const auto lensInfo = findLensInfo(metadata);
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 168 && lensInfo->toLong(2) == 144 ) index = 7;
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toInt64(1) == 168 && lensInfo->toInt64(2) == 144 ) index = 7;
             }
 
             if ( index > 0 )  {
@@ -1348,7 +1348,7 @@ namespace Exiv2 {
             const auto lensInfo = findLensInfo(metadata);
             if ( value.count() == 4 ) {
                 std::string model       = getKeyString("Exif.Image.Model"      ,metadata);
-                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toLong(1) == 131 && lensInfo->toLong(2) == 128 )
+                if ( model.rfind("PENTAX K-3", 0)==0 && lensInfo->count() == 128 && lensInfo->toInt64(1) == 131 && lensInfo->toInt64(2) == 128 )
                     index = 6;
             }
             if ( value.count() == 2 ) {

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -187,7 +187,7 @@ namespace Exiv2 {
 
         readPgfHeaderSize(*io_);
 
-        int w = 0, h = 0;
+        uint32_t w = 0, h = 0;
         DataBuf header      = readPgfHeaderStructure(*io_, w, h);
 
         auto img = ImageFactory::create(ImageType::png);
@@ -278,7 +278,7 @@ namespace Exiv2 {
         return headerSize;
     } // PgfImage::readPgfHeaderSize
 
-    DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, int& width, int& height) const
+    DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, uint32_t& width, uint32_t& height) const
     {
         DataBuf header(16);
         long bufRead = iIo.read(header.data(), header.size());

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -65,7 +65,7 @@ namespace Exiv2
 {
     namespace Internal
     {
-        void PngChunk::decodeIHDRChunk(const DataBuf& data, int* outWidth, int* outHeight)
+        void PngChunk::decodeIHDRChunk(const DataBuf& data, uint32_t* outWidth, uint32_t* outHeight)
         {
             assert(data.size() >= 8);
 

--- a/src/pngchunk_int.hpp
+++ b/src/pngchunk_int.hpp
@@ -68,8 +68,8 @@ namespace Exiv2 {
           @param outHeight Integer pointer to be set to the height of the image.
         */
         static void decodeIHDRChunk(const DataBuf& data,
-                                    int*           outWidth,
-                                    int*           outHeight);
+                                    uint32_t*      outWidth,
+                                    uint32_t*      outHeight);
 
         /*!
           @brief Decode PNG tEXt, zTXt, or iTXt chunk data from \em pImage passed by data buffer

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -522,13 +522,13 @@ namespace {
         const ExifData &exifData = image_.exifData();
         auto pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
         if (pos != exifData.end() && pos->count() > 0) {
-            offset_ = pos->toLong();
+            offset_ = pos->toInt64();
         }
 
         size_ = 0;
         pos = exifData.findKey(ExifKey(param_[parIdx].sizeKey_));
         if (pos != exifData.end() && pos->count() > 0) {
-            size_ = pos->toLong();
+            size_ = pos->toInt64();
         }
 
         if (offset_ == 0 || size_ == 0) return;
@@ -536,7 +536,7 @@ namespace {
         if (param_[parIdx].baseOffsetKey_) {
             pos = exifData.findKey(ExifKey(param_[parIdx].baseOffsetKey_));
             if (pos != exifData.end() && pos->count() > 0) {
-                offset_ += pos->toLong();
+                offset_ += pos->toInt64();
             }
         }
 
@@ -712,19 +712,19 @@ namespace {
         if (pos == exifData.end()) return;
         if (offsetCount != pos->value().count()) return;
         for (int i = 0; i < offsetCount; i++) {
-            size_ += pos->toLong(i);
+            size_ += pos->toInt64(i);
         }
 
         if (size_ == 0) return;
 
         pos = exifData.findKey(ExifKey(std::string("Exif.") + group_ + ".ImageWidth"));
         if (pos != exifData.end() && pos->count() > 0) {
-            width_ = pos->toLong();
+            width_ = pos->toInt64();
         }
 
         pos = exifData.findKey(ExifKey(std::string("Exif.") + group_ + ".ImageLength"));
         if (pos != exifData.end() && pos->count() > 0) {
-            height_ = pos->toLong();
+            height_ = pos->toInt64();
         }
 
         if (width_ == 0 || height_ == 0) return;
@@ -852,8 +852,8 @@ namespace {
 
         if (formatDatum->toString() != "JPEG") return;
 
-        width_ = widthDatum->toLong();
-        height_ = heightDatum->toLong();
+        width_ = widthDatum->toInt64();
+        height_ = heightDatum->toInt64();
         preview_ = decodeBase64(imageDatum->toString());
         size_ = static_cast<uint32_t>(preview_.size());
         valid_ = true;

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -522,13 +522,13 @@ namespace {
         const ExifData &exifData = image_.exifData();
         auto pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
         if (pos != exifData.end() && pos->count() > 0) {
-            offset_ = pos->toInt64();
+            offset_ = pos->toUint32();
         }
 
         size_ = 0;
         pos = exifData.findKey(ExifKey(param_[parIdx].sizeKey_));
         if (pos != exifData.end() && pos->count() > 0) {
-            size_ = pos->toInt64();
+            size_ = pos->toUint32();
         }
 
         if (offset_ == 0 || size_ == 0) return;
@@ -536,7 +536,7 @@ namespace {
         if (param_[parIdx].baseOffsetKey_) {
             pos = exifData.findKey(ExifKey(param_[parIdx].baseOffsetKey_));
             if (pos != exifData.end() && pos->count() > 0) {
-                offset_ += pos->toInt64();
+                offset_ += pos->toUint32();
             }
         }
 
@@ -712,19 +712,19 @@ namespace {
         if (pos == exifData.end()) return;
         if (offsetCount != pos->value().count()) return;
         for (int i = 0; i < offsetCount; i++) {
-            size_ += pos->toInt64(i);
+            size_ += pos->toUint32(i);
         }
 
         if (size_ == 0) return;
 
         pos = exifData.findKey(ExifKey(std::string("Exif.") + group_ + ".ImageWidth"));
         if (pos != exifData.end() && pos->count() > 0) {
-            width_ = pos->toInt64();
+            width_ = pos->toUint32();
         }
 
         pos = exifData.findKey(ExifKey(std::string("Exif.") + group_ + ".ImageLength"));
         if (pos != exifData.end() && pos->count() > 0) {
-            height_ = pos->toInt64();
+            height_ = pos->toUint32();
         }
 
         if (width_ == 0 || height_ == 0) return;
@@ -852,8 +852,8 @@ namespace {
 
         if (formatDatum->toString() != "JPEG") return;
 
-        width_ = widthDatum->toInt64();
-        height_ = heightDatum->toInt64();
+        width_ = widthDatum->toUint32();
+        height_ = heightDatum->toUint32();
         preview_ = decodeBase64(imageDatum->toString());
         size_ = static_cast<uint32_t>(preview_.size());
         valid_ = true;

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -55,7 +55,7 @@ namespace Exiv2 {
     {
         auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
-            return widthIter->toLong();
+            return widthIter->toInt64();
         }
         return 0;
     }
@@ -64,7 +64,7 @@ namespace Exiv2 {
     {
         auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
-            return heightIter->toLong();
+            return heightIter->toInt64();
         }
         return 0;
     }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -51,20 +51,20 @@ namespace Exiv2 {
         return "image/x-fuji-raf";
     }
 
-    int RafImage::pixelWidth() const
+    uint32_t RafImage::pixelWidth() const
     {
         auto widthIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelXDimension"));
         if (widthIter != exifData_.end() && widthIter->count() > 0) {
-            return widthIter->toInt64();
+            return widthIter->toUint32();
         }
         return 0;
     }
 
-    int RafImage::pixelHeight() const
+    uint32_t RafImage::pixelHeight() const
     {
         auto heightIter = exifData_.findKey(Exiv2::ExifKey("Exif.Photo.PixelYDimension"));
         if (heightIter != exifData_.end() && heightIter->count() > 0) {
-            return heightIter->toInt64();
+            return heightIter->toUint32();
         }
         return 0;
     }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -56,7 +56,7 @@ namespace Exiv2 {
         auto imageWidth =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toLong();
+            return imageWidth->toInt64();
         }
         return 0;
     }
@@ -66,7 +66,7 @@ namespace Exiv2 {
         auto imageHeight =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorHeight"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toLong();
+            return imageHeight->toInt64();
         }
         return 0;
     }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -51,22 +51,22 @@ namespace Exiv2 {
         return "image/x-panasonic-rw2";
     }
 
-    int Rw2Image::pixelWidth() const
+    uint32_t Rw2Image::pixelWidth() const
     {
         auto imageWidth =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorWidth"));
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            return imageWidth->toInt64();
+            return imageWidth->toUint32();
         }
         return 0;
     }
 
-    int Rw2Image::pixelHeight() const
+    uint32_t Rw2Image::pixelHeight() const
     {
         auto imageHeight =
             exifData_.findKey(Exiv2::ExifKey("Exif.PanasonicRaw.SensorHeight"));
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            return imageHeight->toInt64();
+            return imageHeight->toUint32();
         }
         return 0;
     }

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -857,7 +857,7 @@ namespace Exiv2 {
             return os << "(" << value << ")";
 
         auto pos = metadata->findKey(ExifKey("Exif.Sony2Fp.0x0002"));
-        if (pos != metadata->end() && pos-> count() == 1 && pos->toLong() == 255)
+        if (pos != metadata->end() && pos-> count() == 1 && pos->toInt64() == 255)
             return os << value << " °C";
 
         return os << N_("n/a");
@@ -944,7 +944,7 @@ namespace Exiv2 {
             return os << "(" << value << ")";
 
         auto pos = metadata->findKey(ExifKey("Exif.SonyMisc1.0x0004"));
-        if (pos != metadata->end() && pos->count() == 1 && pos->toLong() != 0 && pos->toLong() < 100)
+        if (pos != metadata->end() && pos->count() == 1 && pos->toInt64() != 0 && pos->toInt64() < 100)
             return os << value << " °C";
 
         return os << N_("n/a");

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -97,7 +97,7 @@ namespace Exiv2 {
         std::string key = "Exif." + primaryGroup() + ".Compression";
         auto md = exifData_.findKey(ExifKey(key));
         if (md != exifData_.end() && md->count() > 0) {
-            const MimeTypeList* i = find(mimeTypeList, static_cast<int>(md->toLong()));
+            const MimeTypeList* i = find(mimeTypeList, static_cast<int>(md->toInt64()));
             if (i) mimeType_ = std::string(i->mimeType_);
         }
         return mimeType_;
@@ -124,7 +124,7 @@ namespace Exiv2 {
         for (auto&& i : keys) {
             auto md = exifData_.findKey(ExifKey(i));
             // Is it the primary image?
-            if (md != exifData_.end() && md->count() > 0 && md->toLong() == 0) {
+            if (md != exifData_.end() && md->count() > 0 && md->toInt64() == 0) {
                 // Sometimes there is a JPEG primary image; that's not our first choice
                 primaryGroup_ = md->groupName();
                 std::string key = "Exif." + primaryGroup_ + ".JPEGInterchangeFormat";
@@ -143,7 +143,7 @@ namespace Exiv2 {
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageWidth"));
         auto imageWidth = exifData_.findKey(key);
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            pixelWidthPrimary_ = static_cast<int>(imageWidth->toLong());
+            pixelWidthPrimary_ = imageWidth->toInt64();
         }
         return pixelWidthPrimary_;
     }
@@ -157,7 +157,7 @@ namespace Exiv2 {
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageLength"));
         auto imageHeight = exifData_.findKey(key);
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            pixelHeightPrimary_ = imageHeight->toLong();
+            pixelHeightPrimary_ = imageHeight->toInt64();
         }
         return pixelHeightPrimary_;
     }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -134,7 +134,7 @@ namespace Exiv2 {
         return primaryGroup_;
     }
 
-    int TiffImage::pixelWidth() const
+    uint32_t TiffImage::pixelWidth() const
     {
         if (pixelWidthPrimary_ != 0) {
             return pixelWidthPrimary_;
@@ -143,12 +143,12 @@ namespace Exiv2 {
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageWidth"));
         auto imageWidth = exifData_.findKey(key);
         if (imageWidth != exifData_.end() && imageWidth->count() > 0) {
-            pixelWidthPrimary_ = imageWidth->toInt64();
+            pixelWidthPrimary_ = imageWidth->toUint32();
         }
         return pixelWidthPrimary_;
     }
 
-    int TiffImage::pixelHeight() const
+    uint32_t TiffImage::pixelHeight() const
     {
         if (pixelHeightPrimary_ != 0) {
             return pixelHeightPrimary_;
@@ -157,7 +157,7 @@ namespace Exiv2 {
         ExifKey key(std::string("Exif.") + primaryGroup() + std::string(".ImageLength"));
         auto imageHeight = exifData_.findKey(key);
         if (imageHeight != exifData_.end() && imageHeight->count() > 0) {
-            pixelHeightPrimary_ = imageHeight->toInt64();
+            pixelHeightPrimary_ = imageHeight->toUint32();
         }
         return pixelHeightPrimary_;
     }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -997,7 +997,7 @@ namespace Exiv2 {
                 uint32_t sizeTotal = 0;
                 object->strips_.clear();
                 for (long i = 0; i < pos->count(); ++i) {
-                    uint32_t len = pos->toInt64(i);
+                    uint32_t len = pos->toUint32(i);
                     object->strips_.emplace_back(zero, len);
                     sizeTotal += len;
                 }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -997,7 +997,7 @@ namespace Exiv2 {
                 uint32_t sizeTotal = 0;
                 object->strips_.clear();
                 for (long i = 0; i < pos->count(); ++i) {
-                    uint32_t len = pos->toLong(i);
+                    uint32_t len = pos->toInt64(i);
                     object->strips_.emplace_back(zero, len);
                     sizeTotal += len;
                 }

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -403,9 +403,9 @@ namespace Exiv2 {
         return p_->value_.get() == nullptr ? "" : p_->value_->toString(n);
     }
 
-    long Xmpdatum::toLong(long n) const
+    int64_t Xmpdatum::toInt64(long n) const
     {
-        return p_->value_.get() == nullptr ? -1 : static_cast<long>(p_->value_->toInt64(n));
+        return p_->value_.get() == nullptr ? -1 : p_->value_->toInt64(n);
     }
 
     float Xmpdatum::toFloat(long n) const


### PR DESCRIPTION
Follow-up to #2062: replace `long` in Metadatum with platform-independent `int64_t`.