### PR TITLE
Make Nikon ContrastDetectAFInFocus tags Bytes that print as "Yes" or "No"

### DIFF
--- a/doc/templates/Makefile
+++ b/doc/templates/Makefile
@@ -80,6 +80,7 @@ TABLES = Exif \
          NikonIi \
          NikonAf \
          NikonAf2 \
+         NikonAf22 \
          NikonAFT \
          NikonFi \
          NikonMe \

--- a/doc/templates/tags-nikon.html.in
+++ b/doc/templates/tags-nikon.html.in
@@ -61,6 +61,11 @@ __NikonAf__
 __NikonAf2__
 <br>
 
+<h3>Nikon Auto Focus 2 V2 Tags</h3>
+<p>Click on a column header to sort the table.</p>
+__NikonAf22__
+<br>
+
 <h3>Nikon AF Fine Tune Tags</h3>
 <p>Click on a column header to sort the table.</p>
 __NikonAFT__

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1142,6 +1142,9 @@ namespace Exiv2 {
         { 0x00a8, "0105",    0, 2,  NA },
         { 0x00a8, "0107",    0, 3,  NA },
         { 0x00a8, "0108",    0, 3,  NA },
+        // NikonAf
+        { 0x00b7, "0100",    0, 0,  NA },
+        { 0x00b7, "0101",    0, 1,  NA },
     };
 
     int nikonSelector(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const /*pRoot*/)
@@ -1149,15 +1152,6 @@ namespace Exiv2 {
         if (size < 4) return -1;
         const NikonArrayIdx* aix = find(nikonArrayIdx, NikonArrayIdx::Key(tag, reinterpret_cast<const char*>(pData), size));
         return aix == nullptr ? -1 : aix->idx_;
-    }
-
-    int nikonAf2Selector(uint16_t tag, const byte* /*pData*/, uint32_t size, TiffComponent* const /*pRoot*/)
-    {
-        int result = tag == 0x00b7 ? 0 : -1 ;
-        if (result > -1 && size == 84 ) {
-            result = 1;
-        }
-        return result;
     }
 
     DataBuf nikonCrypt(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const pRoot)

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1143,8 +1143,8 @@ namespace Exiv2 {
         { 0x00a8, "0107",    0, 3,  NA },
         { 0x00a8, "0108",    0, 3,  NA },
         // NikonAf
-        { 0x00b7, "0100",    0, 0,  NA },
-        { 0x00b7, "0101",    0, 1,  NA },
+        { 0x00b7, "0100",   30, 0,  NA },
+        { 0x00b7, "0101",   84, 1,  NA },
     };
 
     int nikonSelector(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const /*pRoot*/)

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1143,8 +1143,8 @@ namespace Exiv2 {
         { 0x00a8, "0107",    0, 3,  NA },
         { 0x00a8, "0108",    0, 3,  NA },
         // NikonAf
-        { 0x00b7, "0100",   30, 0,  NA },
-        { 0x00b7, "0101",   84, 1,  NA },
+        { 0x00b7, "0100",   30, 0,  NA }, // These sizes have been found in tiff headers of MN
+        { 0x00b7, "0101",   84, 1,  NA }, // tag 0xb7 in sample image metadata for each version
     };
 
     int nikonSelector(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const /*pRoot*/)

--- a/src/makernote_int.hpp
+++ b/src/makernote_int.hpp
@@ -752,17 +752,6 @@ namespace Exiv2 {
     int nikonSelector(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const pRoot);
 
     /*!
-      @brief Function to select cfg + def of a Nikon complex binary array.
-
-      @param tag Tag number of the binary array
-      @param pData Pointer to the raw array data.
-      @param size Size of the array data.
-      @param pRoot Pointer to the root component of the TIFF tree.
-      @return An index into the array set, -1 if no match was found.
-     */
-     int nikonAf2Selector(uint16_t tag, const byte* pData, uint32_t size, TiffComponent* const pRoot);
-
-    /*!
       @brief Encrypt and decrypt Nikon data.
 
       Checks the version of the Nikon data array and en/decrypts (portions of) it as

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -657,7 +657,7 @@ namespace Exiv2 {
         return tagInfo_;
     }
 
-    //! YesNo, used for DaylightSavings, tag index 2
+    //! YesNo, used for DaylightSavings, tag index 2, et al.
     constexpr TagDetails nikonYesNo[] = {
         { 0, N_("No")    },
         { 1, N_("Yes")   }
@@ -904,7 +904,7 @@ namespace Exiv2 {
        { 22, "AFAreaYPosition", N_("AF Area Y Position"), N_("AF area y position"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
        { 24, "AFAreaWidth", N_("AF Area Width"), N_("AF area width"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
        { 26, "AFAreaHeight", N_("AF Area Height"), N_("AF area height"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
-       { 28, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf21Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonOffOn)},
+       { 28, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf21Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonYesNo)},
         // End of list marker
        {0xffff, "(UnknownNikonAf2Tag)", "(UnknownNikonAf2Tag)", N_("Unknown Nikon Auto Focus 2 Tag"), nikonAf21Id, makerTags, unsignedByte, 1, printValue},
     };
@@ -928,7 +928,7 @@ namespace Exiv2 {
        { 76, "AFAreaYPosition", N_("AF Area Y Position"), N_("AF area y position"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
        { 78, "AFAreaWidth", N_("AF Area Width"), N_("AF area width"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
        { 80, "AFAreaHeight", N_("AF Area Height"), N_("AF area height"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
-       { 82, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf22Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonOffOn)},
+       { 82, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf22Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonYesNo)},
         // End of list marker
        {0xffff, "(UnknownNikonAf2Tag)", "(UnknownNikonAf2Tag)", N_("Unknown Nikon Auto Focus 2 Tag"), nikonAf22Id, makerTags, unsignedByte, 1, printValue},
     };

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -904,7 +904,7 @@ namespace Exiv2 {
        { 22, "AFAreaYPosition", N_("AF Area Y Position"), N_("AF area y position"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
        { 24, "AFAreaWidth", N_("AF Area Width"), N_("AF area width"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
        { 26, "AFAreaHeight", N_("AF Area Height"), N_("AF area height"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
-       { 28, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf21Id, makerTags, unsignedShort, 1, printValue},
+       { 28, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf21Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonOffOn)},
         // End of list marker
        {0xffff, "(UnknownNikonAf2Tag)", "(UnknownNikonAf2Tag)", N_("Unknown Nikon Auto Focus 2 Tag"), nikonAf21Id, makerTags, unsignedByte, 1, printValue},
     };
@@ -928,7 +928,7 @@ namespace Exiv2 {
        { 76, "AFAreaYPosition", N_("AF Area Y Position"), N_("AF area y position"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
        { 78, "AFAreaWidth", N_("AF Area Width"), N_("AF area width"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
        { 80, "AFAreaHeight", N_("AF Area Height"), N_("AF area height"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
-       { 82, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf22Id, makerTags, unsignedShort, 1, printValue},
+       { 82, "ContrastDetectAFInFocus", N_("Contrast Detect AF In Focus"), N_("Contrast detect AF in focus"), nikonAf22Id, makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonOffOn)},
         // End of list marker
        {0xffff, "(UnknownNikonAf2Tag)", "(UnknownNikonAf2Tag)", N_("Unknown Nikon Auto Focus 2 Tag"), nikonAf22Id, makerTags, unsignedByte, 1, printValue},
     };

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1731,7 +1731,7 @@ namespace Exiv2 {
         {    0x0098, nikon3Id,         EXV_COMPLEX_BINARY_ARRAY(nikonLdSet, nikonSelector) },
         {    0x00a8, nikon3Id,         EXV_COMPLEX_BINARY_ARRAY(nikonFlSet, nikonSelector) },
         {    0x00b0, nikon3Id,         EXV_BINARY_ARRAY(nikonMeCfg, nikonMeDef)  },
-        {    0x00b7, nikon3Id,         EXV_COMPLEX_BINARY_ARRAY(nikonAf2Set, nikonAf2Selector) },
+        {    0x00b7, nikon3Id,         EXV_COMPLEX_BINARY_ARRAY(nikonAf2Set, nikonSelector) },
         {    0x00b8, nikon3Id,         EXV_BINARY_ARRAY(nikonFiCfg, nikonFiDef)  },
         {    0x00b9, nikon3Id,         EXV_BINARY_ARRAY(nikonAFTCfg, nikonAFTDef)  },
         {  Tag::all, nikon3Id,         newTiffEntry                              },

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -399,7 +399,7 @@ namespace Exiv2 {
         { 22, ttUnsignedShort, 1 }, // AFAreaYPosition
         { 24, ttUnsignedShort, 1 }, // AFAreaWidth
         { 26, ttUnsignedShort, 1 }, // AFAreaHeight
-        { 28, ttUnsignedShort, 1 }, // ContrastDetectAFInFocus
+        { 28, ttUnsignedByte,  1 }, // ContrastDetectAFInFocus
     };
     //! Nikon Auto Focus 22 binary array - configuration
     constexpr ArrayCfg nikonAf22Cfg = {
@@ -426,6 +426,7 @@ namespace Exiv2 {
         { 76, ttUnsignedShort, 1 }, // AFAreaYPosition
         { 78, ttUnsignedShort, 1 }, // AFAreaWidth
         { 80, ttUnsignedShort, 1 }, // AFAreaHeight
+        { 82, ttUnsignedByte,  1 }, // ContrastDetectAFInFocus
     };
 
     //! Nikon AF2 configuration and definitions

--- a/test/data/test_reference_files/CH0_0174.exv.out
+++ b/test/data/test_reference_files/CH0_0174.exv.out
@@ -140,19 +140,7 @@ Exif.NikonMe.MultiExposureMode               Long        1  0  Off
 Exif.NikonMe.MultiExposureShots              Long        1  0  0
 Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
-Exif.NikonAf2.Version                        Undefined   4  48 51 48 48  3.00
-Exif.NikonAf2.ContrastDetectAF               Byte        1  1  On
-Exif.NikonAf2.AFAreaMode                     Byte        1  193  193
-Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
-Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
-Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0
-Exif.NikonAf2.AFImageWidth                   Short       1  0  0
-Exif.NikonAf2.AFImageHeight                  Short       1  0  0
-Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
-Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
-Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
-Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.Nikon3.AFInfo2                          Undefined  60  48 51 48 48 1 193 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 160 23 184 15 208 11 220 7 29 1 52 1 0 0 0 0 0 0  48 51 48 48 1 193 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 160 23 184 15 208 11 220 7 29 1 52 1 0 0 0 0 0 0
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  174  174

--- a/test/data/test_reference_files/CH0_0174.exv.out
+++ b/test/data/test_reference_files/CH0_0174.exv.out
@@ -152,7 +152,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  174  174

--- a/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
+++ b/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  5057  5057
 Exif.NikonAf22.AFAreaYPosition               Short       1  2304  2304
 Exif.NikonAf22.AFAreaWidth                   Short       1  870  870
 Exif.NikonAf22.AFAreaHeight                  Short       1  729  729
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  112  112
 Exif.NikonFi.FileNumber                      Short       1  4925  4925

--- a/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
+++ b/test/data/test_reference_files/Sigma_12-24mm_F4_DG_HSM_Art.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  5057  5057
 Exif.NikonAf22.AFAreaYPosition               Short       1  2304  2304
 Exif.NikonAf22.AFAreaWidth                   Short       1  870  870
 Exif.NikonAf22.AFAreaHeight                  Short       1  729  729
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  112  112
 Exif.NikonFi.FileNumber                      Short       1  4925  4925

--- a/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
+++ b/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  246  246

--- a/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
+++ b/test/data/test_reference_files/Sigma_120-300_DG_OS_HSM_Sport_lens.exv.out
@@ -148,7 +148,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  246  246

--- a/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  105  105
 Exif.NikonFi.FileNumber                      Short       1  2057  2057

--- a/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  105  105
 Exif.NikonFi.FileNumber                      Short       1  2057  2057

--- a/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  105  105
 Exif.NikonFi.FileNumber                      Short       1  2059  2059

--- a/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  105  105
 Exif.NikonFi.FileNumber                      Short       1  2059  2059

--- a/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
+++ b/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  825  825

--- a/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
+++ b/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  825  825

--- a/test/data/test_reference_files/Stonehenge.exv.out
+++ b/test/data/test_reference_files/Stonehenge.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/Stonehenge.exv.out
+++ b/test/data/test_reference_files/Stonehenge.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
+++ b/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  69  69

--- a/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
+++ b/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  69  69

--- a/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  102  102
 Exif.NikonFi.FileNumber                      Short       1  9850  9850

--- a/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  102  102
 Exif.NikonFi.FileNumber                      Short       1  9850  9850

--- a/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
@@ -145,7 +145,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  129  129
 Exif.NikonFi.FileNumber                      Short       1  495  495

--- a/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_35mm_f1.4_Di_USD_F045.exv.out
@@ -145,7 +145,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  129  129
 Exif.NikonFi.FileNumber                      Short       1  495  495

--- a/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
+++ b/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  5296  5296
 Exif.NikonAf2.AFAreaYPosition                Short       1  2528  2528
 Exif.NikonAf2.AFAreaWidth                    Short       1  984  984
 Exif.NikonAf2.AFAreaHeight                   Short       1  816  816
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  1  On
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  1  Yes
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  109  109
 Exif.NikonFi.FileNumber                      Short       1  135  135

--- a/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
+++ b/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
@@ -147,7 +147,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  5296  5296
 Exif.NikonAf2.AFAreaYPosition                Short       1  2528  2528
 Exif.NikonAf2.AFAreaWidth                    Short       1  984  984
 Exif.NikonAf2.AFAreaHeight                   Short       1  816  816
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  1  1
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  1  On
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  109  109
 Exif.NikonFi.FileNumber                      Short       1  135  135

--- a/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
@@ -130,7 +130,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  1848  1848

--- a/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
@@ -130,7 +130,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  1848  1848

--- a/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
@@ -141,7 +141,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  104  104
 Exif.NikonFi.FileNumber                      Short       1  476  476

--- a/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_atx-i_11-16mm_F2.8_CF.exv.out
@@ -141,7 +141,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  104  104
 Exif.NikonFi.FileNumber                      Short       1  476  476

--- a/test/data/test_reference_files/_DSC8437.exv.out
+++ b/test/data/test_reference_files/_DSC8437.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  1  On
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  1  Yes
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  8437  8437

--- a/test/data/test_reference_files/_DSC8437.exv.out
+++ b/test/data/test_reference_files/_DSC8437.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  1 0  1 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  1  On
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  8437  8437

--- a/test/data/test_reference_files/exiv2-bug1014.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014.exv.out
@@ -139,7 +139,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  3  3

--- a/test/data/test_reference_files/exiv2-bug1014.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014.exv.out
@@ -139,7 +139,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  3  3

--- a/test/data/test_reference_files/exiv2-bug1014_2.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014_2.exv.out
@@ -145,7 +145,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  161  161

--- a/test/data/test_reference_files/exiv2-bug1014_2.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014_2.exv.out
@@ -145,7 +145,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  161  161

--- a/test/data/test_reference_files/exiv2-bug1026.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1026.jpg.out
@@ -134,7 +134,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  103  103
 Exif.NikonFi.FileNumber                      Short       1  3811  3811

--- a/test/data/test_reference_files/exiv2-bug1026.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1026.jpg.out
@@ -134,7 +134,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  103  103
 Exif.NikonFi.FileNumber                      Short       1  3811  3811

--- a/test/data/test_reference_files/exiv2-bug1062.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1062.jpg.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  5900  5900

--- a/test/data/test_reference_files/exiv2-bug1062.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1062.jpg.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  5900  5900

--- a/test/data/test_reference_files/exiv2-bug1108.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1108.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/exiv2-bug1108.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1108.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/exiv2-bug1108.xmp.out
+++ b/test/data/test_reference_files/exiv2-bug1108.xmp.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/exiv2-bug1108.xmp.out
+++ b/test/data/test_reference_files/exiv2-bug1108.xmp.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/exiv2-bug1114.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1114.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  1147  1147

--- a/test/data/test_reference_files/exiv2-bug1114.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1114.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  1147  1147

--- a/test/data/test_reference_files/exiv2-bug1199.webp.out
+++ b/test/data/test_reference_files/exiv2-bug1199.webp.out
@@ -78,7 +78,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00

--- a/test/data/test_reference_files/exiv2-bug1199.webp.out
+++ b/test/data/test_reference_files/exiv2-bug1199.webp.out
@@ -78,7 +78,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00

--- a/test/data/test_reference_files/exiv2-bug1225.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1225.exv.out
@@ -89,19 +89,7 @@ Exif.NikonMe.MultiExposureMode               Long        1  0  Off
 Exif.NikonMe.MultiExposureShots              Long        1  0  0
 Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
-Exif.NikonAf2.Version                        Undefined   4  48 50 48 48  2.00
-Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  129  129
-Exif.NikonAf2.PhaseDetectAF                  Byte        1  4  On (73-point)
-Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
-Exif.NikonAf2.AFPointsUsed                   Byte        7  130 0 0 0 8 224 13  130 0 0 0 8 224 13
-Exif.NikonAf2.AFImageWidth                   Short       1  0  0
-Exif.NikonAf2.AFImageHeight                  Short       1  270  270
-Exif.NikonAf2.AFAreaXPosition                Short       1  768  768
-Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
-Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
-Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.Nikon3.AFInfo2                          Undefined  42  48 50 48 48 0 129 4 0 130 0 0 0 8 224 13 0 0 0 14 1 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0  48 50 48 48 0 129 4 0 130 0 0 0 8 224 13 0 0 0 14 1 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 Exif.NikonAFT.AFFineTune                     Byte        1  0  Off
 Exif.NikonAFT.AFFineTuneIndex                Byte        1  255  255
 Exif.NikonAFT.AFFineTuneAdj                  SByte       1  0  0

--- a/test/data/test_reference_files/exiv2-bug1225.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1225.exv.out
@@ -101,7 +101,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  768  768
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonAFT.AFFineTune                     Byte        1  0  Off
 Exif.NikonAFT.AFFineTuneIndex                Byte        1  255  255
 Exif.NikonAFT.AFFineTuneAdj                  SByte       1  0  0

--- a/test/data/test_reference_files/exiv2-bug1348.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1348.exv.out
@@ -90,7 +90,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  120  120
 Exif.NikonFi.FileNumber                      Short       1  939  939

--- a/test/data/test_reference_files/exiv2-bug1348.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1348.exv.out
@@ -90,7 +90,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  120  120
 Exif.NikonFi.FileNumber                      Short       1  939  939

--- a/test/data/test_reference_files/exiv2-bug922a.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug922a.jpg.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  5900  5900

--- a/test/data/test_reference_files/exiv2-bug922a.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug922a.jpg.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  5900  5900

--- a/test/data/test_reference_files/exiv2-issue1208.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1208.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  110  110
 Exif.NikonFi.FileNumber                      Short       1  6176  6176

--- a/test/data/test_reference_files/exiv2-issue1208.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1208.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  110  110
 Exif.NikonFi.FileNumber                      Short       1  6176  6176

--- a/test/data/test_reference_files/exiv2-issue1941-1.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-1.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  6115  6115

--- a/test/data/test_reference_files/exiv2-issue1941-1.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-1.exv.out
@@ -151,7 +151,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaYPosition               Short       1  0  0
 Exif.NikonAf22.AFAreaWidth                   Short       1  0  0
 Exif.NikonAf22.AFAreaHeight                  Short       1  0  0
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  0 0  0 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  6115  6115

--- a/test/data/test_reference_files/exiv2-pr1105.exv.out
+++ b/test/data/test_reference_files/exiv2-pr1105.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  307  307
 Exif.NikonFi.FileNumber                      Short       1  1727  1727

--- a/test/data/test_reference_files/exiv2-pr1105.exv.out
+++ b/test/data/test_reference_files/exiv2-pr1105.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  307  307
 Exif.NikonFi.FileNumber                      Short       1  1727  1727

--- a/test/data/test_reference_files/issue_1934_poc1.exv.out
+++ b/test/data/test_reference_files/issue_1934_poc1.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/issue_1934_poc1.exv.out
+++ b/test/data/test_reference_files/issue_1934_poc1.exv.out
@@ -116,7 +116,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  101  101
 Exif.NikonFi.FileNumber                      Short       1  7154  7154

--- a/test/data/test_reference_files/issue_743.exv.out
+++ b/test/data/test_reference_files/issue_743.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  106  106
 Exif.NikonFi.FileNumber                      Short       1  5190  5190

--- a/test/data/test_reference_files/issue_743.exv.out
+++ b/test/data/test_reference_files/issue_743.exv.out
@@ -140,7 +140,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  106  106
 Exif.NikonFi.FileNumber                      Short       1  5190  5190

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
@@ -79,7 +79,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  0 0 0 0  ()

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
@@ -79,7 +79,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  0 0 0 0  ()

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
@@ -79,7 +79,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  0 0 0 0  ()

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
@@ -79,7 +79,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonCb2b.Version                       Undefined   4  48 50 49 57  2.19
 Exif.NikonCb2b.WB_RGGBLevels                 Short       4  7396 31796 21644 7380  7396 31796 21644 7380
 Exif.NikonFi.Version                         Undefined   4  0 0 0 0  ()

--- a/test/data/test_reference_files/pr_1994_poc1.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc1.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  423  423

--- a/test/data/test_reference_files/pr_1994_poc1.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc1.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  100  100
 Exif.NikonFi.FileNumber                      Short       1  423  423

--- a/test/data/test_reference_files/pr_1994_poc2.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc2.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  200  200
 Exif.NikonFi.FileNumber                      Short       1  4345  4345

--- a/test/data/test_reference_files/pr_1994_poc2.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc2.jpg.out
@@ -143,7 +143,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  200  200
 Exif.NikonFi.FileNumber                      Short       1  4345  4345

--- a/test/data/test_reference_files/test_issue_990.exv.out
+++ b/test/data/test_reference_files/test_issue_990.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Short       1  0  0
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  281  281
 Exif.NikonFi.FileNumber                      Short       1  7965  7965

--- a/test/data/test_reference_files/test_issue_990.exv.out
+++ b/test/data/test_reference_files/test_issue_990.exv.out
@@ -146,7 +146,7 @@ Exif.NikonAf2.AFAreaXPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaYPosition                Short       1  0  0
 Exif.NikonAf2.AFAreaWidth                    Short       1  0  0
 Exif.NikonAf2.AFAreaHeight                   Short       1  0  0
-Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  Off
+Exif.NikonAf2.ContrastDetectAFInFocus        Byte        1  0  No
 Exif.NikonFi.Version                         Undefined   4  48 49 48 48  1.00
 Exif.NikonFi.DirectoryNumber                 Short       1  281  281
 Exif.NikonFi.FileNumber                      Short       1  7965  7965

--- a/tests/bugfixes/github/test_issue_646.py
+++ b/tests/bugfixes/github/test_issue_646.py
@@ -22,7 +22,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        2  1 0
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  On
 """
     ]
     stderr = [ "" ] * len(commands)

--- a/tests/bugfixes/github/test_issue_646.py
+++ b/tests/bugfixes/github/test_issue_646.py
@@ -22,7 +22,7 @@ Exif.NikonAf22.AFAreaXPosition               Short       1  3950
 Exif.NikonAf22.AFAreaYPosition               Short       1  2871
 Exif.NikonAf22.AFAreaWidth                   Short       1  435
 Exif.NikonAf22.AFAreaHeight                  Short       1  360
-Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  On
+Exif.NikonAf22.ContrastDetectAFInFocus       Byte        1  Yes
 """
     ]
     stderr = [ "" ] * len(commands)


### PR DESCRIPTION
This is the follow on PR from #2102, which was closed without merge.

This PR adds the `ContrastDetectAFInFocus` field to the `nikonAf22Def` in tiffimage_int.cpp and defines its type as a single UnsignedByte. It also changes the data type of the same field in `nikonAf21Def`.

This PR also updates the data types and print methods of the corresponding MakerNote TagInfo structures in nikonmn_int.cpp.

The `ContrastDetectAFInFocus` tag is documented on exiftool's web site: https://exiftool.org/TagNames/Nikon.html#AFInfo2.

TO DO:

- [x] Update documentation that gets uploaded to https://exiv2.org/tags-nikon.html