### PR TITLE
Catch std::exception in iptcprint

### DIFF
--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -68,5 +68,9 @@ try {
 }
 catch (Exiv2::AnyError& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return 1;
+}
+catch (const std::exception& e) {
+    std::cout << "Caught exception: '" << e.what() << "'\n";
+    return 1;
 }


### PR DESCRIPTION
The `main` function in the `iptcprint` sample program catches `Exiv2::AnyError` but not `std::exception`. The poc attached to #2050 is a bogus image file that triggers a `std::overflow_error` in this call to `Safe::add()`:

https://github.com/Exiv2/exiv2/blob/0b17cc31f71a06766a38f6c19f71e806381fadea/src/rafimage.cpp#L308

In the exiv2 application, we catch those exceptions and print an error message. We just need to do the same in this sample application.

I also changed the error return code to `1`, because `-1` is non-standard.