### PR TITLE
Add a workflow build/test for macOS+Sanitizers

### DIFF
--- a/.github/workflows/on_PR_mac_special_builds.yml
+++ b/.github/workflows/on_PR_mac_special_builds.yml
@@ -1,0 +1,51 @@
+name: On PRs - Mac Special Builds
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  MacOS_releaseSanitizers:
+    name: 'MacOS - Clang - Release+Sanitizers'
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          brew install ninja
+          pushd /tmp
+          curl -LO https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+          tar xzf   release-1.8.0.tar.gz
+          mkdir -p  googletest-release-1.8.0/build
+          pushd     googletest-release-1.8.0/build
+          cmake .. ; make ; make install
+          popd
+          popd
+
+      - name: Build
+        run: |
+          mkdir build && cd build && \
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DEXIV2_BUILD_SAMPLES=ON \
+            -DEXIV2_ENABLE_PNG=ON \
+            -DEXIV2_ENABLE_WEBREADY=ON \
+            -DEXIV2_ENABLE_CURL=ON \
+            -DEXIV2_BUILD_UNIT_TESTS=ON \
+            -DEXIV2_ENABLE_BMFF=ON \
+            -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
+            -DBUILD_WITH_COVERAGE=OFF \
+            -DEXIV2_TEAM_USE_SANITIZERS=ON \
+            -DCMAKE_INSTALL_PREFIX=install \
+            .. && \
+          cmake --build . --parallel
+
+      - name: Tests
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/src/easyaccess.cpp
+++ b/src/easyaccess.cpp
@@ -135,6 +135,7 @@ namespace Exiv2 {
             std::ostringstream os;
             md->write(os, &ed);
             bool ok = false;
+            if ( os.str().find("inf") != std::string::npos ) break;
             iso_val = parseInt64(os.str(), ok);
             if (ok && iso_val > 0) break;
             while (strcmp(keys[idx++], md->key().c_str()) != 0 && idx < cnt) {}


### PR DESCRIPTION
This is a PR build workflow for macOS+sanitizers. As can be seen at https://github.com/Exiv2/exiv2/issues/2117#issuecomment-1051313605, two test failures are reported in this configuration (for x86_64).

I'm not sure how to test GitHub workflow changes. Let's see if creating this PR activates the workflow in this PR. If it doesn't, I'll look into how to test it independently.