### PR TITLE
Recover IptDataSets::recordId in the API

### DIFF
--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -381,21 +381,6 @@ namespace Exiv2 {
                 false, false, 0, 0, Exiv2::unsignedShort, IptcDataSets::application2, ""},
     };
 
-    uint16_t recordId(const std::string& recordName)
-    {
-        uint16_t i;
-        for (i = IptcDataSets::application2; i > 0; --i) {
-            if (recordInfo_[i].name_ == recordName)
-                break;
-        }
-        if (i == 0) {
-            if (!isHex(recordName, 4, "0x"))
-                throw Error(kerInvalidRecord, recordName);
-            std::istringstream is(recordName);
-            is >> std::hex >> i;
-        }
-        return i;
-    }
 
     constexpr DataSet unknownDataSet{
         0xffff,     "Unknown dataset", N_("Unknown dataset"),       N_("Unknown dataset"), false, true, 0,
@@ -533,6 +518,21 @@ namespace Exiv2 {
         return recordInfo_[recordId].desc_;
     }
 
+    uint16_t IptcDataSets::recordId(const std::string& recordName)
+    {
+        uint16_t i;
+        for (i = IptcDataSets::application2; i > 0; --i) {
+            if (recordInfo_[i].name_ == recordName)
+                break;
+        }
+        if (i == 0) {
+            if (!isHex(recordName, 4, "0x"))
+                throw Error(kerInvalidRecord, recordName);
+            std::istringstream is(recordName);
+            is >> std::hex >> i;
+        }
+        return i;
+    }
 
     void IptcDataSets::dataSetList(std::ostream& os)
     {
@@ -629,7 +629,7 @@ namespace Exiv2 {
         std::string dataSetName = key_.substr(posDot2+1);
 
         // Use the parts of the key to find dataSet and recordId
-        uint16_t recId = recordId(recordName);
+        uint16_t recId = IptcDataSets::recordId(recordName);
         uint16_t dataSet = IptcDataSets::dataSet(dataSetName, recId);
 
         // Possibly translate hex name parts (0xabcd) to real names

--- a/unitTests/test_datasets.cpp
+++ b/unitTests/test_datasets.cpp
@@ -212,6 +212,21 @@ TEST(IptcDataSets, recordDesc_)
 
 // ----------------------
 
+TEST(IptcDataSets, recordId_returnsExpectedIdWithValidRecordName)
+{
+    ASSERT_EQ(IptcDataSets::envelope, IptcDataSets::recordId("Envelope"));
+    ASSERT_EQ(IptcDataSets::application2, IptcDataSets::recordId("Application2"));
+}
+
+TEST(IptcDataSets, recordId_throwsExceptionWithInvalidRecordName)
+{
+    ASSERT_THROW(IptcDataSets::recordId("NonExistingName"), Exiv2::Error);
+    ASSERT_THROW(IptcDataSets::recordId(""), Exiv2::Error);
+}
+
+
+// ----------------------
+
 TEST(IptcDataSets, dataSetLists_printDatasetsIntoOstream)
 {
     std::ostringstream stream;


### PR DESCRIPTION
As it has been pointed out by @jim-easterbrook [here](https://github.com/Exiv2/exiv2/pull/2078) , `IptcDataSets::recordId` was declared in `datasets.hpp` but not defined in `datasets.cpp` (it was actually defined but just as an implementation detail). 

In #2060 I was too aggressive and not careful with some changes in the API. That's why I am recovering that function as part of the API.