### PR TITLE
Another cleanup round in main

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -241,7 +241,6 @@ int Print::printSummary() {
   }
 
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
   Exiv2::ExifData& exifData = image->exifData();
   align_ = 16;
@@ -361,7 +360,6 @@ int Print::printList() {
   }
 
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
   // Set defaults for metadata types and data columns
   if (Params::instance().printTags_ == Exiv2::mdNone) {
@@ -566,7 +564,6 @@ int Print::printComment() {
   }
 
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
   if (Params::instance().verbose_) {
     std::cout << _("JPEG comment") << ": ";
@@ -582,7 +579,6 @@ int Print::printPreviewList() {
   }
 
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
   bool const manyFiles = Params::instance().files_.size() > 1;
   int cnt = 0;
@@ -616,7 +612,6 @@ int Rename::run(const std::string& path) {
       ts.read(path);
 
     auto image = Exiv2::ImageFactory::open(path);
-    assert(image);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -686,7 +681,6 @@ int Erase::run(const std::string& path) {
       ts.read(path);
 
     auto image = Exiv2::ImageFactory::open(path_);
-    assert(image);
     image->readMetadata();
     // Thumbnail must be before Exif
     int rc = 0;
@@ -829,7 +823,6 @@ int Extract::writeThumbnail() const {
     return -1;
   }
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
   Exiv2::ExifData& exifData = image->exifData();
   if (exifData.empty()) {
@@ -874,7 +867,6 @@ int Extract::writePreviews() const {
   }
 
   auto image = Exiv2::ImageFactory::open(path_);
-  assert(image);
   image->readMetadata();
 
   Exiv2::PreviewManager pvMgr(*image);
@@ -911,7 +903,6 @@ int Extract::writeIccProfile(const std::string& target) const {
 
   if (rc == 0) {
     auto image = Exiv2::ImageFactory::open(path_);
-    assert(image);
     image->readMetadata();
     if (!image->iccProfileDefined()) {
       std::cerr << _("No embedded iccProfile: ") << path_ << std::endl;
@@ -1034,7 +1025,6 @@ int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBl
     xmpPacket += static_cast<char>(xmpBlob.read_uint8(i));
   }
   auto image = Exiv2::ImageFactory::open(path);
-  assert(image);
   image->readMetadata();
   image->clearXmpData();
   image->setXmpPacket(xmpPacket);
@@ -1075,7 +1065,6 @@ int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfil
   // read in the metadata
   if (rc == 0) {
     auto image = Exiv2::ImageFactory::open(path);
-    assert(image);
     image->readMetadata();
     // clear existing profile, assign the blob and rewrite image
     image->clearIccProfile();
@@ -1099,7 +1088,6 @@ int Insert::insertThumbnail(const std::string& path) {
     return -1;
   }
   auto image = Exiv2::ImageFactory::open(path);
-  assert(image);
   image->readMetadata();
   Exiv2::ExifThumb exifThumb(image->exifData());
   exifThumb.setJpegThumbnail(thumbPath);
@@ -1123,7 +1111,6 @@ int Modify::run(const std::string& path) {
       ts.read(path);
 
     auto image = Exiv2::ImageFactory::open(path);
-    assert(image);
     image->readMetadata();
 
     int rc = applyCommands(image.get());
@@ -1174,7 +1161,6 @@ int Modify::applyCommands(Exiv2::Image* pImage) {
         regNamespace(cmd);
         break;
       case invalidCmdId:
-        assert(invalidCmdId == cmd.cmdId_);
         break;
     }
   }
@@ -1334,7 +1320,6 @@ int Adjust::run(const std::string& path) try {
     ts.read(path);
 
   auto image = Exiv2::ImageFactory::open(path);
-  assert(image);
   image->readMetadata();
   Exiv2::ExifData& exifData = image->exifData();
   if (exifData.empty()) {
@@ -1452,7 +1437,6 @@ int FixIso::run(const std::string& path) {
       ts.read(path);
 
     auto image = Exiv2::ImageFactory::open(path);
-    assert(image);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -1501,7 +1485,6 @@ int FixCom::run(const std::string& path) {
       ts.read(path);
 
     auto image = Exiv2::ImageFactory::open(path);
-    assert(image);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -1691,7 +1674,6 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
     sourceImage = Exiv2::ImageFactory::open(source);
   }
 
-  assert(sourceImage);
   sourceImage->readMetadata();
 
   // Apply any modification commands to the source image on-the-fly
@@ -1703,11 +1685,9 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
   std::unique_ptr<Exiv2::Image> targetImage;
   if (Exiv2::fileExists(target)) {
     targetImage = Exiv2::ImageFactory::open(target);
-    assert(targetImage);
     targetImage->readMetadata();
   } else {
     targetImage = Exiv2::ImageFactory::create(targetType, target);
-    assert(targetImage);
   }
 
   // Copy each type of metadata
@@ -1932,7 +1912,6 @@ int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const 
     return -1;
   }
   Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
-  assert(image.get() != 0);
   image->printStructure(out, option);
   return 0;
 }

--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -171,12 +171,12 @@ int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::stri
     std::stringstream output(std::stringstream::out | std::stringstream::binary);
     result = printStructure(output, option, path);
     if (result == 0) {
-      size_t size = output.str().size();
-      Exiv2::DataBuf iccProfile(size);
-      Exiv2::DataBuf ascii(size * 3 + 1);
-      ascii.write_uint8(size * 3, 0);
-      iccProfile.copyBytes(0, output.str().c_str(), size);
-      if (Exiv2::base64encode(iccProfile.c_data(), size, reinterpret_cast<char*>(ascii.data()), size * 3)) {
+      std::string str = output.str();
+      Exiv2::DataBuf iccProfile(str.size());
+      Exiv2::DataBuf ascii(str.size() * 3 + 1);
+      ascii.write_uint8(str.size() * 3, 0);
+      std::copy(str.begin(), str.end(), iccProfile.begin());
+      if (Exiv2::base64encode(iccProfile.c_data(), str.size(), reinterpret_cast<char*>(ascii.data()), str.size() * 3)) {
         long chunk = 60;
         std::string code = std::string("data:") + ascii.c_str();
         size_t length = code.size();

--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -30,7 +30,18 @@ class PreviewImage;
 /// @brief Contains all action classes (task subclasses).
 namespace Action {
 //! Enumerates all tasks
-enum TaskType { none, adjust, print, rename, erase, extract, insert, modify, fixiso, fixcom };
+enum TaskType {
+  none,
+  adjust,
+  print,
+  rename,
+  erase,
+  extract,
+  insert,
+  modify,
+  fixiso,
+  fixcom,
+};
 
 // *****************************************************************************
 // class definitions

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* const argv[]) {
     return 0;
   }
 
-  int returnCode = 0;
+  int returnCode = EXIT_SUCCESS;
 
   try {
     // Create the required action class
@@ -141,7 +141,7 @@ int main(int argc, char* const argv[]) {
     auto filesCount = params.files_.size();
     if (params.action_ & Action::extract && params.target_ & Params::ctStdInOut && filesCount > 1) {
       std::cerr << params.progname() << ": " << _("Only one file is allowed when extracting to stdout") << std::endl;
-      returnCode = 1;
+      returnCode = EXIT_FAILURE;
     } else {
       int w = filesCount > 9 ? filesCount > 99 ? 3 : 2 : 1;
       int n = 1;
@@ -153,7 +153,7 @@ int main(int argc, char* const argv[]) {
         }
         task->setBinary(params.binary_);
         int ret = task->run(file);
-        if (returnCode == 0)
+        if (returnCode == EXIT_SUCCESS)
           returnCode = ret;
       }
 
@@ -162,7 +162,7 @@ int main(int argc, char* const argv[]) {
     }
   } catch (const std::exception& exc) {
     std::cerr << "Uncaught exception: " << exc.what() << std::endl;
-    returnCode = 1;
+    returnCode = EXIT_FAILURE;
   }
 
   // Return a positive one byte code for better consistency across platforms

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* const argv[]) {
     return 0;
   }
 
-  int rc = 0;
+  int returnCode = 0;
 
   try {
     // Create the required action class
@@ -141,22 +141,23 @@ int main(int argc, char* const argv[]) {
     assert(task);
 
     // Process all files
-    auto s = static_cast<int>(params.files_.size());
-    if (params.action_ & Action::extract && params.target_ & Params::ctStdInOut && s > 1) {
+    auto filesCount = params.files_.size();
+    if (params.action_ & Action::extract && params.target_ & Params::ctStdInOut && filesCount > 1) {
       std::cerr << params.progname() << ": " << _("Only one file is allowed when extracting to stdout") << std::endl;
-      rc = 1;
+      returnCode = 1;
     } else {
-      int w = s > 9 ? s > 99 ? 3 : 2 : 1;
+      int w = filesCount > 9 ? filesCount > 99 ? 3 : 2 : 1;
       int n = 1;
       for (auto&& file : params.files_) {
         // If extracting to stdout then ignore verbose
         if (params.verbose_ && !(params.action_ & Action::extract && params.target_ & Params::ctStdInOut)) {
-          std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << s << ": " << file << std::endl;
+          std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << filesCount << ": " << file
+                    << std::endl;
         }
         task->setBinary(params.binary_);
         int ret = task->run(file);
-        if (rc == 0)
-          rc = ret;
+        if (returnCode == 0)
+          returnCode = ret;
       }
 
       taskFactory.cleanup();
@@ -164,11 +165,11 @@ int main(int argc, char* const argv[]) {
     }
   } catch (const std::exception& exc) {
     std::cerr << "Uncaught exception: " << exc.what() << std::endl;
-    rc = 1;
+    returnCode = 1;
   }
 
   // Return a positive one byte code for better consistency across platforms
-  return static_cast<unsigned int>(rc) % 256;
+  return static_cast<unsigned int>(returnCode) % 256;
 }  // main
 
 // *****************************************************************************

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -937,10 +937,10 @@ int Params::nonoption(const std::string& argv) {
   return rc;
 }  // Params::nonoption
 
-static int readFileToBuf(FILE* f, Exiv2::DataBuf& buf) {
+static size_t readFileToBuf(FILE* f, Exiv2::DataBuf& buf) {
   const int buff_size = 4 * 1028;
   std::vector<Exiv2::byte> bytes(buff_size);
-  int nBytes = 0;
+  size_t nBytes = 0;
   bool more{true};
   std::array<char, buff_size> buff;
   while (more) {

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -12,7 +12,6 @@
 #include "i18n.h"  // NLS support.
 #include "xmp_exiv2.hpp"
 
-#include <cassert>
 #include <cctype>
 #include <cstring>
 #include <fstream>
@@ -136,9 +135,7 @@ int main(int argc, char* const argv[]) {
 
   try {
     // Create the required action class
-    Action::TaskFactory& taskFactory = Action::TaskFactory::instance();
-    auto task = taskFactory.create(Action::TaskType(params.action_));
-    assert(task);
+    auto task = Action::TaskFactory::instance().create(Action::TaskType(params.action_));
 
     // Process all files
     auto filesCount = params.files_.size();
@@ -160,7 +157,7 @@ int main(int argc, char* const argv[]) {
           returnCode = ret;
       }
 
-      taskFactory.cleanup();
+      Action::TaskFactory::instance().cleanup();
       Exiv2::XmpParser::terminate();
     }
   } catch (const std::exception& exc) {

--- a/app/exiv2app.hpp
+++ b/app/exiv2app.hpp
@@ -20,16 +20,21 @@
 #include <regex>
 #include <set>
 
-// *****************************************************************************
-// class definitions
-
 //! Command identifiers
-enum CmdId { invalidCmdId, add, set, del, reg };
+enum CmdId {
+  invalidCmdId,
+  add,
+  set,
+  del,
+  reg,
+};
 //! Metadata identifiers
-// enum MetadataId { invalidMetadataId, iptc, exif, xmp };
-//! Metadata identifiers
-// mdNone=0, mdExif=1, mdIptc=2, mdComment=4, mdXmp=8
-enum MetadataId { invalidMetadataId = Exiv2::mdNone, iptc = Exiv2::mdIptc, exif = Exiv2::mdExif, xmp = Exiv2::mdXmp };
+enum MetadataId {
+  invalidMetadataId = Exiv2::mdNone,  // 0
+  exif = Exiv2::mdExif,               // 1
+  iptc = Exiv2::mdIptc,               // 2
+  xmp = Exiv2::mdXmp,                 // 8
+};
 
 //! Structure for one parsed modification command
 struct ModifyCmd {
@@ -114,7 +119,16 @@ class Params : public Util::Getopt {
   Params(const Params& rhs) = delete;
 
   //! Enumerates print modes
-  enum PrintMode { pmSummary, pmList, pmComment, pmPreview, pmStructure, pmXMP, pmIccProfile, pmRecursive };
+  enum PrintMode {
+    pmSummary,
+    pmList,
+    pmComment,
+    pmPreview,
+    pmStructure,
+    pmXMP,
+    pmIccProfile,
+    pmRecursive,
+  };
 
   //! Individual items to print, bitmap
   enum PrintItem {
@@ -148,10 +162,18 @@ class Params : public Util::Getopt {
   };
 
   //! Enumerates the policies to handle existing files in rename action
-  enum FileExistsPolicy { overwritePolicy, renamePolicy, askPolicy };
+  enum FileExistsPolicy {
+    overwritePolicy,
+    renamePolicy,
+    askPolicy,
+  };
 
   //! Enumerates year, month and day adjustments.
-  enum Yod { yodYear, yodMonth, yodDay };
+  enum Yod {
+    yodYear,
+    yodMonth,
+    yodDay,
+  };
 
   //! Structure for year, month and day adjustment command line arguments.
   struct YodAdjust {

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -63,7 +63,13 @@ class EXIV2API LogMsg {
     @brief Defined log levels. To suppress all log messages, either set the
            log level to \c mute or set the log message handler to 0.
    */
-  enum Level { debug = 0, info = 1, warn = 2, error = 3, mute = 4 };
+  enum Level {
+    debug = 0,
+    info = 1,
+    warn = 2,
+    error = 3,
+    mute = 4,
+  };
   /*!
     @brief Type for a log message handler function. The function receives
            the log level and message and can process it in an application

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -198,9 +198,6 @@ struct EXIV2API DataBuf {
   uint64_t read_uint64(size_t offset, ByteOrder byteOrder) const;
   void write_uint64(size_t offset, uint64_t x, ByteOrder byteOrder);
 
-  //! Copy bytes into the buffer (starting at address &pData_[offset]).
-  void copyBytes(size_t offset, const void* buf, size_t bufsize);
-
   //! Equivalent to: memcmp(&pData_[offset], buf, bufsize)
   int cmpBytes(size_t offset, const void* buf, size_t bufsize) const;
 

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -10,10 +10,10 @@
 #include "types.hpp"
 
 // + standard includes
+#include <cmath>
 #include <cstring>
 #include <iomanip>
 #include <map>
-#include <cmath>
 
 // *****************************************************************************
 // namespace extensions

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -64,7 +64,7 @@ class EXIV2API WebPImage : public Image {
   void doWriteMetadata(BasicIo& outIo);
   //! @name NOT Implemented
   //@{
-  static long getHeaderOffset(const byte* data, long data_size, const byte* header, long header_size);
+  static long getHeaderOffset(const byte* data, size_t data_size, const byte* header, size_t header_size);
   static bool equalsWebPTag(Exiv2::DataBuf& buf, const char* str);
   void debugPrintHex(byte* data, long size);
   void decodeChunks(long filesize);

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* const argv[]) {
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
     std::string file(argv[1]);
 
@@ -105,9 +105,9 @@ int main(int argc, char* const argv[]) {
     image->setExifData(exifData);
     image->writeMetadata();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -3,7 +3,6 @@
 
 #include <exiv2/exiv2.hpp>
 
-#include <cassert>
 #include <iostream>
 
 int main(int argc, char* const argv[]) {

--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -81,7 +81,7 @@ int main(int argc, const char** argv) {
 
   if (argc < 2) {
     std::cout << "Usage: " << argv[0] << " url {-http1_0}" << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
   std::string url(argv[1]);
   Exiv2::Protocol prot = Exiv2::fileProtocol(url);
@@ -107,14 +107,14 @@ int main(int argc, const char** argv) {
     }
   } catch (const Exiv2::Error& e) {
     std::cout << "Error: '" << e << "'" << std::endl;
-    return -1;
+    return EXIT_FAILURE;
   }
 
   if (!isOk)
     std::cout << "The protocol is unsupported." << std::endl;
   else
     std::cout << "OK." << std::endl;
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 // That's all Folks!

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* const argv[]) {
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -31,9 +31,9 @@ int main(int argc, char* const argv[]) {
     image->setExifData(exifData);
     image->writeMetadata();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -3,7 +3,6 @@
 
 #include <exiv2/exiv2.hpp>
 
-#include <cassert>
 #include <iostream>
 
 int main(int argc, char* const argv[]) {

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -75,9 +75,9 @@ int main(int argc, char** argv) {
       }
     }
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sample program using high-level metadata access functions
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iomanip>
 #include <iostream>

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* const argv[]) {
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -44,9 +44,9 @@ int main(int argc, char* const argv[]) {
 
     image->writeMetadata();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Abstract : Sample program showing how to set the Exif comment of an image, Exif.Photo.UserComment
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iostream>
 

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -23,7 +23,6 @@ int main(int argc, char* const argv[]) {
     std::string file(argv[1]);
 
     auto image = Exiv2::ImageFactory::open(file);
-    assert(image);
     image->readMetadata();
 
     Exiv2::ExifData& ed = image->exifData();

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* const argv[]) {
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
     std::string file(argv[1]);
 
@@ -84,10 +84,10 @@ int main(int argc, char* const argv[]) {
     write(file, ed4);
     print(file);
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -3,7 +3,6 @@
 
 #include <exiv2/exiv2.hpp>
 
-#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -23,10 +23,10 @@ int main(int argc, char* const argv[]) {
     const char* prog = argv[0];
     if (argc == 1) {
       std::cout << "Usage: " << prog << " [ [--lint] path | --version | --version-test ]" << std::endl;
-      return 1;
+      return EXIT_FAILURE;
     }
 
-    int rc = 0;
+    int rc = EXIT_SUCCESS;
     const char* file = argv[1];
     bool bLint = strcmp(file, "--lint") == 0 && argc == 3;
     if (bLint)
@@ -110,6 +110,6 @@ int main(int argc, char* const argv[]) {
     return rc;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e.what() << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) {
 
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " file key\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 
   const char* file = argv[1];
@@ -26,18 +26,18 @@ int main(int argc, char* const argv[]) {
 
   if (exifData.empty()) {
     std::cerr << "no metadata found in file " << file << std::endl;
-    exit(2);
+    return EXIT_FAILURE;
   }
 
   try {
     std::cout << exifData[key] << std::endl;
   } catch (Exiv2::Error& e) {
     std::cerr << "Caught Exiv2 exception '" << e << "'" << std::endl;
-    exit(3);
+    return EXIT_FAILURE;
   } catch (...) {
     std::cerr << "Caught a cold!" << std::endl;
-    exit(4);
+    return EXIT_FAILURE;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -252,7 +252,7 @@ int main(int argc, char* const argv[]) {
     if (argc < 2 || argc > 3) {
       std::cout << "Usage: " << argv[0] << " [-option] file" << std::endl;
       std::cout << "Option: all | exif | iptc | xmp | filesystem" << std::endl;
-      return 1;
+      return EXIT_FAILURE;
     }
     const char* path = argv[argc - 1];
     const char* opt = argc == 3 ? argv[1] : "-all";

--- a/samples/exiv2json.cpp
+++ b/samples/exiv2json.cpp
@@ -5,7 +5,6 @@
 
 #include <sys/stat.h>
 
-#include <cassert>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -262,7 +261,6 @@ int main(int argc, char* const argv[]) {
     char option = opt[0];
 
     Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
-    assert(image.get() != 0);
     image->readMetadata();
 
     Jzon::Object root;

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -114,5 +114,5 @@ int main(int argc, char** const argv) {
   Params params;
   params.getopt(argc, argv);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/samples/ini-test.cpp
+++ b/samples/ini-test.cpp
@@ -19,13 +19,12 @@ int main() {
   Exiv2::enableBMFF();
 #endif
 
-  int result = 0;
   const char* ini = "ini-test.ini";
   Exiv2::INIReader reader(ini);
 
   if (reader.ParseError() < 0) {
     std::cerr << "Can't load '" << ini << "'" << std::endl;
-    result = 1;
+    return EXIT_FAILURE;
   } else {
     std::cout << "Config loaded from : '" << ini << "' "
               << "version=" << reader.GetInteger("protocol", "version", -1)
@@ -37,5 +36,5 @@ int main() {
               << ", 170=" << reader.Get("canon", "170", "UNDEFINED") << std::endl;
   }
 
-  return result;
+  return EXIT_SUCCESS;
 }

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* const argv[]) {
     // Make sure they are all the same size
     if (fileIn.size() != memIo1.size() || memIo1.size() != fileOut1.size()) {
       std::cerr << argv[0] << ": Sizes do not match\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     // Read writereadseek test on MemIo
@@ -134,10 +134,10 @@ int main(int argc, char* const argv[]) {
       }
     }
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cerr << "Caught Exiv2 exception '" << e << "'\n";
-    return 20;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) try {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
   std::string file(argv[1]);
 
@@ -41,8 +41,8 @@ int main(int argc, char* const argv[]) try {
   image->setIptcData(iptcData);
   image->writeMetadata();
 
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
+  return EXIT_FAILURE;
 }

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) try {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 
   auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -35,11 +35,11 @@ int main(int argc, char* const argv[]) try {
               << std::setfill(' ') << std::right << md->count() << "  " << std::dec << md->value() << std::endl;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return 1;
+  return EXIT_FAILURE;
 } catch (const std::exception& e) {
   std::cout << "Caught exception: '" << e.what() << "'\n";
-  return 1;
+  return EXIT_FAILURE;
 }

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -24,7 +24,7 @@ int main(int argc, char* const argv[]) {
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " image\n";
       std::cout << "Commands read from stdin.\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = ImageFactory::open(argv[1]);
@@ -41,10 +41,10 @@ int main(int argc, char* const argv[]) {
     // Save any changes
     image->writeMetadata();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* const argv[]) {
 
     if (argc != 3) {
       std::cout << "Usage: " << argv[0] << " image datafile\n";
-      return 1;
+      return EXIT_FAILURE;
     }
     std::string file(argv[1]);
     std::string data(argv[2]);
@@ -69,9 +69,9 @@ int main(int argc, char* const argv[]) {
     // Set Iptc data and write it to the file
     image->writeMetadata();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -3,7 +3,6 @@
 // Test for large (>65535 bytes) IPTC buffer
 // ***************************************************************** -*- C++ -*-
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iostream>
 

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -55,13 +55,13 @@ int main(int argc, char* const argv[]) {
       writeImg->writeMetadata();
     } catch (const Exiv2::Error&) {
       std::cerr << params.progname() << ": Could not write metadata to (" << params.write_ << ")\n";
-      return 8;
+      return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cerr << "Caught Exiv2 exception '" << e << "'\n";
-    return 10;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -28,13 +28,16 @@ int main(int argc, char* const argv[]) {
     }
     // Map it to memory
     const Exiv2::byte* pData = file.mmap();
-    DataBuf buf(file.size());
+    std::vector<byte> buf(file.size());
+
     // Read from the memory mapped region
-    buf.copyBytes(0, pData, buf.size());
+    std::copy_n(pData, buf.size(), buf.begin());
+
     // Reopen file in write mode and write to it
-    file.write(buf.c_data(), buf.size());
+    file.write(buf.data(), buf.size());
+
     // Read from the mapped region again
-    buf.copyBytes(0, pData, buf.size());
+    std::copy_n(pData, buf.size(), buf.begin());
     file.close();
 
     return EXIT_SUCCESS;

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -7,36 +7,39 @@
 
 using namespace Exiv2;
 
-int main(int argc, char* const argv[]) try {
-  Exiv2::XmpParser::initialize();
-  ::atexit(Exiv2::XmpParser::terminate);
+int main(int argc, char* const argv[]) {
+  try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
 #ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
+    Exiv2::enableBMFF();
 #endif
 
-  if (argc != 2) {
-    std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
-  }
-  const char* path = argv[1];
+    if (argc != 2) {
+      std::cout << "Usage: " << argv[0] << " file\n";
+      return EXIT_FAILURE;
+    }
+    const char* path = argv[1];
 
-  FileIo file(path);
-  // Open the file in read mode
-  if (file.open("rb") != 0) {
-    throw Error(ErrorCode::kerFileOpenFailed, path, "rb", strError());
-  }
-  // Map it to memory
-  const Exiv2::byte* pData = file.mmap();
-  DataBuf buf(file.size());
-  // Read from the memory mapped region
-  buf.copyBytes(0, pData, buf.size());
-  // Reopen file in write mode and write to it
-  file.write(buf.c_data(), buf.size());
-  // Read from the mapped region again
-  buf.copyBytes(0, pData, buf.size());
-  file.close();
+    FileIo file(path);
+    // Open the file in read mode
+    if (file.open("rb") != 0) {
+      throw Error(ErrorCode::kerFileOpenFailed, path, "rb", strError());
+    }
+    // Map it to memory
+    const Exiv2::byte* pData = file.mmap();
+    DataBuf buf(file.size());
+    // Read from the memory mapped region
+    buf.copyBytes(0, pData, buf.size());
+    // Reopen file in write mode and write to it
+    file.write(buf.c_data(), buf.size());
+    // Read from the mapped region again
+    buf.copyBytes(0, pData, buf.size());
+    file.close();
 
-  return 0;
-} catch (const Error& e) {
-  std::cout << e << "\n";
+    return EXIT_SUCCESS;
+  } catch (const Error& e) {
+    std::cout << e << "\n";
+    return EXIT_FAILURE;
+  }
 }

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sample program to extract a Minolta thumbnail from the makernote
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iostream>
 

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) {
   try {
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -43,9 +43,9 @@ int main(int argc, char* const argv[]) {
       file.close();
     }
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/path-test.cpp
+++ b/samples/path-test.cpp
@@ -17,12 +17,12 @@ int main(int argc, char* const argv[]) {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
   std::ifstream file(argv[1]);
   if (!file) {
     std::cerr << *argv[1] << ": Failed to open file for reading\n";
-    return 1;
+    return EXIT_FAILURE;
   }
   std::string line;
   while (std::getline(file, line)) {
@@ -38,5 +38,5 @@ int main(int argc, char* const argv[]) {
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) try {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
   std::string filename(argv[1]);
 
@@ -35,8 +35,8 @@ int main(int argc, char* const argv[]) try {
   // Cleanup
   Exiv2::XmpParser::terminate();
 
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
+  return EXIT_FAILURE;
 }

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -3,7 +3,6 @@
 // It makes some modifications on the metadata of remote file, reads new metadata from that file
 // and reset the metadata back to the original status.
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iomanip>
 #include <iostream>

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -7,96 +7,99 @@
 #include <iomanip>
 #include <iostream>
 
-int main(int argc, char* const argv[]) try {
-  Exiv2::XmpParser::initialize();
-  ::atexit(Exiv2::XmpParser::terminate);
+int main(int argc, char* const argv[]) {
+  try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
 #ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
+    Exiv2::enableBMFF();
 #endif
 
-  if (argc < 2) {
-    std::cout << "Usage: " << argv[0] << " file {--nocurl | --curl}\n\n";
-    return 1;
+    if (argc < 2) {
+      std::cout << "Usage: " << argv[0] << " file {--nocurl | --curl}\n\n";
+      return EXIT_FAILURE;
+    }
+
+    bool useCurlFromExiv2TestApps = true;
+    for (int a = 1; a < argc; a++) {
+      std::string arg(argv[a]);
+      if (arg == "--nocurl")
+        useCurlFromExiv2TestApps = false;
+      else if (arg == "--curl")
+        useCurlFromExiv2TestApps = true;
+    }
+
+    std::string file(argv[1]);
+
+    // set/add metadata
+    std::cout << "Modify the metadata ...\n";
+    Exiv2::ExifData exifData;
+    exifData["Exif.Photo.UserComment"] = "Hello World";   // AsciiValue
+    exifData["Exif.Image.Software"] = "Exiv2";            // AsciiValue
+    exifData["Exif.Image.Copyright"] = "Exiv2";           // AsciiValue
+    exifData["Exif.Image.Make"] = "Canon";                // AsciiValue
+    exifData["Exif.Canon.OwnerName"] = "Tuan";            // UShortValue
+    exifData["Exif.CanonCs.LensType"] = uint16_t(65535);  // LongValue
+    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
+    v->read("2013:06:09 14:30:30");
+    Exiv2::ExifKey key("Exif.Image.DateTime");
+    exifData.add(key, v.get());
+
+    auto writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    writeTest->setExifData(exifData);
+    writeTest->writeMetadata();
+
+    // read the result to make sure everything fine
+    std::cout << "Print out the new metadata ...\n";
+    auto readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    readTest->readMetadata();
+    Exiv2::ExifData& exifReadData = readTest->exifData();
+    if (exifReadData.empty()) {
+      std::string error(argv[1]);
+      error += ": No Exif data found in the file";
+      throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, error);
+    }
+    auto end = exifReadData.end();
+    for (auto i = exifReadData.begin(); i != end; ++i) {
+      const char* tn = i->typeName();
+      std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
+                << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " "
+                << std::setw(9) << std::setfill(' ') << std::left << (tn ? tn : "Unknown") << " " << std::dec
+                << std::setw(3) << std::setfill(' ') << std::right << i->count() << "  " << std::dec << i->value()
+                << "\n";
+    }
+
+    // del, reset the metadata
+    std::cout << "Reset ...\n";
+    exifReadData["Exif.Photo.UserComment"] = "Have a nice day";  // AsciiValue
+    exifReadData["Exif.Image.Software"] = "Exiv2.org";           // AsciiValue
+    exifReadData["Exif.Image.Copyright"] = "Exiv2.org";          // AsciiValue
+    key = Exiv2::ExifKey("Exif.Image.Make");
+    auto pos = exifReadData.findKey(key);
+    if (pos == exifReadData.end())
+      throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Image.Make not found");
+    exifReadData.erase(pos);
+    key = Exiv2::ExifKey("Exif.Image.DateTime");
+    pos = exifReadData.findKey(key);
+    if (pos == exifReadData.end())
+      throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Image.DateTime not found");
+    exifReadData.erase(pos);
+    key = Exiv2::ExifKey("Exif.Canon.OwnerName");
+    pos = exifReadData.findKey(key);
+    if (pos == exifReadData.end())
+      throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Canon.OwnerName not found");
+    exifReadData.erase(pos);
+    key = Exiv2::ExifKey("Exif.CanonCs.LensType");
+    pos = exifReadData.findKey(key);
+    if (pos == exifReadData.end())
+      throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.CanonCs.LensType not found");
+    exifReadData.erase(pos);
+    readTest->setExifData(exifReadData);
+    readTest->writeMetadata();
+
+    return EXIT_SUCCESS;
+  } catch (Exiv2::Error& e) {
+    std::cout << "Caught Exiv2 exception '" << e << "'\n";
+    return EXIT_FAILURE;
   }
-
-  bool useCurlFromExiv2TestApps = true;
-  for (int a = 1; a < argc; a++) {
-    std::string arg(argv[a]);
-    if (arg == "--nocurl")
-      useCurlFromExiv2TestApps = false;
-    else if (arg == "--curl")
-      useCurlFromExiv2TestApps = true;
-  }
-
-  std::string file(argv[1]);
-
-  // set/add metadata
-  std::cout << "Modify the metadata ...\n";
-  Exiv2::ExifData exifData;
-  exifData["Exif.Photo.UserComment"] = "Hello World";   // AsciiValue
-  exifData["Exif.Image.Software"] = "Exiv2";            // AsciiValue
-  exifData["Exif.Image.Copyright"] = "Exiv2";           // AsciiValue
-  exifData["Exif.Image.Make"] = "Canon";                // AsciiValue
-  exifData["Exif.Canon.OwnerName"] = "Tuan";            // UShortValue
-  exifData["Exif.CanonCs.LensType"] = uint16_t(65535);  // LongValue
-  Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
-  v->read("2013:06:09 14:30:30");
-  Exiv2::ExifKey key("Exif.Image.DateTime");
-  exifData.add(key, v.get());
-
-  auto writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
-  writeTest->setExifData(exifData);
-  writeTest->writeMetadata();
-
-  // read the result to make sure everything fine
-  std::cout << "Print out the new metadata ...\n";
-  auto readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
-  readTest->readMetadata();
-  Exiv2::ExifData& exifReadData = readTest->exifData();
-  if (exifReadData.empty()) {
-    std::string error(argv[1]);
-    error += ": No Exif data found in the file";
-    throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, error);
-  }
-  auto end = exifReadData.end();
-  for (auto i = exifReadData.begin(); i != end; ++i) {
-    const char* tn = i->typeName();
-    std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " " << std::setw(9)
-              << std::setfill(' ') << std::left << (tn ? tn : "Unknown") << " " << std::dec << std::setw(3)
-              << std::setfill(' ') << std::right << i->count() << "  " << std::dec << i->value() << "\n";
-  }
-
-  // del, reset the metadata
-  std::cout << "Reset ...\n";
-  exifReadData["Exif.Photo.UserComment"] = "Have a nice day";  // AsciiValue
-  exifReadData["Exif.Image.Software"] = "Exiv2.org";           // AsciiValue
-  exifReadData["Exif.Image.Copyright"] = "Exiv2.org";          // AsciiValue
-  key = Exiv2::ExifKey("Exif.Image.Make");
-  auto pos = exifReadData.findKey(key);
-  if (pos == exifReadData.end())
-    throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Image.Make not found");
-  exifReadData.erase(pos);
-  key = Exiv2::ExifKey("Exif.Image.DateTime");
-  pos = exifReadData.findKey(key);
-  if (pos == exifReadData.end())
-    throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Image.DateTime not found");
-  exifReadData.erase(pos);
-  key = Exiv2::ExifKey("Exif.Canon.OwnerName");
-  pos = exifReadData.findKey(key);
-  if (pos == exifReadData.end())
-    throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.Canon.OwnerName not found");
-  exifReadData.erase(pos);
-  key = Exiv2::ExifKey("Exif.CanonCs.LensType");
-  pos = exifReadData.findKey(key);
-  if (pos == exifReadData.end())
-    throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, "Exif.CanonCs.LensType not found");
-  exifReadData.erase(pos);
-  readTest->setExifData(exifReadData);
-  readTest->writeMetadata();
-
-  return 0;
-} catch (Exiv2::Error& e) {
-  std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
 }

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -81,9 +81,9 @@ int main() {
       std::cout << std::endl;
     } catch (Exiv2::Error& e) {
       std::cout << "Caught Exiv2 exception '" << e << "'\n";
-      return -1;
+      return EXIT_FAILURE;
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -15,25 +15,28 @@ void print(const ExifData& exifData);
 void mini1(const char* path);
 void mini9(const char* path);
 
-int main(int argc, char* const argv[]) try {
-  Exiv2::XmpParser::initialize();
-  ::atexit(Exiv2::XmpParser::terminate);
+int main(int argc, char* const argv[]) {
+  try {
+    Exiv2::XmpParser::initialize();
+    ::atexit(Exiv2::XmpParser::terminate);
 #ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
+    Exiv2::enableBMFF();
 #endif
 
-  if (argc != 2) {
-    std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    if (argc != 2) {
+      std::cout << "Usage: " << argv[0] << " file\n";
+      return EXIT_FAILURE;
+    }
+
+    const char* path = argv[1];
+    mini1(path);
+    mini9(path);
+
+    return EXIT_SUCCESS;
+  } catch (const Error& e) {
+    std::cout << e << "\n";
+    return EXIT_FAILURE;
   }
-
-  const char* path = argv[1];
-  mini1(path);
-  mini9(path);
-
-  return 0;
-} catch (const Error& e) {
-  std::cout << e << "\n";
 }
 
 void mini1(const char* path) {

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -4,7 +4,6 @@
 #include <enforce.hpp>
 #include <exiv2/exiv2.hpp>
 
-#include <cassert>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -45,14 +44,12 @@ void mini1(const char* path) {
   // Write nothing to a new structure, without a previous binary image
   wm = ExifParser::encode(blob, nullptr, 0, bigEndian, exifData);
   enforce(wm == wmIntrusive, Exiv2::ErrorCode::kerErrorMessage, "encode returned an unexpected value");
-  assert(blob.empty());
   std::cout << "Test 1: Writing empty Exif data without original binary data: ok.\n";
 
   // Write nothing, this time with a previous binary image
   DataBuf buf = readFile(path);
   wm = ExifParser::encode(blob, buf.c_data(), buf.size(), bigEndian, exifData);
   enforce(wm == wmIntrusive, Exiv2::ErrorCode::kerErrorMessage, "encode returned an unexpected value");
-  assert(blob.empty());
   std::cout << "Test 2: Writing empty Exif data with original binary data: ok.\n";
 
   // Write something to a new structure, without a previous binary image

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* const argv[]) {
     if (argc != 3) {
       std::cout << "Usage: write-test file case\n\n"
                 << "where case is an integer between 1 and 11\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     std::string testFile = argv[1];
@@ -34,7 +34,7 @@ int main(int argc, char* const argv[]) {
     int testNo = 0;
     iss >> testNo;
 
-    int rc = 0;
+    int rc = EXIT_SUCCESS;
     switch (testNo) {
       case 1:
         std::cerr << "Case 1: ";
@@ -101,14 +101,14 @@ int main(int argc, char* const argv[]) {
       default:
         std::cout << "Usage: exiftest file case\n\n"
                   << "where case is an integer between 1 and 11\n";
-        rc = 1;
+        rc = EXIT_FAILURE;
         break;
     }
 
     return rc;
   } catch (Error& e) {
     std::cerr << "Caught Exiv2 exception '" << e << "'\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* const argv[]) {
   try {
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
     std::string file(argv[1]);
 
@@ -186,10 +186,10 @@ int main(int argc, char* const argv[]) {
     write(file, ed7);
     print(file);
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }
 

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* const argv[]) {
   try {
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -28,9 +28,9 @@ int main(int argc, char* const argv[]) {
     }
     std::cout << xmpPacket << "\n";
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* const argv[]) try {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 
   Exiv2::DataBuf buf = Exiv2::readFile(argv[1]);
@@ -36,8 +36,8 @@ int main(int argc, char* const argv[]) try {
               << md.count() << "  " << std::dec << md.toString() << std::endl;
   }
   Exiv2::XmpParser::terminate();
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
+  return EXIT_FAILURE;
 }

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* const argv[]) try {
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";
-    return 1;
+    return EXIT_FAILURE;
   }
   std::string filename(argv[1]);
   Exiv2::DataBuf buf = Exiv2::readFile(filename);
@@ -51,8 +51,8 @@ int main(int argc, char* const argv[]) try {
     throw Exiv2::Error(Exiv2::ErrorCode::kerCallFailed, filename, Exiv2::strError(), "FileIo::write");
   }
   Exiv2::XmpParser::terminate();
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
+  return EXIT_FAILURE;
 }

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv) {
   try {
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";
-      return 1;
+      return EXIT_FAILURE;
     }
 
     auto image = Exiv2::ImageFactory::open(argv[1]);
@@ -42,9 +42,9 @@ int main(int argc, char** argv) {
 
     Exiv2::XmpParser::terminate();
 
-    return 0;
+    return EXIT_SUCCESS;
   } catch (Exiv2::Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";
-    return -1;
+    return EXIT_FAILURE;
   }
 }

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Read an XMP from a video or graphic file, parse it and print  all (known) properties.
 
-#include <cassert>
 #include <exiv2/exiv2.hpp>
 #include <iomanip>
 #include <iostream>

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -202,8 +202,8 @@ int main() try {
   // Cleanup
   Exiv2::XmpParser::terminate();
 
-  return 0;
+  return EXIT_SUCCESS;
 } catch (Exiv2::Error &e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
-  return -1;
+  return EXIT_FAILURE;
 }

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -728,7 +728,7 @@ void MemIo::transfer(BasicIo& src) {
 }
 
 size_t MemIo::write(BasicIo& src) {
-  if (static_cast<BasicIo*>(this) == &src)
+  if (this == &src)
     return 0;
   if (!src.isopen())
     return 0;

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -16,7 +16,6 @@
 #include "types.hpp"
 
 // + standard includes
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <iostream>

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -506,7 +506,7 @@ void BmffImage::parseTiff(uint32_t root_tag, uint64_t length) {
   if (length > 8) {
     enforce(length - 8 <= io_->size() - io_->tell(), ErrorCode::kerCorruptedMetadata);
     enforce(length - 8 <= std::numeric_limits<uint64_t>::max(), ErrorCode::kerCorruptedMetadata);
-    DataBuf data(static_cast<size_t>(length) - 8);
+    DataBuf data(static_cast<size_t>(length - 8u));
     const size_t bufRead = io_->read(data.data(), data.size());
 
     if (io_->error())
@@ -514,8 +514,7 @@ void BmffImage::parseTiff(uint32_t root_tag, uint64_t length) {
     if (bufRead != data.size())
       throw Error(ErrorCode::kerInputDataReadFailed);
 
-    Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(), data.c_data(),
-                                       static_cast<uint32_t>(data.size()), root_tag,
+    Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(), data.c_data(), data.size(), root_tag,
                                        Internal::TiffMapping::findDecoder);
   }
 }
@@ -526,13 +525,12 @@ void BmffImage::parseXmp(uint64_t length, uint64_t start) {
     enforce(length <= io_->size() - start, ErrorCode::kerCorruptedMetadata);
 
     long restore = io_->tell();
-    enforce(start <= std::numeric_limits<uint64_t>::max(), ErrorCode::kerCorruptedMetadata);
     io_->seek(static_cast<long>(start), BasicIo::beg);
 
-    enforce(length < std::numeric_limits<uint64_t>::max(), ErrorCode::kerCorruptedMetadata);
-    DataBuf xmp(static_cast<size_t>(length + 1));
-    xmp.write_uint8(static_cast<size_t>(length), 0);  // ensure xmp is null terminated!
-    if (io_->read(xmp.data(), static_cast<size_t>(length)) != length)
+    size_t lengthSizeT = static_cast<size_t>(length);
+    DataBuf xmp(lengthSizeT + 1);
+    xmp.write_uint8(lengthSizeT, 0);  // ensure xmp is null terminated!
+    if (io_->read(xmp.data(), lengthSizeT) != lengthSizeT)
       throw Error(ErrorCode::kerInputDataReadFailed);
     if (io_->error())
       throw Error(ErrorCode::kerFailedToReadImageData);
@@ -554,7 +552,7 @@ void BmffImage::parseCr3Preview(DataBuf& data, std::ostream& out, bool bTrace, u
   enforce(here >= 0 && here <= std::numeric_limits<long>::max() - static_cast<long>(relative_position),
           ErrorCode::kerCorruptedMetadata);
   NativePreview nativePreview;
-  nativePreview.position_ = here + static_cast<long>(relative_position);
+  nativePreview.position_ = here + relative_position;
   nativePreview.width_ = data.read_uint16(width_offset, endian_);
   nativePreview.height_ = data.read_uint16(height_offset, endian_);
   nativePreview.size_ = data.read_uint32(size_offset, endian_);

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -44,7 +44,7 @@ DataBuf Cr2Header::write() const {
 
   buf.write_uint16(2, tag(), byteOrder());
   buf.write_uint32(4, 0x00000010, byteOrder());
-  buf.copyBytes(8, cr2sig_, 4);
+  std::copy_n(cr2sig_, 4, buf.begin() + 8);
   // Write a dummy value for the RAW IFD offset. The offset-writer is used to set this offset in a second pass.
   buf.write_uint32(12, 0x00000000, byteOrder());
   return buf;

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -37,8 +37,7 @@ DataBuf Cr2Header::write() const {
     case bigEndian:
       buf.write_uint8(0, 'M');
       break;
-    case invalidByteOrder:
-      assert(false);
+    default:
       break;
   }
   buf.write_uint8(1, buf.read_uint8(0));

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -101,9 +101,6 @@ void CrwImage::writeMetadata() {
 }  // CrwImage::writeMetadata
 
 void CrwParser::decode(CrwImage* pCrwImage, const byte* pData, size_t size) {
-  assert(pCrwImage);
-  assert(pData);
-
   // Parse the image, starting with a CIFF header component
   CiffHeader header;
   header.read(pData, size);

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -244,7 +244,7 @@ void CiffDirectory::readDirectory(const byte* pData, size_t size, ByteOrder byte
   std::cout << "Directory at offset " << std::dec << o << ", " << count << " entries \n";
 #endif
   o += 2;
-  if (static_cast<uint32_t>(count) * 10 > size - o)
+  if (count * 10u > size - o)
     throw Error(ErrorCode::kerCorruptedMetadata);
 
   for (uint16_t i = 0; i < count; ++i) {

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -874,7 +874,7 @@ void CrwMap::encode0x0805(const Image& image, const CrwMapping* pCrwMapping, Cif
     if (cc && cc->size() > size)
       size = cc->size();
     DataBuf buf(size);
-    buf.copyBytes(0, comment.data(), comment.size());
+    std::copy(comment.begin(), comment.end(), buf.begin());
     pHead->add(pCrwMapping->crwTagId_, pCrwMapping->crwDir_, std::move(buf));
   } else {
     if (cc) {
@@ -984,7 +984,7 @@ void CrwMap::encode0x1810(const Image& image, const CrwMapping* pCrwMapping, Cif
     }
     DataBuf buf(size);
     if (cc)
-      buf.copyBytes(8, cc->pData() + 8, cc->size() - 8);
+      std::copy_n(cc->pData() + 8, cc->size() - 8, buf.begin() + 8);
     if (edX != edEnd && edX->size() == 4) {
       edX->copy(buf.data(), pHead->byteOrder());
     }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -6,7 +6,6 @@
 #include "error.hpp"
 #include "i18n.h"  // NLS support.
 
-#include <cassert>
 #include <ctime>
 #include <iostream>
 
@@ -188,7 +187,6 @@ void CiffComponent::doRead(const byte* pData, size_t size, uint32_t start, ByteO
   tag_ = getUShort(pData + start, byteOrder);
 
   DataLocId dl = dataLocation();
-  assert(dl == directoryData || dl == valueData);
 
   if (dl == valueData) {
     size_ = getULong(pData + start + 2, byteOrder);
@@ -288,7 +286,6 @@ void CiffDirectory::doDecode(Image& image, ByteOrder byteOrder) const {
 }  // CiffDirectory::doDecode
 
 void CiffHeader::write(Blob& blob) const {
-  assert(byteOrder_ == littleEndian || byteOrder_ == bigEndian);
   if (byteOrder_ == littleEndian) {
     blob.push_back('I');
     blob.push_back('I');
@@ -305,7 +302,6 @@ void CiffHeader::write(Blob& blob) const {
   o += 8;
   // Pad as needed
   if (!pPadding_.empty()) {
-    assert(padded_ == offset_ - o);
     append(blob, pPadding_.data(), padded_);
   } else {
     for (uint32_t i = o; i < offset_; ++i) {
@@ -392,7 +388,6 @@ void CiffComponent::writeDirEntry(Blob& blob, ByteOrder byteOrder) const {
   byte buf[4];
 
   DataLocId dl = dataLocation();
-  assert(dl == directoryData || dl == valueData);
 
   if (dl == valueData) {
     us2Data(buf, tag_, byteOrder);
@@ -407,7 +402,6 @@ void CiffComponent::writeDirEntry(Blob& blob, ByteOrder byteOrder) const {
 
   if (dl == directoryData) {
     // Only 8 bytes fit in the directory entry
-    assert(size_ <= 8);
 
     us2Data(buf, tag_, byteOrder);
     append(blob, buf, 2);
@@ -527,7 +521,6 @@ void CiffHeader::add(uint16_t crwTagId, uint16_t crwDir, DataBuf&& buf) {
   CrwDirs crwDirs;
   CrwMap::loadStack(crwDirs, crwDir);
   [[maybe_unused]] uint16_t rootDirectory = crwDirs.top().crwDir_;
-  assert(rootDirectory == 0x0000);
   crwDirs.pop();
   if (!pRootDir_) {
     pRootDir_ = std::make_unique<CiffDirectory>();
@@ -600,7 +593,6 @@ void CiffHeader::remove(uint16_t crwTagId, uint16_t crwDir) {
     CrwDirs crwDirs;
     CrwMap::loadStack(crwDirs, crwDir);
     [[maybe_unused]] uint16_t rootDirectory = crwDirs.top().crwDir_;
-    assert(rootDirectory == 0x0000);
     crwDirs.pop();
     pRootDir_->remove(crwDirs, crwTagId);
   }
@@ -725,7 +717,6 @@ void CrwMap::decodeArray(const CiffComponent& ciffComponent, const CrwMapping* p
       ifdId = canonPiId;
       break;
   }
-  assert(ifdId != ifdIdNotSet);
 
   std::string groupName(Internal::groupName(ifdId));
   const size_t component_size = ciffComponent.size();
@@ -771,7 +762,6 @@ void CrwMap::decode0x180e(const CiffComponent& ciffComponent, const CrwMapping* 
   if (ciffComponent.size() < 8 || ciffComponent.typeId() != unsignedLong) {
     return decodeBasic(ciffComponent, pCrwMapping, image, byteOrder);
   }
-  assert(pCrwMapping != 0);
   ULongValue v;
   v.read(ciffComponent.pData(), 8, byteOrder);
   time_t t = v.value_.at(0);
@@ -818,7 +808,6 @@ void CrwMap::decode0x2008(const CiffComponent& ciffComponent, const CrwMapping* 
 
 void CrwMap::decodeBasic(const CiffComponent& ciffComponent, const CrwMapping* pCrwMapping, Image& image,
                          ByteOrder byteOrder) {
-  assert(pCrwMapping != 0);
   // create a key and value pair
   ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
   std::unique_ptr<Value> value;
@@ -862,9 +851,6 @@ void CrwMap::encode(CiffHeader* pHead, const Image& image) {
 }  // CrwMap::encode
 
 void CrwMap::encodeBasic(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   // Determine the source Exif metadatum
   ExifKey ek(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
   auto ed = image.exifData().findKey(ek);
@@ -880,9 +866,6 @@ void CrwMap::encodeBasic(const Image& image, const CrwMapping* pCrwMapping, Ciff
 }  // CrwMap::encodeBasic
 
 void CrwMap::encode0x0805(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   std::string comment = image.comment();
 
   CiffComponent* cc = pHead->findComponent(pCrwMapping->crwTagId_, pCrwMapping->crwDir_);
@@ -903,9 +886,6 @@ void CrwMap::encode0x0805(const Image& image, const CrwMapping* pCrwMapping, Cif
 }  // CrwMap::encode0x0805
 
 void CrwMap::encode0x080a(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   const ExifKey k1("Exif.Image.Make");
   const ExifKey k2("Exif.Image.Model");
   const auto ed1 = image.exifData().findKey(k1);
@@ -928,7 +908,6 @@ void CrwMap::encode0x080a(const Image& image, const CrwMapping* pCrwMapping, Cif
       ed2->copy(buf.data(pos), pHead->byteOrder());
       pos += ed2->size();
     }
-    assert(pos == size);
     pHead->add(pCrwMapping->crwTagId_, pCrwMapping->crwDir_, std::move(buf));
   } else {
     pHead->remove(pCrwMapping->crwTagId_, pCrwMapping->crwDir_);
@@ -936,9 +915,6 @@ void CrwMap::encode0x080a(const Image& image, const CrwMapping* pCrwMapping, Cif
 }
 
 void CrwMap::encodeArray(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   IfdId ifdId = ifdIdNotSet;
   switch (pCrwMapping->tag_) {
     case 0x0001:
@@ -954,7 +930,6 @@ void CrwMap::encodeArray(const Image& image, const CrwMapping* pCrwMapping, Ciff
       ifdId = canonPiId;
       break;
   }
-  assert(ifdId != ifdIdNotSet);
   DataBuf buf = packIfdId(image.exifData(), ifdId, pHead->byteOrder());
   if (buf.empty()) {
     // Try the undecoded tag
@@ -970,9 +945,6 @@ void CrwMap::encodeArray(const Image& image, const CrwMapping* pCrwMapping, Ciff
 }  // CrwMap::encodeArray
 
 void CrwMap::encode0x180e(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   time_t t = 0;
   const ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
   const auto ed = image.exifData().findKey(key);
@@ -993,9 +965,6 @@ void CrwMap::encode0x180e(const Image& image, const CrwMapping* pCrwMapping, Cif
 }  // CrwMap::encode0x180e
 
 void CrwMap::encode0x1810(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   const ExifKey kX("Exif.Photo.PixelXDimension");
   const ExifKey kY("Exif.Photo.PixelYDimension");
   const ExifKey kO("Exif.Image.Orientation");
@@ -1034,9 +1003,6 @@ void CrwMap::encode0x1810(const Image& image, const CrwMapping* pCrwMapping, Cif
 }  // CrwMap::encode0x1810
 
 void CrwMap::encode0x2008(const Image& image, const CrwMapping* pCrwMapping, CiffHeader* pHead) {
-  assert(pCrwMapping != 0);
-  assert(pHead != 0);
-
   ExifThumbC exifThumb(image.exifData());
   DataBuf buf = exifThumb.copy();
   if (!buf.empty()) {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -7,7 +7,6 @@
 
 // + standard includes
 #include <array>
-#include <cassert>
 #include <iostream>
 
 namespace {
@@ -144,8 +143,8 @@ void LogMsg::defaultHandler(int level, const char* s) {
     case LogMsg::error:
       std::cerr << "Error: ";
       break;
-    case LogMsg::mute:
-      assert(false);
+    default:
+      break;
   }
   std::cerr << s;
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -38,7 +38,6 @@
 #include "xmpsidecar.hpp"
 
 // + standard includes
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <limits>
@@ -851,7 +850,6 @@ Image::UniquePtr ImageFactory::create(ImageType type, BasicIo::UniquePtr io) {
 
 void append(Blob& blob, const byte* buf, size_t len) {
   if (len != 0) {
-    assert(buf);
     Blob::size_type size = blob.size();
     if (blob.capacity() - size < len) {
       blob.reserve(size + 65536);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -602,7 +602,7 @@ void Image::setComment(std::string_view comment) {
 
 void Image::setIccProfile(Exiv2::DataBuf&& iccProfile, bool bTestValid) {
   if (bTestValid) {
-    if (iccProfile.size() < static_cast<long>(sizeof(long))) {
+    if (iccProfile.size() < sizeof(long)) {
       throw Error(ErrorCode::kerInvalidIccProfile);
     }
     const size_t size = iccProfile.read_uint32(0, bigEndian);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -361,8 +361,8 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
       }
       // Overflow check
       enforce(allocate64 <= std::numeric_limits<size_t>::max(), ErrorCode::kerCorruptedMetadata);
-      DataBuf buf(allocate64);             // allocate a buffer
-      buf.copyBytes(0, dir.c_data(8), 4);  // copy dir[8:11] into buffer (short strings)
+      DataBuf buf(allocate64);                     // allocate a buffer
+      std::copy_n(dir.c_data(8), 4, buf.begin());  // copy dir[8:11] into buffer (short strings)
 
       // We have already checked that this multiplication cannot overflow.
       const size_t count_x_size = count * size;

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -2,7 +2,6 @@
 
 #include "image_int.hpp"
 
-#include <cassert>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdio>
@@ -27,7 +26,6 @@ std::string stringFormat(const char* format, ...) {
     va_start(args, format);  // args start after format
     rc = vsnprintf(&buffer[0], buffer.size(), format, args);
     va_end(args);     // free the args
-    assert(rc >= 0);  // rc < 0 => we have made an error in the format string
     if (rc > 0)
       need = static_cast<size_t>(rc);
   } while (buffer.size() <= need);

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -25,7 +25,7 @@ std::string stringFormat(const char* format, ...) {
     va_list args;            // variable arg list
     va_start(args, format);  // args start after format
     rc = vsnprintf(&buffer[0], buffer.size(), format, args);
-    va_end(args);     // free the args
+    va_end(args);  // free the args
     if (rc > 0)
       need = static_cast<size_t>(rc);
   } while (buffer.size() <= need);

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -39,7 +39,6 @@ bool Photoshop::isIrb(const byte* pPsData, size_t sizePsData) {
   if (sizePsData < 4)
     return false;
   for (auto&& i : irbId_) {
-    assert(strlen(i) == 4);
     if (memcmp(pPsData, i, 4) == 0)
       return true;
   }
@@ -64,9 +63,6 @@ bool Photoshop::valid(const byte* pPsData, size_t sizePsData) {
 //       if this also makes sense for psTag != Photoshop::iptc
 int Photoshop::locateIrb(const byte* pPsData, size_t sizePsData, uint16_t psTag, const byte** record,
                          uint32_t* const sizeHdr, uint32_t* const sizeData) {
-  assert(record);
-  assert(sizeHdr);
-  assert(sizeData);
   if (sizePsData < 12) {
     return 3;
   }
@@ -147,8 +143,6 @@ int Photoshop::locatePreviewIrb(const byte* pPsData, size_t sizePsData, const by
 }
 
 DataBuf Photoshop::setIptcIrb(const byte* pPsData, size_t sizePsData, const IptcData& iptcData) {
-  if (sizePsData > 0)
-    assert(pPsData);
 #ifdef EXIV2_DEBUG_MESSAGES
   std::cerr << "IRB block at the beginning of Photoshop::setIptcIrb\n";
   if (sizePsData == 0)
@@ -498,7 +492,6 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, in
       // Read the rest of the segment.
       DataBuf buf(size);
       if (size > 0) {
-        assert(size >= 2);  // enforced above
         io_->readOrThrow(buf.data(2), size - 2, ErrorCode::kerFailedToReadImageData);
         buf.copyBytes(0, sizebuf, 2);
       }
@@ -508,8 +501,6 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, in
 
       // print signature for APPn
       if (marker >= app0_ && marker <= (app0_ | 0x0F)) {
-        assert(markerHasLength(marker));
-        assert(size >= 2);  // Because this marker has a length field.
         // http://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf p75
         const std::string signature = string_from_unterminated(buf.c_str(2), size - 2);
 
@@ -646,8 +637,6 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, in
 
       // print COM marker
       if (bPrint && marker == com_) {
-        assert(markerHasLength(marker));
-        assert(size >= 2);  // Because this marker has a length field.
         // size includes 2 for the two bytes for size!
         const size_t n = (size - 2) > 32 ? 32 : size - 2;
         // start after the two bytes
@@ -756,7 +745,6 @@ DataBuf JpegBase::readNextSegment(byte marker) {
   // Read the rest of the segment.
   DataBuf buf(size);
   if (size > 0) {
-    assert(size >= 2);  // enforced above
     io_->readOrThrow(buf.data(2), size - 2, ErrorCode::kerFailedToReadImageData);
     buf.copyBytes(0, sizebuf, 2);
   }
@@ -972,11 +960,9 @@ void JpegBase::doWriteMetadata(BasicIo& outIo) {
 
         const long chunk_size = 256 * 256 - 40;  // leave bytes for marker, header and padding
         size_t size = iccProfile_.size();
-        assert(size > 0);  // Because iccProfileDefined() == true
         if (size >= 255 * chunk_size)
           throw Error(ErrorCode::kerTooLargeJpegSegment, "IccProfile");
         const size_t chunks = 1 + (size - 1) / chunk_size;
-        assert(chunks <= 255);  // Because size < 255 * chunk_size
         for (size_t chunk = 0; chunk < chunks; chunk++) {
           size_t bytes = size > chunk_size ? chunk_size : size;  // bytes to write
           size -= bytes;

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -133,7 +133,6 @@ TiffComponent* TiffMnCreator::create(uint16_t tag, IfdId group, const std::strin
   TiffComponent* tc = nullptr;
   const TiffMnRegistry* tmr = find(registry_, make);
   if (tmr) {
-    assert(tmr->newMnFct_);
     tc = tmr->newMnFct_(tag, group, tmr->mnGroup_, pData, size, byteOrder);
   }
   return tc;
@@ -147,7 +146,6 @@ TiffComponent* TiffMnCreator::create(uint16_t tag, IfdId group, IfdId mnGroup) {
       std::cout << "mnGroup = " << mnGroup << "\n";
     }
 
-    assert(tmr->newMnFct2_);
     tc = tmr->newMnFct2_(tag, group, mnGroup);
   }
   return tc;
@@ -355,8 +353,6 @@ bool Nikon3MnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*
 }  // Nikon3MnHeader::read
 
 size_t Nikon3MnHeader::write(IoWrapper& ioWrapper, ByteOrder byteOrder) const {
-  assert(buf_.size() >= 10);
-
   ioWrapper.write(buf_.c_data(), 10);
   /// \todo: This removes any gap between the header and makernote IFD. The gap should be copied too.
   TiffHeader th(byteOrder);
@@ -493,7 +489,6 @@ const byte SigmaMnHeader::signature1_[] = {'S', 'I', 'G', 'M', 'A', '\0', '\0', 
 const byte SigmaMnHeader::signature2_[] = {'F', 'O', 'V', 'E', 'O', 'N', '\0', '\0', 0x01, 0x00};
 
 size_t SigmaMnHeader::sizeOfSignature() {
-  assert(sizeof(signature1_) == sizeof(signature2_));
   return sizeof(signature1_);
 }
 

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -188,7 +188,7 @@ bool OlympusMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder
   if (!pData || size < sizeOfSignature())
     return false;
   header_.alloc(sizeOfSignature());
-  header_.copyBytes(0, pData, header_.size());
+  std::copy_n(pData, header_.size(), header_.data());
   return !(header_.size() < sizeOfSignature() || 0 != header_.cmpBytes(0, signature_, 6));
 }
 
@@ -223,7 +223,7 @@ bool Olympus2MnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrde
   if (!pData || size < sizeOfSignature())
     return false;
   header_.alloc(sizeOfSignature());
-  header_.copyBytes(0, pData, header_.size());
+  std::copy_n(pData, header_.size(), header_.data());
   return !(header_.size() < sizeOfSignature() || 0 != header_.cmpBytes(0, signature_, 10));
 }
 
@@ -263,7 +263,7 @@ bool FujiMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*/)
   if (!pData || size < sizeOfSignature())
     return false;
   header_.alloc(sizeOfSignature());
-  header_.copyBytes(0, pData, header_.size());
+  std::copy_n(pData, header_.size(), header_.data());
   // Read offset to the IFD relative to the start of the makernote
   // from the header. Note that we ignore the byteOrder argument
   start_ = header_.read_uint32(8, byteOrder_);
@@ -299,7 +299,7 @@ bool Nikon2MnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*
   if (0 != memcmp(pData, signature_, 6))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   start_ = sizeOfSignature();
   return true;
 }  // Nikon2MnHeader::read
@@ -318,7 +318,7 @@ size_t Nikon3MnHeader::sizeOfSignature() {
 
 Nikon3MnHeader::Nikon3MnHeader() : byteOrder_(invalidByteOrder), start_(sizeOfSignature()) {
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, signature_, buf_.size());
+  std::copy_n(signature_, buf_.size(), buf_.data());
 }
 
 size_t Nikon3MnHeader::size() const {
@@ -343,7 +343,7 @@ bool Nikon3MnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*
   if (0 != memcmp(pData, signature_, 6))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   TiffHeader th;
   if (!th.read(buf_.data(10), 8))
     return false;
@@ -389,7 +389,7 @@ bool PanasonicMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrd
   if (0 != memcmp(pData, signature_, 9))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   start_ = sizeOfSignature();
   return true;
 }  // PanasonicMnHeader::read
@@ -425,7 +425,7 @@ bool PentaxDngMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrd
   if (!pData || size < sizeOfSignature())
     return false;
   header_.alloc(sizeOfSignature());
-  header_.copyBytes(0, pData, header_.size());
+  std::copy_n(pData, header_.size(), header_.data());
   return !(header_.size() < sizeOfSignature() || 0 != header_.cmpBytes(0, signature_, 7));
 }
 
@@ -456,7 +456,7 @@ bool PentaxMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*
   if (!pData || size < sizeOfSignature())
     return false;
   header_.alloc(sizeOfSignature());
-  header_.copyBytes(0, pData, header_.size());
+  std::copy_n(pData, header_.size(), header_.data());
   return !(header_.size() < sizeOfSignature() || 0 != header_.cmpBytes(0, signature_, 3));
 }
 
@@ -510,7 +510,7 @@ bool SigmaMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*/
   if (0 != memcmp(pData, signature1_, 8) && 0 != memcmp(pData, signature2_, 8))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   start_ = sizeOfSignature();
   return true;
 }  // SigmaMnHeader::read
@@ -544,7 +544,7 @@ bool SonyMnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*/)
   if (0 != memcmp(pData, signature_, sizeOfSignature()))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   start_ = sizeOfSignature();
   return true;
 }  // SonyMnHeader::read
@@ -583,7 +583,7 @@ bool Casio2MnHeader::read(const byte* pData, size_t size, ByteOrder /*byteOrder*
   if (0 != memcmp(pData, signature_, sizeOfSignature()))
     return false;
   buf_.alloc(sizeOfSignature());
-  buf_.copyBytes(0, pData, buf_.size());
+  std::copy_n(pData, buf_.size(), buf_.data());
   start_ = sizeOfSignature();
   return true;
 }  // Casio2MnHeader::read
@@ -891,7 +891,7 @@ DataBuf nikonCrypt(uint16_t tag, const byte* pData, size_t size, TiffComponent* 
     }
   }
   buf.alloc(size);
-  buf.copyBytes(0, pData, buf.size());
+  std::copy_n(pData, buf.size(), buf.data());
   ncrypt(buf.data(nci->start_), static_cast<uint32_t>(buf.size()) - nci->start_, count, serial);
   return buf;
 }

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -106,7 +106,7 @@ void MrwImage::readMetadata() {
   io_->read(buf.data(), buf.size());
   enforce(!io_->error() && !io_->eof(), ErrorCode::kerFailedToReadImageData);
 
-  ByteOrder bo = TiffParser::decode(exifData_, iptcData_, xmpData_, buf.c_data(), static_cast<uint32_t>(buf.size()));
+  ByteOrder bo = TiffParser::decode(exifData_, iptcData_, xmpData_, buf.c_data(), buf.size());
   setByteOrder(bo);
 }  // MrwImage::readMetadata
 

--- a/src/orfimage_int.cpp
+++ b/src/orfimage_int.cpp
@@ -35,8 +35,7 @@ DataBuf OrfHeader::write() const {
     case bigEndian:
       buf.write_uint8(0, 'M');
       break;
-    case invalidByteOrder:
-      assert(false);
+    default:
       break;
   }
   buf.write_uint8(1, buf.read_uint8(0));

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -90,13 +90,13 @@ void PgfImage::readMetadata() {
   // And now, the most interesting, the user data byte array where metadata are stored as small image.
 
   enforce(headerSize <= std::numeric_limits<size_t>::max() - 8, ErrorCode::kerCorruptedMetadata);
-  long size = static_cast<long>(headerSize) + 8 - io_->tell();
+  size_t size = headerSize + 8 - static_cast<size_t>(io_->tell());
 
 #ifdef EXIV2_DEBUG_MESSAGES
   std::cout << "Exiv2::PgfImage::readMetadata: Found Image data (" << size << " bytes)\n";
 #endif
 
-  if (size < 0 || static_cast<size_t>(size) > io_->size())
+  if (size > io_->size())
     throw Error(ErrorCode::kerInputDataReadFailed);
   if (size == 0)
     return;

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -180,7 +180,7 @@ void PgfImage::doWriteMetadata(BasicIo& outIo) {
   // Write new Header size.
   uint32_t newHeaderSize = static_cast<uint32_t>(header.size() + imgSize);
   DataBuf buffer(4);
-  buffer.copyBytes(0, &newHeaderSize, 4);
+  std::copy_n(&newHeaderSize, 4, buffer.data());
   byteSwap_(buffer, 0, bSwap_);
   if (outIo.write(buffer.c_data(), 4) != 4)
     throw Error(ErrorCode::kerImageWriteFailed);
@@ -259,7 +259,7 @@ DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, uint32_t& width, uint32_t
     throw Error(ErrorCode::kerInputDataReadFailed);
 
   DataBuf work(8);  // don't disturb the binary data - doWriteMetadata reuses it
-  work.copyBytes(0, header.c_data(), 8);
+  std::copy_n(header.c_data(), 8, work.begin());
   width = byteSwap_(work, 0, bSwap_);
   height = byteSwap_(work, 4, bSwap_);
 

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -19,7 +19,6 @@
 
 // standard includes
 #include <algorithm>
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <iomanip>
@@ -43,10 +42,7 @@ constexpr size_t nullSeparators = 2;
 // class member definitions
 namespace Exiv2::Internal {
 void PngChunk::decodeIHDRChunk(const DataBuf& data, uint32_t* outWidth, uint32_t* outHeight) {
-  assert(data.size() >= 8);
-
   // Extract image width and height from IHDR chunk.
-
   *outWidth = data.read_uint32(0, bigEndian);
   *outHeight = data.read_uint32(4, bigEndian);
 }
@@ -340,7 +336,7 @@ std::string PngChunk::makeMetadataChunk(const std::string& metadata, MetadataId 
     case mdIccProfile:
       break;
     case mdNone:
-      assert(false);
+      break;
   }
 
   return chunk;
@@ -356,7 +352,6 @@ void PngChunk::zlibUncompress(const byte* compressedText, unsigned int compresse
     arr.alloc(uncompressedLen);
     zlibResult = uncompress(arr.data(), &uncompressedLen, compressedText, compressedTextSize);
     if (zlibResult == Z_OK) {
-      assert((uLongf)arr.size() >= uncompressedLen);
       arr.resize(uncompressedLen);
     } else if (zlibResult == Z_BUF_ERROR) {
       // the uncompressedArray needs to be larger
@@ -390,7 +385,6 @@ std::string PngChunk::zlibCompress(const std::string& text) {
 
     switch (zlibResult) {
       case Z_OK:
-        assert((uLongf)arr.size() >= compressedLen);
         arr.resize(compressedLen);
         break;
       case Z_BUF_ERROR:

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -490,7 +490,7 @@ DataBuf PngChunk::readRawProfile(const DataBuf& text, bool iTXt) {
 
   if (iTXt) {
     info.alloc(text.size());
-    info.copyBytes(0, text.c_data(), text.size());
+    std::copy(text.cbegin(), text.cend(), info.begin());
     return info;
   }
 

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -37,10 +37,9 @@ constexpr unsigned char pngBlank[] = {
 
 const auto nullComp = reinterpret_cast<const Exiv2::byte*>("\0\0");
 const auto typeICCP = reinterpret_cast<const Exiv2::byte*>("iCCP");
-/// \todo use string_view and remove the last parameter
-inline bool compare(const char* str, const Exiv2::DataBuf& buf, size_t length) {
-  const auto minlen = std::min(length, buf.size());
-  return buf.cmpBytes(0, str, minlen) == 0;
+inline bool compare(std::string_view str, const Exiv2::DataBuf& buf) {
+  const auto minlen = std::min(str.size(), buf.size());
+  return buf.cmpBytes(0, str.data(), minlen) == 0;
 }
 }  // namespace
 
@@ -640,11 +639,10 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
     } else if (!strcmp(szChunk, "tEXt") || !strcmp(szChunk, "zTXt") || !strcmp(szChunk, "iTXt") ||
                !strcmp(szChunk, "iCCP")) {
       DataBuf key = PngChunk::keyTXTChunk(chunkBuf, true);
-      if (!key.empty() &&
-          (compare("Raw profile type exif", key, 21) || compare("Raw profile type APP1", key, 21) ||
-           compare("Raw profile type iptc", key, 21) || compare("Raw profile type xmp", key, 20) ||
-           compare("XML:com.adobe.xmp", key, 17) || compare("icc", key, 3) ||  // see test/data/imagemagick.png
-           compare("ICC", key, 3) || compare("Description", key, 11))) {
+      if (!key.empty() && (compare("Raw profile type exif", key) || compare("Raw profile type APP1", key) ||
+                           compare("Raw profile type iptc", key) || compare("Raw profile type xmp", key) ||
+                           compare("XML:com.adobe.xmp", key) || compare("icc", key) ||  // see test/data/imagemagick.png
+                           compare("ICC", key) || compare("Description", key))) {
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngImage::doWriteMetadata: strip " << szChunk << " chunk (length: " << dataOffset << ")"
                   << std::endl;

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -340,10 +340,10 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, in
           }
 
           if (bSoft && !dataBuf.empty()) {
-            DataBuf s(dataBuf.size() + 1);                     // allocate buffer with an extra byte
-            s.copyBytes(0, dataBuf.c_data(), dataBuf.size());  // copy in the dataBuf
-            s.write_uint8(dataBuf.size(), 0);                  // nul terminate it
-            const auto str = s.c_str();                        // give it name
+            DataBuf s(dataBuf.size() + 1);                         // allocate buffer with an extra byte
+            std::copy(dataBuf.begin(), dataBuf.end(), s.begin());  // copy in the dataBuf
+            s.write_uint8(dataBuf.size(), 0);                      // nul terminate it
+            const auto str = s.c_str();                            // give it name
             out << Internal::indent(depth) << buff.c_str() << ": " << str;
             bLF = true;
           }
@@ -526,7 +526,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
     // Read whole chunk : Chunk header + Chunk data (not fixed size - can be null) + CRC (4 bytes).
 
     DataBuf chunkBuf(8 + dataOffset + 4);                   // Chunk header (8 bytes) + Chunk data + CRC (4 bytes).
-    chunkBuf.copyBytes(0, cheaderBuf.c_data(), 8);          // Copy header.
+    std::copy_n(cheaderBuf.begin(), 8, chunkBuf.begin());   // Copy header.
     bufRead = io_->read(chunkBuf.data(8), dataOffset + 4);  // Extract chunk data + CRC
     if (io_->error())
       throw Error(ErrorCode::kerFailedToReadImageData);

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -37,8 +37,8 @@ constexpr unsigned char pngBlank[] = {
 
 const auto nullComp = reinterpret_cast<const Exiv2::byte*>("\0\0");
 const auto typeICCP = reinterpret_cast<const Exiv2::byte*>("iCCP");
+/// \todo use string_view and remove the last parameter
 inline bool compare(const char* str, const Exiv2::DataBuf& buf, size_t length) {
-  assert(strlen(str) <= length);
   const auto minlen = std::min(length, buf.size());
   return buf.cmpBytes(0, str, minlen) == 0;
 }

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -31,7 +31,7 @@ bool cmpPreviewProperties(const PreviewProperties &lhs, const PreviewProperties 
 }
 
 /// @brief Decode a Hex string.
-DataBuf decodeHex(const byte *src, long srcSize);
+DataBuf decodeHex(const byte *src, size_t srcSize);
 
 /// @brief Decode a Base64 string.
 DataBuf decodeBase64(const std::string &src);
@@ -409,12 +409,12 @@ DataBuf LoaderNative::getData() const {
     return {data + nativePreview_.position_, nativePreview_.size_};
   }
   if (nativePreview_.filter_ == "hex-ai7thumbnail-pnm") {
-    const DataBuf ai7thumbnail = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
+    const DataBuf ai7thumbnail = decodeHex(data + nativePreview_.position_, nativePreview_.size_);
     const DataBuf rgb = decodeAi7Thumbnail(ai7thumbnail);
     return makePnm(width_, height_, rgb);
   }
   if (nativePreview_.filter_ == "hex-irb") {
-    const DataBuf psData = decodeHex(data + nativePreview_.position_, static_cast<long>(nativePreview_.size_));
+    const DataBuf psData = decodeHex(data + nativePreview_.position_, nativePreview_.size_);
     const byte *record;
     uint32_t sizeHdr = 0;
     uint32_t sizeData = 0;
@@ -479,7 +479,7 @@ LoaderExifJpeg::LoaderExifJpeg(PreviewId id, const Image &image, int parIdx) : L
     }
   }
 
-  if (Safe::add(offset_, size_) > static_cast<uint32_t>(image_.io().size()))
+  if (Safe::add(offset_, size_) > image_.io().size())
     return;
 
   valid_ = true;
@@ -648,7 +648,7 @@ LoaderTiff::LoaderTiff(PreviewId id, const Image &image, int parIdx) :
   if (offsetCount != pos->value().count())
     return;
   for (size_t i = 0; i < offsetCount; i++) {
-    size_ += pos->toUint32(static_cast<long>(i));
+    size_ += pos->toUint32(i);
   }
 
   if (size_ == 0)
@@ -727,7 +727,7 @@ DataBuf LoaderTiff::getData() const {
           dataValue.setDataArea(base + offset, size);
       } else {
         // FIXME: the buffer is probably copied twice, it should be optimized
-        enforce(size_ <= static_cast<uint32_t>(io.size()), ErrorCode::kerCorruptedMetadata);
+        enforce(size_ <= io.size(), ErrorCode::kerCorruptedMetadata);
         DataBuf buf(size_);
         uint32_t idxBuf = 0;
         for (size_t i = 0; i < sizes.count(); i++) {
@@ -792,7 +792,7 @@ LoaderXmpJpeg::LoaderXmpJpeg(PreviewId id, const Image &image, int parIdx) : Loa
   width_ = widthDatum->toUint32();
   height_ = heightDatum->toUint32();
   preview_ = decodeBase64(imageDatum->toString());
-  size_ = static_cast<uint32_t>(preview_.size());
+  size_ = preview_.size();
   valid_ = true;
 }
 
@@ -817,7 +817,7 @@ bool LoaderXmpJpeg::readDimensions() {
   return valid();
 }
 
-DataBuf decodeHex(const byte *src, long srcSize) {
+DataBuf decodeHex(const byte *src, size_t srcSize) {
   // create decoding table
   byte invalid = 16;
   std::array<byte, 256> decodeHexTable;
@@ -831,17 +831,17 @@ DataBuf decodeHex(const byte *src, long srcSize) {
 
   // calculate dest size
   long validSrcSize = 0;
-  for (long srcPos = 0; srcPos < srcSize; srcPos++) {
+  for (size_t srcPos = 0; srcPos < srcSize; srcPos++) {
     if (decodeHexTable[src[srcPos]] != invalid)
       validSrcSize++;
   }
-  const long destSize = validSrcSize / 2;
+  const size_t destSize = validSrcSize / 2;
 
   // allocate dest buffer
   DataBuf dest(destSize);
 
   // decode
-  for (long srcPos = 0, destPos = 0; destPos < destSize; destPos++) {
+  for (size_t srcPos = 0, destPos = 0; destPos < destSize; destPos++) {
     byte buffer = 0;
     for (int bufferPos = 1; bufferPos >= 0 && srcPos < srcSize; srcPos++) {
       byte srcValue = decodeHexTable[src[srcPos]];
@@ -880,7 +880,7 @@ DataBuf decodeBase64(const std::string &src) {
   // allocate dest buffer
   if (destSize > LONG_MAX)
     return {};  // avoid integer overflow
-  DataBuf dest(static_cast<long>(destSize));
+  DataBuf dest(destSize);
 
   // decode
   for (unsigned long srcPos = 0, destPos = 0; destPos < destSize;) {
@@ -901,7 +901,7 @@ DataBuf decodeBase64(const std::string &src) {
 
 DataBuf decodeAi7Thumbnail(const DataBuf &src) {
   const byte *colorTable = src.c_data();
-  const long colorTableSize = 256 * 3;
+  const size_t colorTableSize = 256 * 3;
   if (src.size() < colorTableSize) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Invalid size of AI7 thumbnail: " << src.size() << "\n";
@@ -909,10 +909,10 @@ DataBuf decodeAi7Thumbnail(const DataBuf &src) {
     return {};
   }
   const byte *imageData = src.c_data(colorTableSize);
-  const long imageDataSize = static_cast<long>(src.size()) - colorTableSize;
+  const size_t imageDataSize = src.size() - colorTableSize;
   const bool rle = (imageDataSize >= 3 && imageData[0] == 'R' && imageData[1] == 'L' && imageData[2] == 'E');
   std::string dest;
-  for (long i = rle ? 3 : 0; i < imageDataSize;) {
+  for (size_t i = rle ? 3 : 0; i < imageDataSize;) {
     byte num = 1;
     byte value = imageData[i++];
     if (rle && value == 0xFD) {
@@ -1029,8 +1029,8 @@ PreviewPropertiesList PreviewManager::getPreviewProperties() const {
     auto loader = Loader::create(id, image_);
     if (loader && loader->readDimensions()) {
       PreviewProperties props = loader->getProperties();
-      DataBuf buf = loader->getData();                  // #16 getPreviewImage()
-      props.size_ = static_cast<uint32_t>(buf.size());  //     update the size
+      DataBuf buf = loader->getData();  // #16 getPreviewImage()
+      props.size_ = buf.size();         //     update the size
       list.push_back(props);
     }
   }

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -12,6 +12,7 @@
 #include "tiffimage.hpp"
 #include "tiffimage_int.hpp"
 
+#include <algorithm>
 #include <climits>
 
 namespace {
@@ -739,7 +740,7 @@ DataBuf LoaderTiff::getData() const {
           // That's why we check again for each step here to really make sure we don't overstep
           enforce(Safe::add(idxBuf, size) <= size_, ErrorCode::kerCorruptedMetadata);
           if (size != 0 && Safe::add(offset, size) <= static_cast<uint32_t>(io.size())) {
-            buf.copyBytes(idxBuf, base + offset, size);
+            std::copy_n(base + offset, size, buf.begin() + idxBuf);
           }
 
           idxBuf += size;
@@ -953,9 +954,9 @@ DataBuf makePnm(size_t width, size_t height, const DataBuf &rgb) {
   const std::string header = "P6\n" + toString(width) + " " + toString(height) + "\n255\n";
   const auto headerBytes = reinterpret_cast<const byte *>(header.data());
 
-  DataBuf dest(static_cast<long>(header.size() + rgb.size()));
-  dest.copyBytes(0, headerBytes, header.size());
-  dest.copyBytes(header.size(), rgb.c_data(), rgb.size());
+  DataBuf dest(header.size() + rgb.size());
+  std::copy_n(headerBytes, header.size(), dest.begin());
+  std::copy_n(rgb.c_data(), rgb.size(), dest.begin() + header.size());
   return dest;
 }
 

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -217,7 +217,7 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       io_->read(rawIPTC.data(), rawIPTC.size());
       if (io_->error() || io_->eof())
         throw Error(ErrorCode::kerFailedToReadImageData);
-      if (IptcParser::decode(iptcData_, rawIPTC.c_data(), static_cast<uint32_t>(rawIPTC.size()))) {
+      if (IptcParser::decode(iptcData_, rawIPTC.c_data(), rawIPTC.size())) {
 #ifndef SUPPRESS_WARNINGS
         EXV_WARNING << "Failed to decode IPTC metadata.\n";
 #endif
@@ -484,8 +484,7 @@ void PsdImage::doWriteMetadata(BasicIo& outIo) {
       readTotal = 0;
       while (readTotal < pResourceSize) {
         /// \todo almost same code as in lines 403-410. Factor out & reuse!
-        size_t toRead = (pResourceSize - readTotal) < lbuf.size() ? static_cast<long>(pResourceSize - readTotal)
-                                                                  : static_cast<long>(lbuf.size());
+        size_t toRead = (pResourceSize - readTotal) < lbuf.size() ? pResourceSize - readTotal : lbuf.size();
         if (io_->read(lbuf.data(), toRead) != toRead) {
           throw Error(ErrorCode::kerNotAnImage, "Photoshop");
         }

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -233,8 +233,6 @@ void ExifKey::Impl::decomposeKey(const std::string& key) {
 }
 
 void ExifKey::Impl::makeKey(uint16_t tag, IfdId ifdId, const TagInfo* tagInfo) {
-  assert(tagInfo);
-
   tagInfo_ = tagInfo;
   tag_ = tag;
   ifdId_ = ifdId;

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -217,7 +217,7 @@ void TiffEntryBase::setData(const std::shared_ptr<DataBuf>& buf) {
   size_ = buf->size();
 }
 
-void TiffEntryBase::setData(byte* pData, uint32_t size, const std::shared_ptr<DataBuf>& storage) {
+void TiffEntryBase::setData(byte* pData, size_t size, const std::shared_ptr<DataBuf>& storage) {
   pData_ = pData;
   size_ = size;
   storage_ = storage;
@@ -352,7 +352,7 @@ uint32_t TiffIfdMakernote::baseOffset() const {
   return pHeader_->baseOffset(mnOffset_);
 }
 
-bool TiffIfdMakernote::readHeader(const byte* pData, uint32_t size, ByteOrder byteOrder) {
+bool TiffIfdMakernote::readHeader(const byte* pData, size_t size, ByteOrder byteOrder) {
   if (!pHeader_)
     return true;
   return pHeader_->read(pData, size, byteOrder);

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -79,7 +79,6 @@ TiffIfdMakernote::TiffIfdMakernote(uint16_t tag, IfdId group, IfdId mnGroup, MnH
 TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArrayCfg* arrayCfg, const ArrayDef* arrayDef,
                                  int defSize) :
     TiffEntryBase(tag, group, arrayCfg->elTiffType_), arrayCfg_(arrayCfg), arrayDef_(arrayDef), defSize_(defSize) {
-  assert(arrayCfg);
 }
 
 TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arraySet, int setSize,
@@ -89,8 +88,6 @@ TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arra
     arraySet_(arraySet),
     setSize_(setSize) {
   // We'll figure out the correct cfg later
-  assert(cfgSelFct);
-  assert(arraySet_);
 }
 
 TiffBinaryElement::TiffBinaryElement(uint16_t tag, IfdId group) :
@@ -191,12 +188,10 @@ TiffSubIfd* TiffSubIfd::doClone() const {
 }
 
 TiffMnEntry* TiffMnEntry::doClone() const {
-  assert(false);  // Not implemented
   return nullptr;
 }
 
 TiffIfdMakernote* TiffIfdMakernote::doClone() const {
-  assert(false);  // Not implemented
   return nullptr;
 }
 
@@ -341,7 +336,6 @@ size_t TiffIfdMakernote::ifdOffset() const {
 }
 
 ByteOrder TiffIfdMakernote::byteOrder() const {
-  assert(imageByteOrder_ != invalidByteOrder);
   if (!pHeader_ || pHeader_->byteOrder() == invalidByteOrder) {
     return imageByteOrder_;
   }
@@ -420,8 +414,6 @@ void TiffBinaryArray::iniOrigDataBuf() {
 }
 
 bool TiffBinaryArray::updOrigDataBuf(const byte* pData, size_t size) {
-  assert(pData);
-
   if (origSize_ != size)
     return false;
   if (origData_ == pData)
@@ -437,7 +429,6 @@ uint32_t TiffBinaryArray::addElement(uint32_t idx, const ArrayDef& def) {
   auto tp = dynamic_cast<TiffBinaryElement*>(tc.get());
   // The assertion typically fails if a component is not configured in
   // the TIFF structure table (TiffCreator::tiffTreeStruct_)
-  assert(tp);
   tp->setStart(pData() + idx);
   tp->setData(const_cast<byte*>(pData() + idx), sz, storage());
   tp->setElDef(def);
@@ -458,7 +449,6 @@ TiffComponent* TiffComponent::doAddPath(uint16_t /*tag*/, TiffPath& /*tiffPath*/
 
 TiffComponent* TiffDirectory::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
                                         TiffComponent::UniquePtr object) {
-  assert(tiffPath.size() > 1);
   tiffPath.pop();
   const TiffPathItem tpi = tiffPath.top();
 
@@ -486,7 +476,6 @@ TiffComponent* TiffDirectory::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffCo
     } else {
       atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
     }
-    assert(atc);
 
     // Prevent dangling sub-IFD tags: Do not add a sub-IFD component without children.
     // Todo: How to check before creating the component?
@@ -504,7 +493,6 @@ TiffComponent* TiffDirectory::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffCo
 
 TiffComponent* TiffSubIfd::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
                                      TiffComponent::UniquePtr object) {
-  assert(!tiffPath.empty());
   const TiffPathItem tpi1 = tiffPath.top();
   tiffPath.pop();
   if (tiffPath.empty()) {
@@ -535,7 +523,6 @@ TiffComponent* TiffSubIfd::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffCompo
 
 TiffComponent* TiffMnEntry::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComponent* const pRoot,
                                       TiffComponent::UniquePtr object) {
-  assert(!tiffPath.empty());
   const TiffPathItem tpi1 = tiffPath.top();
   tiffPath.pop();
   if (tiffPath.empty()) {
@@ -547,7 +534,6 @@ TiffComponent* TiffMnEntry::doAddPath(uint16_t tag, TiffPath& tiffPath, TiffComp
   if (!mn_) {
     mnGroup_ = tpi2.group();
     mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
-    assert(mn_);
   }
   return mn_->addPath(tag, tiffPath, pRoot, std::move(object));
 }  // TiffMnEntry::doAddPath
@@ -587,8 +573,6 @@ TiffComponent* TiffBinaryArray::doAddPath(uint16_t tag, TiffPath& tiffPath, Tiff
     } else {
       atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
     }
-    assert(atc);
-    assert(tpi.extendedTag() != Tag::next);
     tc = addChild(std::move(atc));
     setCount(elements_.size());
   }
@@ -611,7 +595,6 @@ TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent)
 
 TiffComponent* TiffSubIfd::doAddChild(TiffComponent::UniquePtr tiffComponent) {
   auto d = dynamic_cast<TiffDirectory*>(tiffComponent.release());
-  assert(d);
   ifds_.push_back(d);
   return d;
 }  // TiffSubIfd::doAddChild
@@ -926,7 +909,6 @@ uint32_t TiffDirectory::doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64
     ioWrapper.write(buf, 4);
     idx += 4;
   }
-  assert(idx == sizeDir);
 
   // 2nd: Write IFD values - may contain pointers to additional data
   valueIdx = static_cast<uint32_t>(sizeDir);
@@ -947,7 +929,6 @@ uint32_t TiffDirectory::doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64
     sd += sd & 1;  // Align data to word boundary
     dataIdx += sd;
   }
-  assert(idx == sizeDir + sizeValue);
 
   // 3rd: Write data - may contain offsets too (eg sub-IFD)
   dataIdx = static_cast<uint32_t>(sizeDir + sizeValue);
@@ -969,9 +950,7 @@ uint32_t TiffDirectory::doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64
 uint32_t TiffDirectory::writeDirEntry(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset,
                                       TiffComponent* pTiffComponent, uint32_t valueIdx, uint32_t dataIdx,
                                       uint32_t& imageIdx) {
-  assert(pTiffComponent);
   auto pDirEntry = dynamic_cast<TiffEntryBase*>(pTiffComponent);
-  assert(pDirEntry);
   byte buf[8];
   us2Data(buf, pDirEntry->tag(), byteOrder);
   us2Data(buf + 2, pDirEntry->tiffType(), byteOrder);
@@ -1122,7 +1101,7 @@ uint32_t TiffBinaryArray::doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int
         idx += ul2Data(buf, static_cast<uint32_t>(size()), byteOrder);
         break;
       default:
-        assert(false);
+        break;
     }
     mioWrapper.write(buf, elSize);
   }
@@ -1229,9 +1208,8 @@ uint32_t TiffSubIfd::doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int6
 
 uint32_t TiffIfdMakernote::doWriteData(IoWrapper& /*ioWrapper*/, ByteOrder /*byteOrder*/, int64_t /*offset*/,
                                        uint32_t /*dataIdx*/, uint32_t& /*imageIdx*/) const {
-  assert(false);
   return 0;
-}  // TiffIfdMakernote::doWriteData
+}
 
 uint32_t TiffComponent::writeImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const {
   return doWriteImage(ioWrapper, byteOrder);
@@ -1413,7 +1391,6 @@ size_t TiffComponent::sizeData() const {
 }
 
 size_t TiffDirectory::doSizeData() const {
-  assert(false);
   return 0;
 }
 
@@ -1445,7 +1422,6 @@ size_t TiffSubIfd::doSizeData() const {
 }
 
 size_t TiffIfdMakernote::doSizeData() const {
-  assert(false);
   return 0;
 }
 
@@ -1537,16 +1513,12 @@ TiffType toTiffType(TypeId typeId) {
 }
 
 bool cmpTagLt(TiffComponent const* lhs, TiffComponent const* rhs) {
-  assert(lhs);
-  assert(rhs);
   if (lhs->tag() != rhs->tag())
     return lhs->tag() < rhs->tag();
   return lhs->idx() < rhs->idx();
 }
 
 bool cmpGroupLt(TiffComponent const* lhs, TiffComponent const* rhs) {
-  assert(lhs);
-  assert(rhs);
   return lhs->group() < rhs->group();
 }
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -422,7 +422,7 @@ class TiffEntryBase : public TiffComponent {
                    you should pass std::shared_ptr<DataBuf>(), which is essentially
                    a nullptr.
    */
-  void setData(byte* pData, uint32_t size, const std::shared_ptr<DataBuf>& storage);
+  void setData(byte* pData, size_t size, const std::shared_ptr<DataBuf>& storage);
   /*!
     @brief Set the entry's data buffer. A shared_ptr is used to manage the DataBuf
            because TiffEntryBase has a clone method so it is possible (in theory) for
@@ -1113,7 +1113,7 @@ class TiffIfdMakernote : public TiffComponent {
 
     The default implementation simply returns true.
    */
-  bool readHeader(const byte* pData, uint32_t size, ByteOrder byteOrder);
+  bool readHeader(const byte* pData, size_t size, ByteOrder byteOrder);
   /*!
     @brief Set the byte order for the makernote.
    */

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -220,8 +220,7 @@ ByteOrder TiffParser::decode(ExifData& exifData, IptcData& iptcData, XmpData& xm
     }
   }
 
-  return TiffParserWorker::decode(exifData, iptcData, xmpData, pData, static_cast<uint32_t>(size), root,
-                                  TiffMapping::findDecoder);
+  return TiffParserWorker::decode(exifData, iptcData, xmpData, pData, size, root, TiffMapping::findDecoder);
 }  // TiffParser::decode
 
 WriteMethod TiffParser::encode(BasicIo& io, const byte* pData, size_t size, ByteOrder byteOrder,

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1832,7 +1832,6 @@ void TiffCreator::getPath(TiffPath& tiffPath, uint32_t extendedTag, IfdId group,
   do {
     tiffPath.push(TiffPathItem(extendedTag, group));
     ts = find(tiffTreeStruct_, TiffTreeStruct::Key(root, group));
-    assert(ts);
     extendedTag = ts->parentExtTag_;
     group = ts->parentGroup_;
   } while (!(ts->root_ == root && ts->group_ == ifdIdNotSet));
@@ -1867,8 +1866,6 @@ WriteMethod TiffParserWorker::encode(BasicIo& io, const byte* pData, size_t size
         writing"). If there is a parsed tree, it is only used to access the
         image data in this case.
    */
-  assert(pHeader);
-  assert(pHeader->byteOrder() != invalidByteOrder);
   WriteMethod writeMethod = wmIntrusive;
   auto parsedTree = parse(pData, size, root, pHeader);
   PrimaryGroups primaryGroups;
@@ -1985,7 +1982,6 @@ DataBuf TiffHeaderBase::write() const {
       buf.write_uint8(0, 'M');
       break;
     case invalidByteOrder:
-      assert(false);
       break;
   }
   buf.write_uint8(1, buf.read_uint8(0));

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -512,7 +512,7 @@ void TiffEncoder::encodeIptc() {
     if (rawIptc.size() % 4 != 0) {
       // Pad the last unsignedLong value with 0s
       buf.alloc((rawIptc.size() / 4) * 4 + 4);
-      buf.copyBytes(0, rawIptc.c_data(), rawIptc.size());
+      std::copy(rawIptc.begin(), rawIptc.end(), buf.begin());
     } else {
       buf = std::move(rawIptc);  // Note: This resets rawIptc
     }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -54,12 +54,10 @@ TiffVisitor::TiffVisitor() {
 }
 
 void TiffVisitor::setGo(GoEvent event, bool go) {
-  assert(event >= 0 && static_cast<int>(event) < events_);
   go_[event] = go;
 }
 
 bool TiffVisitor::go(GoEvent event) const {
-  assert(event >= 0 && static_cast<int>(event) < events_);
   return go_[event];
 }
 
@@ -132,14 +130,9 @@ void TiffFinder::visitBinaryElement(TiffBinaryElement* object) {
 TiffCopier::TiffCopier(TiffComponent* pRoot, uint32_t root, const TiffHeaderBase* pHeader,
                        const PrimaryGroups* pPrimaryGroups) :
     pRoot_(pRoot), root_(root), pHeader_(pHeader), pPrimaryGroups_(pPrimaryGroups) {
-  assert(pRoot_);
-  assert(pHeader_);
-  assert(pPrimaryGroups_);
 }
 
 void TiffCopier::copyObject(TiffComponent* object) {
-  assert(object);
-
   if (pHeader_->isImageTag(object->tag(), object->group(), pPrimaryGroups_)) {
     auto clone = object->clone();
     // Assumption is that the corresponding TIFF entry doesn't exist
@@ -201,8 +194,6 @@ TiffDecoder::TiffDecoder(ExifData& exifData, IptcData& iptcData, XmpData& xmpDat
     pRoot_(pRoot),
     findDecoderFct_(findDecoderFct),
     decodedIptc_(false) {
-  assert(pRoot);
-
   // #1402 Fujifilm RAF. Search for the make
   // Find camera make in existing metadata (read from the JPEG)
   ExifKey key("Exif.Image.Make");
@@ -249,8 +240,6 @@ void TiffDecoder::visitMnEntry(TiffMnEntry* object) {
 }
 
 void TiffDecoder::visitIfdMakernote(TiffIfdMakernote* object) {
-  assert(object);
-
   exifData_["Exif.MakerNote.Offset"] = object->mnOffset();
   switch (object->byteOrder()) {
     case littleEndian:
@@ -260,7 +249,6 @@ void TiffDecoder::visitIfdMakernote(TiffIfdMakernote* object) {
       exifData_["Exif.MakerNote.ByteOrder"] = "MM";
       break;
     case invalidByteOrder:
-      assert(object->byteOrder() != invalidByteOrder);
       break;
   }
 }
@@ -434,8 +422,6 @@ void TiffDecoder::decodeCanonAFInfo(const TiffEntryBase* object) {
 }
 
 void TiffDecoder::decodeTiffEntry(const TiffEntryBase* object) {
-  assert(object);
-
   // Don't decode the entry if value is not set
   if (!object->pValue())
     return;
@@ -448,7 +434,6 @@ void TiffDecoder::decodeTiffEntry(const TiffEntryBase* object) {
 }  // TiffDecoder::decodeTiffEntry
 
 void TiffDecoder::decodeStdTiffEntry(const TiffEntryBase* object) {
-  assert(object);
   ExifKey key(object->tag(), groupName(object->group()));
   key.setIdx(object->idx());
   exifData_.add(key, object->pValue());
@@ -480,10 +465,6 @@ TiffEncoder::TiffEncoder(ExifData exifData, const IptcData& iptcData, const XmpD
     findEncoderFct_(findEncoderFct),
     dirty_(false),
     writeMethod_(wmNonIntrusive) {
-  assert(pRoot);
-  assert(pPrimaryGroups);
-  assert(pHeader);
-
   byteOrder_ = pHeader->byteOrder();
   origByteOrder_ = byteOrder_;
 
@@ -616,8 +597,6 @@ void TiffEncoder::visitDirectory(TiffDirectory* /*object*/) {
 
 void TiffEncoder::visitDirectoryNext(TiffDirectory* object) {
   // Update type and count in IFD entries, in case they changed
-  assert(object);
-
   byte* p = object->start() + 2;
   for (auto&& component : object->components_) {
     p += updateDirEntry(p, byteOrder(), component);
@@ -625,10 +604,7 @@ void TiffEncoder::visitDirectoryNext(TiffDirectory* object) {
 }
 
 uint32_t TiffEncoder::updateDirEntry(byte* buf, ByteOrder byteOrder, TiffComponent* pTiffComponent) {
-  assert(buf);
-  assert(pTiffComponent);
   auto pTiffEntry = dynamic_cast<TiffEntryBase*>(pTiffComponent);
-  assert(pTiffEntry);
   us2Data(buf + 2, pTiffEntry->tiffType(), byteOrder);
   ul2Data(buf + 4, static_cast<uint32_t>(pTiffEntry->count()), byteOrder);
   // Move data to offset field, if it fits and is not yet there.
@@ -663,8 +639,6 @@ void TiffEncoder::visitMnEntry(TiffMnEntry* object) {
 }
 
 void TiffEncoder::visitIfdMakernote(TiffIfdMakernote* object) {
-  assert(object);
-
   auto pos = exifData_.findKey(ExifKey("Exif.MakerNote.ByteOrder"));
   if (pos != exifData_.end()) {
     // Set Makernote byte order
@@ -705,8 +679,6 @@ void TiffEncoder::visitBinaryArray(TiffBinaryArray* object) {
 }
 
 void TiffEncoder::visitBinaryArrayEnd(TiffBinaryArray* object) {
-  assert(object);
-
   if (!object->cfg() || !object->decoded())
     return;
   size_t size = object->TiffEntryBase::doSize();
@@ -747,8 +719,6 @@ bool TiffEncoder::isImageTag(uint16_t tag, IfdId group) const {
 }
 
 void TiffEncoder::encodeTiffComponent(TiffEntryBase* object, const Exifdatum* datum) {
-  assert(object);
-
   auto pos = exifData_.end();
   const Exifdatum* ed = datum;
   if (!ed) {
@@ -809,8 +779,6 @@ void TiffEncoder::encodeDataEntry(TiffDataEntry* object, const Exifdatum* datum)
   encodeOffsetEntry(object, datum);
 
   if (!dirty_ && writeMethod() == wmNonIntrusive) {
-    assert(object);
-    assert(object->pValue());
     if (object->sizeDataArea_ < static_cast<uint32_t>(object->pValue()->sizeDataArea())) {
 #ifdef EXIV2_DEBUG_MESSAGES
       ExifKey key(object->tag(), groupName(object->group()));
@@ -922,9 +890,6 @@ void TiffEncoder::encodeSubIfd(TiffSubIfd* object, const Exifdatum* datum) {
 }  // TiffEncoder::encodeSubIfd
 
 void TiffEncoder::encodeTiffEntryBase(TiffEntryBase* object, const Exifdatum* datum) {
-  assert(object);
-  assert(datum);
-
 #ifdef EXIV2_DEBUG_MESSAGES
   bool tooLarge = false;
 #endif
@@ -946,9 +911,6 @@ void TiffEncoder::encodeTiffEntryBase(TiffEntryBase* object, const Exifdatum* da
 }
 
 void TiffEncoder::encodeOffsetEntry(TiffEntryBase* object, const Exifdatum* datum) {
-  assert(object);
-  assert(datum);
-
   size_t newSize = datum->size();
   if (newSize > object->size_) {  // value doesn't fit, encode for intrusive writing
     setDirty();
@@ -969,8 +931,6 @@ void TiffEncoder::encodeOffsetEntry(TiffEntryBase* object, const Exifdatum* datu
 }
 
 void TiffEncoder::add(TiffComponent* pRootDir, TiffComponent* pSourceDir, uint32_t root) {
-  assert(pRootDir);
-
   writeMethod_ = wmIntrusive;
   pSourceTree_ = pSourceDir;
 
@@ -1044,8 +1004,6 @@ TiffReader::TiffReader(const byte* pData, size_t size, TiffComponent* pRoot, Tif
     mnState_(state),
     postProc_(false) {
   pState_ = &origState_;
-  assert(pData_);
-  assert(size_);
 
 }  // TiffReader::TiffReader
 
@@ -1066,18 +1024,14 @@ void TiffReader::setMnState(const TiffRwState* state) {
 }
 
 ByteOrder TiffReader::byteOrder() const {
-  assert(pState_);
   return pState_->byteOrder();
 }
 
 uint32_t TiffReader::baseOffset() const {
-  assert(pState_);
   return pState_->baseOffset();
 }
 
 void TiffReader::readDataEntryBase(TiffDataEntryBase* object) {
-  assert(object);
-
   readTiffEntry(object);
   TiffFinder finder(object->szTag(), object->szGroup());
   pRoot_->accept(finder);
@@ -1100,8 +1054,6 @@ void TiffReader::visitImageEntry(TiffImageEntry* object) {
 }
 
 void TiffReader::visitSizeEntry(TiffSizeEntry* object) {
-  assert(object);
-
   readTiffEntry(object);
   TiffFinder finder(object->dtTag(), object->dtGroup());
   pRoot_->accept(finder);
@@ -1139,10 +1091,7 @@ void TiffReader::postProcess() {
 }
 
 void TiffReader::visitDirectory(TiffDirectory* object) {
-  assert(object);
-
   const byte* p = object->start();
-  assert(p >= pData_);
 
   if (circularReference(object->start(), object->group()))
     return;
@@ -1217,8 +1166,6 @@ void TiffReader::visitDirectory(TiffDirectory* object) {
 }  // TiffReader::visitDirectory
 
 void TiffReader::visitSubIfd(TiffSubIfd* object) {
-  assert(object);
-
   readTiffEntry(object);
   if ((object->tiffType() == ttUnsignedLong || object->tiffType() == ttSignedLong || object->tiffType() == ttTiffIfd) &&
       object->count() >= 1) {
@@ -1258,8 +1205,6 @@ void TiffReader::visitSubIfd(TiffSubIfd* object) {
 }  // TiffReader::visitSubIfd
 
 void TiffReader::visitMnEntry(TiffMnEntry* object) {
-  assert(object);
-
   readTiffEntry(object);
   // Find camera make
   TiffFinder finder(0x010f, ifd0Id);
@@ -1278,8 +1223,6 @@ void TiffReader::visitMnEntry(TiffMnEntry* object) {
 }  // TiffReader::visitMnEntry
 
 void TiffReader::visitIfdMakernote(TiffIfdMakernote* object) {
-  assert(object);
-
   object->setImageByteOrder(byteOrder());  // set the byte order for the image
 
   if (!object->readHeader(object->start(), static_cast<uint32_t>(pLast_ - object->start()), byteOrder())) {
@@ -1310,10 +1253,7 @@ void TiffReader::visitIfdMakernoteEnd(TiffIfdMakernote* /*object*/) {
 }  // TiffReader::visitIfdMakernoteEnd
 
 void TiffReader::readTiffEntry(TiffEntryBase* object) {
-  assert(object);
-
   byte* p = object->start();
-  assert(p >= pData_);
 
   if (p + 12 > pLast_) {
 #ifndef SUPPRESS_WARNINGS
@@ -1421,8 +1361,6 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
 }  // TiffReader::readTiffEntry
 
 void TiffReader::visitBinaryArray(TiffBinaryArray* object) {
-  assert(object);
-
   if (!postProc_) {
     // Defer reading children until after all other components are read, but
     // since state (offset) is not set during post-processing, read entry here

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -10,7 +10,6 @@
 
 // + standard includes
 #include <array>
-#include <cassert>
 #include <cctype>
 #include <climits>
 #include <cmath>
@@ -331,7 +330,6 @@ float getFloat(const byte* buf, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the float
   // type is the 4-byte IEEE 754 binary32 format, which is common but not
   // required by the C++ standard.
-  assert(sizeof(float) == 4);
   union {
     uint32_t ul_;
     float f_;
@@ -344,7 +342,6 @@ double getDouble(const byte* buf, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the double
   // type is the 8-byte IEEE 754 binary64 format, which is common but not
   // required by the C++ standard.
-  assert(sizeof(double) == 8);
   union {
     uint64_t ull_;
     double d_;
@@ -447,7 +444,6 @@ long f2Data(byte* buf, float f, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the float
   // type is the 4-byte IEEE 754 binary32 format, which is common but not
   // required by the C++ standard.
-  assert(sizeof(float) == 4);
   union {
     uint32_t ul_;
     float f_;
@@ -460,7 +456,6 @@ long d2Data(byte* buf, double d, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the double
   // type is the 8-byte IEEE 754 binary64 format, which is common but not
   // required by the C++ standard.
-  assert(sizeof(double) == 8);
   union {
     uint64_t ull_;
     double d_;
@@ -524,8 +519,6 @@ bool isHex(const std::string& str, size_t size, const std::string& prefix) {
 }  // isHex
 
 int exifTime(const char* buf, struct tm* tm) {
-  assert(buf);
-  assert(tm);
   int rc = 1;
   int year = 0, mon = 0, mday = 0, hour = 0, min = 0, sec = 0;
   int scanned = std::sscanf(buf, "%4d:%2d:%2d %2d:%2d:%2d", &year, &mon, &mday, &hour, &min, &sec);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -164,15 +164,6 @@ void Exiv2::DataBuf::write_uint64(size_t offset, uint64_t x, ByteOrder byteOrder
   ull2Data(&pData_[offset], x, byteOrder);
 }
 
-void Exiv2::DataBuf::copyBytes(size_t offset, const void* buf, size_t bufsize) {
-  if (pData_.size() < bufsize || offset > pData_.size() - bufsize) {
-    throw std::overflow_error("Overflow in Exiv2::DataBuf::copyBytes");
-  }
-  if (bufsize > 0) {
-    memcpy(&pData_[offset], buf, bufsize);
-  }
-}
-
 int Exiv2::DataBuf::cmpBytes(size_t offset, const void* buf, size_t bufsize) const {
   if (pData_.size() < bufsize || offset > pData_.size() - bufsize) {
     throw std::overflow_error("Overflow in Exiv2::DataBuf::cmpBytes");

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -155,8 +155,8 @@ DataValue* DataValue::clone_() const {
 }
 
 std::ostream& DataValue::write(std::ostream& os) const {
-  std::vector<byte>::size_type end = value_.size();
-  for (std::vector<byte>::size_type i = 0; i != end; ++i) {
+  size_t end = value_.size();
+  for (size_t i = 0; i != end; ++i) {
     os << static_cast<int>(value_.at(i));
     if (i < end - 1)
       os << " ";

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -9,7 +9,6 @@
 #include "types.hpp"
 
 // + standard includes
-
 #include <regex>
 #include <sstream>
 
@@ -223,7 +222,6 @@ size_t StringValueBase::copy(byte* buf, ByteOrder /*byteOrder*/) const {
   if (value_.empty())
     return 0;
   // byteOrder not needed
-  assert(buf);
   return value_.copy(reinterpret_cast<char*>(buf), value_.size());
 }
 
@@ -381,16 +379,13 @@ size_t CommentValue::copy(byte* buf, ByteOrder byteOrder) const {
     [[maybe_unused]] const size_t sz = c.size();
     if (byteOrder_ == littleEndian && byteOrder == bigEndian) {
       convertStringCharset(c, "UCS-2LE", "UCS-2BE");
-      assert(c.size() == sz);
     } else if (byteOrder_ == bigEndian && byteOrder == littleEndian) {
       convertStringCharset(c, "UCS-2BE", "UCS-2LE");
-      assert(c.size() == sz);
     }
     c = value_.substr(0, 8) + c;
   }
   if (c.empty())
     return 0;
-  assert(buf);
   return c.copy(reinterpret_cast<char*>(buf), c.size());
 }
 
@@ -849,7 +844,6 @@ size_t DateValue::copy(byte* buf, ByteOrder /*byteOrder*/) const {
   // sprintf wants to add the null terminator, so use oversized buffer
   char temp[9];
   size_t wrote = static_cast<size_t>(snprintf(temp, sizeof(temp), "%04d%02d%02d", date_.year, date_.month, date_.day));
-  assert(wrote == 8);
   std::memcpy(buf, temp, wrote);
   return wrote;
 }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -680,18 +680,18 @@ void WebPImage::decodeChunks(long filesize) {
 
       if (s_header) {
         us2Data(size_buff2, static_cast<uint16_t>(sizePayload - 6), bigEndian);
-        rawExifData.copyBytes(0, reinterpret_cast<char*>(&exifLongHeader), 4);
-        rawExifData.copyBytes(4, reinterpret_cast<char*>(&size_buff2), 2);
+        std::copy_n(reinterpret_cast<char*>(&exifLongHeader), 4, rawExifData.begin());
+        std::copy_n(reinterpret_cast<char*>(&size_buff2), 2, rawExifData.begin() + 4);
       }
 
       if (be_header || le_header) {
         us2Data(size_buff2, static_cast<uint16_t>(sizePayload - 6), bigEndian);
-        rawExifData.copyBytes(0, reinterpret_cast<char*>(&exifLongHeader), 4);
-        rawExifData.copyBytes(4, reinterpret_cast<char*>(&size_buff2), 2);
-        rawExifData.copyBytes(6, reinterpret_cast<char*>(&exifShortHeader), 6);
+        std::copy_n(reinterpret_cast<char*>(&exifLongHeader), 4, rawExifData.begin());
+        std::copy_n(reinterpret_cast<char*>(&size_buff2), 2, rawExifData.begin() + 4);
+        std::copy_n(reinterpret_cast<char*>(&exifShortHeader), 6, rawExifData.begin() + 6);
       }
 
-      rawExifData.copyBytes(offset, payload.c_data(), payload.size());
+      std::copy(payload.begin(), payload.end(), rawExifData.begin() + offset);
 
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Display Hex Dump [size:" << static_cast<unsigned long>(sizePayload) << "]" << std::endl;

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -184,10 +184,8 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
     const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
     // Check that `size_u32` is safe to cast to `long`.
-    enforce(size_u32 <= static_cast<size_t>(std::numeric_limits<unsigned int>::max()),
-            Exiv2::ErrorCode::kerCorruptedMetadata);
-    const auto size = static_cast<long>(size_u32);
-    DataBuf payload(size);
+    enforce(size_u32 <= std::numeric_limits<uint32_t>::max(), Exiv2::ErrorCode::kerCorruptedMetadata);
+    DataBuf payload(size_u32);
     io_->readOrThrow(payload.data(), payload.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
     if (payload.size() % 2) {
       byte c = 0;
@@ -200,7 +198,7 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
       has_vp8x = true;
     }
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8X) && !has_size) {
-      enforce(size >= 10, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 10, Exiv2::ErrorCode::kerCorruptedMetadata);
       has_size = true;
       byte size_buf[WEBP_TAG_SIZE];
 
@@ -229,7 +227,7 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
     }
 #endif
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8) && !has_size) {
-      enforce(size >= 10, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 10, Exiv2::ErrorCode::kerCorruptedMetadata);
       has_size = true;
       byte size_buf[2];
 
@@ -247,13 +245,13 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
 
     /* Chunk with lossless image data. */
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8L) && !has_alpha) {
-      enforce(size >= 5, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 5, Exiv2::ErrorCode::kerCorruptedMetadata);
       if ((payload.read_uint8(4) & WEBP_VP8X_ALPHA_BIT) == WEBP_VP8X_ALPHA_BIT) {
         has_alpha = true;
       }
     }
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8L) && !has_size) {
-      enforce(size >= 5, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 5, Exiv2::ErrorCode::kerCorruptedMetadata);
       has_size = true;
       byte size_buf_w[2];
       byte size_buf_h[3];
@@ -277,13 +275,13 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
 
     /* Chunk with animation frame. */
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_ANMF) && !has_alpha) {
-      enforce(size >= 6, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 6, Exiv2::ErrorCode::kerCorruptedMetadata);
       if ((payload.read_uint8(5) & 0x2) == 0x2) {
         has_alpha = true;
       }
     }
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_ANMF) && !has_size) {
-      enforce(size >= 12, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 12, Exiv2::ErrorCode::kerCorruptedMetadata);
       has_size = true;
       byte size_buf[WEBP_TAG_SIZE];
 
@@ -317,17 +315,15 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
     const uint32_t size_u32 = Exiv2::getULong(size_buff, littleEndian);
 
     // Check that `size_u32` is safe to cast to `long`.
-    enforce(size_u32 <= static_cast<size_t>(std::numeric_limits<unsigned int>::max()),
-            Exiv2::ErrorCode::kerCorruptedMetadata);
-    const auto size = static_cast<long>(size_u32);
+    enforce(size_u32 <= std::numeric_limits<uint32_t>::max(), Exiv2::ErrorCode::kerCorruptedMetadata);
 
-    DataBuf payload(size);
-    io_->readOrThrow(payload.data(), size, Exiv2::ErrorCode::kerCorruptedMetadata);
+    DataBuf payload(size_u32);
+    io_->readOrThrow(payload.data(), size_u32, Exiv2::ErrorCode::kerCorruptedMetadata);
     if (io_->tell() % 2)
       io_->seek(+1, BasicIo::cur);  // skip pad
 
     if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_VP8X)) {
-      enforce(size >= 1, Exiv2::ErrorCode::kerCorruptedMetadata);
+      enforce(size_u32 >= 1, Exiv2::ErrorCode::kerCorruptedMetadata);
       if (has_icc) {
         const uint8_t x = payload.read_uint8(0);
         payload.write_uint8(0, x | WEBP_VP8X_ICC_BIT);
@@ -643,26 +639,22 @@ void WebPImage::decodeChunks(long filesize) {
       bool s_header = false;
       bool le_header = false;
       bool be_header = false;
-      long pos = getHeaderOffset(payload.c_data(), static_cast<long>(payload.size()),
-                                 reinterpret_cast<byte*>(&exifLongHeader), 4);
+      long pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 4);
 
       if (pos == -1) {
-        pos = getHeaderOffset(payload.c_data(), static_cast<long>(payload.size()),
-                              reinterpret_cast<byte*>(&exifLongHeader), 6);
+        pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifLongHeader), 6);
         if (pos != -1) {
           s_header = true;
         }
       }
       if (pos == -1) {
-        pos = getHeaderOffset(payload.c_data(), static_cast<long>(payload.size()),
-                              reinterpret_cast<byte*>(&exifTiffLEHeader), 3);
+        pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifTiffLEHeader), 3);
         if (pos != -1) {
           le_header = true;
         }
       }
       if (pos == -1) {
-        pos = getHeaderOffset(payload.c_data(), static_cast<long>(payload.size()),
-                              reinterpret_cast<byte*>(&exifTiffBEHeader), 4);
+        pos = getHeaderOffset(payload.c_data(), payload.size(), reinterpret_cast<byte*>(&exifTiffBEHeader), 4);
         if (pos != -1) {
           be_header = true;
         }
@@ -835,14 +827,14 @@ void WebPImage::inject_VP8X(BasicIo& iIo, bool has_xmp, bool has_exif, bool has_
   }
 }
 
-long WebPImage::getHeaderOffset(const byte* data, long data_size, const byte* header, long header_size) {
+long WebPImage::getHeaderOffset(const byte* data, size_t data_size, const byte* header, size_t header_size) {
   if (data_size < header_size) {
     return -1;
   }
   long pos = -1;
-  for (long i = 0; i < data_size - header_size; i++) {
+  for (size_t i = 0; i < data_size - header_size; i++) {
     if (memcmp(header, &data[i], header_size) == 0) {
-      pos = i;
+      pos = static_cast<long>(i);
       break;
     }
   }

--- a/unitTests/test_bmpimage.cpp
+++ b/unitTests/test_bmpimage.cpp
@@ -85,7 +85,7 @@ TEST(BmpImage, readMetadataReadsImageDimensionsWhenDataIsAvailable) {
       0x20, 0x03, 0x00, 0x00,  // The bitmap height in pixels (unsigned 16 bit)                     off:22, size:4
   };
 
-  auto memIo = std::make_unique<MemIo>(header.data(), static_cast<long>(header.size()));
+  auto memIo = std::make_unique<MemIo>(header.data(), header.size());
   BmpImage bmp(std::move(memIo));
   ASSERT_NO_THROW(bmp.readMetadata());
   ASSERT_EQ(1280, bmp.pixelWidth());
@@ -104,7 +104,7 @@ TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {
       0x20, 0x03, 0x00, 0x00,  // The bitmap height in pixels (unsigned 16 bit)                     off:22, size:4
   };
 
-  auto memIo = std::make_unique<MemIo>(header.data(), static_cast<long>(header.size()));
+  auto memIo = std::make_unique<MemIo>(header.data(), header.size());
   BmpImage bmp(std::move(memIo));
   try {
     bmp.readMetadata();
@@ -117,7 +117,7 @@ TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {
 
 TEST(BmpImage, readMetadataThrowsWhenThereIsNotEnoughInfoToRead) {
   const std::array<unsigned char, 1> header{'B'};
-  auto memIo = std::make_unique<MemIo>(header.data(), static_cast<long>(header.size()));
+  auto memIo = std::make_unique<MemIo>(header.data(), header.size());
   BmpImage bmp(std::move(memIo));
   try {
     bmp.readMetadata();
@@ -147,7 +147,7 @@ TEST(newBmpInstance, createsValidInstace) {
       0x00, 0x00,              // Reserved
       0x00, 0x00, 0x00, 0x00   // Offset of the byte where the bitmap image data can be found
   };
-  auto memIo = std::make_unique<MemIo>(bitmapHeader.data(), static_cast<long>(bitmapHeader.size()));
+  auto memIo = std::make_unique<MemIo>(bitmapHeader.data(), bitmapHeader.size());
   auto img = newBmpInstance(std::move(memIo), false);
   ASSERT_TRUE(img->good());
 }
@@ -166,7 +166,7 @@ TEST(isBmpType, withValidSignatureReturnsTrue) {
       0x00, 0x00,              // Reserved
       0x00, 0x00, 0x00, 0x00   // Offset of the byte where the bitmap image data can be found
   };
-  MemIo memIo(bitmapHeader.data(), static_cast<long>(bitmapHeader.size()));
+  MemIo memIo(bitmapHeader.data(), bitmapHeader.size());
   ASSERT_TRUE(isBmpType(memIo, false));
 }
 
@@ -178,6 +178,6 @@ TEST(isBmpType, withInvalidSignatureReturnsFalse) {
       0x00, 0x00,              // Reserved
       0x00, 0x00, 0x00, 0x00   // Offset of the byte where the bitmap image data can be found
   };
-  MemIo memIo(bitmapHeader.data(), static_cast<long>(bitmapHeader.size()));
+  MemIo memIo(bitmapHeader.data(), bitmapHeader.size());
   ASSERT_FALSE(isBmpType(memIo, false));
 }

--- a/unitTests/test_pngimage.cpp
+++ b/unitTests/test_pngimage.cpp
@@ -18,7 +18,7 @@ TEST(PngChunk, keyTxtChunkExtractsKeywordCorrectlyInPresenceOfNullChar) {
                                           0x20, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x20, 0x74, 0x79,
                                           0x70, 0x65, 0x20, 0x65, 0x78, 0x69, 0x66, 0x00, 0x00, 0x78};
 
-  DataBuf chunkBuf(data.data(), static_cast<long>(data.size()));
+  DataBuf chunkBuf(data.data(), data.size());
   DataBuf key = Internal::PngChunk::keyTXTChunk(chunkBuf, true);
   ASSERT_EQ(21, key.size());
 
@@ -31,13 +31,13 @@ TEST(PngChunk, keyTxtChunkThrowsExceptionWhenThereIsNoNullChar) {
                                           0x77, 0x20, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x20,
                                           0x74, 0x79, 0x70, 0x65, 0x20, 0x65, 0x78, 0x69, 0x66, 0x78};
 
-  DataBuf chunkBuf(data.data(), static_cast<long>(data.size()));
+  DataBuf chunkBuf(data.data(), data.size());
   ASSERT_THROW(Internal::PngChunk::keyTXTChunk(chunkBuf, true), Exiv2::Error);
 }
 
 TEST(PngChunk, keyTxtChunkThrowsIfSizeIsNotEnough) {
   const std::array<std::uint8_t, 4> data{0x00, 0x00, 0x22, 0x41};
-  DataBuf chunkBuf(data.data(), static_cast<long>(data.size()));
+  DataBuf chunkBuf(data.data(), data.size());
   ASSERT_THROW(Internal::PngChunk::keyTXTChunk(chunkBuf, true), Exiv2::Error);
 
   DataBuf emptyChunk(data.data(), 0);


### PR DESCRIPTION
This is another round of cleanups I applied to the codebase. Each commit has different topics and is self-isolated. The commits that could raise more discussions are:

* Usage of `EXIT_SUCCESS` & `EXIT_FAILURE`. I always use these in my projects as I think they make the code more readable.
* Removal of calls to `assert`. I have a strong positioning against the usage of assert in production code, as such code would only be relevant in debug builds. Any check that is worth to be added in production should be present in all kind of builds, and for that we have `enforce` in our codebase. Specially ugly were the `assert(false);` statements ... those ones simply highlight that certain paths of the code can be considered as "dead-code". If at any point we would add a test covering those areas, the tests would simply fail in debug mode. 