### PR TITLE
add .git-blame-ignore-revs file and add clang-format commit to it

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # ignore global clang-format
 30bf563f4d71ff284b5f42d45f77226200a2e571
+# fic formatting followup from #2158
+a3cb054746beed514679592ffec9378acc9e5d41

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ignore global clang-format
+30bf563f4d71ff284b5f42d45f77226200a2e571

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -314,8 +314,8 @@ class EXIV2API JpegImage : public JpegBase {
  private:
   // Constant data
   static constexpr byte soi_ = 0xd8;  // SOI marker
-  static const byte blank_[];  // Minimal Jpeg image
-};                             // class JpegImage
+  static const byte blank_[];         // Minimal Jpeg image
+};                                    // class JpegImage
 
 //! Helper class to access %Exiv2 files
 class EXIV2API ExvImage : public JpegBase {


### PR DESCRIPTION
See [github doc](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) for more info

I've also included a fix for the wrong formatting that was merged in #2158 