### PR TITLE
also run clang-format check action on pull request

### DIFF
--- a/.github/workflows/on_push_clang_format.yml
+++ b/.github/workflows/on_push_clang_format.yml
@@ -1,5 +1,5 @@
 name: Clang Format Checker
-on: [push]
+on: [push, pull_request]
 jobs:
   clang-format-checking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes sure the clang-format action is run for PRs. Otherwise it wouldn't show up in the PR's list of checks if a PR is made from a fork.