### PR TITLE
Update .clang-format to align pointers to the types

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,10 @@ ColumnLimit: 120
 Language: Cpp
 BasedOnStyle: Google
 
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
 # Useful for sorting the project inclusions and standard library inclusions separately 
 IncludeBlocks: Preserve
 

--- a/samples/Jzon.cpp
+++ b/samples/Jzon.cpp
@@ -43,11 +43,11 @@ class FormatInterpreter {
   FormatInterpreter() {
     SetFormat(NoFormat);
   }
-  explicit FormatInterpreter(const Format &format) {
+  explicit FormatInterpreter(const Format& format) {
     SetFormat(format);
   }
 
-  void SetFormat(const Format &format) {
+  void SetFormat(const Format& format) {
     this->format = format;
     indentationChar = (format.useTabs ? '\t' : ' ');
     spacing = (format.spacing ? " " : "");
@@ -60,10 +60,10 @@ class FormatInterpreter {
     return "";
   }
 
-  inline const std::string &GetNewline() const {
+  inline const std::string& GetNewline() const {
     return newline;
   }
-  inline const std::string &GetSpacing() const {
+  inline const std::string& GetSpacing() const {
     return spacing;
   }
 
@@ -81,38 +81,38 @@ inline bool IsNumber(char c) {
   return ((c >= '0' && c <= '9') || c == '.' || c == '-');
 }
 
-Object &Node::AsObject() {
+Object& Node::AsObject() {
   if (IsObject())
-    return dynamic_cast<Object &>(*this);
+    return dynamic_cast<Object&>(*this);
   throw TypeException();
 }
-const Object &Node::AsObject() const {
+const Object& Node::AsObject() const {
   if (IsObject())
-    return dynamic_cast<const Object &>(*this);
+    return dynamic_cast<const Object&>(*this);
   throw TypeException();
 }
-Array &Node::AsArray() {
+Array& Node::AsArray() {
   if (IsArray())
-    return dynamic_cast<Array &>(*this);
+    return dynamic_cast<Array&>(*this);
   throw TypeException();
 }
-const Array &Node::AsArray() const {
+const Array& Node::AsArray() const {
   if (IsArray())
-    return dynamic_cast<const Array &>(*this);
+    return dynamic_cast<const Array&>(*this);
   throw TypeException();
 }
-Value &Node::AsValue() {
+Value& Node::AsValue() {
   if (IsValue())
-    return dynamic_cast<Value &>(*this);
+    return dynamic_cast<Value&>(*this);
   throw TypeException();
 }
-const Value &Node::AsValue() const {
+const Value& Node::AsValue() const {
   if (IsValue())
-    return dynamic_cast<const Value &>(*this);
+    return dynamic_cast<const Value&>(*this);
   throw TypeException();
 }
 
-Node::Type Node::DetermineType(const std::string &json) {
+Node::Type Node::DetermineType(const std::string& json) {
   auto jsonIt = std::find_if(json.begin(), json.end(), IsWhitespace);
   if (jsonIt == json.end())
     return T_VALUE;
@@ -130,20 +130,20 @@ Node::Type Node::DetermineType(const std::string &json) {
 Value::Value() {
   SetNull();
 }
-Value::Value(const Value &rhs) {
+Value::Value(const Value& rhs) {
   Set(rhs);
 }
-Value::Value(const Node &rhs) {
-  const Value &value = rhs.AsValue();
+Value::Value(const Node& rhs) {
+  const Value& value = rhs.AsValue();
   Set(value);
 }
-Value::Value(ValueType type, const std::string &value) {
+Value::Value(ValueType type, const std::string& value) {
   Set(type, value);
 }
-Value::Value(const std::string &value) {
+Value::Value(const std::string& value) {
   Set(value);
 }
-Value::Value(const char *value) {
+Value::Value(const char* value) {
   Set(value);
 }
 Value::Value(const int value) {
@@ -209,21 +209,21 @@ void Value::SetNull() {
   valueStr = "";
   type = VT_NULL;
 }
-void Value::Set(const Value &value) {
+void Value::Set(const Value& value) {
   if (this != &value) {
     valueStr = value.valueStr;
     type = value.type;
   }
 }
-void Value::Set(ValueType type, const std::string &value) {
+void Value::Set(ValueType type, const std::string& value) {
   valueStr = value;
   this->type = type;
 }
-void Value::Set(const std::string &value) {
+void Value::Set(const std::string& value) {
   valueStr = UnescapeString(value);
   type = VT_STRING;
 }
-void Value::Set(const char *value) {
+void Value::Set(const char* value) {
   valueStr = UnescapeString(std::string(value));
   type = VT_STRING;
 }
@@ -250,73 +250,73 @@ void Value::Set(const bool value) {
   type = VT_BOOL;
 }
 
-Value &Value::operator=(const Value &rhs) {
+Value& Value::operator=(const Value& rhs) {
   if (this != &rhs)
     Set(rhs);
   return *this;
 }
-Value &Value::operator=(const Node &rhs) {
+Value& Value::operator=(const Node& rhs) {
   if (this != &rhs)
     Set(rhs.AsValue());
   return *this;
 }
-Value &Value::operator=(const std::string &rhs) {
+Value& Value::operator=(const std::string& rhs) {
   Set(rhs);
   return *this;
 }
-Value &Value::operator=(const char *rhs) {
+Value& Value::operator=(const char* rhs) {
   Set(rhs);
   return *this;
 }
-Value &Value::operator=(const int rhs) {
+Value& Value::operator=(const int rhs) {
   Set(rhs);
   return *this;
 }
-Value &Value::operator=(const float rhs) {
+Value& Value::operator=(const float rhs) {
   Set(rhs);
   return *this;
 }
-Value &Value::operator=(const double rhs) {
+Value& Value::operator=(const double rhs) {
   Set(rhs);
   return *this;
 }
-Value &Value::operator=(const bool rhs) {
+Value& Value::operator=(const bool rhs) {
   Set(rhs);
   return *this;
 }
 
-bool Value::operator==(const Value &other) const {
+bool Value::operator==(const Value& other) const {
   return ((type == other.type) && (valueStr == other.valueStr));
 }
-bool Value::operator!=(const Value &other) const {
+bool Value::operator!=(const Value& other) const {
   return !(*this == other);
 }
 
-Node *Value::GetCopy() const {
+Node* Value::GetCopy() const {
   return new Value(*this);
 }
 
 // This is not the most beautiful place for these, but it'll do
 using chrPair = struct {
   char first;
-  const char *second;
+  const char* second;
 };
 static constexpr std::array<chrPair, 8> chars{
     chrPair{'\\', "\\\\"}, chrPair{'/', "\\/"},  chrPair{'\"', "\\\""}, chrPair{'\n', "\\n"},
     chrPair{'\t', "\\t"},  chrPair{'\b', "\\b"}, chrPair{'\f', "\\f"},  chrPair{'\r', "\\r"},
 };
 static constexpr char nullUnescaped = '\0';
-static constexpr const char *nullEscaped = "\0\0";
-const char *const &getEscaped(const char &c) {
-  for (auto &&chr : chars) {
+static constexpr const char* nullEscaped = "\0\0";
+const char* const& getEscaped(const char& c) {
+  for (auto&& chr : chars) {
     if (chr.first == c) {
       return chr.second;
     }
   }
   return nullEscaped;
 }
-const char &getUnescaped(const char &c1, const char &c2) {
-  for (auto &&chr : chars) {
+const char& getUnescaped(const char& c1, const char& c2) {
+  for (auto&& chr : chars) {
     if (c1 == chars[0].first && c2 == chars[1].first) {
       return chr.first;
     }
@@ -324,11 +324,11 @@ const char &getUnescaped(const char &c1, const char &c2) {
   return nullUnescaped;
 }
 
-std::string Value::EscapeString(const std::string &value) {
+std::string Value::EscapeString(const std::string& value) {
   std::string escaped;
 
-  for (auto &&c : value) {
-    auto &&a = getEscaped(c);
+  for (auto&& c : value) {
+    auto&& a = getEscaped(c);
     if (a[0] != '\0') {
       escaped += a[0];
       escaped += a[1];
@@ -339,16 +339,16 @@ std::string Value::EscapeString(const std::string &value) {
 
   return escaped;
 }
-std::string Value::UnescapeString(const std::string &value) {
+std::string Value::UnescapeString(const std::string& value) {
   std::string unescaped;
 
   for (auto it = value.cbegin(); it != value.cend(); ++it) {
-    const char &c = (*it);
+    const char& c = (*it);
     char c2 = '\0';
     if (it + 1 != value.end())
       c2 = *(it + 1);
 
-    const char &a = getUnescaped(c, c2);
+    const char& a = getUnescaped(c, c2);
     if (a != '\0') {
       unescaped += a;
       if (it + 1 != value.end())
@@ -361,13 +361,13 @@ std::string Value::UnescapeString(const std::string &value) {
   return unescaped;
 }
 
-Object::Object(const Object &other) {
+Object::Object(const Object& other) {
   std::transform(other.children.begin(), other.children.end(), std::back_inserter(children),
-                 [](const NamedNodePtr &child) { return NamedNodePtr(child.first, child.second->GetCopy()); });
+                 [](const NamedNodePtr& child) { return NamedNodePtr(child.first, child.second->GetCopy()); });
 }
-Object::Object(const Node &other) {
+Object::Object(const Node& other) {
   std::transform(other.AsObject().children.begin(), other.AsObject().children.end(), std::back_inserter(children),
-                 [](const NamedNodePtr &child) { return NamedNodePtr(child.first, child.second->GetCopy()); });
+                 [](const NamedNodePtr& child) { return NamedNodePtr(child.first, child.second->GetCopy()); });
 }
 Object::~Object() {
   Clear();
@@ -377,13 +377,13 @@ Node::Type Object::GetType() const {
   return T_OBJECT;
 }
 
-void Object::Add(const std::string &name, Node &node) {
+void Object::Add(const std::string& name, Node& node) {
   children.emplace_back(name, node.GetCopy());
 }
-void Object::Add(const std::string &name, const Value &node) {
+void Object::Add(const std::string& name, const Value& node) {
   children.emplace_back(name, new Value(node));
 }
-void Object::Remove(const std::string &name) {
+void Object::Remove(const std::string& name) {
   for (auto it = children.cbegin(); it != children.cend(); ++it) {
     if ((*it).first == name) {
       delete (*it).second;
@@ -394,7 +394,7 @@ void Object::Remove(const std::string &name) {
 }
 
 void Object::Clear() {
-  for (auto &&child : children) {
+  for (auto&& child : children) {
     delete child.second;
     child.second = nullptr;
   }
@@ -424,14 +424,14 @@ Object::const_iterator Object::end() const {
   return {nullptr};
 }
 
-bool Object::Has(const std::string &name) const {
-  return std::any_of(children.begin(), children.end(), [&](const NamedNodePtr &child) { return child.first == name; });
+bool Object::Has(const std::string& name) const {
+  return std::any_of(children.begin(), children.end(), [&](const NamedNodePtr& child) { return child.first == name; });
 }
 size_t Object::GetCount() const {
   return children.size();
 }
-Node &Object::Get(const std::string &name) const {
-  for (auto &&child : children) {
+Node& Object::Get(const std::string& name) const {
+  for (auto&& child : children) {
     if (child.first == name) {
       return *child.second;
     }
@@ -440,20 +440,20 @@ Node &Object::Get(const std::string &name) const {
   throw NotFoundException();
 }
 
-Node *Object::GetCopy() const {
+Node* Object::GetCopy() const {
   return new Object(*this);
 }
 
-Array::Array(const Array &other) {
-  for (auto &&value : other.children) {
+Array::Array(const Array& other) {
+  for (auto&& value : other.children) {
     children.push_back(value->GetCopy());
   }
 }
 
-Array::Array(const Node &other) {
-  const Array &array = other.AsArray();
+Array::Array(const Node& other) {
+  const Array& array = other.AsArray();
 
-  for (auto &&value : array.children) {
+  for (auto&& value : array.children) {
     children.push_back(value->GetCopy());
   }
 }
@@ -466,10 +466,10 @@ Node::Type Array::GetType() const {
   return T_ARRAY;
 }
 
-void Array::Add(Node &node) {
+void Array::Add(Node& node) {
   children.push_back(node.GetCopy());
 }
-void Array::Add(const Value &node) {
+void Array::Add(const Value& node) {
   children.push_back(new Value(node));
 }
 void Array::Remove(size_t index) {
@@ -480,7 +480,7 @@ void Array::Remove(size_t index) {
   }
 }
 void Array::Clear() {
-  for (auto &&child : children) {
+  for (auto&& child : children) {
     delete child;
     child = nullptr;
   }
@@ -511,7 +511,7 @@ Array::const_iterator Array::end() const {
 size_t Array::GetCount() const {
   return children.size();
 }
-Node &Array::Get(size_t index) const {
+Node& Array::Get(size_t index) const {
   if (index < children.size()) {
     return *children.at(index);
   }
@@ -519,19 +519,19 @@ Node &Array::Get(size_t index) const {
   throw NotFoundException();
 }
 
-Node *Array::GetCopy() const {
+Node* Array::GetCopy() const {
   return new Array(*this);
 }
 
 FileWriter::FileWriter(std::string filename) : filename(std::move(filename)) {
 }
 
-void FileWriter::WriteFile(const std::string &filename, const Node &root, const Format &format) {
+void FileWriter::WriteFile(const std::string& filename, const Node& root, const Format& format) {
   FileWriter writer(filename);
   writer.Write(root, format);
 }
 
-void FileWriter::Write(const Node &root, const Format &format) {
+void FileWriter::Write(const Node& root, const Format& format) {
   Writer writer(root, format);
   writer.Write();
 
@@ -540,18 +540,18 @@ void FileWriter::Write(const Node &root, const Format &format) {
   file.close();
 }
 
-FileReader::FileReader(const std::string &filename) {
+FileReader::FileReader(const std::string& filename) {
   if (!loadFile(filename, json)) {
     error = "Failed to load file";
   }
 }
 
-bool FileReader::ReadFile(const std::string &filename, Node &node) {
+bool FileReader::ReadFile(const std::string& filename, Node& node) {
   FileReader reader(filename);
   return reader.Read(node);
 }
 
-bool FileReader::Read(Node &node) {
+bool FileReader::Read(Node& node) {
   if (!error.empty())
     return false;
 
@@ -567,11 +567,11 @@ Node::Type FileReader::DetermineType() {
   return Node::DetermineType(json);
 }
 
-const std::string &FileReader::GetError() const {
+const std::string& FileReader::GetError() const {
   return error;
 }
 
-bool FileReader::loadFile(const std::string &filename, std::string &json) {
+bool FileReader::loadFile(const std::string& filename, std::string& json) {
   std::fstream file(filename.c_str(), std::ios::in | std::ios::binary);
 
   if (!file.is_open()) {
@@ -588,7 +588,7 @@ bool FileReader::loadFile(const std::string &filename, std::string &json) {
   return true;
 }
 
-Writer::Writer(const Node &root, const Format &format) : fi(new FormatInterpreter), root(root) {
+Writer::Writer(const Node& root, const Format& format) : fi(new FormatInterpreter), root(root) {
   SetFormat(format);
 }
 Writer::~Writer() {
@@ -596,20 +596,20 @@ Writer::~Writer() {
   fi = nullptr;
 }
 
-void Writer::SetFormat(const Format &format) {
+void Writer::SetFormat(const Format& format) {
   fi->SetFormat(format);
 }
-const std::string &Writer::Write() {
+const std::string& Writer::Write() {
   result.clear();
   writeNode(root, 0);
   return result;
 }
 
-const std::string &Writer::GetResult() const {
+const std::string& Writer::GetResult() const {
   return result;
 }
 
-void Writer::writeNode(const Node &node, size_t level) {
+void Writer::writeNode(const Node& node, size_t level) {
   switch (node.GetType()) {
     case Node::T_OBJECT:
       writeObject(node.AsObject(), level);
@@ -622,11 +622,11 @@ void Writer::writeNode(const Node &node, size_t level) {
       break;
   }
 }
-void Writer::writeObject(const Object &node, size_t level) {
+void Writer::writeObject(const Object& node, size_t level) {
   result += "{" + fi->GetNewline();
 
   for (auto it = node.begin(); it != node.end(); ++it) {
-    const std::string &name = (*it).first;
+    const std::string& name = (*it).first;
     // const Node &value = (*it).second;
 
     if (it != node.begin())
@@ -637,11 +637,11 @@ void Writer::writeObject(const Object &node, size_t level) {
 
   result += fi->GetNewline() + fi->GetIndentation(level) + "}";
 }
-void Writer::writeArray(const Array &node, size_t level) {
+void Writer::writeArray(const Array& node, size_t level) {
   result += "[" + fi->GetNewline();
 
   for (auto it = node.begin(); it != node.end(); ++it) {
-    const Node &value = (*it);
+    const Node& value = (*it);
 
     if (it != node.begin())
       result += "," + fi->GetNewline();
@@ -651,7 +651,7 @@ void Writer::writeArray(const Array &node, size_t level) {
 
   result += fi->GetNewline() + fi->GetIndentation(level) + "]";
 }
-void Writer::writeValue(const Value &node) {
+void Writer::writeValue(const Value& node) {
   if (node.IsString()) {
     result += "\"" + Value::EscapeString(node.ToString()) + "\"";
   } else {
@@ -659,13 +659,13 @@ void Writer::writeValue(const Value &node) {
   }
 }
 
-Parser::Parser(Node &root) : root(root) {
+Parser::Parser(Node& root) : root(root) {
 }
-Parser::Parser(Node &root, const std::string &json) : root(root) {
+Parser::Parser(Node& root, const std::string& json) : root(root) {
   SetJson(json);
 }
 
-void Parser::SetJson(const std::string &json) {
+void Parser::SetJson(const std::string& json) {
   this->json = json;
   jsonSize = json.size();
 }
@@ -678,7 +678,7 @@ bool Parser::Parse() {
   return success;
 }
 
-const std::string &Parser::GetError() const {
+const std::string& Parser::GetError() const {
   return error;
 }
 
@@ -766,7 +766,7 @@ void Parser::tokenize() {
   }
 }
 bool Parser::assemble() {
-  std::stack<std::pair<std::string, Node *>> nodeStack;
+  std::stack<std::pair<std::string, Node*>> nodeStack;
 
   std::string name;
 
@@ -777,13 +777,13 @@ bool Parser::assemble() {
 
     switch (token) {
       case T_UNKNOWN: {
-        const std::string &unknownToken = data.front().second;
+        const std::string& unknownToken = data.front().second;
         error = "Unknown token: " + unknownToken;
         data.pop();
         return false;
       }
       case T_OBJ_BEGIN: {
-        Node *node = nullptr;
+        Node* node = nullptr;
         if (nodeStack.empty()) {
           if (!root.IsObject()) {
             error = "The given root node is not an object";
@@ -800,7 +800,7 @@ bool Parser::assemble() {
         break;
       }
       case T_ARRAY_BEGIN: {
-        Node *node = nullptr;
+        Node* node = nullptr;
         if (nodeStack.empty()) {
           if (!root.IsArray()) {
             error = "The given root node is not an array";
@@ -832,7 +832,7 @@ bool Parser::assemble() {
         }
 
         std::string name = nodeStack.top().first;
-        Node *node = nodeStack.top().second;
+        Node* node = nodeStack.top().second;
         nodeStack.pop();
 
         if (!nodeStack.empty()) {
@@ -860,7 +860,7 @@ bool Parser::assemble() {
           name = data.front().second;
           data.pop();
         } else {
-          Node *node = nullptr;
+          Node* node = nullptr;
           if (nodeStack.empty()) {
             if (!root.IsValue()) {
               error = "The given root node is not a value";
@@ -873,9 +873,9 @@ bool Parser::assemble() {
           }
 
           if (data.front().first == Value::VT_STRING) {
-            dynamic_cast<Value *>(node)->Set(data.front().second);  // This method calls UnescapeString()
+            dynamic_cast<Value*>(node)->Set(data.front().second);  // This method calls UnescapeString()
           } else {
-            dynamic_cast<Value *>(node)->Set(data.front().first, data.front().second);
+            dynamic_cast<Value*>(node)->Set(data.front().first, data.front().second);
           }
           data.pop();
 
@@ -951,7 +951,7 @@ void Parser::readString() {
 
   data.emplace(Value::VT_STRING, str);
 }
-bool Parser::interpretValue(const std::string &value) {
+bool Parser::interpretValue(const std::string& value) {
   std::string upperValue;
   upperValue.reserve(value.size());
   std::transform(value.begin(), value.end(), upperValue.begin(), toupper);

--- a/samples/Jzon.h
+++ b/samples/Jzon.h
@@ -43,8 +43,8 @@ class Node;
 class Value;
 class Object;
 class Array;
-using NamedNode = std::pair<std::string, Node &>;
-using NamedNodePtr = std::pair<std::string, Node *>;
+using NamedNode = std::pair<std::string, Node&>;
+using NamedNodePtr = std::pair<std::string, Node*>;
 
 class TypeException : public std::logic_error {
  public:
@@ -88,12 +88,12 @@ class JzonAPI Node {
     return (GetType() == T_VALUE);
   }
 
-  Object &AsObject();
-  const Object &AsObject() const;
-  Array &AsArray();
-  const Array &AsArray() const;
-  Value &AsValue();
-  const Value &AsValue() const;
+  Object& AsObject();
+  const Object& AsObject() const;
+  Array& AsArray();
+  const Array& AsArray() const;
+  Value& AsValue();
+  const Value& AsValue() const;
 
   virtual inline bool IsNull() const {
     return false;
@@ -124,23 +124,23 @@ class JzonAPI Node {
     throw TypeException();
   }
 
-  virtual bool Has(const std::string & /*name*/) const {
+  virtual bool Has(const std::string& /*name*/) const {
     throw TypeException();
   }
   virtual size_t GetCount() const {
     return 0;
   }
-  virtual Node &Get(const std::string & /*name*/) const {
+  virtual Node& Get(const std::string& /*name*/) const {
     throw TypeException();
   }
-  virtual Node &Get(size_t /*index*/) const {
+  virtual Node& Get(size_t /*index*/) const {
     throw TypeException();
   }
 
-  static Type DetermineType(const std::string &json);
+  static Type DetermineType(const std::string& json);
 
  protected:
-  virtual Node *GetCopy() const = 0;
+  virtual Node* GetCopy() const = 0;
 };
 
 class JzonAPI Value : public Node {
@@ -148,11 +148,11 @@ class JzonAPI Value : public Node {
   enum ValueType { VT_NULL, VT_STRING, VT_NUMBER, VT_BOOL };
 
   Value();
-  Value(const Value &rhs);
-  Value(const Node &rhs);
-  Value(ValueType type, const std::string &value);
-  Value(const std::string &value);
-  Value(const char *value);
+  Value(const Value& rhs);
+  Value(const Node& rhs);
+  Value(ValueType type, const std::string& value);
+  Value(const std::string& value);
+  Value(const char* value);
   Value(const int value);
   Value(const float value);
   Value(const double value);
@@ -182,32 +182,32 @@ class JzonAPI Value : public Node {
   bool ToBool() const override;
 
   void SetNull();
-  void Set(const Value &value);
-  void Set(ValueType type, const std::string &value);
-  void Set(const std::string &value);
-  void Set(const char *value);
+  void Set(const Value& value);
+  void Set(ValueType type, const std::string& value);
+  void Set(const std::string& value);
+  void Set(const char* value);
   void Set(const int value);
   void Set(const float value);
   void Set(const double value);
   void Set(const bool value);
 
-  Value &operator=(const Value &rhs);
-  Value &operator=(const Node &rhs);
-  Value &operator=(const std::string &rhs);
-  Value &operator=(const char *rhs);
-  Value &operator=(const int rhs);
-  Value &operator=(const float rhs);
-  Value &operator=(const double rhs);
-  Value &operator=(const bool rhs);
+  Value& operator=(const Value& rhs);
+  Value& operator=(const Node& rhs);
+  Value& operator=(const std::string& rhs);
+  Value& operator=(const char* rhs);
+  Value& operator=(const int rhs);
+  Value& operator=(const float rhs);
+  Value& operator=(const double rhs);
+  Value& operator=(const bool rhs);
 
-  bool operator==(const Value &other) const;
-  bool operator!=(const Value &other) const;
+  bool operator==(const Value& other) const;
+  bool operator!=(const Value& other) const;
 
-  static std::string EscapeString(const std::string &value);
-  static std::string UnescapeString(const std::string &value);
+  static std::string EscapeString(const std::string& value);
+  static std::string UnescapeString(const std::string& value);
 
  protected:
-  Node *GetCopy() const override;
+  Node* GetCopy() const override;
 
  private:
   std::string valueStr;
@@ -220,12 +220,12 @@ class JzonAPI Object : public Node {
  public:
   class iterator : public std::iterator<std::input_iterator_tag, NamedNode> {
    public:
-    iterator(NamedNodePtr *o) : p(o) {
+    iterator(NamedNodePtr* o) : p(o) {
     }
-    iterator(const iterator &it) : p(it.p) {
+    iterator(const iterator& it) : p(it.p) {
     }
 
-    iterator &operator++() {
+    iterator& operator++() {
       ++p;
       return *this;
     }
@@ -235,10 +235,10 @@ class JzonAPI Object : public Node {
       return tmp;
     }
 
-    bool operator==(const iterator &rhs) {
+    bool operator==(const iterator& rhs) {
       return p == rhs.p;
     }
-    bool operator!=(const iterator &rhs) {
+    bool operator!=(const iterator& rhs) {
       return p != rhs.p;
     }
 
@@ -247,16 +247,16 @@ class JzonAPI Object : public Node {
     }
 
    private:
-    NamedNodePtr *p;
+    NamedNodePtr* p;
   };
   class const_iterator : public std::iterator<std::input_iterator_tag, const NamedNode> {
    public:
-    const_iterator(const NamedNodePtr *o) : p(o) {
+    const_iterator(const NamedNodePtr* o) : p(o) {
     }
-    const_iterator(const const_iterator &it) : p(it.p) {
+    const_iterator(const const_iterator& it) : p(it.p) {
     }
 
-    const_iterator &operator++() {
+    const_iterator& operator++() {
       ++p;
       return *this;
     }
@@ -266,10 +266,10 @@ class JzonAPI Object : public Node {
       return tmp;
     }
 
-    bool operator==(const const_iterator &rhs) {
+    bool operator==(const const_iterator& rhs) {
       return p == rhs.p;
     }
-    bool operator!=(const const_iterator &rhs) {
+    bool operator!=(const const_iterator& rhs) {
       return p != rhs.p;
     }
 
@@ -278,19 +278,19 @@ class JzonAPI Object : public Node {
     }
 
    private:
-    const NamedNodePtr *p;
+    const NamedNodePtr* p;
   };
 
   Object() = default;
-  Object(const Object &other);
-  Object(const Node &other);
+  Object(const Object& other);
+  Object(const Node& other);
   ~Object() override;
 
   Type GetType() const override;
 
-  void Add(const std::string &name, Node &node);
-  void Add(const std::string &name, const Value &node);
-  void Remove(const std::string &name);
+  void Add(const std::string& name, Node& node);
+  void Add(const std::string& name, const Value& node);
+  void Remove(const std::string& name);
   void Clear();
 
   iterator begin();
@@ -298,13 +298,13 @@ class JzonAPI Object : public Node {
   iterator end();
   const_iterator end() const;
 
-  bool Has(const std::string &name) const override;
+  bool Has(const std::string& name) const override;
   size_t GetCount() const override;
-  Node &Get(const std::string &name) const override;
+  Node& Get(const std::string& name) const override;
   using Node::Get;
 
  protected:
-  Node *GetCopy() const override;
+  Node* GetCopy() const override;
 
  private:
   using ChildList = std::vector<NamedNodePtr>;
@@ -315,12 +315,12 @@ class JzonAPI Array : public Node {
  public:
   class iterator : public std::iterator<std::input_iterator_tag, Node> {
    public:
-    iterator(Node **o) : p(o) {
+    iterator(Node** o) : p(o) {
     }
-    iterator(const iterator &it) : p(it.p) {
+    iterator(const iterator& it) : p(it.p) {
     }
 
-    iterator &operator++() {
+    iterator& operator++() {
       ++p;
       return *this;
     }
@@ -330,28 +330,28 @@ class JzonAPI Array : public Node {
       return tmp;
     }
 
-    bool operator==(const iterator &rhs) {
+    bool operator==(const iterator& rhs) {
       return p == rhs.p;
     }
-    bool operator!=(const iterator &rhs) {
+    bool operator!=(const iterator& rhs) {
       return p != rhs.p;
     }
 
-    Node &operator*() {
+    Node& operator*() {
       return **p;
     }
 
    private:
-    Node **p;
+    Node** p;
   };
   class const_iterator : public std::iterator<std::input_iterator_tag, const Node> {
    public:
-    const_iterator(const Node *const *o) : p(o) {
+    const_iterator(const Node* const* o) : p(o) {
     }
-    const_iterator(const const_iterator &it) : p(it.p) {
+    const_iterator(const const_iterator& it) : p(it.p) {
     }
 
-    const_iterator &operator++() {
+    const_iterator& operator++() {
       ++p;
       return *this;
     }
@@ -361,30 +361,30 @@ class JzonAPI Array : public Node {
       return tmp;
     }
 
-    bool operator==(const const_iterator &rhs) {
+    bool operator==(const const_iterator& rhs) {
       return p == rhs.p;
     }
-    bool operator!=(const const_iterator &rhs) {
+    bool operator!=(const const_iterator& rhs) {
       return p != rhs.p;
     }
 
-    const Node &operator*() {
+    const Node& operator*() {
       return **p;
     }
 
    private:
-    const Node *const *p;
+    const Node* const* p;
   };
 
   Array() = default;
-  Array(const Array &other);
-  Array(const Node &other);
+  Array(const Array& other);
+  Array(const Node& other);
   ~Array() override;
 
   Type GetType() const override;
 
-  void Add(Node &node);
-  void Add(const Value &node);
+  void Add(Node& node);
+  void Add(const Value& node);
   void Remove(size_t index);
   void Clear();
 
@@ -394,14 +394,14 @@ class JzonAPI Array : public Node {
   const_iterator end() const;
 
   size_t GetCount() const override;
-  Node &Get(size_t index) const override;
+  Node& Get(size_t index) const override;
   using Node::Get;
 
  protected:
-  Node *GetCopy() const override;
+  Node* GetCopy() const override;
 
  private:
-  using ChildList = std::vector<Node *>;
+  using ChildList = std::vector<Node*>;
   ChildList children;
 };
 
@@ -410,9 +410,9 @@ class JzonAPI FileWriter {
   FileWriter(std::string filename);
   ~FileWriter() = default;
 
-  static void WriteFile(const std::string &filename, const Node &root, const Format &format = NoFormat);
+  static void WriteFile(const std::string& filename, const Node& root, const Format& format = NoFormat);
 
-  void Write(const Node &root, const Format &format = NoFormat);
+  void Write(const Node& root, const Format& format = NoFormat);
 
  private:
   std::string filename;
@@ -420,63 +420,63 @@ class JzonAPI FileWriter {
 
 class JzonAPI FileReader {
  public:
-  FileReader(const std::string &filename);
+  FileReader(const std::string& filename);
   ~FileReader() = default;
 
-  static bool ReadFile(const std::string &filename, Node &node);
+  static bool ReadFile(const std::string& filename, Node& node);
 
-  bool Read(Node &node);
+  bool Read(Node& node);
 
   Node::Type DetermineType();
 
-  const std::string &GetError() const;
+  const std::string& GetError() const;
 
  private:
-  static bool loadFile(const std::string &filename, std::string &json);
+  static bool loadFile(const std::string& filename, std::string& json);
   std::string json;
   std::string error;
 };
 
 class JzonAPI Writer {
  public:
-  Writer(const Node &root, const Format &format = NoFormat);
+  Writer(const Node& root, const Format& format = NoFormat);
   ~Writer();
 
-  void SetFormat(const Format &format);
-  const std::string &Write();
+  void SetFormat(const Format& format);
+  const std::string& Write();
 
   // Return result from last call to Write()
-  const std::string &GetResult() const;
+  const std::string& GetResult() const;
 
   // Disable assignment operator
-  Writer &operator=(const Writer &) = delete;
+  Writer& operator=(const Writer&) = delete;
 
  private:
-  void writeNode(const Node &node, size_t level);
-  void writeObject(const Object &node, size_t level);
-  void writeArray(const Array &node, size_t level);
-  void writeValue(const Value &node);
+  void writeNode(const Node& node, size_t level);
+  void writeObject(const Object& node, size_t level);
+  void writeArray(const Array& node, size_t level);
+  void writeValue(const Value& node);
 
   std::string result;
 
-  class FormatInterpreter *fi;
+  class FormatInterpreter* fi;
 
-  const Node &root;
+  const Node& root;
 };
 
 class JzonAPI Parser {
  public:
-  Parser(Node &root);
-  Parser(Node &root, const std::string &json);
+  Parser(Node& root);
+  Parser(Node& root, const std::string& json);
   ~Parser() = default;
 
-  void SetJson(const std::string &json);
+  void SetJson(const std::string& json);
   bool Parse();
 
-  const std::string &GetError() const;
+  const std::string& GetError() const;
 
   // Disable assignment operator
-  Parser &operator=(const Parser &) = delete;
+  Parser& operator=(const Parser&) = delete;
 
  private:
   enum Token {
@@ -498,7 +498,7 @@ class JzonAPI Parser {
   void jumpToCommentEnd();
 
   void readString();
-  bool interpretValue(const std::string &value);
+  bool interpretValue(const std::string& value);
 
   std::string json;
   std::size_t jsonSize{0};
@@ -508,7 +508,7 @@ class JzonAPI Parser {
 
   std::size_t cursor{0};
 
-  Node &root;
+  Node& root;
 
   std::string error;
 };

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -53,13 +53,13 @@ int main() try {
   assert(xmpData["Xmp.dc.one"].toInt64() == -1);
   assert(xmpData["Xmp.dc.one"].value().ok());
 
-  [[maybe_unused]] const Exiv2::Value &getv1 = xmpData["Xmp.dc.one"].value();
+  [[maybe_unused]] const Exiv2::Value& getv1 = xmpData["Xmp.dc.one"].value();
   assert(isEqual(getv1.toFloat(), -1));
   assert(getv1.ok());
   assert(getv1.toRational() == Exiv2::Rational(-1, 1));
   assert(getv1.ok());
 
-  [[maybe_unused]] const Exiv2::Value &getv2 = xmpData["Xmp.dc.two"].value();
+  [[maybe_unused]] const Exiv2::Value& getv2 = xmpData["Xmp.dc.two"].value();
   assert(isEqual(getv2.toFloat(), 3.1415f));
   assert(getv2.ok());
   assert(getv2.toInt64() == 3);
@@ -68,7 +68,7 @@ int main() try {
   assert(getv2.ok());
   assert(isEqual(static_cast<float>(R.first) / R.second, 3.1415f));
 
-  [[maybe_unused]] const Exiv2::Value &getv3 = xmpData["Xmp.dc.three"].value();
+  [[maybe_unused]] const Exiv2::Value& getv3 = xmpData["Xmp.dc.three"].value();
   assert(isEqual(getv3.toFloat(), 5.0f / 7.0f));
   assert(getv3.ok());
   assert(getv3.toInt64() == 0);  // long(5.0 / 7.0)
@@ -76,7 +76,7 @@ int main() try {
   assert(getv3.toRational() == Exiv2::Rational(5, 7));
   assert(getv3.ok());
 
-  [[maybe_unused]] const Exiv2::Value &getv6 = xmpData["Xmp.dc.six"].value();
+  [[maybe_unused]] const Exiv2::Value& getv6 = xmpData["Xmp.dc.six"].value();
   assert(getv6.toInt64() == 0);
   assert(getv6.ok());
   assert(getv6.toFloat() == 0.0f);
@@ -84,11 +84,11 @@ int main() try {
   assert(getv6.toRational() == Exiv2::Rational(0, 1));
   assert(getv6.ok());
 
-  const Exiv2::Value &getv7 = xmpData["Xmp.dc.seven"].value();
+  const Exiv2::Value& getv7 = xmpData["Xmp.dc.seven"].value();
   getv7.toInt64();  // this should fail
   assert(!getv7.ok());
 
-  [[maybe_unused]] const Exiv2::Value &getv8 = xmpData["Xmp.dc.eight"].value();
+  [[maybe_unused]] const Exiv2::Value& getv8 = xmpData["Xmp.dc.eight"].value();
   assert(getv8.toInt64() == 1);
   assert(getv8.ok());
   assert(getv8.toFloat() == 1.0f);
@@ -185,7 +185,7 @@ int main() try {
 
   // -------------------------------------------------------------------------
   // Output XMP properties
-  for (auto &&md : xmpData) {
+  for (auto&& md : xmpData) {
     std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9) << std::setfill(' ')
               << std::left << md.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right
               << md.count() << "  " << std::dec << md.value() << std::endl;
@@ -203,7 +203,7 @@ int main() try {
   Exiv2::XmpParser::terminate();
 
   return EXIT_SUCCESS;
-} catch (Exiv2::Error &e) {
+} catch (Exiv2::Error& e) {
   std::cout << "Caught Exiv2 exception '" << e << "'\n";
   return EXIT_FAILURE;
 }

--- a/src/jp2image_int.cpp
+++ b/src/jp2image_int.cpp
@@ -9,7 +9,7 @@
 
 namespace Exiv2::Internal {
 
-bool isValidBoxFileType(const std::vector<uint8_t> &boxData) {
+bool isValidBoxFileType(const std::vector<uint8_t>& boxData) {
   // BR & MinV are obligatory (4 + 4 bytes). Afterwards we have N compatibility lists (of size 4)
   if ((boxData.size() - 8u) % 4u != 0) {
     return false;

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -24,23 +24,23 @@ using Exiv2::byte;
          of both lhs and rhs are available or else by size.
          Return true if lhs is smaller than rhs.
  */
-bool cmpPreviewProperties(const PreviewProperties &lhs, const PreviewProperties &rhs) {
+bool cmpPreviewProperties(const PreviewProperties& lhs, const PreviewProperties& rhs) {
   auto l = lhs.width_ * lhs.height_;
   auto r = rhs.width_ * rhs.height_;
   return l < r;
 }
 
 /// @brief Decode a Hex string.
-DataBuf decodeHex(const byte *src, size_t srcSize);
+DataBuf decodeHex(const byte* src, size_t srcSize);
 
 /// @brief Decode a Base64 string.
-DataBuf decodeBase64(const std::string &src);
+DataBuf decodeBase64(const std::string& src);
 
 /// @brief Decode an Illustrator thumbnail that follows after %AI7_Thumbnail.
-DataBuf decodeAi7Thumbnail(const DataBuf &src);
+DataBuf decodeAi7Thumbnail(const DataBuf& src);
 
 /// @brief Create a PNM image from raw RGB data.
-DataBuf makePnm(size_t width, size_t height, const DataBuf &rgb);
+DataBuf makePnm(size_t width, size_t height, const DataBuf& rgb);
 
 /*!
   Base class for image loaders. Provides virtual methods for reading properties
@@ -55,7 +55,7 @@ class Loader {
   using UniquePtr = std::unique_ptr<Loader>;
 
   //! Create a Loader subclass for requested id
-  static UniquePtr create(PreviewId id, const Image &image);
+  static UniquePtr create(PreviewId id, const Image& image);
 
   //! Check if a preview image with given params exists in the image
   virtual bool valid() const {
@@ -78,14 +78,14 @@ class Loader {
 
  protected:
   //! Constructor. Sets all image properties to unknown.
-  Loader(PreviewId id, const Image &image);
+  Loader(PreviewId id, const Image& image);
 
   //! Functions that creates a loader from given parameters
-  using CreateFunc = UniquePtr (*)(PreviewId, const Image &, int);
+  using CreateFunc = UniquePtr (*)(PreviewId, const Image&, int);
 
   //! Structure to list possible loaders
   struct LoaderList {
-    const char *imageMimeType_;  //!< Image type for which the loader is valid, 0 matches all images
+    const char* imageMimeType_;  //!< Image type for which the loader is valid, 0 matches all images
     CreateFunc create_;          //!< Function that creates particular loader instance
     int parIdx_;                 //!< Parameter that is passed into CreateFunc
   };
@@ -97,7 +97,7 @@ class Loader {
   PreviewId id_;
 
   //! Source image reference
-  const Image &image_;
+  const Image& image_;
 
   //! Preview image width
   size_t width_;
@@ -116,7 +116,7 @@ class Loader {
 class LoaderNative : public Loader {
  public:
   //! Constructor
-  LoaderNative(PreviewId id, const Image &image, int parIdx);
+  LoaderNative(PreviewId id, const Image& image, int parIdx);
 
   //! Get properties of a preview image with given params
   PreviewProperties getProperties() const override;
@@ -133,13 +133,13 @@ class LoaderNative : public Loader {
 };
 
 //! Function to create new LoaderNative
-Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx);
+Loader::UniquePtr createLoaderNative(PreviewId id, const Image& image, int parIdx);
 
 //! Loader for Jpeg previews that are not read into ExifData directly
 class LoaderExifJpeg : public Loader {
  public:
   //! Constructor
-  LoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
+  LoaderExifJpeg(PreviewId id, const Image& image, int parIdx);
 
   //! Get properties of a preview image with given params
   PreviewProperties getProperties() const override;
@@ -153,9 +153,9 @@ class LoaderExifJpeg : public Loader {
  protected:
   //! Structure that lists offset/size tag pairs
   struct Param {
-    const char *offsetKey_;      //!< Offset tag
-    const char *sizeKey_;        //!< Size tag
-    const char *baseOffsetKey_;  //!< Tag that holds base offset or 0
+    const char* offsetKey_;      //!< Offset tag
+    const char* sizeKey_;        //!< Size tag
+    const char* baseOffsetKey_;  //!< Tag that holds base offset or 0
   };
 
   //! Table that holds all possible offset/size pairs. parIdx is an index to this table
@@ -166,13 +166,13 @@ class LoaderExifJpeg : public Loader {
 };
 
 //! Function to create new LoaderExifJpeg
-Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
+Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image& image, int parIdx);
 
 //! Loader for Jpeg previews that are read into ExifData
 class LoaderExifDataJpeg : public Loader {
  public:
   //! Constructor
-  LoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
+  LoaderExifDataJpeg(PreviewId id, const Image& image, int parIdx);
 
   //! Get properties of a preview image with given params
   PreviewProperties getProperties() const override;
@@ -186,8 +186,8 @@ class LoaderExifDataJpeg : public Loader {
  protected:
   //! Structure that lists data/size tag pairs
   struct Param {
-    const char *dataKey_;  //!< Data tag
-    const char *sizeKey_;  //!< Size tag
+    const char* dataKey_;  //!< Data tag
+    const char* sizeKey_;  //!< Size tag
   };
 
   //! Table that holds all possible data/size pairs. parIdx is an index to this table
@@ -198,13 +198,13 @@ class LoaderExifDataJpeg : public Loader {
 };
 
 //! Function to create new LoaderExifDataJpeg
-Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
+Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image& image, int parIdx);
 
 //! Loader for Tiff previews - it can get image data from ExifData or image_.io() as needed
 class LoaderTiff : public Loader {
  public:
   //! Constructor
-  LoaderTiff(PreviewId id, const Image &image, int parIdx);
+  LoaderTiff(PreviewId id, const Image& image, int parIdx);
 
   //! Get properties of a preview image with given params
   PreviewProperties getProperties() const override;
@@ -214,7 +214,7 @@ class LoaderTiff : public Loader {
 
  protected:
   //! Name of the group that contains the preview image
-  const char *group_;
+  const char* group_;
 
   //! Tag that contains image data. Possible values are "StripOffsets" or "TileOffsets"
   std::string offsetTag_;
@@ -224,9 +224,9 @@ class LoaderTiff : public Loader {
 
   //! Structure that lists preview groups
   struct Param {
-    const char *group_;       //!< Group name
-    const char *checkTag_;    //!< Tag to check or NULL
-    const char *checkValue_;  //!< The preview image is valid only if the checkTag_ has this value
+    const char* group_;       //!< Group name
+    const char* checkTag_;    //!< Tag to check or NULL
+    const char* checkValue_;  //!< The preview image is valid only if the checkTag_ has this value
   };
 
   //! Table that holds all possible groups. parIdx is an index to this table.
@@ -234,13 +234,13 @@ class LoaderTiff : public Loader {
 };
 
 //! Function to create new LoaderTiff
-Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx);
+Loader::UniquePtr createLoaderTiff(PreviewId id, const Image& image, int parIdx);
 
 //! Loader for JPEG previews stored in the XMP metadata
 class LoaderXmpJpeg : public Loader {
  public:
   //! Constructor
-  LoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
+  LoaderXmpJpeg(PreviewId id, const Image& image, int parIdx);
 
   //! Get properties of a preview image with given params
   PreviewProperties getProperties() const override;
@@ -257,7 +257,7 @@ class LoaderXmpJpeg : public Loader {
 };
 
 //! Function to create new LoaderXmpJpeg
-Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
+Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image& image, int parIdx);
 
 // *****************************************************************************
 // class member definitions
@@ -319,7 +319,7 @@ const LoaderTiff::Param LoaderTiff::param_[] = {
     {"Image2", nullptr, nullptr}                          // 7
 };
 
-Loader::UniquePtr Loader::create(PreviewId id, const Image &image) {
+Loader::UniquePtr Loader::create(PreviewId id, const Image& image) {
   if (id < 0 || id >= Loader::getNumLoaders())
     return nullptr;
 
@@ -334,7 +334,7 @@ Loader::UniquePtr Loader::create(PreviewId id, const Image &image) {
   return loader;
 }
 
-Loader::Loader(PreviewId id, const Image &image) :
+Loader::Loader(PreviewId id, const Image& image) :
     id_(id), image_(image), width_(0), height_(0), size_(0), valid_(false) {
 }
 
@@ -351,7 +351,7 @@ PreviewId Loader::getNumLoaders() {
   return PreviewId(std::size(loaderList_));
 }
 
-LoaderNative::LoaderNative(PreviewId id, const Image &image, int parIdx) : Loader(id, image) {
+LoaderNative::LoaderNative(PreviewId id, const Image& image, int parIdx) : Loader(id, image) {
   if (!(0 <= parIdx && static_cast<size_t>(parIdx) < image.nativePreviews().size()))
     return;
   nativePreview_ = image.nativePreviews()[parIdx];
@@ -365,7 +365,7 @@ LoaderNative::LoaderNative(PreviewId id, const Image &image, int parIdx) : Loade
   }
 }
 
-Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx) {
+Loader::UniquePtr createLoaderNative(PreviewId id, const Image& image, int parIdx) {
   return std::make_unique<LoaderNative>(id, image, parIdx);
 }
 
@@ -393,12 +393,12 @@ DataBuf LoaderNative::getData() const {
   if (!valid())
     return {};
 
-  BasicIo &io = image_.io();
+  BasicIo& io = image_.io();
   if (io.open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io.path(), strError());
   }
   IoCloser closer(io);
-  const byte *data = io.mmap();
+  const byte* data = io.mmap();
   if (io.size() < nativePreview_.position_ + nativePreview_.size_) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Invalid native preview position or size.\n";
@@ -415,7 +415,7 @@ DataBuf LoaderNative::getData() const {
   }
   if (nativePreview_.filter_ == "hex-irb") {
     const DataBuf psData = decodeHex(data + nativePreview_.position_, nativePreview_.size_);
-    const byte *record;
+    const byte* record;
     uint32_t sizeHdr = 0;
     uint32_t sizeData = 0;
     if (Photoshop::locatePreviewIrb(psData.c_data(), psData.size(), &record, &sizeHdr, &sizeData) != 0) {
@@ -447,7 +447,7 @@ bool LoaderNative::readDimensions() {
 
     width_ = image->pixelWidth();
     height_ = image->pixelHeight();
-  } catch (const Error & /* error */) {
+  } catch (const Error& /* error */) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Invalid native preview image.\n";
 #endif
@@ -456,8 +456,8 @@ bool LoaderNative::readDimensions() {
   return true;
 }
 
-LoaderExifJpeg::LoaderExifJpeg(PreviewId id, const Image &image, int parIdx) : Loader(id, image), offset_(0) {
-  const ExifData &exifData = image_.exifData();
+LoaderExifJpeg::LoaderExifJpeg(PreviewId id, const Image& image, int parIdx) : Loader(id, image), offset_(0) {
+  const ExifData& exifData = image_.exifData();
   auto pos = exifData.findKey(ExifKey(param_[parIdx].offsetKey_));
   if (pos != exifData.end() && pos->count() > 0) {
     offset_ = pos->toUint32();
@@ -485,7 +485,7 @@ LoaderExifJpeg::LoaderExifJpeg(PreviewId id, const Image &image, int parIdx) : L
   valid_ = true;
 }
 
-Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx) {
+Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image& image, int parIdx) {
   return std::make_unique<LoaderExifJpeg>(id, image, parIdx);
 }
 
@@ -499,14 +499,14 @@ PreviewProperties LoaderExifJpeg::getProperties() const {
 DataBuf LoaderExifJpeg::getData() const {
   if (!valid())
     return {};
-  BasicIo &io = image_.io();
+  BasicIo& io = image_.io();
 
   if (io.open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io.path(), strError());
   }
   IoCloser closer(io);
 
-  const Exiv2::byte *base = io.mmap();
+  const Exiv2::byte* base = io.mmap();
 
   return {base + offset_, size_};
 }
@@ -517,13 +517,13 @@ bool LoaderExifJpeg::readDimensions() {
   if (width_ || height_)
     return true;
 
-  BasicIo &io = image_.io();
+  BasicIo& io = image_.io();
 
   if (io.open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io.path(), strError());
   }
   IoCloser closer(io);
-  const Exiv2::byte *base = io.mmap();
+  const Exiv2::byte* base = io.mmap();
 
   try {
     auto image = ImageFactory::open(base + offset_, size_);
@@ -533,7 +533,7 @@ bool LoaderExifJpeg::readDimensions() {
 
     width_ = image->pixelWidth();
     height_ = image->pixelHeight();
-  } catch (const Error & /* error */) {
+  } catch (const Error& /* error */) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Invalid JPEG preview image.\n";
 #endif
@@ -543,7 +543,7 @@ bool LoaderExifJpeg::readDimensions() {
   return true;
 }
 
-LoaderExifDataJpeg::LoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx) :
+LoaderExifDataJpeg::LoaderExifDataJpeg(PreviewId id, const Image& image, int parIdx) :
     Loader(id, image), dataKey_(param_[parIdx].dataKey_) {
   auto pos = image_.exifData().findKey(dataKey_);
   if (pos != image_.exifData().end()) {
@@ -558,7 +558,7 @@ LoaderExifDataJpeg::LoaderExifDataJpeg(PreviewId id, const Image &image, int par
   valid_ = true;
 }
 
-Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx) {
+Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image& image, int parIdx) {
   return std::make_unique<LoaderExifDataJpeg>(id, image, parIdx);
 }
 
@@ -605,16 +605,16 @@ bool LoaderExifDataJpeg::readDimensions() {
 
     width_ = image->pixelWidth();
     height_ = image->pixelHeight();
-  } catch (const Error & /* error */) {
+  } catch (const Error& /* error */) {
     return false;
   }
 
   return true;
 }
 
-LoaderTiff::LoaderTiff(PreviewId id, const Image &image, int parIdx) :
+LoaderTiff::LoaderTiff(PreviewId id, const Image& image, int parIdx) :
     Loader(id, image), group_(param_[parIdx].group_) {
-  const ExifData &exifData = image_.exifData();
+  const ExifData& exifData = image_.exifData();
 
   size_t offsetCount = 0;
   ExifData::const_iterator pos;
@@ -670,7 +670,7 @@ LoaderTiff::LoaderTiff(PreviewId id, const Image &image, int parIdx) :
   valid_ = true;
 }
 
-Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx) {
+Loader::UniquePtr createLoaderTiff(PreviewId id, const Image& image, int parIdx) {
   return std::make_unique<LoaderTiff>(id, image, parIdx);
 }
 
@@ -682,12 +682,12 @@ PreviewProperties LoaderTiff::getProperties() const {
 }
 
 DataBuf LoaderTiff::getData() const {
-  const ExifData &exifData = image_.exifData();
+  const ExifData& exifData = image_.exifData();
 
   ExifData preview;
 
   // copy tags
-  for (auto &&pos : exifData) {
+  for (auto&& pos : exifData) {
     if (pos.groupName() == group_) {
       /*
          Write only the necessary TIFF image tags
@@ -703,20 +703,20 @@ DataBuf LoaderTiff::getData() const {
     }
   }
 
-  Value &dataValue = const_cast<Value &>(preview["Exif.Image." + offsetTag_].value());
+  Value& dataValue = const_cast<Value&>(preview["Exif.Image." + offsetTag_].value());
 
   if (dataValue.sizeDataArea() == 0) {
     // image data are not available via exifData, read them from image_.io()
-    BasicIo &io = image_.io();
+    BasicIo& io = image_.io();
 
     if (io.open() != 0) {
       throw Error(ErrorCode::kerDataSourceOpenFailed, io.path(), strError());
     }
     IoCloser closer(io);
 
-    const Exiv2::byte *base = io.mmap();
+    const Exiv2::byte* base = io.mmap();
 
-    const Value &sizes = preview["Exif.Image." + sizeTag_].value();
+    const Value& sizes = preview["Exif.Image." + sizeTag_].value();
 
     if (sizes.count() == dataValue.count()) {
       if (sizes.count() == 1) {
@@ -763,10 +763,10 @@ DataBuf LoaderTiff::getData() const {
   return {mio.mmap(), mio.size()};
 }
 
-LoaderXmpJpeg::LoaderXmpJpeg(PreviewId id, const Image &image, int parIdx) : Loader(id, image) {
+LoaderXmpJpeg::LoaderXmpJpeg(PreviewId id, const Image& image, int parIdx) : Loader(id, image) {
   (void)parIdx;
 
-  const XmpData &xmpData = image_.xmpData();
+  const XmpData& xmpData = image_.xmpData();
 
   std::string prefix = "xmpGImg";
   if (xmpData.findKey(XmpKey("Xmp.xmp.Thumbnails[1]/xapGImg:image")) != xmpData.end()) {
@@ -796,7 +796,7 @@ LoaderXmpJpeg::LoaderXmpJpeg(PreviewId id, const Image &image, int parIdx) : Loa
   valid_ = true;
 }
 
-Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx) {
+Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image& image, int parIdx) {
   return std::make_unique<LoaderXmpJpeg>(id, image, parIdx);
 }
 
@@ -817,7 +817,7 @@ bool LoaderXmpJpeg::readDimensions() {
   return valid();
 }
 
-DataBuf decodeHex(const byte *src, size_t srcSize) {
+DataBuf decodeHex(const byte* src, size_t srcSize) {
   // create decoding table
   byte invalid = 16;
   std::array<byte, 256> decodeHexTable;
@@ -857,7 +857,7 @@ DataBuf decodeHex(const byte *src, size_t srcSize) {
 
 const char encodeBase64Table[64 + 1] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-DataBuf decodeBase64(const std::string &src) {
+DataBuf decodeBase64(const std::string& src) {
   const size_t srcSize = src.size();
 
   // create decoding table
@@ -899,8 +899,8 @@ DataBuf decodeBase64(const std::string &src) {
   return dest;
 }
 
-DataBuf decodeAi7Thumbnail(const DataBuf &src) {
-  const byte *colorTable = src.c_data();
+DataBuf decodeAi7Thumbnail(const DataBuf& src) {
+  const byte* colorTable = src.c_data();
   const size_t colorTableSize = 256 * 3;
   if (src.size() < colorTableSize) {
 #ifndef SUPPRESS_WARNINGS
@@ -908,7 +908,7 @@ DataBuf decodeAi7Thumbnail(const DataBuf &src) {
 #endif
     return {};
   }
-  const byte *imageData = src.c_data(colorTableSize);
+  const byte* imageData = src.c_data(colorTableSize);
   const size_t imageDataSize = src.size() - colorTableSize;
   const bool rle = (imageDataSize >= 3 && imageData[0] == 'R' && imageData[1] == 'L' && imageData[2] == 'E');
   std::string dest;
@@ -935,13 +935,13 @@ DataBuf decodeAi7Thumbnail(const DataBuf &src) {
       }
     }
     for (; num != 0; num--) {
-      dest.append(reinterpret_cast<const char *>(colorTable + (3 * value)), 3);
+      dest.append(reinterpret_cast<const char*>(colorTable + (3 * value)), 3);
     }
   }
-  return {reinterpret_cast<const byte *>(dest.data()), dest.size()};
+  return {reinterpret_cast<const byte*>(dest.data()), dest.size()};
 }
 
-DataBuf makePnm(size_t width, size_t height, const DataBuf &rgb) {
+DataBuf makePnm(size_t width, size_t height, const DataBuf& rgb) {
   const size_t expectedSize = width * height * 3UL;
   if (rgb.size() != expectedSize) {
 #ifndef SUPPRESS_WARNINGS
@@ -952,7 +952,7 @@ DataBuf makePnm(size_t width, size_t height, const DataBuf &rgb) {
   }
 
   const std::string header = "P6\n" + toString(width) + " " + toString(height) + "\n255\n";
-  const auto headerBytes = reinterpret_cast<const byte *>(header.data());
+  const auto headerBytes = reinterpret_cast<const byte*>(header.data());
 
   DataBuf dest(header.size() + rgb.size());
   std::copy_n(headerBytes, header.size(), dest.begin());
@@ -965,14 +965,14 @@ DataBuf makePnm(size_t width, size_t height, const DataBuf &rgb) {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-PreviewImage::PreviewImage(PreviewProperties properties, DataBuf &&data) :
+PreviewImage::PreviewImage(PreviewProperties properties, DataBuf&& data) :
     properties_(std::move(properties)), preview_(std::move(data)) {
 }
 
-PreviewImage::PreviewImage(const PreviewImage &rhs) : properties_(rhs.properties_), preview_(rhs.pData(), rhs.size()) {
+PreviewImage::PreviewImage(const PreviewImage& rhs) : properties_(rhs.properties_), preview_(rhs.pData(), rhs.size()) {
 }
 
-PreviewImage &PreviewImage::operator=(const PreviewImage &rhs) {
+PreviewImage& PreviewImage::operator=(const PreviewImage& rhs) {
   if (this == &rhs)
     return *this;
   properties_ = rhs.properties_;
@@ -980,7 +980,7 @@ PreviewImage &PreviewImage::operator=(const PreviewImage &rhs) {
   return *this;
 }
 
-size_t PreviewImage::writeFile(const std::string &path) const {
+size_t PreviewImage::writeFile(const std::string& path) const {
   std::string name = path + extension();
   // Todo: Creating a DataBuf here unnecessarily copies the memory
   DataBuf buf(pData(), size());
@@ -991,7 +991,7 @@ DataBuf PreviewImage::copy() const {
   return {pData(), size()};
 }
 
-const byte *PreviewImage::pData() const {
+const byte* PreviewImage::pData() const {
   return preview_.c_data();
 }
 
@@ -1019,7 +1019,7 @@ PreviewId PreviewImage::id() const {
   return properties_.id_;
 }
 
-PreviewManager::PreviewManager(const Image &image) : image_(image) {
+PreviewManager::PreviewManager(const Image& image) : image_(image) {
 }
 
 PreviewPropertiesList PreviewManager::getPreviewProperties() const {
@@ -1038,7 +1038,7 @@ PreviewPropertiesList PreviewManager::getPreviewProperties() const {
   return list;
 }
 
-PreviewImage PreviewManager::getPreviewImage(const PreviewProperties &properties) const {
+PreviewImage PreviewManager::getPreviewImage(const PreviewProperties& properties) const {
   auto loader = Loader::create(properties.id_, image_);
   DataBuf buf;
   if (loader) {

--- a/src/private.h
+++ b/src/private.h
@@ -197,8 +197,8 @@ static char privatehid[] = "@(#)private.h	7.53";
 #if HAVE_INCOMPATIBLE_CTIME_R
 #undef asctime_r
 #undef ctime_r
-char *asctime_r P((struct tm const *, char *));
-char *ctime_r P((time_t const *, char *));
+char* asctime_r P((struct tm const*, char*));
+char* ctime_r P((time_t const*, char*));
 #endif /* HAVE_INCOMPATIBLE_CTIME_R */
 
 /*

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -32,7 +32,7 @@ TEST(DataBuf, pointsToNullByDefault) {
 
 TEST(DataBuf, allocatesDataWithNonEmptyConstructor) {
   DataBuf instance(5);
-  ASSERT_NE(static_cast<byte *>(nullptr), instance.c_data());  /// \todo use nullptr once we move to c++11
+  ASSERT_NE(static_cast<byte*>(nullptr), instance.c_data());  /// \todo use nullptr once we move to c++11
   ASSERT_EQ(5, instance.size());
 }
 


### PR DESCRIPTION
As we discussed [here](https://github.com/Exiv2/exiv2/pull/2176#discussion_r838534841), I am proposing a new change to the .clang-format file so that we are explicit about the alignment of pointers and references. Luckily not too much got affected. 