### PR TITLE
ci: Try to fix job which is killed due to low memory?

### DIFF
--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -39,17 +39,17 @@ jobs:
           cd build && \
           cmake -DCMAKE_BUILD_TYPE=Debug \
             -DBUILD_SHARED_LIBS=ON \
-            -DEXIV2_BUILD_SAMPLES=ON \
             -DEXIV2_ENABLE_PNG=ON \
             -DEXIV2_ENABLE_WEBREADY=ON \
             -DEXIV2_ENABLE_CURL=ON \
             -DEXIV2_BUILD_UNIT_TESTS=ON \
             -DEXIV2_ENABLE_BMFF=ON \
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
+            -DEXIV2_BUILD_SAMPLES=ON \
             -DBUILD_WITH_COVERAGE=ON \
             -DCMAKE_INSTALL_PREFIX=install \
             .. && \
-          cmake --build . --parallel
+          cmake --build .
 
       - name: Tests + Upload coverage
         run: |


### PR DESCRIPTION
As we discussed in the team chat, I am trying to fix the Debug+Coverage jobs which runs on PUSH on the `main` branch every time we merge a PR:
https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml

These jobs fail with this error:
```
[ 75%] Building CXX object samples/CMakeFiles/conntest.dir/conntest.cpp.o
[ 75%] Building CXX object samples/CMakeFiles/remotetest.dir/remotetest.cpp.o
c++: fatal error: Killed signal terminated program cc1plus
compilation terminated.
```
And we think it might be caused by the job running out of RAM memory. It is weird but the same jobs runs perfectly fine on PRs. The specs of the runners used by Github can be found here:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

In this experiment we are trying to remove the `--parallel` flag to compile the project just with 1 single core. 