### PR TITLE
Produce releases with Interprocedural optimisations (LTO)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,17 @@ jobs:
 
       - name: Build packaged release
         run: |
-          cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DEXIV2_BUILD_DOC=ON ..
-          cmake --build . -t doc
-          cmake --build . -t package
-          tree -L 3
+          cmake -GNinja -S . -B build \
+            -DEXIV2_TEAM_PACKAGING=ON \
+            -DBUILD_SHARED_LIBS=ON \
+            -DEXIV2_ENABLE_WEBREADY=OFF \
+            -DEXIV2_ENABLE_NLS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DEXIV2_ENABLE_BMFF=ON \
+            -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
+            -DEXIV2_BUILD_DOC=ON
+          cmake --build build -t doc
+          cmake --build build -t package
 
       - uses: actions/upload-artifact@v3
         with:
@@ -68,11 +74,19 @@ jobs:
 
       - name: Build packaged release
         run: |
-          mkdir build && cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=ON -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DEXIV2_BUILD_DOC=ON -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" ..
-          cmake --build . -t doc
-          cmake --build . -t package
-          tree -L 3
+          mkdir build
+          cmake -GNinja -S . -B build \
+            -DEXIV2_TEAM_PACKAGING=ON \
+            -DBUILD_SHARED_LIBS=ON \
+            -DEXIV2_ENABLE_WEBREADY=OFF \
+            -DEXIV2_ENABLE_NLS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DEXIV2_ENABLE_BMFF=ON \
+            -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
+            -DEXIV2_BUILD_DOC=ON \
+            -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations"
+          cmake --build build -t doc
+          cmake --build build -t package
 
       - uses: actions/upload-artifact@v3
         with:
@@ -121,11 +135,17 @@ jobs:
 
       - name: Build packaged release
         run: |
-          cd build
-          cmake -GNinja -DEXIV2_TEAM_PACKAGING=ON -DBUILD_SHARED_LIBS=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_NLS=OFF -DCMAKE_BUILD_TYPE=Release -DEXIV2_ENABLE_BMFF=ON -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON -DEXIV2_BUILD_DOC=ON ..
-          cmake --build . -t doc
-          cmake --build . -t package
-          tree -L 3
+          cmake -GNinja -S . -B build `
+            -DEXIV2_TEAM_PACKAGING=ON `
+            -DBUILD_SHARED_LIBS=ON `
+            -DEXIV2_ENABLE_WEBREADY=OFF `
+            -DEXIV2_ENABLE_NLS=OFF `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DEXIV2_ENABLE_BMFF=ON `
+            -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON `
+            -DEXIV2_BUILD_DOC=ON
+          cmake --build build -t doc
+          cmake --build build -t package
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DEXIV2_ENABLE_BMFF=ON \
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
             -DEXIV2_BUILD_DOC=ON
           cmake --build build -t doc
           cmake --build build -t package
@@ -84,6 +85,7 @@ jobs:
             -DEXIV2_ENABLE_BMFF=ON \
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON \
             -DEXIV2_BUILD_DOC=ON \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
             -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations"
           cmake --build build -t doc
           cmake --build build -t package
@@ -143,6 +145,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DEXIV2_ENABLE_BMFF=ON `
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=ON `
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON `
             -DEXIV2_BUILD_DOC=ON
           cmake --build build -t doc
           cmake --build build -t package

--- a/xmpsdk/CMakeLists.txt
+++ b/xmpsdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(exiv2-xmp STATIC
+add_library(exiv2-xmp OBJECT
     src/ExpatAdapter.cpp
     src/MD5.cpp
     src/ParseRDF.cpp


### PR DESCRIPTION
As I mentioned at #2184 , it has some benefits to use Link-Time Optimisations when generating the binaries, in terms of speed and size. 

By studying how different settings affect to the final size of the binaries (static libs, dynamic ones and executables) I realised that we actually do not need to deploy in our tarballs the `exiv2-xmp` target that was being treated as a STATIC library. By treating that target as a OBJECT library, we will not need to deploy it separately. The object code needed by `libexiv2` will be incorporated in the shared lib.

You can compare the latest [nightly](https://github.com/Exiv2/exiv2/releases/tag/nightly) build (without LTO)  and the [build with LTO](https://github.com/Exiv2/exiv2/releases/tag/testIPO_exiv2-xmp-OBJECT).

As always, any feedback is welcome!