### PR TITLE
Fix compilation issues when when using Ubuntu 18.04 + clang12

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -16,10 +16,7 @@ macro(fuzzer name)
                     COMPILE_FLAGS "-fsanitize=fuzzer"
                     LINK_FLAGS "-fsanitize=fuzzer")
     endif()
-    target_link_libraries(${name}
-            PRIVATE
-            exiv2lib
-            )
+    target_link_libraries(${name} PRIVATE exiv2lib std::filesystem)
 endmacro()
 
 fuzzer(fuzz-read-print-write)


### PR DESCRIPTION
I found some issues when using a non very common setup:
- OS: Ubuntu 18.04 x64
- Compiler: clang-12, downloaded from the pre-compiler binaries available at LLVM 

I was trying to create a build with CLANG and the FUZZ app enabled in order to debug some issues and I found out 2 problems:
1. The fuzz app could be compiler but it was missing the std::filesystem symbols.
2. The unit tests target could not be compiled because it was used some deprecated functions

```bash
# 1
[2/5] Linking CXX executable bin/fuzz-read-print-write
FAILED: bin/fuzz-read-print-write 
: && ccache /opt/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-/bin/clang++  -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all -g3 -gstrict-dwarf -O0  -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all    -fsanitize=fuzzer  -fstack-protector-strong fuzz/CMakeFiles/fuzz-read-print-write.dir/fuzz-read-print-write.cpp.o  -o bin/fuzz-read-print-write  -Wl,-rpath,/home/users/diazmasl/personal/exiv2/buildFuzz/lib  lib/libexiv2.so.1.0.0.9 && :
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::current_path[abi:cxx11]()'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::__cxx11::path::has_root_directory() const'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::rename(std::filesystem::__cxx11::path const&, std::filesystem::__cxx11::path const&)'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::__cxx11::path::has_filename() const'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::remove(std::filesystem::__cxx11::path const&)'
lib/libexiv2.so.1.0.0.9: undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)

```

```bash
#2
[3/7] Building CXX object unitTests/CMakeFiles/unit_tests.dir/test_slice.cpp.o
FAILED: unitTests/CMakeFiles/unit_tests.dir/test_slice.cpp.o 
ccache /opt/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-/bin/clang++  -DTESTDATA_PATH=\"/home/users/diazmasl/personal/exiv2/test/data\" -Dexiv2lib_STATIC -I. -I../src -I../include/exiv2 -I../include -isystem /home/users/diazmasl/.conan/data/gtest/1.10.0/_/_/package/579bb3da356b87ffe3f10143f6025bb63a25a8d7/include -fsanitize=fuzzer-no-link -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=all -g3 -gstrict-dwarf -O0 -fvisibility=hidden -fvisibility-inlines-hidden     -fstack-clash-protection -fcf-protection -fstack-protector-strong -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Wcast-align -Wpointer-arith -Wformat-security -Wmissing-format-attribute -Woverloaded-virtual -W -Wno-error=format-nonliteral -Werror -Wdeprecated-copy -std=gnu++17 -MD -MT unitTests/CMakeFiles/unit_tests.dir/test_slice.cpp.o -MF unitTests/CMakeFiles/unit_tests.dir/test_slice.cpp.o.d -o unitTests/CMakeFiles/unit_tests.dir/test_slice.cpp.o -c ../unitTests/test_slice.cpp
../unitTests/test_slice.cpp:114:1: error: 'TypedTestCase_P_IsDeprecated' is deprecated: TYPED_TEST_CASE_P is deprecated, please use TYPED_TEST_SUITE_P [-Werror,-Wdeprecated-declarations]
TYPED_TEST_CASE_P(slice);
```

Althought we are not seeing any of these 2 issues at the moment in our CI jobs, this PR should fix those 2 "hiden issues". 