### PR TITLE
types cleanup exiv2app.hpp

### DIFF
--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -187,10 +187,10 @@ class Adjust : public Task {
  private:
   int adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, const std::string& path) const;
 
-  long adjustment_{0};
-  long yearAdjustment_{0};
-  long monthAdjustment_{0};
-  long dayAdjustment_{0};
+  int64_t adjustment_{0};
+  int64_t yearAdjustment_{0};
+  int64_t monthAdjustment_{0};
+  int64_t dayAdjustment_{0};
 
 };  // class Adjust
 

--- a/app/app_utils.cpp
+++ b/app/app_utils.cpp
@@ -1,19 +1,26 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "app_utils.hpp"
 #include <climits>
 #include <cstdlib>
+#include <limits>
 
 namespace Util {
-bool strtol(const char* nptr, long& n) {
+bool strtol(const char* nptr, int64_t& n) {
   if (!nptr || *nptr == '\0')
     return false;
   char* endptr = nullptr;
-  long tmp = std::strtol(nptr, &endptr, 10);
+  long long tmp = std::strtoll(nptr, &endptr, 10);
   if (*endptr != '\0')
     return false;
-  if (tmp == LONG_MAX || tmp == LONG_MIN)
+  // strtoll returns LLONG_MAX or LLONG_MIN if an overflow occurs.
+  if (tmp == LLONG_MAX || tmp == LLONG_MIN)
     return false;
-  n = tmp;
+  if (tmp < std::numeric_limits<int64_t>::min())
+    return false;
+  if (tmp > std::numeric_limits<int64_t>::max())
+    return false;
+  n = static_cast<int64_t>(tmp);
   return true;
 }
 

--- a/app/app_utils.hpp
+++ b/app/app_utils.hpp
@@ -3,13 +3,15 @@
 #ifndef APP_UTILS_HPP_
 #define APP_UTILS_HPP_
 
+#include <cstdint>
+
 namespace Util {
 /*!
-  @brief Convert a C string to a long value, which is returned in n.
+  @brief Convert a C string to an int64_t value, which is returned in n.
          Returns true if the conversion is successful, else false.
          n is not modified if the conversion is unsuccessful. See strtol(2).
  */
-bool strtol(const char* nptr, long& n);
+bool strtol(const char* nptr, int64_t& n);
 }  // namespace Util
 
 #endif  // #ifndef UTILS_HPP_

--- a/app/exiv2app.hpp
+++ b/app/exiv2app.hpp
@@ -21,28 +21,40 @@
 #include <set>
 
 //! Command identifiers
-enum CmdId {
-  invalidCmdId,
+enum class CmdId {
+  invalid,
   add,
   set,
   del,
   reg,
 };
 //! Metadata identifiers
-enum MetadataId {
-  invalidMetadataId = Exiv2::mdNone,  // 0
-  exif = Exiv2::mdExif,               // 1
-  iptc = Exiv2::mdIptc,               // 2
-  xmp = Exiv2::mdXmp,                 // 8
+enum class MetadataId : uint32_t {
+  invalid = Exiv2::mdNone,  // 0
+  exif = Exiv2::mdExif,     // 1
+  iptc = Exiv2::mdIptc,     // 2
+  xmp = Exiv2::mdXmp,       // 8
 };
+
+inline MetadataId operator&(MetadataId x, MetadataId y) {
+  return (MetadataId)(uint32_t(x) & uint32_t(y));
+}
+
+inline MetadataId operator|(MetadataId x, MetadataId y) {
+  return (MetadataId)(uint32_t(x) | uint32_t(y));
+}
+
+inline MetadataId& operator|=(MetadataId& x, MetadataId y) {
+  return x = x | y;
+}
 
 //! Structure for one parsed modification command
 struct ModifyCmd {
   //! C'tor
   ModifyCmd() = default;
-  CmdId cmdId_{invalidCmdId};                   //!< Command identifier
+  CmdId cmdId_{CmdId::invalid};                 //!< Command identifier
   std::string key_;                             //!< Exiv2 key string
-  MetadataId metadataId_{invalidMetadataId};    //!< Metadata identifier
+  MetadataId metadataId_{MetadataId::invalid};  //!< Metadata identifier
   Exiv2::TypeId typeId_{Exiv2::invalidTypeId};  //!< Exiv2 type identifier
   //! Flag to indicate if the type was explicitly specified (true)
   bool explicitType_{false};
@@ -125,7 +137,7 @@ class Params : public Util::Getopt {
   };
 
   //! Individual items to print, bitmap
-  enum PrintItem {
+  enum PrintItem : uint32_t {
     prTag = 1,
     prGroup = 2,
     prKey = 4,
@@ -141,7 +153,7 @@ class Params : public Util::Getopt {
   };
 
   //! Enumerates common targets, bitmap
-  enum CommonTarget {
+  enum CommonTarget : uint32_t {
     ctExif = 1,
     ctIptc = 2,
     ctComment = 4,
@@ -173,7 +185,7 @@ class Params : public Util::Getopt {
   struct YodAdjust {
     bool flag_;           //!< Adjustment flag.
     const char* option_;  //!< Adjustment option string.
-    long adjustment_;     //!< Adjustment value.
+    int64_t adjustment_;  //!< Adjustment value.
   };
 
   bool help_{false};                              //!< Help option flag.
@@ -188,13 +200,13 @@ class Params : public Util::Getopt {
   FileExistsPolicy fileExistsPolicy_{askPolicy};  //!< What to do if file to rename exists.
   bool adjust_{false};                            //!< Adjustment flag.
   PrintMode printMode_{pmSummary};                //!< Print mode.
-  unsigned long printItems_{0};                   //!< Print items.
-  unsigned long printTags_{Exiv2::mdNone};        //!< Print tags (bitmap of MetadataId flags).
+  PrintItem printItems_{0};                       //!< Print items.
+  MetadataId printTags_{Exiv2::mdNone};           //!< Print tags (bitmap of MetadataId flags).
   //! %Action (integer rather than TaskType to avoid dependency).
   int action_{0};
-  int target_;  //!< What common target to process.
+  CommonTarget target_;  //!< What common target to process.
 
-  long adjustment_{0};             //!< Adjustment in seconds.
+  int64_t adjustment_{0};          //!< Adjustment in seconds.
   YodAdjust yodAdjust_[3];         //!< Year, month and day adjustment info.
   std::string format_;             //!< Filename format (-r option arg).
   bool formatSet_{false};          //!< Whether the format is set with -r
@@ -269,5 +281,21 @@ class Params : public Util::Getopt {
   void getStdin(Exiv2::DataBuf& buf);
 
 };  // class Params
+
+inline Params::CommonTarget operator|(Params::CommonTarget x, Params::CommonTarget y) {
+  return (Params::CommonTarget)(uint32_t(x) | uint32_t(y));
+}
+
+inline Params::CommonTarget& operator|=(Params::CommonTarget& x, Params::CommonTarget y) {
+  return x = x | y;
+}
+
+inline Params::PrintItem operator|(Params::PrintItem x, Params::PrintItem y) {
+  return (Params::PrintItem)(uint32_t(x) | uint32_t(y));
+}
+
+inline Params::PrintItem& operator|=(Params::PrintItem& x, Params::PrintItem y) {
+  return x = x | y;
+}
 
 #endif  // #ifndef EXIV2APP_HPP_

--- a/tests/bugfixes/github/test_pr_2244.py
+++ b/tests/bugfixes/github/test_pr_2244.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, CopyTmpFiles, path
+@CopyTmpFiles("$data_path/test_issue_1180.exv")
+
+class test_pr_2244(metaclass=CaseMeta):
+
+    filename  = path("$tmp_path/test_issue_1180.exv")
+    commands  = [ "$exiv2 -Y 10000000000        $filename",
+                  "$exiv2 -Y -10000000000       $filename",
+                  "$exiv2 -O 10000000000        $filename",
+                  "$exiv2 -O -10000000000       $filename",
+                  "$exiv2 -D 1000000000000000   $filename",
+                  "$exiv2 -D -1000000000000000  $filename"
+                 ]
+    stdout   =  [ "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  ""
+                ]
+    stderr =    [ "Uncaught exception: year adjustment too high\n",
+                  "Uncaught exception: year adjustment too low\n",
+                  "Uncaught exception: month adjustment too high\n",
+                  "Uncaught exception: month adjustment too low\n",
+                  "Uncaught exception: day adjustment too high\n",
+                  "Uncaught exception: day adjustment too low\n"
+                 ]
+    retval =    [ 1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                 ]


### PR DESCRIPTION
There are a few uses of `long` or `unsigned long` in exiv2app.hpp. Some, I have replaced with `int64_t`. The others were used to store an enum, so I have updated some of the enum code so that there are fewer conversion from enum to int.