### PR TITLE
add missing memory header for std::unique_ptr in values.hpp

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <iomanip>
 #include <map>
+#include <memory>
 
 // *****************************************************************************
 // namespace extensions


### PR DESCRIPTION
76f01fd4d3b502869074b9a6d390caf2d542d55a removes the memory header
which is required to use std::unique_ptr for some builds
(e.g. archlinux using gcc 12.1.0).

Due to this some CI nightly builds are also failing.