### PR TITLE
Fix special builds for main

### DIFF
--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -8,6 +8,7 @@ on:
     - '!*'
     paths-ignore:
       - "*.md"
+  workflow_dispatch:
 
 jobs:
   special_debugRelease:
@@ -19,8 +20,9 @@ jobs:
 
       - name: install dependencies
         run: |
+          sudo apt-get install ninja-build
           pip3 install conan==1.48.1
-          pip install gcovr
+          pip3 install gcovr
 
       - name: Conan common config
         run: |


### PR DESCRIPTION
At the moment this job is failing on `main`. I am trying to fix it but unfortunately we cannot see the effect of this change until the branch is merged. To avoid this situation in the future I added `workflow_dispatch` so that we can trigger that CI job at discretion when desired. 