### PR TITLE
C++11 compatibility for headers

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -693,12 +693,12 @@ class EXIV2API XPathIo : public FileIo {
       @brief The extension of the temporary file which is created when getting input data
               to read metadata. This file will be deleted in destructor.
   */
-  static constexpr std::string_view TEMP_FILE_EXT = ".exiv2_temp";
+  static constexpr auto TEMP_FILE_EXT = ".exiv2_temp";
   /*!
       @brief The extension of the generated file which is created when getting input data
               to add or modify the metadata.
   */
-  static constexpr std::string_view GEN_FILE_EXT = ".exiv2";
+  static constexpr auto GEN_FILE_EXT = ".exiv2";
 
   //! @name Creators
   //@{

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -97,15 +97,15 @@ class EXIV2API BmffImage : public Image {
 
   //! @name Manipulators
   //@{
-  void readMetadata() override /* override */;
-  void writeMetadata() override /* override */;
-  void setComment(std::string_view comment) override /* override */;
+  void readMetadata() override;
+  void writeMetadata() override;
+  void setComment(const std::string& comment) override;
   void printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) override;
   //@}
 
   //! @name Accessors
   //@{
-  [[nodiscard]] std::string mimeType() const override /* override */;
+  [[nodiscard]] std::string mimeType() const override;
   [[nodiscard]] uint32_t pixelWidth() const override;
   [[nodiscard]] uint32_t pixelHeight() const override;
   //@}

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -66,7 +66,7 @@ class EXIV2API BmpImage : public Image {
   void setIptcData(const IptcData& iptcData) override;
 
   /// @throws Error(ErrorCode::kerInvalidSettingForImage)
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -61,7 +61,7 @@ class EXIV2API Cr2Image : public Image {
     @brief Not supported. CR2 format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -65,7 +65,7 @@ class EXIV2API EpsImage : public Image {
     @brief Not supported.
         Calling this function will throw an instance of Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -31,7 +31,7 @@ EXIV2API std::string getEnv(int env_var);
   @note Source: http://www.geekhideout.com/urlcode.shtml
   @todo This function can probably be hidden into the implementation details
  */
-EXIV2API std::string urlencode(std::string_view str);
+EXIV2API std::string urlencode(const std::string& str);
 
 /*!
   @brief Like urlencode(char* str) but accept the input url in the std::string and modify it.

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -69,7 +69,7 @@ class EXIV2API GifImage : public Image {
     @brief Not supported. Calling this function will throw an instance
         of Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -177,7 +177,7 @@ class EXIV2API Image {
   virtual void clearXmpData();
 
   /// @brief Set the image comment. The comment is written to the image when writeMetadata() is called.
-  virtual void setComment(std::string_view comment);
+  virtual void setComment(const std::string& comment);
 
   /*!
     @brief Erase any buffered comment. Comment is not removed

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -56,7 +56,7 @@ class EXIV2API Jp2Image : public Image {
     @brief Todo: Not supported yet(?). Calling this function will throw
         an instance of Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -72,7 +72,7 @@ class EXIV2API MrwImage : public Image {
     @brief Not supported. MRW format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -59,7 +59,7 @@ class EXIV2API OrfImage : public TiffImage {
     @brief Not supported. ORF format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/photoshop.hpp
+++ b/include/exiv2/photoshop.hpp
@@ -16,10 +16,10 @@ class IptcData;
 /// @brief Helper class, has methods to deal with %Photoshop "Information Resource Blocks" (IRBs).
 struct EXIV2API Photoshop {
   // Todo: Public for now
-  static constexpr std::array irbId_{"8BIM", "AgHg", "DCSR", "PHUT"};  //!< %Photoshop IRB markers
-  static constexpr auto ps3Id_ = "Photoshop 3.0\0";                    //!< %Photoshop marker
-  static constexpr uint16_t iptc_ = 0x0404;                            //!< %Photoshop IPTC marker
-  static constexpr uint16_t preview_ = 0x040c;                         //!< %Photoshop preview marker
+  static constexpr std::array<const char*, 4> irbId_{"8BIM", "AgHg", "DCSR", "PHUT"};  //!< %Photoshop IRB markers
+  static constexpr auto ps3Id_ = "Photoshop 3.0\0";                                    //!< %Photoshop marker
+  static constexpr uint16_t iptc_ = 0x0404;                                            //!< %Photoshop IPTC marker
+  static constexpr uint16_t preview_ = 0x040c;                                         //!< %Photoshop preview marker
 
   /// @brief Checks an IRB
   /// @param pPsData  Existing IRB buffer. It is expected to be of size 4.

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -53,7 +53,7 @@ class EXIV2API PsdImage : public Image {
   /*!
     @brief Not supported. Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -64,7 +64,7 @@ class EXIV2API RafImage : public Image {
     @brief Not supported. RAF format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -62,7 +62,7 @@ class EXIV2API Rw2Image : public Image {
     @brief Not supported. RW2 format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -263,7 +263,7 @@ struct ContainerStorage {
 
   using const_iterator = typename container::const_iterator;
 
-  using value_type = std::remove_cv_t<typename container::value_type>;
+  using value_type = typename std::remove_cv<typename container::value_type>::type;
 
   /*!
    * @throw std::out_of_range when end is larger than the container's
@@ -324,7 +324,7 @@ struct ContainerStorage {
  */
 template <typename storage_type>
 struct PtrSliceStorage {
-  using value_type = std::remove_cv_t<std::remove_pointer_t<storage_type>>;
+  using value_type = typename std::remove_cv<typename std::remove_pointer<storage_type>::type>::type;
   using iterator = value_type*;
   using const_iterator = const value_type*;
 
@@ -423,7 +423,7 @@ struct Slice : public Internal::MutableSliceBase<Internal::ContainerStorage, con
 
   using const_iterator = typename container::const_iterator;
 
-  using value_type = std::remove_cv_t<typename container::value_type>;
+  using value_type = typename std::remove_cv<typename container::value_type>::type;
 
   /*!
    * @brief Construct a slice of the container `cont` starting at `begin`
@@ -476,7 +476,7 @@ struct Slice<const container> : public Internal::ConstSliceBase<Internal::Contai
 
   using const_iterator = typename container::const_iterator;
 
-  using value_type = std::remove_cv_t<typename container::value_type>;
+  using value_type = typename std::remove_cv<typename container::value_type>::type;
 
   Slice(const container& cont, size_t begin, size_t end) :
       Internal::ConstSliceBase<Internal::ContainerStorage, const container>(cont, begin, end) {

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -68,7 +68,7 @@ class EXIV2API TgaImage : public Image {
     @brief Not supported. Calling this function will throw an instance
         of Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -58,7 +58,7 @@ class EXIV2API TiffImage : public Image {
     @brief Not supported. TIFF format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1261,7 +1261,8 @@ class ValueType : public Value {
   //! Utility for toInt64, toUint32, etc.
   template <typename I>
   inline I rational_to_integer_helper(size_t n) const {
-    auto&& [a, b] = value_.at(n);
+    auto a = value_.at(n).first;
+    auto b = value_.at(n).second;
 
     // Protect against divide-by-zero.
     if (b <= 0) {
@@ -1269,16 +1270,16 @@ class ValueType : public Value {
     }
 
     // Check for integer overflow.
-    if (std::is_signed_v<I> == std::is_signed_v<decltype(a)>) {
+    if (std::is_signed<I>::value == std::is_signed<decltype(a)>::value) {
       // conversion does not change sign
       const auto imin = std::numeric_limits<I>::min();
       const auto imax = std::numeric_limits<I>::max();
       if (imax < b || a < imin || imax < a) {
         return 0;
       }
-    } else if (std::is_signed_v<I>) {
+    } else if (std::is_signed<I>::value) {
       // conversion is from unsigned to signed
-      const auto imax = std::make_unsigned_t<I>(std::numeric_limits<I>::max());
+      const auto imax = typename std::make_unsigned<I>::type(std::numeric_limits<I>::max());
       if (imax < b || imax < a) {
         return 0;
       }
@@ -1289,8 +1290,8 @@ class ValueType : public Value {
         return 0;
       }
       // Inputs are not negative so convert them to unsigned.
-      const auto a_u = std::make_unsigned_t<decltype(a)>(a);
-      const auto b_u = std::make_unsigned_t<decltype(b)>(b);
+      const auto a_u = typename std::make_unsigned<decltype(a)>::type(a);
+      const auto b_u = typename std::make_unsigned<decltype(b)>::type(b);
       if (imax < b_u || imax < a_u) {
         return 0;
       }

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -46,7 +46,7 @@ class EXIV2API WebPImage : public Image {
   /*!
     @brief Not supported. Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   void setIptcData(const IptcData& /*iptcData*/) override;
 
   //! @name Accessors

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -46,7 +46,7 @@ class EXIV2API XmpSidecar : public Image {
     @brief Not supported. XMP sidecar files do not contain a comment.
         Calling this function will throw an instance of Error(ErrorCode::kerInvalidSettingForImage).
    */
-  void setComment(std::string_view comment) override;
+  void setComment(const std::string&) override;
   //@}
 
   //! @name Accessors

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -570,7 +570,7 @@ void BmffImage::parseCr3Preview(DataBuf& data, std::ostream& out, bool bTrace, u
   }
 }
 
-void BmffImage::setComment(std::string_view /*comment*/) {
+void BmffImage::setComment(const std::string&) {
   // bmff files are read-only
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "BMFF"));
 }

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -35,7 +35,7 @@ void BmpImage::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "BMP"));
 }
 
-void BmpImage::setComment(std::string_view /*comment*/) {
+void BmpImage::setComment(const std::string&) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "BMP"));
 }
 

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -49,7 +49,7 @@ void Cr2Image::printStructure(std::ostream& out, Exiv2::PrintStructureOption opt
   printTiffStructure(io(), out, option, depth - 1);
 }
 
-void Cr2Image::setComment(std::string_view /*comment*/) {
+void Cr2Image::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "CR2"));
 }

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1099,7 +1099,7 @@ std::string EpsImage::mimeType() const {
   return "application/postscript";
 }
 
-void EpsImage::setComment(std::string_view /*comment*/) {
+void EpsImage::setComment(const std::string&) {
   throw Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "EPS");
 }
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -79,7 +79,7 @@ char from_hex(char ch) {
   return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
 }
 
-std::string urlencode(std::string_view str) {
+std::string urlencode(const std::string& str) {
   std::string encoded;
   encoded.reserve(str.size() * 3);
   for (uint8_t c : str) {

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -29,7 +29,7 @@ void GifImage::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "GIF"));
 }
 
-void GifImage::setComment(std::string_view /*comment*/) {
+void GifImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "GIF"));
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -593,7 +593,7 @@ void Image::clearComment() {
   comment_.erase();
 }
 
-void Image::setComment(std::string_view comment) {
+void Image::setComment(const std::string& comment) {
   comment_ = comment;
 }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -123,7 +123,7 @@ std::string Jp2Image::mimeType() const {
   return "image/jp2";
 }
 
-void Jp2Image::setComment(std::string_view /*comment*/) {
+void Jp2Image::setComment(const std::string&) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "JP2"));
 }
 

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -48,7 +48,7 @@ void MrwImage::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "MRW"));
 }
 
-void MrwImage::setComment(std::string_view /*comment*/) {
+void MrwImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "MRW"));
 }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -46,7 +46,7 @@ uint32_t OrfImage::pixelHeight() const {
   return 0;
 }
 
-void OrfImage::setComment(std::string_view /*comment*/) {
+void OrfImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "ORF"));
 }

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -107,7 +107,7 @@ std::string PsdImage::mimeType() const {
   return "image/x-photoshop";
 }
 
-void PsdImage::setComment(std::string_view /*comment*/) {
+void PsdImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "Photoshop"));
 }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -52,7 +52,7 @@ void RafImage::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "RAF"));
 }
 
-void RafImage::setComment(std::string_view /*comment*/) {
+void RafImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "RAF"));
 }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -56,7 +56,7 @@ void Rw2Image::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "RW2"));
 }
 
-void Rw2Image::setComment(std::string_view /*comment*/) {
+void Rw2Image::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "RW2"));
 }

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -31,7 +31,7 @@ void TgaImage::setIptcData(const IptcData& /*iptcData*/) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "TGA"));
 }
 
-void TgaImage::setComment(std::string_view /*comment*/) {
+void TgaImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "TGA"));
 }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -119,7 +119,7 @@ uint32_t TiffImage::pixelHeight() const {
   return pixelHeightPrimary_;
 }
 
-void TiffImage::setComment(std::string_view /*comment*/) {
+void TiffImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "TIFF"));
 }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -84,7 +84,7 @@ void WebPImage::setIptcData(const IptcData& /*iptcData*/) {
   // throw(Error(ErrorCode::kerInvalidSettingForImage, "IPTC metadata", "WebP"));
 }
 
-void WebPImage::setComment(std::string_view /*comment*/) {
+void WebPImage::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "WebP"));
 }

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -33,7 +33,7 @@ std::string XmpSidecar::mimeType() const {
   return "application/rdf+xml";
 }
 
-void XmpSidecar::setComment(std::string_view /*comment*/) {
+void XmpSidecar::setComment(const std::string&) {
   // not supported
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "XMP"));
 }


### PR DESCRIPTION
I'll put this as a draft.

I tested compilation with darktable and it seems that compilation worked.

OTOH, when I look at some of the other stuff in the headers like std::remove_cv_t, that gets introduced in C++14. I need a way to test C++11 compilation of all the headers.