### PR TITLE
fix nightly release build by disabling webready and curl for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install ninja-build gettext doxygen graphviz
-          pip3 install conan==1.45.0
+          pip3 install conan==1.48.1
 
       - name: Conan common config
         run: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build packaged release
         run: |
-          cmake --preset linux-all -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+          cmake --preset linux-all -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_CURL=OFF
           cmake --build build -t doc
           cmake --build build -t package
 
@@ -105,20 +105,28 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.7
 
       - name: Install doxygen
         run: |
           choco install doxygen.install
           choco install graphviz
 
+      - name: Restore conan cache
+        uses: actions/cache@v2
+        with:
+            path: ${{github.workspace}}/conanCache
+            key: ${{runner.os}}-release-win-${{ hashFiles('conanfile.py') }}
+
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.45.0"
+          pip.exe install "conan==1.48.1"
           conan profile new --detect default
+          conan profile show default
           conan profile update settings.build_type=Release default
           conan profile update settings.compiler="Visual Studio" default
           conan profile update settings.compiler.version=17 default
+          conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
 
       - name: Run Conan
         run: |
@@ -128,9 +136,9 @@ jobs:
 
       - name: Build packaged release
         run: |
-          cmake --preset win-release -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DEXIV2_BUILD_DOC=ON
-          cmake --build build -t doc
-          cmake --build build -t package
+          cmake --preset win-release -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DEXIV2_BUILD_DOC=ON -DEXIV2_ENABLE_WEBREADY=OFF -DEXIV2_ENABLE_CURL=OFF
+          cmake --build build --parallel -t doc
+          cmake --build build --parallel -t package
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The introduction of the presets broke the nightly builds because they changed the values for 
`DEXIV2_ENABLE_WEBREADY` and `DEXIV2_ENABLE_CURL`.    

 
Linux release build now works again, but there is a build error in the Windows build that doesn't show up in the normal windows buils.  

But the workflow instructions are identical to the usual windows build... :thinking:   
I don't have a windows machine, so can't reproduce this easily...  

@piponazo do you maybe have time to look into this?