### PR TITLE
Fix build error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install ninja-build gettext doxygen graphviz
-          pip3 install conan==1.45.0
+          pip3 install conan==1.48.1
 
       - name: Conan common config
         run: |
@@ -35,7 +35,7 @@ jobs:
           mkdir build && cd build
           conan profile list
           conan profile show default
-          conan install .. -o webready=False --build missing
+          conan install .. -o webready=True --build missing
 
       - name: Build packaged release
         run: |
@@ -112,23 +112,32 @@ jobs:
           choco install doxygen.install
           choco install graphviz
 
+      - name: Restore Conan cache
+        uses: actions/cache@v2
+        with:
+            path: ${{github.workspace}}/conanCache
+            key: ${{runner.os}}-Windows-release-${{ hashFiles('conanfile.py') }}
+
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.45.0"
+          pip.exe install "conan==1.48.1"
+          conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile update settings.build_type=Release default
           conan profile update settings.compiler="Visual Studio" default
           conan profile update settings.compiler.version=17 default
+          conan config set storage.path=$Env:GITHUB_WORKSPACE/conanCache
 
       - name: Run Conan
         run: |
           md build
           cd build
+          conan profile list
           conan install .. --build missing
 
       - name: Build packaged release
         run: |
-          cmake --preset win-release -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DEXIV2_BUILD_DOC=ON
+          cmake --preset win-release -S . -B build -DEXIV2_TEAM_PACKAGING=ON -DEXIV2_BUILD_DOC=ON
           cmake --build build -t doc
           cmake --build build -t package
 


### PR DESCRIPTION
The release workflow is currently broken on Linux and Windows. The Linux failure was something about curl not being found, which I fixed by setting `webready=True`, which is consistent with other workflows like `on_PR_windows_matrix.yml`. There were two problems on Windows. The first was a versioning problem which I fixed by upgrading conan to 1.48.1 (the same as our other workflows). The second was a crash during linking. There was no error message, but I suspect it was an out-of-memory error caused by the `DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` setting.