### PR TITLE
Fix some incorrect format specifiers

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -565,7 +565,7 @@ void BmffImage::parseCr3Preview(DataBuf& data, std::ostream& out, bool bTrace, u
   nativePreviews_.push_back(nativePreview);
 
   if (bTrace) {
-    out << Internal::stringFormat("width,height,size = %u,%u,%u", nativePreview.width_, nativePreview.height_,
+    out << Internal::stringFormat("width,height,size = %zu,%zu,%zu", nativePreview.width_, nativePreview.height_,
                                   nativePreview.size_);
   }
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -381,7 +381,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
         const std::string offsetString = bOffsetIsPointer ? Internal::stringFormat("%10u", offset) : "";
 
         out << Internal::indent(depth)
-            << Internal::stringFormat("%8u | %#06x %-28s |%10s |%9u |%10s | ", address, tag, tagName(tag).c_str(),
+            << Internal::stringFormat("%8zu | %#06x %-28s |%10s |%9u |%10s | ", address, tag, tagName(tag).c_str(),
                                       typeName(type), count, offsetString.c_str());
         if (isShortType(type)) {
           for (size_t k = 0; k < kount; k++) {

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -468,7 +468,7 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, in
             DataBuf data(subBox.length - boxHSize);
             io_->read(data.data(), data.size());
             if (bPrint) {
-              out << Internal::stringFormat("%8ld | %8ld |  sub:", address, subBox.length) << toAscii(subBox.type)
+              out << Internal::stringFormat("%8zu | %8u |  sub:", address, subBox.length) << toAscii(subBox.type)
                   << " | "
                   << Internal::binaryToString(makeSlice(data, 0, std::min(static_cast<size_t>(30), data.size())));
               bLF = true;


### PR DESCRIPTION
A few incorrect format specifiers were flagged up by CodeQL. I switched to [`%zu`](https://en.cppreference.com/w/c/io/fprintf) for `size_t` values , but didn't bother with the excessively verbose `PRIu32` for the `uint32_t` values because I think `%u` will be correct on all the platforms that we support.