### PR TITLE
Eliminate some false positive results

### DIFF
--- a/.github/codeql-queries/exiv2-cpp-queries/unsafe_vector_access.ql
+++ b/.github/codeql-queries/exiv2-cpp-queries/unsafe_vector_access.ql
@@ -53,7 +53,7 @@ predicate indexK_with_fixedarray(ClassTemplateInstantiation t, ArrayIndexCall ca
     t.getSimpleName() = "array" and
     idx = call.getArgument(0) and
     lowerBound(idx) >= 0 and
-    upperBound(idx) < t.getTemplateArgument(1).(Literal).getValue().toInt()
+    upperBound(idx) < lowerBound(t.getTemplateArgument(1))
   )
 }
 


### PR DESCRIPTION
Small tweak to the CodeQL query which will hopefully eliminate quite a few false-positive results, like [this one](https://github.com/Exiv2/exiv2/security/code-scanning/760). Those false positives were happening because it wasn't correctly calculating the number of elements in a `std::array`.