### PR TITLE
Fix some "unsafe vector access" warnings

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -99,8 +99,6 @@ constexpr auto registry = std::array{
 #ifdef EXV_ENABLE_BMFF
     Registry{ImageType::bmff, newBmffInstance, isBmffType, amRead, amRead, amRead, amNone},
 #endif  // EXV_ENABLE_BMFF
-        // End of list marker
-    Registry{ImageType::none, nullptr, nullptr, amNone, amNone, amNone, amNone},
 };
 
 std::string pathOfFileUrl(const std::string& url) {
@@ -751,9 +749,9 @@ ImageType ImageFactory::getType(BasicIo& io) {
   if (io.open() != 0)
     return ImageType::none;
   IoCloser closer(io);
-  for (unsigned int i = 0; registry[i].imageType_ != ImageType::none; ++i) {
-    if (registry[i].isThisType_(io, false)) {
-      return registry[i].imageType_;
+  for (const auto& r : registry) {
+    if (r.isThisType_(io, false)) {
+      return r.imageType_;
     }
   }
   return ImageType::none;
@@ -798,9 +796,9 @@ Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io) {
   if (io->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io->path(), strError());
   }
-  for (unsigned int i = 0; registry[i].imageType_ != ImageType::none; ++i) {
-    if (registry[i].isThisType_(*io, false)) {
-      return registry[i].newInstance_(std::move(io), false);
+  for (const auto& r : registry) {
+    if (r.isThisType_(*io, false)) {
+      return r.newInstance_(std::move(io), false);
     }
   }
   return nullptr;

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -237,20 +237,13 @@ std::ostream& Nikon1MakerNote::print0x0088(std::ostream& os, const Value& value,
     os << "; ";
     const uint32_t focusPoint = value.toUint32(1);
 
-    switch (focusPoint) {
-      // Could use array nikonFocuspoints
-      case 0:
-      case 1:
-      case 2:
-      case 3:
-      case 4:
-        os << nikonFocuspoints[focusPoint];
-        break;
-      default:
-        os << value;
-        if (focusPoint < nikonFocuspoints.size())
-          os << " " << _("guess") << " " << nikonFocuspoints[focusPoint];
-        break;
+    if (focusPoint <= 4) {
+      os << nikonFocuspoints[focusPoint];
+    } else {
+      os << value;
+      if (focusPoint < nikonFocuspoints.size()) {
+        os << " " << _("guess") << " " << nikonFocuspoints[focusPoint];
+      }
     }
   }
   if (value.count() >= 3) {

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -127,10 +127,12 @@ static bool tEXtToDataBuf(const byte* bytes, size_t length, DataBuf& result) {
   static bool bFirst = true;
   if (bFirst) {
     value.fill(0);
-    const char* hexdigits = "0123456789ABCDEF";
-    for (int i = 0; i < 16; i++) {
-      value[tolower(hexdigits[i])] = i + 1;
-      value[toupper(hexdigits[i])] = i + 1;
+    for (int i = 0; i < 10; i++) {
+      value['0' + i] = i + 1;
+    }
+    for (int i = 0; i < 6; i++) {
+      value['a' + i] = i + 10 + 1;
+      value['A' + i] = i + 10 + 1;
     }
     bFirst = false;
   }

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -353,13 +353,4 @@ TEST(TheImageFactory, getsExpectedModesForXmpImages) {
   EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::xmp, mdIccProfile));
 }
 
-TEST(TheImageFactory, getsExpectedModesForNoneValue) {
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdNone));
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdExif));
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIptc));
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdXmp));
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdComment));
-  EXPECT_EQ(amNone, ImageFactory::checkMode(ImageType::none, mdIccProfile));
-}
-
 /// \todo check why JpegBase is taking ImageType in the constructor


### PR DESCRIPTION
Fix a few of the "unsafe vector access" warnings flagged by CodeQL.