### PR TITLE
Use int32_t in TimeValue

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -932,16 +932,16 @@ class EXIV2API DateValue : public Value {
   //! Default constructor.
   DateValue();
   //! Constructor
-  DateValue(int year, int month, int day);
+  DateValue(int32_t year, int32_t month, int32_t day);
   //! Virtual destructor.
   ~DateValue() override = default;
   //@}
 
   //! Simple Date helper structure
   struct EXIV2API Date {
-    int year{0};   //!< Year
-    int month{0};  //!< Month
-    int day{0};    //!< Day
+    int32_t year{0};   //!< Year
+    int32_t month{0};  //!< Month
+    int32_t day{0};    //!< Day
   };
 
   //! @name Manipulators
@@ -1025,7 +1025,7 @@ class EXIV2API TimeValue : public Value {
   //! Default constructor.
   TimeValue();
   //! Constructor
-  TimeValue(int hour, int minute, int second = 0, int tzHour = 0, int tzMinute = 0);
+  TimeValue(int32_t hour, int32_t minute, int32_t second = 0, int32_t tzHour = 0, int32_t tzMinute = 0);
 
   //! Virtual destructor.
   ~TimeValue() override = default;
@@ -1035,11 +1035,11 @@ class EXIV2API TimeValue : public Value {
   struct Time {
     Time() = default;
 
-    int hour{0};      //!< Hour
-    int minute{0};    //!< Minute
-    int second{0};    //!< Second
-    int tzHour{0};    //!< Hours ahead or behind UTC
-    int tzMinute{0};  //!< Minutes ahead or behind UTC
+    int32_t hour{0};      //!< Hour
+    int32_t minute{0};    //!< Minute
+    int32_t second{0};    //!< Second
+    int32_t tzHour{0};    //!< Hours ahead or behind UTC
+    int32_t tzMinute{0};  //!< Minutes ahead or behind UTC
   };
 
   //! @name Manipulators

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -785,7 +785,7 @@ LangAltValue* LangAltValue::clone_() const {
 DateValue::DateValue() : Value(date) {
 }
 
-DateValue::DateValue(int year, int month, int day) : Value(date) {
+DateValue::DateValue(int32_t year, int32_t month, int32_t day) : Value(date) {
   date_.year = year;
   date_.month = month;
   date_.day = day;
@@ -904,7 +904,7 @@ Rational DateValue::toRational(size_t n) const {
 TimeValue::TimeValue() : Value(time) {
 }
 
-TimeValue::TimeValue(int hour, int minute, int second, int tzHour, int tzMinute) : Value(date) {
+TimeValue::TimeValue(int32_t hour, int32_t minute, int32_t second, int32_t tzHour, int32_t tzMinute) : Value(date) {
   time_.hour = hour;
   time_.minute = minute;
   time_.second = second;


### PR DESCRIPTION
Use `int32_t` which is guaranteed to be the same size on all platforms.