### PR TITLE
Change the return type of the 2Data functions to size_t

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -277,47 +277,47 @@ EXIV2API std::istream& operator>>(std::istream& is, URational& r);
   @brief Convert an unsigned short to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long us2Data(byte* buf, uint16_t s, ByteOrder byteOrder);
+EXIV2API size_t us2Data(byte* buf, uint16_t s, ByteOrder byteOrder);
 /*!
   @brief Convert an unsigned long to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder);
+EXIV2API size_t ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder);
 /*!
   @brief Convert an uint64_t to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder);
+EXIV2API size_t ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder);
 /*!
   @brief Convert an unsigned rational to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long ur2Data(byte* buf, URational l, ByteOrder byteOrder);
+EXIV2API size_t ur2Data(byte* buf, URational l, ByteOrder byteOrder);
 /*!
   @brief Convert a signed short to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long s2Data(byte* buf, int16_t s, ByteOrder byteOrder);
+EXIV2API size_t s2Data(byte* buf, int16_t s, ByteOrder byteOrder);
 /*!
   @brief Convert a signed long to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long l2Data(byte* buf, int32_t l, ByteOrder byteOrder);
+EXIV2API size_t l2Data(byte* buf, int32_t l, ByteOrder byteOrder);
 /*!
   @brief Convert a signed rational to data, write the data to the buffer,
          return number of bytes written.
  */
-EXIV2API long r2Data(byte* buf, Rational l, ByteOrder byteOrder);
+EXIV2API size_t r2Data(byte* buf, Rational l, ByteOrder byteOrder);
 /*!
   @brief Convert a single precision floating point (IEEE 754 binary32) float
          to data, write the data to the buffer, return number of bytes written.
  */
-EXIV2API long f2Data(byte* buf, float f, ByteOrder byteOrder);
+EXIV2API size_t f2Data(byte* buf, float f, ByteOrder byteOrder);
 /*!
   @brief Convert a double precision floating point (IEEE 754 binary64) double
          to data, write the data to the buffer, return number of bytes written.
  */
-EXIV2API long d2Data(byte* buf, double d, ByteOrder byteOrder);
+EXIV2API size_t d2Data(byte* buf, double d, ByteOrder byteOrder);
 
 /*!
   @brief Print len bytes from buf in hex and ASCII format to the given

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1397,13 +1397,13 @@ inline double getValue(const byte* buf, ByteOrder byteOrder) {
   @return The number of bytes written to the buffer.
  */
 template <typename T>
-long toData(byte* buf, T t, ByteOrder byteOrder);
+size_t toData(byte* buf, T t, ByteOrder byteOrder);
 /*!
   @brief Specialization to write an unsigned short to the data buffer.
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, uint16_t t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, uint16_t t, ByteOrder byteOrder) {
   return us2Data(buf, t, byteOrder);
 }
 /*!
@@ -1411,7 +1411,7 @@ inline long toData(byte* buf, uint16_t t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, uint32_t t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, uint32_t t, ByteOrder byteOrder) {
   return ul2Data(buf, t, byteOrder);
 }
 /*!
@@ -1419,7 +1419,7 @@ inline long toData(byte* buf, uint32_t t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, URational t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, URational t, ByteOrder byteOrder) {
   return ur2Data(buf, t, byteOrder);
 }
 /*!
@@ -1427,7 +1427,7 @@ inline long toData(byte* buf, URational t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, int16_t t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, int16_t t, ByteOrder byteOrder) {
   return s2Data(buf, t, byteOrder);
 }
 /*!
@@ -1435,7 +1435,7 @@ inline long toData(byte* buf, int16_t t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, int32_t t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, int32_t t, ByteOrder byteOrder) {
   return l2Data(buf, t, byteOrder);
 }
 /*!
@@ -1443,7 +1443,7 @@ inline long toData(byte* buf, int32_t t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, Rational t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, Rational t, ByteOrder byteOrder) {
   return r2Data(buf, t, byteOrder);
 }
 /*!
@@ -1451,7 +1451,7 @@ inline long toData(byte* buf, Rational t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, float t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, float t, ByteOrder byteOrder) {
   return f2Data(buf, t, byteOrder);
 }
 /*!
@@ -1459,7 +1459,7 @@ inline long toData(byte* buf, float t, ByteOrder byteOrder) {
          Return the number of bytes written.
  */
 template <>
-inline long toData(byte* buf, double t, ByteOrder byteOrder) {
+inline size_t toData(byte* buf, double t, ByteOrder byteOrder) {
   return d2Data(buf, t, byteOrder);
 }
 

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -986,11 +986,11 @@ uint32_t TiffEntryBase::writeOffset(byte* buf, size_t offset, TiffType tiffType,
     case ttSignedShort:
       if (offset > std::numeric_limits<uint16_t>::max())
         throw Error(ErrorCode::kerOffsetOutOfRange);
-      rc = us2Data(buf, static_cast<uint16_t>(offset), byteOrder);
+      rc = static_cast<uint32_t>(us2Data(buf, static_cast<uint16_t>(offset), byteOrder));
       break;
     case ttUnsignedLong:
     case ttSignedLong:
-      rc = l2Data(buf, static_cast<uint32_t>(offset), byteOrder);
+      rc = static_cast<uint32_t>(l2Data(buf, static_cast<uint32_t>(offset), byteOrder));
       break;
     default:
       throw Error(ErrorCode::kerUnsupportedDataAreaOffsetType);
@@ -1092,10 +1092,10 @@ uint32_t TiffBinaryArray::doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, siz
     size_t elSize = TypeInfo::typeSize(toTypeId(cfg()->elTiffType_, 0, cfg()->group_));
     switch (elSize) {
       case 2:
-        idx += us2Data(buf, static_cast<uint16_t>(size()), byteOrder);
+        idx += static_cast<uint32_t>(us2Data(buf, static_cast<uint16_t>(size()), byteOrder));
         break;
       case 4:
-        idx += ul2Data(buf, static_cast<uint32_t>(size()), byteOrder);
+        idx += static_cast<uint32_t>(ul2Data(buf, static_cast<uint32_t>(size()), byteOrder));
         break;
       default:
         break;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -331,7 +331,7 @@ double getDouble(const byte* buf, ByteOrder byteOrder) {
   return u.d_;
 }
 
-long us2Data(byte* buf, uint16_t s, ByteOrder byteOrder) {
+size_t us2Data(byte* buf, uint16_t s, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     buf[0] = static_cast<byte>(s & 0x00ffU);
     buf[1] = static_cast<byte>((s & 0xff00U) >> 8);
@@ -342,7 +342,7 @@ long us2Data(byte* buf, uint16_t s, ByteOrder byteOrder) {
   return 2;
 }
 
-long ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder) {
+size_t ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     buf[0] = static_cast<byte>(l & 0x000000ffU);
     buf[1] = static_cast<byte>((l & 0x0000ff00U) >> 8);
@@ -357,7 +357,7 @@ long ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder) {
   return 4;
 }
 
-long ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder) {
+size_t ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     for (size_t i = 0; i < 8; i++) {
       buf[i] = static_cast<byte>(l & 0xff);
@@ -372,13 +372,13 @@ long ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder) {
   return 8;
 }
 
-long ur2Data(byte* buf, URational l, ByteOrder byteOrder) {
-  long o = ul2Data(buf, l.first, byteOrder);
+size_t ur2Data(byte* buf, URational l, ByteOrder byteOrder) {
+  size_t o = ul2Data(buf, l.first, byteOrder);
   o += ul2Data(buf + o, l.second, byteOrder);
   return o;
 }
 
-long s2Data(byte* buf, int16_t s, ByteOrder byteOrder) {
+size_t s2Data(byte* buf, int16_t s, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     buf[0] = static_cast<byte>(s & 0x00ffU);
     buf[1] = static_cast<byte>((s & 0xff00U) >> 8);
@@ -389,7 +389,7 @@ long s2Data(byte* buf, int16_t s, ByteOrder byteOrder) {
   return 2;
 }
 
-long l2Data(byte* buf, int32_t l, ByteOrder byteOrder) {
+size_t l2Data(byte* buf, int32_t l, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     buf[0] = static_cast<byte>(l & 0x000000ffU);
     buf[1] = static_cast<byte>((l & 0x0000ff00U) >> 8);
@@ -404,13 +404,13 @@ long l2Data(byte* buf, int32_t l, ByteOrder byteOrder) {
   return 4;
 }
 
-long r2Data(byte* buf, Rational l, ByteOrder byteOrder) {
-  long o = l2Data(buf, l.first, byteOrder);
+size_t r2Data(byte* buf, Rational l, ByteOrder byteOrder) {
+  size_t o = l2Data(buf, l.first, byteOrder);
   o += l2Data(buf + o, l.second, byteOrder);
   return o;
 }
 
-long f2Data(byte* buf, float f, ByteOrder byteOrder) {
+size_t f2Data(byte* buf, float f, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the float
   // type is the 4-byte IEEE 754 binary32 format, which is common but not
   // required by the C++ standard.
@@ -422,7 +422,7 @@ long f2Data(byte* buf, float f, ByteOrder byteOrder) {
   return ul2Data(buf, u.ul_, byteOrder);
 }
 
-long d2Data(byte* buf, double d, ByteOrder byteOrder) {
+size_t d2Data(byte* buf, double d, ByteOrder byteOrder) {
   // This algorithm assumes that the internal representation of the double
   // type is the 8-byte IEEE 754 binary64 format, which is common but not
   // required by the C++ standard.


### PR DESCRIPTION
The 2Data functions (`us2Data`, `ul2Data`, ...) return the number of bytes written, so `size_t` is more appropriate than `long`.