### PR TITLE
Convert type of depth parameter to size_t

### DIFF
--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -100,7 +100,7 @@ class EXIV2API BmffImage : public Image {
   void readMetadata() override;
   void writeMetadata() override;
   void setComment(const std::string& comment) override;
-  void printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, Exiv2::PrintStructureOption option, size_t depth) override;
   //@}
 
   //! @name Accessors
@@ -122,10 +122,7 @@ class EXIV2API BmffImage : public Image {
     @return address of next box
     @warning This function should only be called by readMetadata()
    */
-  uint64_t boxHandler(std::ostream& out, Exiv2::PrintStructureOption option, uint64_t pbox_end, int depth);
-  [[nodiscard]] static std::string indent(int i) {
-    return std::string(2 * i, ' ');
-  }
+  uint64_t boxHandler(std::ostream& out, Exiv2::PrintStructureOption option, uint64_t pbox_end, size_t depth);
 
   uint32_t fileType_{0};
   std::set<size_t> visits_;

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -56,7 +56,7 @@ class EXIV2API Cr2Image : public Image {
           not valid (does not look like data of the specific image type).
     @warning This function is not thread safe and intended for exiv2 -pS for debugging.
    */
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   /*!
     @brief Not supported. CR2 format does not contain a comment.
         Calling this function will throw an Error(ErrorCode::kerInvalidSettingForImage).

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -73,7 +73,7 @@ class EXIV2API Image {
     @warning This function is not thread safe and intended for exiv2 -pS for debugging.
     @warning You may need to put the stream into binary mode (see src/actions.cpp)
    */
-  virtual void printStructure(std::ostream& out, PrintStructureOption option = kpsNone, int depth = 0);
+  virtual void printStructure(std::ostream& out, PrintStructureOption option = kpsNone, size_t depth = 0);
   /*!
     @brief Read all metadata supported by a specific image format from the
         image. Before this method is called, the image metadata will be
@@ -293,13 +293,13 @@ class EXIV2API Image {
     @throw Error if reading of the file fails or the image data is
           not valid (does not look like data of the specific image type).
    */
-  void printTiffStructure(BasicIo& io, std::ostream& out, PrintStructureOption option, int depth, size_t offset = 0);
+  void printTiffStructure(BasicIo& io, std::ostream& out, PrintStructureOption option, size_t depth, size_t offset = 0);
 
   /*!
     @brief Print out the structure of a TIFF IFD
    */
   void printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, size_t start, bool bSwap,
-                         char c, int depth);
+                         char c, size_t depth);
 
   /*!
     @brief is the host platform bigEndian

--- a/include/exiv2/iptc.hpp
+++ b/include/exiv2/iptc.hpp
@@ -259,7 +259,7 @@ class EXIV2API IptcData {
   [[nodiscard]] const char* detectCharset() const;
 
   //!  @brief dump iptc formatted binary data (used by printStructure kpsRecursive)
-  static void printStructure(std::ostream& out, const Slice<byte*>& bytes, uint32_t depth);
+  static void printStructure(std::ostream& out, const Slice<byte*>& bytes, size_t depth);
   //@}
 
  private:

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -50,7 +50,7 @@ class EXIV2API Jp2Image : public Image {
           not valid (does not look like data of the specific image type).
     @warning This function is not thread safe and intended for exiv2 -pS for debugging.
    */
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
 
   /*!
     @brief Todo: Not supported yet(?). Calling this function will throw

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -24,7 +24,7 @@ class EXIV2API JpegBase : public Image {
   //@{
   void readMetadata() override;
   void writeMetadata() override;
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   //@}
 
   ~JpegBase() override = default;

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -52,7 +52,7 @@ class EXIV2API OrfImage : public TiffImage {
 
   //! @name Manipulators
   //@{
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   void readMetadata() override;
   void writeMetadata() override;
   /*!

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -52,7 +52,7 @@ class EXIV2API PngImage : public Image {
           not valid (does not look like data of the specific image type).
     @warning This function is not thread safe and intended for exiv2 -pS for debugging.
    */
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   //@}
 
   //! @name Accessors

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -43,7 +43,7 @@ class EXIV2API RafImage : public Image {
 
   //! @name Manipulators
   //@{
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   void readMetadata() override;
   /*!
     @brief Todo: Write metadata back to the image. This method is not

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -41,7 +41,7 @@ class EXIV2API Rw2Image : public Image {
 
   //! @name Manipulators
   //@{
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   void readMetadata() override;
   /*!
     @brief Todo: Write metadata back to the image. This method is not

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -52,7 +52,7 @@ class EXIV2API TiffImage : public Image {
           not valid (does not look like data of the specific image type).
     @warning This function is not thread safe and intended for exiv2 -p{S|R} as a file debugging aid
    */
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth = 0) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
 
   /*!
     @brief Not supported. TIFF format does not contain a comment.

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -40,7 +40,7 @@ class EXIV2API WebPImage : public Image {
   //@{
   void readMetadata() override;
   void writeMetadata() override;
-  void printStructure(std::ostream& out, PrintStructureOption option, int depth) override;
+  void printStructure(std::ostream& out, PrintStructureOption option, size_t depth) override;
   //@}
 
   /*!

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -153,7 +153,7 @@ std::string BmffImage::uuidName(Exiv2::DataBuf& uuid) {
 }
 
 uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintStructureOption option /* = kpsNone */,
-                               uint64_t pbox_end, int depth) {
+                               uint64_t pbox_end, size_t depth) {
   const size_t address = io_->tell();
   // never visit a box twice!
   if (depth == 0)
@@ -184,7 +184,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 
   if (bTrace) {
     bLF = true;
-    out << indent(depth) << "Exiv2::BmffImage::boxHandler: " << toAscii(box_type)
+    out << Internal::indent(depth) << "Exiv2::BmffImage::boxHandler: " << toAscii(box_type)
         << Internal::stringFormat(" %8ld->%" PRIu64 " ", address, box_length);
   }
 
@@ -299,14 +299,14 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
         if (ilocs_.find(exifID_) != ilocs_.end()) {
           const Iloc& iloc = ilocs_.find(exifID_)->second;
           if (bTrace) {
-            out << indent(depth) << "Exiv2::BMFF Exif: " << iloc.toString() << std::endl;
+            out << Internal::indent(depth) << "Exiv2::BMFF Exif: " << iloc.toString() << std::endl;
           }
           parseTiff(Internal::Tag::root, iloc.length_, iloc.start_);
         }
         if (ilocs_.find(xmpID_) != ilocs_.end()) {
           const Iloc& iloc = ilocs_.find(xmpID_)->second;
           if (bTrace) {
-            out << indent(depth) << "Exiv2::BMFF XMP: " << iloc.toString() << std::endl;
+            out << Internal::indent(depth) << "Exiv2::BMFF XMP: " << iloc.toString() << std::endl;
           }
           parseXmp(iloc.length_, iloc.start_);
         }
@@ -351,7 +351,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 
           uint32_t ldata = data.read_uint32(skip + step - 4, endian_);
           if (bTrace) {
-            out << indent(depth)
+            out << Internal::indent(depth)
                 << Internal::stringFormat("%8ld | %8ld |   ID | %4u | %6u,%6u", address + skip, step, ID, offset, ldata)
                 << std::endl;
           }
@@ -607,7 +607,7 @@ void BmffImage::readMetadata() {
   bReadMetadata_ = true;
 }  // BmffImage::readMetadata
 
-void BmffImage::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) {
+void BmffImage::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, size_t depth) {
   if (!bReadMetadata_)
     readMetadata();
 

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -46,7 +46,7 @@ void Cr2Image::printStructure(std::ostream& out, Exiv2::PrintStructureOption opt
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   io_->seek(0, BasicIo::beg);
-  printTiffStructure(io(), out, option, depth - 1);
+  printTiffStructure(io(), out, option, depth);
 }
 
 void Cr2Image::setComment(const std::string&) {

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -42,7 +42,7 @@ uint32_t Cr2Image::pixelHeight() const {
   return 0;
 }
 
-void Cr2Image::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) {
+void Cr2Image::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, size_t depth) {
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   io_->seek(0, BasicIo::beg);

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -362,8 +362,8 @@ void readWriteEpsMetadata(BasicIo& io, std::string& xmpPacket, NativePreviewList
   size_t posPageTrailer = posEndEps;
   size_t posEof = posEndEps;
   std::vector<std::pair<size_t, size_t>> removableEmbeddings;
-  unsigned int depth = 0;
-  const unsigned int maxDepth = UINT_MAX;
+  size_t depth = 0;
+  const size_t maxDepth = std::numeric_limits<size_t>::max();
   bool illustrator8 = false;
   bool corelDraw = false;
   bool implicitPage = false;
@@ -372,7 +372,7 @@ void readWriteEpsMetadata(BasicIo& io, std::string& xmpPacket, NativePreviewList
   bool inDefaultsPreviewPrologSetup = false;
   bool inRemovableEmbedding = false;
   std::string removableEmbeddingEndLine;
-  unsigned int removableEmbeddingsWithUnmarkedTrailer = 0;
+  size_t removableEmbeddingsWithUnmarkedTrailer = 0;
   for (size_t pos = posEps; pos < posEof;) {
     const size_t startPos = pos;
     std::string line;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -123,7 +123,7 @@ Image::Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io) 
 #endif
 }
 
-void Image::printStructure(std::ostream&, PrintStructureOption, int /*depth*/) {
+void Image::printStructure(std::ostream&, PrintStructureOption, size_t /*depth*/) {
   throw Error(ErrorCode::kerUnsupportedImageType, io_->path());
 }
 
@@ -284,7 +284,7 @@ static bool typeValid(uint16_t type) {
 static std::set<size_t> visits;  // #547
 
 void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, size_t start,
-                              bool bSwap, char c, int depth) {
+                              bool bSwap, char c, size_t depth) {
   if (depth == 1)
     visits.clear();
   bool bFirst = true;
@@ -405,7 +405,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
           for (size_t k = 0; k < count; k++) {
             const size_t restore = io.tell();
             offset = byteSwap4(buf, k * size, bSwap);
-            printIFDStructure(io, out, option, offset, bSwap, c, depth+1);
+            printIFDStructure(io, out, option, offset, bSwap, c, depth + 1);
             io.seekOrThrow(restore, BasicIo::beg, ErrorCode::kerCorruptedMetadata);
           }
         } else if (option == kpsRecursive && tag == 0x83bb /* IPTCNAA */) {
@@ -442,12 +442,12 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
             DataBuf bytes(byteslen);                                                  // allocate a buffer
             io.readOrThrow(bytes.data(), byteslen, ErrorCode::kerCorruptedMetadata);  // read
             MemIo memIo(bytes.c_data(), byteslen);                                    // create a file
-            printTiffStructure(memIo, out, option, depth+1);
+            printTiffStructure(memIo, out, option, depth + 1);
           } else {
             // tag is an IFD
             uint32_t punt = bSony ? 12 : 0;
             io.seekOrThrow(0, BasicIo::beg, ErrorCode::kerCorruptedMetadata);  // position
-            printIFDStructure(io, out, option, offset + punt, bSwap, c, depth+1);
+            printIFDStructure(io, out, option, offset + punt, bSwap, c, depth + 1);
           }
 
           io.seekOrThrow(restore, BasicIo::beg, ErrorCode::kerCorruptedMetadata);  // restore
@@ -474,7 +474,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
   out.flush();
 }
 
-void Image::printTiffStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, int depth,
+void Image::printTiffStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, size_t depth,
                                size_t offset /*=0*/) {
   if (option == kpsBasic || option == kpsXMP || option == kpsRecursive || option == kpsIccProfile) {
     // buffer

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -285,7 +285,6 @@ static std::set<size_t> visits;  // #547
 
 void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStructureOption option, size_t start,
                               bool bSwap, char c, int depth) {
-  depth++;
   if (depth == 1)
     visits.clear();
   bool bFirst = true;
@@ -406,7 +405,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
           for (size_t k = 0; k < count; k++) {
             const size_t restore = io.tell();
             offset = byteSwap4(buf, k * size, bSwap);
-            printIFDStructure(io, out, option, offset, bSwap, c, depth);
+            printIFDStructure(io, out, option, offset, bSwap, c, depth+1);
             io.seekOrThrow(restore, BasicIo::beg, ErrorCode::kerCorruptedMetadata);
           }
         } else if (option == kpsRecursive && tag == 0x83bb /* IPTCNAA */) {
@@ -448,7 +447,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
             // tag is an IFD
             uint32_t punt = bSony ? 12 : 0;
             io.seekOrThrow(0, BasicIo::beg, ErrorCode::kerCorruptedMetadata);  // position
-            printIFDStructure(io, out, option, offset + punt, bSwap, c, depth);
+            printIFDStructure(io, out, option, offset + punt, bSwap, c, depth+1);
           }
 
           io.seekOrThrow(restore, BasicIo::beg, ErrorCode::kerCorruptedMetadata);  // restore
@@ -487,7 +486,7 @@ void Image::printTiffStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruc
     auto c = dir.read_uint8(0);
     bool bSwap = (c == 'M' && isLittleEndianPlatform()) || (c == 'I' && isBigEndianPlatform());
     size_t start = byteSwap4(dir, 4, bSwap);
-    printIFDStructure(io, out, option, start + offset, bSwap, c, depth);
+    printIFDStructure(io, out, option, start + offset, bSwap, c, depth+1);
   }
 }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -442,7 +442,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
             DataBuf bytes(byteslen);                                                  // allocate a buffer
             io.readOrThrow(bytes.data(), byteslen, ErrorCode::kerCorruptedMetadata);  // read
             MemIo memIo(bytes.c_data(), byteslen);                                    // create a file
-            printTiffStructure(memIo, out, option, depth);
+            printTiffStructure(memIo, out, option, depth+1);
           } else {
             // tag is an IFD
             uint32_t punt = bSony ? 12 : 0;
@@ -486,7 +486,7 @@ void Image::printTiffStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruc
     auto c = dir.read_uint8(0);
     bool bSwap = (c == 'M' && isLittleEndianPlatform()) || (c == 'I' && isBigEndianPlatform());
     size_t start = byteSwap4(dir, 4, bSwap);
-    printIFDStructure(io, out, option, start + offset, bSwap, c, depth+1);
+    printIFDStructure(io, out, option, start + offset, bSwap, c, depth);
   }
 }
 

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -35,12 +35,8 @@ std::string stringFormat(const char* format, ...) {
   return result;
 }
 
-std::string indent(int32_t d) {
-  std::string result;
-  if (d > 0)
-    while (d--)
-      result += "  ";
-  return result;
+[[nodiscard]] std::string indent(size_t i) {
+  return std::string(2 * i, ' ');
 }
 
 }  // namespace Exiv2::Internal

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -98,7 +98,7 @@ inline binaryToStringHelper<T> binaryToString(const Slice<T> sl) noexcept {
 }
 
 /// @brief indent output for kpsRecursive in \em printStructure() \em .
-std::string indent(int32_t depth);
+std::string indent(size_t depth);
 
 }  // namespace Exiv2::Internal
 

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -275,7 +275,7 @@ IptcData::iterator IptcData::erase(IptcData::iterator pos) {
   return iptcMetadata_.erase(pos);
 }
 
-void IptcData::printStructure(std::ostream& out, const Slice<byte*>& bytes, uint32_t depth) {
+void IptcData::printStructure(std::ostream& out, const Slice<byte*>& bytes, size_t depth) {
   if (bytes.size() < 3) {
     return;
   }

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -553,7 +553,7 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, in
               const char b = rawData.read_uint8(1);
               if (a == b && (a == 'I' || a == 'M')) {
                 MemIo p(rawData.c_data(), rawData.size());
-                printTiffStructure(p, out, option, depth);
+                printTiffStructure(p, out, option, depth+1);
               }
             }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -388,7 +388,7 @@ void Jp2Image::readMetadata() {
 
 }  // Jp2Image::readMetadata
 
-void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
 
@@ -553,7 +553,7 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, in
               const char b = rawData.read_uint8(1);
               if (a == b && (a == 'I' || a == 'M')) {
                 MemIo p(rawData.c_data(), rawData.size());
-                printTiffStructure(p, out, option, depth+1);
+                printTiffStructure(p, out, option, depth + 1);
               }
             }
 

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -293,7 +293,7 @@ void JpegBase::readMetadata() {
   if ((option == kpsBasic || option == kpsRecursive)) \
   out << Internal::stringFormat("%8ld | 0xff%02x %-5s", io_->tell() - 2, marker, nm[marker].c_str())
 
-void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   // Ensure that this is the correct image type
@@ -485,7 +485,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, in
             if (start < max) {
               // create a copy on write memio object with the data, then print the structure
               MemIo p(buf.c_data(start), size - start);
-              printTiffStructure(p, out, option, depth+1);
+              printTiffStructure(p, out, option, depth + 1);
             }
           }
 

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -485,7 +485,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, in
             if (start < max) {
               // create a copy on write memio object with the data, then print the structure
               MemIo p(buf.c_data(start), size - start);
-              printTiffStructure(p, out, option, depth);
+              printTiffStructure(p, out, option, depth+1);
             }
           }
 

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -65,7 +65,7 @@ void OrfImage::printStructure(std::ostream& out, PrintStructureOption option, in
 
   io_->seek(0, BasicIo::beg);
 
-  printTiffStructure(io(), out, option, depth - 1);
+  printTiffStructure(io(), out, option, depth);
 }  // OrfImage::printStructure
 
 void OrfImage::readMetadata() {

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -51,7 +51,7 @@ void OrfImage::setComment(const std::string&) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "ORF"));
 }
 
-void OrfImage::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void OrfImage::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   out << "ORF IMAGE" << std::endl;
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -330,7 +330,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, in
               if (bExif) {
                 // create memio object with the data, then print the structure
                 MemIo p(parsedBuf.c_data(6), parsedBuf.size() - 6);
-                printTiffStructure(p, out, option, depth);
+                printTiffStructure(p, out, option, depth+1);
               }
               if (bIptc) {
                 IptcData::printStructure(out, makeSlice(parsedBuf, 0, parsedBuf.size()), depth);
@@ -361,7 +361,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, in
           if (eXIf && option == kpsRecursive) {
             // create memio object with the data, then print the structure
             MemIo p(data.c_data(), dataOffset);
-            printTiffStructure(p, out, option, depth);
+            printTiffStructure(p, out, option, depth+1);
           }
 
           if (bLF)

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -178,7 +178,7 @@ std::string::size_type findi(const std::string& str, const std::string& substr) 
   return str.find(substr);
 }
 
-void PngImage::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void PngImage::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   }
@@ -330,7 +330,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, in
               if (bExif) {
                 // create memio object with the data, then print the structure
                 MemIo p(parsedBuf.c_data(6), parsedBuf.size() - 6);
-                printTiffStructure(p, out, option, depth+1);
+                printTiffStructure(p, out, option, depth + 1);
               }
               if (bIptc) {
                 IptcData::printStructure(out, makeSlice(parsedBuf, 0, parsedBuf.size()), depth);
@@ -361,7 +361,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, in
           if (eXIf && option == kpsRecursive) {
             // create memio object with the data, then print the structure
             MemIo p(data.c_data(), dataOffset);
-            printTiffStructure(p, out, option, depth+1);
+            printTiffStructure(p, out, option, depth + 1);
           }
 
           if (bLF)

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -57,7 +57,7 @@ void RafImage::setComment(const std::string&) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "RAF"));
 }
 
-void RafImage::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void RafImage::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -61,7 +61,7 @@ void Rw2Image::setComment(const std::string&) {
   throw(Error(ErrorCode::kerInvalidSettingForImage, "Image comment", "RW2"));
 }
 
-void Rw2Image::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void Rw2Image::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   out << "RW2 IMAGE" << std::endl;
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -75,7 +75,7 @@ void Rw2Image::printStructure(std::ostream& out, PrintStructureOption option, in
 
   io_->seek(0, BasicIo::beg);
 
-  printTiffStructure(io(), out, option, depth - 1);
+  printTiffStructure(io(), out, option, depth);
 }  // Rw2Image::printStructure
 
 void Rw2Image::readMetadata() {

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -276,7 +276,7 @@ void TiffImage::printStructure(std::ostream& out, Exiv2::PrintStructureOption op
 
   io_->seek(0, BasicIo::beg);
 
-  printTiffStructure(io(), out, option, depth - 1);
+  printTiffStructure(io(), out, option, depth);
 }
 
 }  // namespace Exiv2

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -262,7 +262,7 @@ bool isTiffType(BasicIo& iIo, bool advance) {
   return rc;
 }
 
-void TiffImage::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, int depth) {
+void TiffImage::printStructure(std::ostream& out, Exiv2::PrintStructureOption option, size_t depth) {
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   // Ensure that this is the correct image type

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -407,7 +407,7 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
 
 /* =========================================== */
 
-void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, int depth) {
+void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   }
@@ -450,7 +450,7 @@ void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, i
       if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option == kpsRecursive) {
         // create memio object with the payload, then print the structure
         MemIo p(payload.c_data(), payload.size());
-        printTiffStructure(p, out, option, depth+1);
+        printTiffStructure(p, out, option, depth + 1);
       }
 
       bool bPrintPayload = (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP) && option == kpsXMP) ||

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -450,7 +450,7 @@ void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, i
       if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option == kpsRecursive) {
         // create memio object with the payload, then print the structure
         MemIo p(payload.c_data(), payload.size());
-        printTiffStructure(p, out, option, depth);
+        printTiffStructure(p, out, option, depth+1);
       }
 
       bool bPrintPayload = (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP) && option == kpsXMP) ||


### PR DESCRIPTION
The `depth` parameter is the number of spaces to indent by, so it cannot be negative. `size_t` seems a more appropriate type than `int`.

I also did some refactoring to ensure that we never subtract from depth. (See the 1st and 2nd commit.)