### PR TITLE
remove friend operator

### DIFF
--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -65,8 +65,6 @@ struct binaryToStringHelper {
   explicit binaryToStringHelper(const Slice<T> myBuf) noexcept : buf_(myBuf) {
   }
 
-  friend std::ostream& operator<<<T>(std::ostream& stream, const binaryToStringHelper<T>& binToStr);
-
   // the Slice is stored by value to avoid dangling references, in case we
   // invoke:
   // binaryToString(makeSlice(buf, 0, n));


### PR DESCRIPTION
Seems to be unused. It's also inconsistent between various clang-format
versions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>