### PR TITLE
Use size_t for the offset argument in TiffComponent

### DIFF
--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -1416,7 +1416,7 @@ size_t TiffImageEntry::doSizeData() const {
 size_t TiffDataEntry::doSizeData() const {
   if (!pValue())
     return 0;
-  return static_cast<uint32_t>(pValue()->sizeDataArea());
+  return pValue()->sizeDataArea();
 }
 
 size_t TiffSubIfd::doSizeData() const {

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -703,8 +703,8 @@ class TiffDataEntry : public TiffDataEntryBase {
 
  private:
   // DATA
-  byte* pDataArea_{};        //!< Pointer to the data area (never alloc'd)
-  size_t sizeDataArea_{};    //!< Size of the data area
+  byte* pDataArea_{};      //!< Pointer to the data area (never alloc'd)
+  size_t sizeDataArea_{};  //!< Size of the data area
 
 };  // class TiffDataEntry
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -772,7 +772,7 @@ class TiffImageEntry : public TiffDataEntryBase {
 
  private:
   //! Pointers to the image data (strips) and their sizes.
-  using Strips = std::vector<std::pair<const byte*, uint32_t>>;
+  using Strips = std::vector<std::pair<const byte*, size_t>>;
 
   // DATA
   Strips strips_;  //!< Image strips data (never alloc'd) and sizes

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -704,7 +704,7 @@ class TiffDataEntry : public TiffDataEntryBase {
  private:
   // DATA
   byte* pDataArea_{};        //!< Pointer to the data area (never alloc'd)
-  uint32_t sizeDataArea_{};  //!< Size of the data area
+  size_t sizeDataArea_{};    //!< Size of the data area
 
 };  // class TiffDataEntry
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -129,7 +129,7 @@ class IoWrapper {
    */
   int putb(byte data);
   //! Wrapper for OffsetWriter::setTarget(), using an int instead of the enum to reduce include deps
-  void setTarget(int id, int64_t target);
+  void setTarget(int id, size_t target);
   //@}
 
  private:
@@ -221,7 +221,7 @@ class TiffComponent {
                       nested components.
     @throw            Error If the component cannot be written.
    */
-  uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t write(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                  uint32_t& imageIdx);
   //@}
 
@@ -250,7 +250,7 @@ class TiffComponent {
            Return the number of bytes written. Components derived from
            TiffEntryBase implement this method if needed.
    */
-  uint32_t writeData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t writeData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                      uint32_t& imageIdx) const;
   /*!
     @brief Write the image data of this component to a binary image.
@@ -302,7 +302,7 @@ class TiffComponent {
   //! Implements accept().
   virtual void doAccept(TiffVisitor& visitor) = 0;
   //! Implements write().
-  virtual uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx,
+  virtual uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx,
                            uint32_t dataIdx, uint32_t& imageIdx) = 0;
   //@}
 
@@ -311,7 +311,7 @@ class TiffComponent {
   //! Internal virtual copy constructor, implements clone().
   [[nodiscard]] virtual TiffComponent* doClone() const = 0;
   //! Implements writeData().
-  virtual uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  virtual uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                                uint32_t& imageIdx) const = 0;
   //! Implements writeImage().
   virtual uint32_t doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const = 0;
@@ -410,7 +410,7 @@ class TiffEntryBase : public TiffComponent {
    */
   void encode(TiffEncoder& encoder, const Exifdatum* datum);
   //! Set the offset
-  void setOffset(int64_t offset) {
+  void setOffset(size_t offset) {
     offset_ = offset;
   }
   /*!
@@ -459,7 +459,7 @@ class TiffEntryBase : public TiffComponent {
     @brief Return the offset to the data area relative to the base
            for the component (usually the start of the TIFF header)
    */
-  [[nodiscard]] int64_t offset() const {
+  [[nodiscard]] size_t offset() const {
     return offset_;
   }
   /*!
@@ -503,7 +503,7 @@ class TiffEntryBase : public TiffComponent {
            the \em ioWrapper, return the number of bytes written. Only the
            \em ioWrapper and \em byteOrder arguments are used.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -515,7 +515,7 @@ class TiffEntryBase : public TiffComponent {
     @brief Implements writeData(). Standard TIFF entries have no data:
            write nothing and return 0.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   /*!
     @brief Implements writeImage(). Standard TIFF entries have no image data:
@@ -531,7 +531,7 @@ class TiffEntryBase : public TiffComponent {
   //@}
 
   //! Helper function to write an \em offset to a preallocated binary buffer
-  static uint32_t writeOffset(byte* buf, int64_t offset, TiffType tiffType, ByteOrder byteOrder);
+  static uint32_t writeOffset(byte* buf, size_t offset, TiffType tiffType, ByteOrder byteOrder);
 
   //! Used (internally) to create another reference to the DataBuf reference by storage_.
   [[nodiscard]] const std::shared_ptr<DataBuf>& storage() const {
@@ -542,7 +542,7 @@ class TiffEntryBase : public TiffComponent {
   // DATA
   TiffType tiffType_;  //!< Field TIFF type
   size_t count_{};     //!< The number of values of the indicated type
-  int64_t offset_{};   //!< Offset to the data area
+  size_t offset_{};    //!< Offset to the data area
   size_t size_{};      //!< Size of the data buffer holding the value in bytes, there is no minimum size.
 
   // Notes on the ownership model of pData_: pData_ is a always a
@@ -681,7 +681,7 @@ class TiffDataEntry : public TiffDataEntryBase {
     on write. The type of the value can only be signed or unsigned short or
     long.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -692,7 +692,7 @@ class TiffDataEntry : public TiffDataEntryBase {
     @brief Implements writeData(). Write the data area to the \em ioWrapper.
            Return the number of bytes written.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   // Using doWriteImage from base class
   // Using doSize() from base class
@@ -740,7 +740,7 @@ class TiffImageEntry : public TiffDataEntryBase {
            \em ioWrapper. Return the number of bytes written. The \em valueIdx
            and \em dataIdx  arguments are not used.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -755,7 +755,7 @@ class TiffImageEntry : public TiffDataEntryBase {
     directory. It is used for TIFF image entries in the makernote (large
     preview images) so that the image data remains in the makernote IFD.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   /*!
     @brief Implements writeImage(). Write the image data area to the \em ioWrapper.
@@ -879,7 +879,7 @@ class TiffDirectory : public TiffComponent {
            additional data, including the next-IFD, if any, to the
            \em ioWrapper, return the number of bytes written.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -890,7 +890,7 @@ class TiffDirectory : public TiffComponent {
     @brief This class does not really implement writeData(), it only has
            write(). This method must not be called; it commits suicide.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   /*!
     @brief Implements writeImage(). Write the image data of the TIFF
@@ -925,8 +925,8 @@ class TiffDirectory : public TiffComponent {
   //! @name Private Accessors
   //@{
   //! Write a binary directory entry for a TIFF component.
-  static uint32_t writeDirEntry(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset,
-                                TiffComponent* pTiffComponent, uint32_t valueIdx, uint32_t dataIdx, uint32_t& imageIdx);
+  static uint32_t writeDirEntry(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, TiffComponent* pTiffComponent,
+                                uint32_t valueIdx, uint32_t dataIdx, uint32_t& imageIdx);
   //@}
 
   // DATA
@@ -975,7 +975,7 @@ class TiffSubIfd : public TiffEntryBase {
            return the number of bytes written. The \em valueIdx and
            \em imageIdx arguments are not used.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -986,7 +986,7 @@ class TiffSubIfd : public TiffEntryBase {
     @brief Implements writeData(). Write the sub-IFDs to the \em ioWrapper.
            Return the number of bytes written.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   /*!
     @brief Implements writeImage(). Write the image data of each sub-IFD to
@@ -1053,7 +1053,7 @@ class TiffMnEntry : public TiffEntryBase {
     @brief Implements write() by forwarding the call to the actual
            concrete Makernote, if there is one.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -1186,7 +1186,7 @@ class TiffIfdMakernote : public TiffComponent {
            values and additional data to the \em ioWrapper, return the
            number of bytes written.
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -1197,7 +1197,7 @@ class TiffIfdMakernote : public TiffComponent {
     @brief This class does not really implement writeData(), it only has
            write(). This method must not be called; it commits suicide.
    */
-  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t dataIdx,
+  uint32_t doWriteData(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t dataIdx,
                        uint32_t& imageIdx) const override;
   /*!
     @brief Implements writeImage(). Write the image data of the IFD of
@@ -1384,7 +1384,7 @@ class TiffBinaryArray : public TiffEntryBase {
   /*!
     @brief Implements write(). Todo: Document it!
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 
@@ -1472,7 +1472,7 @@ class TiffBinaryElement : public TiffEntryBase {
   /*!
     @brief Implements write(). Todo: Document it!
    */
-  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, int64_t offset, uint32_t valueIdx, uint32_t dataIdx,
+  uint32_t doWrite(IoWrapper& ioWrapper, ByteOrder byteOrder, size_t offset, uint32_t valueIdx, uint32_t dataIdx,
                    uint32_t& imageIdx) override;
   //@}
 


### PR DESCRIPTION
The `offset` parameter in the methods of `TiffComponent` is never negative, so I think `size_t` is a better type than `int64_t`.