### PR TITLE
Use std::map for faster lookup

### DIFF
--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1227,551 +1227,551 @@ const TiffTreeStruct TiffCreator::tiffTreeStruct_[] = {
   the corresponding TIFF component create function.
  */
 #define ignoreTiffComponent 0
-const TiffGroupStruct TiffCreator::tiffGroupStruct_[] = {
+const TiffGroupTable TiffCreator::tiffGroupTable_ = {
     // ext. tag  group             create function
     //---------  ----------------- -----------------------------------------
     // Root directory
-    {Tag::root, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::ifd0Id>},
+    {{Tag::root, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::ifd0Id>},
 
     // Fujifilm RAF #1402.  Use different root when parsing embedded tiff.
-    {Tag::fuji, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::fujiId>},
-    {0xf000, IfdId::fujiId, newTiffSubIfd<IfdId::fujiId>},
+    {{Tag::fuji, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::fujiId>},
+    {{0xf000, IfdId::fujiId}, newTiffSubIfd<IfdId::fujiId>},
 
     // CR3 images #1475
-    {Tag::cmt2, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::exifId>},
-    {Tag::cmt3, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::canonId>},
-    {Tag::cmt4, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::gpsId>},
+    {{Tag::cmt2, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::exifId>},
+    {{Tag::cmt3, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::canonId>},
+    {{Tag::cmt4, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::gpsId>},
 
     // IFD0
-    {0x8769, IfdId::ifd0Id, newTiffSubIfd<IfdId::exifId>},
-    {0x8825, IfdId::ifd0Id, newTiffSubIfd<IfdId::gpsId>},
-    {0x0111, IfdId::ifd0Id, newTiffImageData<0x0117, IfdId::ifd0Id>},
-    {0x0117, IfdId::ifd0Id, newTiffImageSize<0x0111, IfdId::ifd0Id>},
-    {0x0144, IfdId::ifd0Id, newTiffImageData<0x0145, IfdId::ifd0Id>},
-    {0x0145, IfdId::ifd0Id, newTiffImageSize<0x0144, IfdId::ifd0Id>},
-    {0x0201, IfdId::ifd0Id, newTiffImageData<0x0202, IfdId::ifd0Id>},
-    {0x0202, IfdId::ifd0Id, newTiffImageSize<0x0201, IfdId::ifd0Id>},
-    {0x014a, IfdId::ifd0Id, newTiffSubIfd<IfdId::subImage1Id>},
-    {0xc634, IfdId::ifd0Id, newTiffMnEntry},
-    {Tag::next, IfdId::ifd0Id, newTiffDirectory<IfdId::ifd1Id>},
-    {Tag::all, IfdId::ifd0Id, newTiffEntry},
+    {{0x8769, IfdId::ifd0Id}, newTiffSubIfd<IfdId::exifId>},
+    {{0x8825, IfdId::ifd0Id}, newTiffSubIfd<IfdId::gpsId>},
+    {{0x0111, IfdId::ifd0Id}, newTiffImageData<0x0117, IfdId::ifd0Id>},
+    {{0x0117, IfdId::ifd0Id}, newTiffImageSize<0x0111, IfdId::ifd0Id>},
+    {{0x0144, IfdId::ifd0Id}, newTiffImageData<0x0145, IfdId::ifd0Id>},
+    {{0x0145, IfdId::ifd0Id}, newTiffImageSize<0x0144, IfdId::ifd0Id>},
+    {{0x0201, IfdId::ifd0Id}, newTiffImageData<0x0202, IfdId::ifd0Id>},
+    {{0x0202, IfdId::ifd0Id}, newTiffImageSize<0x0201, IfdId::ifd0Id>},
+    {{0x014a, IfdId::ifd0Id}, newTiffSubIfd<IfdId::subImage1Id>},
+    {{0xc634, IfdId::ifd0Id}, newTiffMnEntry},
+    {{Tag::next, IfdId::ifd0Id}, newTiffDirectory<IfdId::ifd1Id>},
+    {{Tag::all, IfdId::ifd0Id}, newTiffEntry},
 
     // Subdir subImage1
-    {0x0111, IfdId::subImage1Id, newTiffImageData<0x0117, IfdId::subImage1Id>},
-    {0x0117, IfdId::subImage1Id, newTiffImageSize<0x0111, IfdId::subImage1Id>},
-    {0x0144, IfdId::subImage1Id, newTiffImageData<0x0145, IfdId::subImage1Id>},
-    {0x0145, IfdId::subImage1Id, newTiffImageSize<0x0144, IfdId::subImage1Id>},
-    {0x0201, IfdId::subImage1Id, newTiffImageData<0x0202, IfdId::subImage1Id>},
-    {0x0202, IfdId::subImage1Id, newTiffImageSize<0x0201, IfdId::subImage1Id>},
-    {Tag::next, IfdId::subImage1Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage1Id, newTiffEntry},
+    {{0x0111, IfdId::subImage1Id}, newTiffImageData<0x0117, IfdId::subImage1Id>},
+    {{0x0117, IfdId::subImage1Id}, newTiffImageSize<0x0111, IfdId::subImage1Id>},
+    {{0x0144, IfdId::subImage1Id}, newTiffImageData<0x0145, IfdId::subImage1Id>},
+    {{0x0145, IfdId::subImage1Id}, newTiffImageSize<0x0144, IfdId::subImage1Id>},
+    {{0x0201, IfdId::subImage1Id}, newTiffImageData<0x0202, IfdId::subImage1Id>},
+    {{0x0202, IfdId::subImage1Id}, newTiffImageSize<0x0201, IfdId::subImage1Id>},
+    {{Tag::next, IfdId::subImage1Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage1Id}, newTiffEntry},
 
     // Subdir subImage2
-    {0x0111, IfdId::subImage2Id, newTiffImageData<0x0117, IfdId::subImage2Id>},
-    {0x0117, IfdId::subImage2Id, newTiffImageSize<0x0111, IfdId::subImage2Id>},
-    {0x0144, IfdId::subImage2Id, newTiffImageData<0x0145, IfdId::subImage2Id>},
-    {0x0145, IfdId::subImage2Id, newTiffImageSize<0x0144, IfdId::subImage2Id>},
-    {0x0201, IfdId::subImage2Id, newTiffImageData<0x0202, IfdId::subImage2Id>},
-    {0x0202, IfdId::subImage2Id, newTiffImageSize<0x0201, IfdId::subImage2Id>},
-    {Tag::next, IfdId::subImage2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage2Id, newTiffEntry},
+    {{0x0111, IfdId::subImage2Id}, newTiffImageData<0x0117, IfdId::subImage2Id>},
+    {{0x0117, IfdId::subImage2Id}, newTiffImageSize<0x0111, IfdId::subImage2Id>},
+    {{0x0144, IfdId::subImage2Id}, newTiffImageData<0x0145, IfdId::subImage2Id>},
+    {{0x0145, IfdId::subImage2Id}, newTiffImageSize<0x0144, IfdId::subImage2Id>},
+    {{0x0201, IfdId::subImage2Id}, newTiffImageData<0x0202, IfdId::subImage2Id>},
+    {{0x0202, IfdId::subImage2Id}, newTiffImageSize<0x0201, IfdId::subImage2Id>},
+    {{Tag::next, IfdId::subImage2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage2Id}, newTiffEntry},
 
     // Subdir subImage3
-    {0x0111, IfdId::subImage3Id, newTiffImageData<0x0117, IfdId::subImage3Id>},
-    {0x0117, IfdId::subImage3Id, newTiffImageSize<0x0111, IfdId::subImage3Id>},
-    {0x0144, IfdId::subImage3Id, newTiffImageData<0x0145, IfdId::subImage3Id>},
-    {0x0145, IfdId::subImage3Id, newTiffImageSize<0x0144, IfdId::subImage3Id>},
-    {0x0201, IfdId::subImage3Id, newTiffImageData<0x0202, IfdId::subImage3Id>},
-    {0x0202, IfdId::subImage3Id, newTiffImageSize<0x0201, IfdId::subImage3Id>},
-    {Tag::next, IfdId::subImage3Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage3Id, newTiffEntry},
+    {{0x0111, IfdId::subImage3Id}, newTiffImageData<0x0117, IfdId::subImage3Id>},
+    {{0x0117, IfdId::subImage3Id}, newTiffImageSize<0x0111, IfdId::subImage3Id>},
+    {{0x0144, IfdId::subImage3Id}, newTiffImageData<0x0145, IfdId::subImage3Id>},
+    {{0x0145, IfdId::subImage3Id}, newTiffImageSize<0x0144, IfdId::subImage3Id>},
+    {{0x0201, IfdId::subImage3Id}, newTiffImageData<0x0202, IfdId::subImage3Id>},
+    {{0x0202, IfdId::subImage3Id}, newTiffImageSize<0x0201, IfdId::subImage3Id>},
+    {{Tag::next, IfdId::subImage3Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage3Id}, newTiffEntry},
 
     // Subdir subImage4
-    {0x0111, IfdId::subImage4Id, newTiffImageData<0x0117, IfdId::subImage4Id>},
-    {0x0117, IfdId::subImage4Id, newTiffImageSize<0x0111, IfdId::subImage4Id>},
-    {0x0144, IfdId::subImage4Id, newTiffImageData<0x0145, IfdId::subImage4Id>},
-    {0x0145, IfdId::subImage4Id, newTiffImageSize<0x0144, IfdId::subImage4Id>},
-    {0x0201, IfdId::subImage4Id, newTiffImageData<0x0202, IfdId::subImage4Id>},
-    {0x0202, IfdId::subImage4Id, newTiffImageSize<0x0201, IfdId::subImage4Id>},
-    {Tag::next, IfdId::subImage4Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage4Id, newTiffEntry},
+    {{0x0111, IfdId::subImage4Id}, newTiffImageData<0x0117, IfdId::subImage4Id>},
+    {{0x0117, IfdId::subImage4Id}, newTiffImageSize<0x0111, IfdId::subImage4Id>},
+    {{0x0144, IfdId::subImage4Id}, newTiffImageData<0x0145, IfdId::subImage4Id>},
+    {{0x0145, IfdId::subImage4Id}, newTiffImageSize<0x0144, IfdId::subImage4Id>},
+    {{0x0201, IfdId::subImage4Id}, newTiffImageData<0x0202, IfdId::subImage4Id>},
+    {{0x0202, IfdId::subImage4Id}, newTiffImageSize<0x0201, IfdId::subImage4Id>},
+    {{Tag::next, IfdId::subImage4Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage4Id}, newTiffEntry},
 
     // Subdir subImage5
-    {0x0111, IfdId::subImage5Id, newTiffImageData<0x0117, IfdId::subImage5Id>},
-    {0x0117, IfdId::subImage5Id, newTiffImageSize<0x0111, IfdId::subImage5Id>},
-    {0x0144, IfdId::subImage5Id, newTiffImageData<0x0145, IfdId::subImage5Id>},
-    {0x0145, IfdId::subImage5Id, newTiffImageSize<0x0144, IfdId::subImage5Id>},
-    {0x0201, IfdId::subImage5Id, newTiffImageData<0x0202, IfdId::subImage5Id>},
-    {0x0202, IfdId::subImage5Id, newTiffImageSize<0x0201, IfdId::subImage5Id>},
-    {Tag::next, IfdId::subImage5Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage5Id, newTiffEntry},
+    {{0x0111, IfdId::subImage5Id}, newTiffImageData<0x0117, IfdId::subImage5Id>},
+    {{0x0117, IfdId::subImage5Id}, newTiffImageSize<0x0111, IfdId::subImage5Id>},
+    {{0x0144, IfdId::subImage5Id}, newTiffImageData<0x0145, IfdId::subImage5Id>},
+    {{0x0145, IfdId::subImage5Id}, newTiffImageSize<0x0144, IfdId::subImage5Id>},
+    {{0x0201, IfdId::subImage5Id}, newTiffImageData<0x0202, IfdId::subImage5Id>},
+    {{0x0202, IfdId::subImage5Id}, newTiffImageSize<0x0201, IfdId::subImage5Id>},
+    {{Tag::next, IfdId::subImage5Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage5Id}, newTiffEntry},
 
     // Subdir subImage6
-    {0x0111, IfdId::subImage6Id, newTiffImageData<0x0117, IfdId::subImage6Id>},
-    {0x0117, IfdId::subImage6Id, newTiffImageSize<0x0111, IfdId::subImage6Id>},
-    {0x0144, IfdId::subImage6Id, newTiffImageData<0x0145, IfdId::subImage6Id>},
-    {0x0145, IfdId::subImage6Id, newTiffImageSize<0x0144, IfdId::subImage6Id>},
-    {0x0201, IfdId::subImage6Id, newTiffImageData<0x0202, IfdId::subImage6Id>},
-    {0x0202, IfdId::subImage6Id, newTiffImageSize<0x0201, IfdId::subImage6Id>},
-    {Tag::next, IfdId::subImage6Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage6Id, newTiffEntry},
+    {{0x0111, IfdId::subImage6Id}, newTiffImageData<0x0117, IfdId::subImage6Id>},
+    {{0x0117, IfdId::subImage6Id}, newTiffImageSize<0x0111, IfdId::subImage6Id>},
+    {{0x0144, IfdId::subImage6Id}, newTiffImageData<0x0145, IfdId::subImage6Id>},
+    {{0x0145, IfdId::subImage6Id}, newTiffImageSize<0x0144, IfdId::subImage6Id>},
+    {{0x0201, IfdId::subImage6Id}, newTiffImageData<0x0202, IfdId::subImage6Id>},
+    {{0x0202, IfdId::subImage6Id}, newTiffImageSize<0x0201, IfdId::subImage6Id>},
+    {{Tag::next, IfdId::subImage6Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage6Id}, newTiffEntry},
 
     // Subdir subImage7
-    {0x0111, IfdId::subImage7Id, newTiffImageData<0x0117, IfdId::subImage7Id>},
-    {0x0117, IfdId::subImage7Id, newTiffImageSize<0x0111, IfdId::subImage7Id>},
-    {0x0144, IfdId::subImage7Id, newTiffImageData<0x0145, IfdId::subImage7Id>},
-    {0x0145, IfdId::subImage7Id, newTiffImageSize<0x0144, IfdId::subImage7Id>},
-    {0x0201, IfdId::subImage7Id, newTiffImageData<0x0202, IfdId::subImage7Id>},
-    {0x0202, IfdId::subImage7Id, newTiffImageSize<0x0201, IfdId::subImage7Id>},
-    {Tag::next, IfdId::subImage7Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage7Id, newTiffEntry},
+    {{0x0111, IfdId::subImage7Id}, newTiffImageData<0x0117, IfdId::subImage7Id>},
+    {{0x0117, IfdId::subImage7Id}, newTiffImageSize<0x0111, IfdId::subImage7Id>},
+    {{0x0144, IfdId::subImage7Id}, newTiffImageData<0x0145, IfdId::subImage7Id>},
+    {{0x0145, IfdId::subImage7Id}, newTiffImageSize<0x0144, IfdId::subImage7Id>},
+    {{0x0201, IfdId::subImage7Id}, newTiffImageData<0x0202, IfdId::subImage7Id>},
+    {{0x0202, IfdId::subImage7Id}, newTiffImageSize<0x0201, IfdId::subImage7Id>},
+    {{Tag::next, IfdId::subImage7Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage7Id}, newTiffEntry},
 
     // Subdir subImage8
-    {0x0111, IfdId::subImage8Id, newTiffImageData<0x0117, IfdId::subImage8Id>},
-    {0x0117, IfdId::subImage8Id, newTiffImageSize<0x0111, IfdId::subImage8Id>},
-    {0x0144, IfdId::subImage8Id, newTiffImageData<0x0145, IfdId::subImage8Id>},
-    {0x0145, IfdId::subImage8Id, newTiffImageSize<0x0144, IfdId::subImage8Id>},
-    {0x0201, IfdId::subImage8Id, newTiffImageData<0x0202, IfdId::subImage8Id>},
-    {0x0202, IfdId::subImage8Id, newTiffImageSize<0x0201, IfdId::subImage8Id>},
-    {Tag::next, IfdId::subImage8Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage8Id, newTiffEntry},
+    {{0x0111, IfdId::subImage8Id}, newTiffImageData<0x0117, IfdId::subImage8Id>},
+    {{0x0117, IfdId::subImage8Id}, newTiffImageSize<0x0111, IfdId::subImage8Id>},
+    {{0x0144, IfdId::subImage8Id}, newTiffImageData<0x0145, IfdId::subImage8Id>},
+    {{0x0145, IfdId::subImage8Id}, newTiffImageSize<0x0144, IfdId::subImage8Id>},
+    {{0x0201, IfdId::subImage8Id}, newTiffImageData<0x0202, IfdId::subImage8Id>},
+    {{0x0202, IfdId::subImage8Id}, newTiffImageSize<0x0201, IfdId::subImage8Id>},
+    {{Tag::next, IfdId::subImage8Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage8Id}, newTiffEntry},
 
     // Subdir subImage9
-    {0x0111, IfdId::subImage9Id, newTiffImageData<0x0117, IfdId::subImage9Id>},
-    {0x0117, IfdId::subImage9Id, newTiffImageSize<0x0111, IfdId::subImage9Id>},
-    {0x0144, IfdId::subImage9Id, newTiffImageData<0x0145, IfdId::subImage9Id>},
-    {0x0145, IfdId::subImage9Id, newTiffImageSize<0x0144, IfdId::subImage9Id>},
-    {0x0201, IfdId::subImage9Id, newTiffImageData<0x0202, IfdId::subImage9Id>},
-    {0x0202, IfdId::subImage9Id, newTiffImageSize<0x0201, IfdId::subImage9Id>},
-    {Tag::next, IfdId::subImage9Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subImage9Id, newTiffEntry},
+    {{0x0111, IfdId::subImage9Id}, newTiffImageData<0x0117, IfdId::subImage9Id>},
+    {{0x0117, IfdId::subImage9Id}, newTiffImageSize<0x0111, IfdId::subImage9Id>},
+    {{0x0144, IfdId::subImage9Id}, newTiffImageData<0x0145, IfdId::subImage9Id>},
+    {{0x0145, IfdId::subImage9Id}, newTiffImageSize<0x0144, IfdId::subImage9Id>},
+    {{0x0201, IfdId::subImage9Id}, newTiffImageData<0x0202, IfdId::subImage9Id>},
+    {{0x0202, IfdId::subImage9Id}, newTiffImageSize<0x0201, IfdId::subImage9Id>},
+    {{Tag::next, IfdId::subImage9Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subImage9Id}, newTiffEntry},
 
     // Exif subdir
-    {0xa005, IfdId::exifId, newTiffSubIfd<IfdId::iopId>},
-    {0x927c, IfdId::exifId, newTiffMnEntry},
-    {Tag::next, IfdId::exifId, ignoreTiffComponent},
-    {Tag::all, IfdId::exifId, newTiffEntry},
+    {{0xa005, IfdId::exifId}, newTiffSubIfd<IfdId::iopId>},
+    {{0x927c, IfdId::exifId}, newTiffMnEntry},
+    {{Tag::next, IfdId::exifId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::exifId}, newTiffEntry},
 
     // GPS subdir
-    {Tag::next, IfdId::gpsId, ignoreTiffComponent},
-    {Tag::all, IfdId::gpsId, newTiffEntry},
+    {{Tag::next, IfdId::gpsId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::gpsId}, newTiffEntry},
 
     // IOP subdir
-    {Tag::next, IfdId::iopId, ignoreTiffComponent},
-    {Tag::all, IfdId::iopId, newTiffEntry},
+    {{Tag::next, IfdId::iopId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::iopId}, newTiffEntry},
 
     // IFD1
-    {0x0111, IfdId::ifd1Id, newTiffThumbData<0x0117, IfdId::ifd1Id>},
-    {0x0117, IfdId::ifd1Id, newTiffThumbSize<0x0111, IfdId::ifd1Id>},
-    {0x0144, IfdId::ifd1Id, newTiffImageData<0x0145, IfdId::ifd1Id>},
-    {0x0145, IfdId::ifd1Id, newTiffImageSize<0x0144, IfdId::ifd1Id>},
-    {0x014a, IfdId::ifd1Id, newTiffSubIfd<IfdId::subThumb1Id>},
-    {0x0201, IfdId::ifd1Id, newTiffThumbData<0x0202, IfdId::ifd1Id>},
-    {0x0202, IfdId::ifd1Id, newTiffThumbSize<0x0201, IfdId::ifd1Id>},
-    {Tag::next, IfdId::ifd1Id, newTiffDirectory<IfdId::ifd2Id>},
-    {Tag::all, IfdId::ifd1Id, newTiffEntry},
+    {{0x0111, IfdId::ifd1Id}, newTiffThumbData<0x0117, IfdId::ifd1Id>},
+    {{0x0117, IfdId::ifd1Id}, newTiffThumbSize<0x0111, IfdId::ifd1Id>},
+    {{0x0144, IfdId::ifd1Id}, newTiffImageData<0x0145, IfdId::ifd1Id>},
+    {{0x0145, IfdId::ifd1Id}, newTiffImageSize<0x0144, IfdId::ifd1Id>},
+    {{0x014a, IfdId::ifd1Id}, newTiffSubIfd<IfdId::subThumb1Id>},
+    {{0x0201, IfdId::ifd1Id}, newTiffThumbData<0x0202, IfdId::ifd1Id>},
+    {{0x0202, IfdId::ifd1Id}, newTiffThumbSize<0x0201, IfdId::ifd1Id>},
+    {{Tag::next, IfdId::ifd1Id}, newTiffDirectory<IfdId::ifd2Id>},
+    {{Tag::all, IfdId::ifd1Id}, newTiffEntry},
 
     // Subdir subThumb1
-    {0x0111, IfdId::subThumb1Id, newTiffImageData<0x0117, IfdId::subThumb1Id>},
-    {0x0117, IfdId::subThumb1Id, newTiffImageSize<0x0111, IfdId::subThumb1Id>},
-    {0x0144, IfdId::subThumb1Id, newTiffImageData<0x0145, IfdId::subThumb1Id>},
-    {0x0145, IfdId::subThumb1Id, newTiffImageSize<0x0144, IfdId::subThumb1Id>},
-    {0x0201, IfdId::subThumb1Id, newTiffImageData<0x0202, IfdId::subThumb1Id>},
-    {0x0202, IfdId::subThumb1Id, newTiffImageSize<0x0201, IfdId::subThumb1Id>},
-    {Tag::next, IfdId::subThumb1Id, ignoreTiffComponent},
-    {Tag::all, IfdId::subThumb1Id, newTiffEntry},
+    {{0x0111, IfdId::subThumb1Id}, newTiffImageData<0x0117, IfdId::subThumb1Id>},
+    {{0x0117, IfdId::subThumb1Id}, newTiffImageSize<0x0111, IfdId::subThumb1Id>},
+    {{0x0144, IfdId::subThumb1Id}, newTiffImageData<0x0145, IfdId::subThumb1Id>},
+    {{0x0145, IfdId::subThumb1Id}, newTiffImageSize<0x0144, IfdId::subThumb1Id>},
+    {{0x0201, IfdId::subThumb1Id}, newTiffImageData<0x0202, IfdId::subThumb1Id>},
+    {{0x0202, IfdId::subThumb1Id}, newTiffImageSize<0x0201, IfdId::subThumb1Id>},
+    {{Tag::next, IfdId::subThumb1Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::subThumb1Id}, newTiffEntry},
 
     // IFD2 (eg, in Pentax PEF and Canon CR2 files)
-    {0x0111, IfdId::ifd2Id, newTiffImageData<0x0117, IfdId::ifd2Id>},
-    {0x0117, IfdId::ifd2Id, newTiffImageSize<0x0111, IfdId::ifd2Id>},
-    {0x0144, IfdId::ifd1Id, newTiffImageData<0x0145, IfdId::ifd2Id>},
-    {0x0145, IfdId::ifd1Id, newTiffImageSize<0x0144, IfdId::ifd2Id>},
-    {0x0201, IfdId::ifd2Id, newTiffImageData<0x0202, IfdId::ifd2Id>},
-    {0x0202, IfdId::ifd2Id, newTiffImageSize<0x0201, IfdId::ifd2Id>},
-    {Tag::next, IfdId::ifd2Id, newTiffDirectory<IfdId::ifd3Id>},
-    {Tag::all, IfdId::ifd2Id, newTiffEntry},
+    {{0x0111, IfdId::ifd2Id}, newTiffImageData<0x0117, IfdId::ifd2Id>},
+    {{0x0117, IfdId::ifd2Id}, newTiffImageSize<0x0111, IfdId::ifd2Id>},
+    {{0x0144, IfdId::ifd1Id}, newTiffImageData<0x0145, IfdId::ifd2Id>},
+    {{0x0145, IfdId::ifd1Id}, newTiffImageSize<0x0144, IfdId::ifd2Id>},
+    {{0x0201, IfdId::ifd2Id}, newTiffImageData<0x0202, IfdId::ifd2Id>},
+    {{0x0202, IfdId::ifd2Id}, newTiffImageSize<0x0201, IfdId::ifd2Id>},
+    {{Tag::next, IfdId::ifd2Id}, newTiffDirectory<IfdId::ifd3Id>},
+    {{Tag::all, IfdId::ifd2Id}, newTiffEntry},
 
     // IFD3 (eg, in Canon CR2 files)
-    {0x0111, IfdId::ifd3Id, newTiffImageData<0x0117, IfdId::ifd3Id>},
-    {0x0117, IfdId::ifd3Id, newTiffImageSize<0x0111, IfdId::ifd3Id>},
-    {0x0144, IfdId::ifd1Id, newTiffImageData<0x0145, IfdId::ifd3Id>},
-    {0x0145, IfdId::ifd1Id, newTiffImageSize<0x0144, IfdId::ifd3Id>},
-    {0x0201, IfdId::ifd3Id, newTiffImageData<0x0202, IfdId::ifd3Id>},
-    {0x0202, IfdId::ifd3Id, newTiffImageSize<0x0201, IfdId::ifd3Id>},
-    {Tag::next, IfdId::ifd3Id, ignoreTiffComponent},
-    {Tag::all, IfdId::ifd3Id, newTiffEntry},
+    {{0x0111, IfdId::ifd3Id}, newTiffImageData<0x0117, IfdId::ifd3Id>},
+    {{0x0117, IfdId::ifd3Id}, newTiffImageSize<0x0111, IfdId::ifd3Id>},
+    {{0x0144, IfdId::ifd1Id}, newTiffImageData<0x0145, IfdId::ifd3Id>},
+    {{0x0145, IfdId::ifd1Id}, newTiffImageSize<0x0144, IfdId::ifd3Id>},
+    {{0x0201, IfdId::ifd3Id}, newTiffImageData<0x0202, IfdId::ifd3Id>},
+    {{0x0202, IfdId::ifd3Id}, newTiffImageSize<0x0201, IfdId::ifd3Id>},
+    {{Tag::next, IfdId::ifd3Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::ifd3Id}, newTiffEntry},
 
     // Olympus makernote - some Olympus cameras use Minolta structures
     // Todo: Adding such tags will not work (maybe result in a Minolta makernote), need separate groups
-    {0x0001, IfdId::olympusId, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
-    {0x0003, IfdId::olympusId, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
-    {Tag::next, IfdId::olympusId, ignoreTiffComponent},
-    {Tag::all, IfdId::olympusId, newTiffEntry},
+    {{0x0001, IfdId::olympusId}, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
+    {{0x0003, IfdId::olympusId}, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
+    {{Tag::next, IfdId::olympusId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::olympusId}, newTiffEntry},
 
     // Olympus2 makernote
-    {0x0001, IfdId::olympus2Id, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
-    {0x0003, IfdId::olympus2Id, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
-    {0x2010, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusEqId>},
-    {0x2020, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusCsId>},
-    {0x2030, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusRdId>},
-    {0x2031, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusRd2Id>},
-    {0x2040, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusIpId>},
-    {0x2050, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFiId>},
-    {0x2100, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe1Id>},
-    {0x2200, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe2Id>},
-    {0x2300, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe3Id>},
-    {0x2400, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe4Id>},
-    {0x2500, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe5Id>},
-    {0x2600, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe6Id>},
-    {0x2700, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe7Id>},
-    {0x2800, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe8Id>},
-    {0x2900, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusFe9Id>},
-    {0x3000, IfdId::olympus2Id, newTiffSubIfd<IfdId::olympusRiId>},
-    {Tag::next, IfdId::olympus2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::olympus2Id, newTiffEntry},
+    {{0x0001, IfdId::olympus2Id}, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
+    {{0x0003, IfdId::olympus2Id}, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
+    {{0x2010, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusEqId>},
+    {{0x2020, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusCsId>},
+    {{0x2030, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusRdId>},
+    {{0x2031, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusRd2Id>},
+    {{0x2040, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusIpId>},
+    {{0x2050, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFiId>},
+    {{0x2100, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe1Id>},
+    {{0x2200, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe2Id>},
+    {{0x2300, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe3Id>},
+    {{0x2400, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe4Id>},
+    {{0x2500, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe5Id>},
+    {{0x2600, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe6Id>},
+    {{0x2700, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe7Id>},
+    {{0x2800, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe8Id>},
+    {{0x2900, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusFe9Id>},
+    {{0x3000, IfdId::olympus2Id}, newTiffSubIfd<IfdId::olympusRiId>},
+    {{Tag::next, IfdId::olympus2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::olympus2Id}, newTiffEntry},
 
     // Olympus2 equipment subdir
-    {Tag::all, IfdId::olympusEqId, newTiffEntry},
+    {{Tag::all, IfdId::olympusEqId}, newTiffEntry},
 
     // Olympus2 camera settings subdir
-    {0x0101, IfdId::olympusCsId, newTiffImageData<0x0102, IfdId::olympusCsId>},
-    {0x0102, IfdId::olympusCsId, newTiffImageSize<0x0101, IfdId::olympusCsId>},
-    {Tag::all, IfdId::olympusCsId, newTiffEntry},
+    {{0x0101, IfdId::olympusCsId}, newTiffImageData<0x0102, IfdId::olympusCsId>},
+    {{0x0102, IfdId::olympusCsId}, newTiffImageSize<0x0101, IfdId::olympusCsId>},
+    {{Tag::all, IfdId::olympusCsId}, newTiffEntry},
 
     // Olympus2 raw development subdir
-    {Tag::all, IfdId::olympusRdId, newTiffEntry},
+    {{Tag::all, IfdId::olympusRdId}, newTiffEntry},
 
     // Olympus2 raw development 2 subdir
-    {Tag::all, IfdId::olympusRd2Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusRd2Id}, newTiffEntry},
 
     // Olympus2 image processing subdir
-    {Tag::all, IfdId::olympusIpId, newTiffEntry},
+    {{Tag::all, IfdId::olympusIpId}, newTiffEntry},
 
     // Olympus2 focus info subdir
-    {Tag::all, IfdId::olympusFiId, newTiffEntry},
+    {{Tag::all, IfdId::olympusFiId}, newTiffEntry},
 
     // Olympus2 FE 1 subdir
-    {Tag::all, IfdId::olympusFe1Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe1Id}, newTiffEntry},
 
     // Olympus2 FE 2 subdir
-    {Tag::all, IfdId::olympusFe2Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe2Id}, newTiffEntry},
 
     // Olympus2 FE 3 subdir
-    {Tag::all, IfdId::olympusFe3Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe3Id}, newTiffEntry},
 
     // Olympus2 FE 4 subdir
-    {Tag::all, IfdId::olympusFe4Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe4Id}, newTiffEntry},
 
     // Olympus2 FE 5 subdir
-    {Tag::all, IfdId::olympusFe5Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe5Id}, newTiffEntry},
 
     // Olympus2 FE 6 subdir
-    {Tag::all, IfdId::olympusFe6Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe6Id}, newTiffEntry},
 
     // Olympus2 FE 7 subdir
-    {Tag::all, IfdId::olympusFe7Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe7Id}, newTiffEntry},
 
     // Olympus2 FE 8 subdir
-    {Tag::all, IfdId::olympusFe8Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe8Id}, newTiffEntry},
 
     // Olympus2 FE 9 subdir
-    {Tag::all, IfdId::olympusFe9Id, newTiffEntry},
+    {{Tag::all, IfdId::olympusFe9Id}, newTiffEntry},
 
     // Olympus2 Raw Info subdir
-    {Tag::all, IfdId::olympusRiId, newTiffEntry},
+    {{Tag::all, IfdId::olympusRiId}, newTiffEntry},
 
     // Fujifilm makernote
-    {Tag::next, IfdId::fujiId, ignoreTiffComponent},
-    {Tag::all, IfdId::fujiId, newTiffEntry},
+    {{Tag::next, IfdId::fujiId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::fujiId}, newTiffEntry},
 
     // Canon makernote
-    {0x0001, IfdId::canonId, EXV_BINARY_ARRAY(canonCsCfg, canonCsDef)},
-    {0x0004, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonSiCfg)},
-    {0x0005, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonPaCfg)},
-    {0x000f, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonCfCfg)},
-    {0x0012, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonPiCfg)},
-    {0x0035, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonTiCfg)},
-    {0x0093, IfdId::canonId, EXV_BINARY_ARRAY(canonFiCfg, canonFiDef)},
-    {0x00a0, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonPrCfg)},
-    {0x4013, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonAfMiAdjCfg)},
-    //  {    0x4015, IfdId::canonId,          EXV_SIMPLE_BINARY_ARRAY(canonVigCorCfg)   },
-    {0x4016, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonVigCor2Cfg)},
-    {0x4018, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonLiOpCfg)},
-    {0x4019, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonLeCfg)},
-    {0x4020, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonAmCfg)},
-    {0x4021, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonMeCfg)},
-    {0x4024, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonFilCfg)},
-    {0x4025, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonHdrCfg)},
-    {0x4028, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonAfCCfg)},
-    {0x403f, IfdId::canonId, EXV_SIMPLE_BINARY_ARRAY(canonRawBCfg)},
-    {Tag::next, IfdId::canonId, ignoreTiffComponent},
-    {Tag::all, IfdId::canonId, newTiffEntry},
+    {{0x0001, IfdId::canonId}, EXV_BINARY_ARRAY(canonCsCfg, canonCsDef)},
+    {{0x0004, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonSiCfg)},
+    {{0x0005, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonPaCfg)},
+    {{0x000f, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonCfCfg)},
+    {{0x0012, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonPiCfg)},
+    {{0x0035, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonTiCfg)},
+    {{0x0093, IfdId::canonId}, EXV_BINARY_ARRAY(canonFiCfg, canonFiDef)},
+    {{0x00a0, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonPrCfg)},
+    {{0x4013, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonAfMiAdjCfg)},
+    //  {{    0x4015, IfdId::canonId,          EXV_SIMPLE_BINARY_ARRAY(canonVigCorCfg)   },
+    {{0x4016, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonVigCor2Cfg)},
+    {{0x4018, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonLiOpCfg)},
+    {{0x4019, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonLeCfg)},
+    {{0x4020, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonAmCfg)},
+    {{0x4021, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonMeCfg)},
+    {{0x4024, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonFilCfg)},
+    {{0x4025, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonHdrCfg)},
+    {{0x4028, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonAfCCfg)},
+    {{0x403f, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonRawBCfg)},
+    {{Tag::next, IfdId::canonId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::canonId}, newTiffEntry},
 
     // Canon makernote composite tags
-    {Tag::all, IfdId::canonCsId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonSiId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonPaId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonCfId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonPiId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonTiId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonFiId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonPrId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonAfMiAdjId, newTiffBinaryElement},
-    // {  Tag::all, IfdId::canonVigCorId,    newTiffBinaryElement                      },
-    {Tag::all, IfdId::canonVigCor2Id, newTiffBinaryElement},
-    {Tag::all, IfdId::canonLiOpId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonLeId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonAmId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonMeId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonFilId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonHdrId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonAfCId, newTiffBinaryElement},
-    {Tag::all, IfdId::canonRawBId, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonCsId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonSiId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonPaId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonCfId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonPiId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonTiId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonFiId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonPrId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonAfMiAdjId}, newTiffBinaryElement},
+    // {{  Tag::all, IfdId::canonVigCorId,    newTiffBinaryElement                      },
+    {{Tag::all, IfdId::canonVigCor2Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonLiOpId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonLeId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonAmId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonMeId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonFilId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonHdrId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonAfCId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::canonRawBId}, newTiffBinaryElement},
 
     // Nikon1 makernote
-    {Tag::next, IfdId::nikon1Id, ignoreTiffComponent},
-    {Tag::all, IfdId::nikon1Id, newTiffEntry},
+    {{Tag::next, IfdId::nikon1Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::nikon1Id}, newTiffEntry},
 
     // Nikon2 makernote
-    {Tag::next, IfdId::nikon2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::nikon2Id, newTiffEntry},
+    {{Tag::next, IfdId::nikon2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::nikon2Id}, newTiffEntry},
 
     // Nikon3 makernote
-    {Tag::next, IfdId::nikon3Id, ignoreTiffComponent},
-    {0x0011, IfdId::nikon3Id, newTiffSubIfd<IfdId::nikonPvId>},
-    {0x001f, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonVrCfg, nikonVrDef)},
-    {0x0023, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonPcCfg, nikonPcDef)},
-    {0x0024, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonWtCfg, nikonWtDef)},
-    {0x0025, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonIiCfg, nikonIiDef)},
-    {0x0088, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonAfCfg, nikonAfDef)},
-    {0x0091, IfdId::nikon3Id, EXV_COMPLEX_BINARY_ARRAY(nikonSiSet, nikonSelector)},
-    {0x0097, IfdId::nikon3Id, EXV_COMPLEX_BINARY_ARRAY(nikonCbSet, nikonSelector)},
-    {0x0098, IfdId::nikon3Id, EXV_COMPLEX_BINARY_ARRAY(nikonLdSet, nikonSelector)},
-    {0x00a8, IfdId::nikon3Id, EXV_COMPLEX_BINARY_ARRAY(nikonFlSet, nikonSelector)},
-    {0x00b0, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonMeCfg, nikonMeDef)},
-    {0x00b7, IfdId::nikon3Id, EXV_COMPLEX_BINARY_ARRAY(nikonAf2Set, nikonSelector)},
-    {0x00b8, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonFiCfg, nikonFiDef)},
-    {0x00b9, IfdId::nikon3Id, EXV_BINARY_ARRAY(nikonAFTCfg, nikonAFTDef)},
-    {Tag::all, IfdId::nikon3Id, newTiffEntry},
+    {{Tag::next, IfdId::nikon3Id}, ignoreTiffComponent},
+    {{0x0011, IfdId::nikon3Id}, newTiffSubIfd<IfdId::nikonPvId>},
+    {{0x001f, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonVrCfg, nikonVrDef)},
+    {{0x0023, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonPcCfg, nikonPcDef)},
+    {{0x0024, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonWtCfg, nikonWtDef)},
+    {{0x0025, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonIiCfg, nikonIiDef)},
+    {{0x0088, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonAfCfg, nikonAfDef)},
+    {{0x0091, IfdId::nikon3Id}, EXV_COMPLEX_BINARY_ARRAY(nikonSiSet, nikonSelector)},
+    {{0x0097, IfdId::nikon3Id}, EXV_COMPLEX_BINARY_ARRAY(nikonCbSet, nikonSelector)},
+    {{0x0098, IfdId::nikon3Id}, EXV_COMPLEX_BINARY_ARRAY(nikonLdSet, nikonSelector)},
+    {{0x00a8, IfdId::nikon3Id}, EXV_COMPLEX_BINARY_ARRAY(nikonFlSet, nikonSelector)},
+    {{0x00b0, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonMeCfg, nikonMeDef)},
+    {{0x00b7, IfdId::nikon3Id}, EXV_COMPLEX_BINARY_ARRAY(nikonAf2Set, nikonSelector)},
+    {{0x00b8, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonFiCfg, nikonFiDef)},
+    {{0x00b9, IfdId::nikon3Id}, EXV_BINARY_ARRAY(nikonAFTCfg, nikonAFTDef)},
+    {{Tag::all, IfdId::nikon3Id}, newTiffEntry},
 
     // Nikon3 makernote preview subdir
-    {0x0201, IfdId::nikonPvId, newTiffThumbData<0x0202, IfdId::nikonPvId>},
-    {0x0202, IfdId::nikonPvId, newTiffThumbSize<0x0201, IfdId::nikonPvId>},
-    {Tag::next, IfdId::nikonPvId, ignoreTiffComponent},
-    {Tag::all, IfdId::nikonPvId, newTiffEntry},
+    {{0x0201, IfdId::nikonPvId}, newTiffThumbData<0x0202, IfdId::nikonPvId>},
+    {{0x0202, IfdId::nikonPvId}, newTiffThumbSize<0x0201, IfdId::nikonPvId>},
+    {{Tag::next, IfdId::nikonPvId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::nikonPvId}, newTiffEntry},
 
     // Nikon3 vibration reduction
-    {Tag::all, IfdId::nikonVrId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonVrId}, newTiffBinaryElement},
 
     // Nikon3 picture control
-    {Tag::all, IfdId::nikonPcId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonPcId}, newTiffBinaryElement},
 
     // Nikon3 world time
-    {Tag::all, IfdId::nikonWtId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonWtId}, newTiffBinaryElement},
 
     // Nikon3 ISO info
-    {Tag::all, IfdId::nikonIiId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonIiId}, newTiffBinaryElement},
 
     // Nikon3 auto focus
-    {Tag::all, IfdId::nikonAfId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonAfId}, newTiffBinaryElement},
 
     // Nikon3 auto focus 2
-    {Tag::all, IfdId::nikonAf21Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonAf22Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonAf21Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonAf22Id}, newTiffBinaryElement},
 
     // Nikon3 AF Fine Tune
-    {Tag::all, IfdId::nikonAFTId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonAFTId}, newTiffBinaryElement},
 
     // Nikon3 file info
-    {Tag::all, IfdId::nikonFiId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonFiId}, newTiffBinaryElement},
 
     // Nikon3 multi exposure
-    {Tag::all, IfdId::nikonMeId, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonMeId}, newTiffBinaryElement},
 
     // Nikon3 flash info
-    {Tag::all, IfdId::nikonFl1Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonFl2Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonFl3Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonFl7Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonFl1Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonFl2Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonFl3Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonFl7Id}, newTiffBinaryElement},
 
     // Nikon3 shot info
-    {Tag::all, IfdId::nikonSi1Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonSi2Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonSi3Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonSi4Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonSi5Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonSi6Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi1Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi2Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi3Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi4Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi5Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonSi6Id}, newTiffBinaryElement},
 
     // Nikon3 color balance
-    {Tag::all, IfdId::nikonCb1Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonCb2Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonCb2aId, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonCb2bId, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonCb3Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonCb4Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb1Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb2Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb2aId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb2bId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb3Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonCb4Id}, newTiffBinaryElement},
 
     // Nikon3 lens data
-    {Tag::all, IfdId::nikonLd1Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonLd2Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonLd3Id, newTiffBinaryElement},
-    {Tag::all, IfdId::nikonLd4Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonLd1Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonLd2Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonLd3Id}, newTiffBinaryElement},
+    {{Tag::all, IfdId::nikonLd4Id}, newTiffBinaryElement},
 
     // Panasonic makernote
-    {Tag::next, IfdId::panasonicId, ignoreTiffComponent},
-    {Tag::all, IfdId::panasonicId, newTiffEntry},
+    {{Tag::next, IfdId::panasonicId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::panasonicId}, newTiffEntry},
 
     // Pentax DNG makernote
-    {0x0003, IfdId::pentaxDngId, newTiffThumbSize<0x0004, IfdId::pentaxDngId>},
-    {0x0004, IfdId::pentaxDngId, newTiffThumbData<0x0003, IfdId::pentaxDngId>},
-    {Tag::next, IfdId::pentaxDngId, ignoreTiffComponent},
-    {Tag::all, IfdId::pentaxDngId, newTiffEntry},
+    {{0x0003, IfdId::pentaxDngId}, newTiffThumbSize<0x0004, IfdId::pentaxDngId>},
+    {{0x0004, IfdId::pentaxDngId}, newTiffThumbData<0x0003, IfdId::pentaxDngId>},
+    {{Tag::next, IfdId::pentaxDngId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::pentaxDngId}, newTiffEntry},
 
     // Pentax makernote
-    {0x0003, IfdId::pentaxId, newTiffThumbSize<0x0004, IfdId::pentaxId>},
-    {0x0004, IfdId::pentaxId, newTiffThumbData<0x0003, IfdId::pentaxId>},
-    {Tag::next, IfdId::pentaxId, ignoreTiffComponent},
-    {Tag::all, IfdId::pentaxId, newTiffEntry},
+    {{0x0003, IfdId::pentaxId}, newTiffThumbSize<0x0004, IfdId::pentaxId>},
+    {{0x0004, IfdId::pentaxId}, newTiffThumbData<0x0003, IfdId::pentaxId>},
+    {{Tag::next, IfdId::pentaxId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::pentaxId}, newTiffEntry},
 
     // Samsung2 makernote
-    {0x0021, IfdId::samsung2Id, EXV_BINARY_ARRAY(samsungPwCfg, samsungPwDef)},
-    {0x0035, IfdId::samsung2Id, newTiffSubIfd<IfdId::samsungPvId>},
-    {Tag::next, IfdId::samsung2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::samsung2Id, newTiffEntry},
+    {{0x0021, IfdId::samsung2Id}, EXV_BINARY_ARRAY(samsungPwCfg, samsungPwDef)},
+    {{0x0035, IfdId::samsung2Id}, newTiffSubIfd<IfdId::samsungPvId>},
+    {{Tag::next, IfdId::samsung2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::samsung2Id}, newTiffEntry},
 
     // Samsung PictureWizard binary array
-    {Tag::all, IfdId::samsungPwId, newTiffBinaryElement},
+    {{Tag::all, IfdId::samsungPwId}, newTiffBinaryElement},
 
     // Samsung2 makernote preview subdir
-    {0x0201, IfdId::samsungPvId, newTiffThumbData<0x0202, IfdId::samsungPvId>},
-    {0x0202, IfdId::samsungPvId, newTiffThumbSize<0x0201, IfdId::samsungPvId>},
-    {Tag::next, IfdId::samsungPvId, ignoreTiffComponent},
-    {Tag::all, IfdId::samsungPvId, newTiffEntry},
+    {{0x0201, IfdId::samsungPvId}, newTiffThumbData<0x0202, IfdId::samsungPvId>},
+    {{0x0202, IfdId::samsungPvId}, newTiffThumbSize<0x0201, IfdId::samsungPvId>},
+    {{Tag::next, IfdId::samsungPvId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::samsungPvId}, newTiffEntry},
 
     // Sigma/Foveon makernote
-    {Tag::next, IfdId::sigmaId, ignoreTiffComponent},
-    {Tag::all, IfdId::sigmaId, newTiffEntry},
+    {{Tag::next, IfdId::sigmaId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::sigmaId}, newTiffEntry},
 
-    {Tag::all, IfdId::sony2010eId, newTiffBinaryElement},
-    {0x2010, IfdId::sony1Id, EXV_COMPLEX_BINARY_ARRAY(sony2010eSet, sony2010eSelector)},
+    {{Tag::all, IfdId::sony2010eId}, newTiffBinaryElement},
+    {{0x2010, IfdId::sony1Id}, EXV_COMPLEX_BINARY_ARRAY(sony2010eSet, sony2010eSelector)},
 
     // Tag 0x9402 Sony2Fp Focus Position
-    {Tag::all, IfdId::sony2FpId, newTiffBinaryElement},
-    {0x9402, IfdId::sony1Id, EXV_COMPLEX_BINARY_ARRAY(sony2FpSet, sony2FpSelector)},
+    {{Tag::all, IfdId::sony2FpId}, newTiffBinaryElement},
+    {{0x9402, IfdId::sony1Id}, EXV_COMPLEX_BINARY_ARRAY(sony2FpSet, sony2FpSelector)},
 
     // Tag 0x9404 SonyMisc2b
-    {Tag::all, IfdId::sonyMisc2bId, newTiffBinaryElement},
-    {0x9404, IfdId::sony1Id, EXV_COMPLEX_BINARY_ARRAY(sonyMisc2bSet, sonyMisc2bSelector)},
+    {{Tag::all, IfdId::sonyMisc2bId}, newTiffBinaryElement},
+    {{0x9404, IfdId::sony1Id}, EXV_COMPLEX_BINARY_ARRAY(sonyMisc2bSet, sonyMisc2bSelector)},
 
     // Tag 0x9400 SonyMisc3c
-    {Tag::all, IfdId::sonyMisc3cId, newTiffBinaryElement},
-    {0x9400, IfdId::sony1Id, EXV_COMPLEX_BINARY_ARRAY(sonyMisc3cSet, sonyMisc3cSelector)},
+    {{Tag::all, IfdId::sonyMisc3cId}, newTiffBinaryElement},
+    {{0x9400, IfdId::sony1Id}, EXV_COMPLEX_BINARY_ARRAY(sonyMisc3cSet, sonyMisc3cSelector)},
 
     // Tag 0x9403 SonyMisc1
-    {Tag::all, IfdId::sonyMisc1Id, newTiffBinaryElement},
-    {0x9403, IfdId::sony1Id, EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def)},
+    {{Tag::all, IfdId::sonyMisc1Id}, newTiffBinaryElement},
+    {{0x9403, IfdId::sony1Id}, EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def)},
 
     // Tag 0x3000 SonySInfo1
-    {Tag::all, IfdId::sonySInfo1Id, newTiffBinaryElement},
-    {0x3000, IfdId::sony1Id, EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def)},
+    {{Tag::all, IfdId::sonySInfo1Id}, newTiffBinaryElement},
+    {{0x3000, IfdId::sony1Id}, EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def)},
 
     // Sony1 makernote
-    {0x0114, IfdId::sony1Id, EXV_COMPLEX_BINARY_ARRAY(sony1CsSet, sonyCsSelector)},
-    {0xb028, IfdId::sony1Id, newTiffSubIfd<IfdId::sonyMltId>},
-    {Tag::next, IfdId::sony1Id, ignoreTiffComponent},
-    {Tag::all, IfdId::sony1Id, newTiffEntry},
+    {{0x0114, IfdId::sony1Id}, EXV_COMPLEX_BINARY_ARRAY(sony1CsSet, sonyCsSelector)},
+    {{0xb028, IfdId::sony1Id}, newTiffSubIfd<IfdId::sonyMltId>},
+    {{Tag::next, IfdId::sony1Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::sony1Id}, newTiffEntry},
 
     // Sony1 camera settings
-    {Tag::all, IfdId::sony1CsId, newTiffBinaryElement},
-    {Tag::all, IfdId::sony1Cs2Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1CsId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1Cs2Id}, newTiffBinaryElement},
 
-    {Tag::all, IfdId::sony2010eId, newTiffBinaryElement},
-    {0x2010, IfdId::sony2Id, EXV_COMPLEX_BINARY_ARRAY(sony2010eSet, sony2010eSelector)},
+    {{Tag::all, IfdId::sony2010eId}, newTiffBinaryElement},
+    {{0x2010, IfdId::sony2Id}, EXV_COMPLEX_BINARY_ARRAY(sony2010eSet, sony2010eSelector)},
 
     // Tag 0x9402 Sony2Fp Focus Position
-    {Tag::all, IfdId::sony2FpId, newTiffBinaryElement},
-    {0x9402, IfdId::sony2Id, EXV_COMPLEX_BINARY_ARRAY(sony2FpSet, sony2FpSelector)},
+    {{Tag::all, IfdId::sony2FpId}, newTiffBinaryElement},
+    {{0x9402, IfdId::sony2Id}, EXV_COMPLEX_BINARY_ARRAY(sony2FpSet, sony2FpSelector)},
 
     // Tag 0x9403 SonyMisc1
-    {Tag::all, IfdId::sonyMisc1Id, newTiffBinaryElement},
-    {0x9403, IfdId::sony2Id, EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def)},
+    {{Tag::all, IfdId::sonyMisc1Id}, newTiffBinaryElement},
+    {{0x9403, IfdId::sony2Id}, EXV_BINARY_ARRAY(sonyMisc1Cfg, sonyMisc1Def)},
 
     // Tag 0x9404 SonyMisc2b
-    {Tag::all, IfdId::sonyMisc2bId, newTiffBinaryElement},
-    {0x9404, IfdId::sony2Id, EXV_COMPLEX_BINARY_ARRAY(sonyMisc2bSet, sonyMisc2bSelector)},
+    {{Tag::all, IfdId::sonyMisc2bId}, newTiffBinaryElement},
+    {{0x9404, IfdId::sony2Id}, EXV_COMPLEX_BINARY_ARRAY(sonyMisc2bSet, sonyMisc2bSelector)},
 
     // Tag 0x9400 SonyMisc3c
-    {Tag::all, IfdId::sonyMisc3cId, newTiffBinaryElement},
-    {0x9400, IfdId::sony2Id, EXV_COMPLEX_BINARY_ARRAY(sonyMisc3cSet, sonyMisc3cSelector)},
+    {{Tag::all, IfdId::sonyMisc3cId}, newTiffBinaryElement},
+    {{0x9400, IfdId::sony2Id}, EXV_COMPLEX_BINARY_ARRAY(sonyMisc3cSet, sonyMisc3cSelector)},
 
     // Tag 0x3000 SonySInfo1
-    {Tag::all, IfdId::sonySInfo1Id, newTiffBinaryElement},
-    {0x3000, IfdId::sony2Id, EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def)},
+    {{Tag::all, IfdId::sonySInfo1Id}, newTiffBinaryElement},
+    {{0x3000, IfdId::sony2Id}, EXV_BINARY_ARRAY(sonySInfo1Cfg, sonySInfo1Def)},
 
     // Sony2 makernote
-    {0x0114, IfdId::sony2Id, EXV_COMPLEX_BINARY_ARRAY(sony2CsSet, sonyCsSelector)},
-    {Tag::next, IfdId::sony2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::sony2Id, newTiffEntry},
+    {{0x0114, IfdId::sony2Id}, EXV_COMPLEX_BINARY_ARRAY(sony2CsSet, sonyCsSelector)},
+    {{Tag::next, IfdId::sony2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::sony2Id}, newTiffEntry},
 
     // Sony2 camera settings
-    {Tag::all, IfdId::sony2CsId, newTiffBinaryElement},
-    {Tag::all, IfdId::sony2Cs2Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony2CsId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony2Cs2Id}, newTiffBinaryElement},
 
     // Sony1 Minolta makernote
-    {0x0001, IfdId::sonyMltId, EXV_SIMPLE_BINARY_ARRAY(sony1MCsoCfg)},
-    {0x0003, IfdId::sonyMltId, EXV_SIMPLE_BINARY_ARRAY(sony1MCsnCfg)},
-    {0x0004, IfdId::sonyMltId, EXV_BINARY_ARRAY(sony1MCs7Cfg, minoCs7Def)},  // minoCs7Def [sic]
-    {0x0088, IfdId::sonyMltId, newTiffThumbData<0x0089, IfdId::sonyMltId>},
-    {0x0089, IfdId::sonyMltId, newTiffThumbSize<0x0088, IfdId::sonyMltId>},
-    {0x0114, IfdId::sonyMltId, EXV_BINARY_ARRAY(sony1MCsA100Cfg, sony1MCsA100Def)},
-    {Tag::next, IfdId::sonyMltId, ignoreTiffComponent},
-    {Tag::all, IfdId::sonyMltId, newTiffEntry},
+    {{0x0001, IfdId::sonyMltId}, EXV_SIMPLE_BINARY_ARRAY(sony1MCsoCfg)},
+    {{0x0003, IfdId::sonyMltId}, EXV_SIMPLE_BINARY_ARRAY(sony1MCsnCfg)},
+    {{0x0004, IfdId::sonyMltId}, EXV_BINARY_ARRAY(sony1MCs7Cfg, minoCs7Def)},  // minoCs7Def [sic]
+    {{0x0088, IfdId::sonyMltId}, newTiffThumbData<0x0089, IfdId::sonyMltId>},
+    {{0x0089, IfdId::sonyMltId}, newTiffThumbSize<0x0088, IfdId::sonyMltId>},
+    {{0x0114, IfdId::sonyMltId}, EXV_BINARY_ARRAY(sony1MCsA100Cfg, sony1MCsA100Def)},
+    {{Tag::next, IfdId::sonyMltId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::sonyMltId}, newTiffEntry},
 
     // Sony1 Minolta makernote composite tags
-    {Tag::all, IfdId::sony1MltCsOldId, newTiffBinaryElement},
-    {Tag::all, IfdId::sony1MltCsNewId, newTiffBinaryElement},
-    {Tag::all, IfdId::sony1MltCs7DId, newTiffBinaryElement},
-    {Tag::all, IfdId::sony1MltCsA100Id, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1MltCsOldId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1MltCsNewId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1MltCs7DId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::sony1MltCsA100Id}, newTiffBinaryElement},
 
     // Minolta makernote
-    {0x0001, IfdId::minoltaId, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
-    {0x0003, IfdId::minoltaId, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
-    {0x0004, IfdId::minoltaId, EXV_BINARY_ARRAY(minoCs7Cfg, minoCs7Def)},
-    {0x0088, IfdId::minoltaId, newTiffThumbData<0x0089, IfdId::minoltaId>},
-    {0x0089, IfdId::minoltaId, newTiffThumbSize<0x0088, IfdId::minoltaId>},
-    {0x0114, IfdId::minoltaId, EXV_BINARY_ARRAY(minoCs5Cfg, minoCs5Def)},
-    {Tag::next, IfdId::minoltaId, ignoreTiffComponent},
-    {Tag::all, IfdId::minoltaId, newTiffEntry},
+    {{0x0001, IfdId::minoltaId}, EXV_SIMPLE_BINARY_ARRAY(minoCsoCfg)},
+    {{0x0003, IfdId::minoltaId}, EXV_SIMPLE_BINARY_ARRAY(minoCsnCfg)},
+    {{0x0004, IfdId::minoltaId}, EXV_BINARY_ARRAY(minoCs7Cfg, minoCs7Def)},
+    {{0x0088, IfdId::minoltaId}, newTiffThumbData<0x0089, IfdId::minoltaId>},
+    {{0x0089, IfdId::minoltaId}, newTiffThumbSize<0x0088, IfdId::minoltaId>},
+    {{0x0114, IfdId::minoltaId}, EXV_BINARY_ARRAY(minoCs5Cfg, minoCs5Def)},
+    {{Tag::next, IfdId::minoltaId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::minoltaId}, newTiffEntry},
 
     // Minolta makernote composite tags
-    {Tag::all, IfdId::minoltaCsOldId, newTiffBinaryElement},
-    {Tag::all, IfdId::minoltaCsNewId, newTiffBinaryElement},
-    {Tag::all, IfdId::minoltaCs7DId, newTiffBinaryElement},
-    {Tag::all, IfdId::minoltaCs5DId, newTiffBinaryElement},
+    {{Tag::all, IfdId::minoltaCsOldId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::minoltaCsNewId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::minoltaCs7DId}, newTiffBinaryElement},
+    {{Tag::all, IfdId::minoltaCs5DId}, newTiffBinaryElement},
 
     // -----------------------------------------------------------------------
     // Root directory of Panasonic RAW images
-    {Tag::pana, IfdId::ifdIdNotSet, newTiffDirectory<IfdId::panaRawId>},
+    {{Tag::pana, IfdId::ifdIdNotSet}, newTiffDirectory<IfdId::panaRawId>},
 
     // IFD0 of Panasonic RAW images
-    {0x8769, IfdId::panaRawId, newTiffSubIfd<IfdId::exifId>},
-    {0x8825, IfdId::panaRawId, newTiffSubIfd<IfdId::gpsId>},
-    //        {    0x0111, IfdId::panaRawId,        newTiffImageData<0x0117, IfdId::panaRawId>       },
-    //        {    0x0117, IfdId::panaRawId,        newTiffImageSize<0x0111, IfdId::panaRawId>       },
-    {Tag::next, IfdId::panaRawId, ignoreTiffComponent},
-    {Tag::all, IfdId::panaRawId, newTiffEntry},
+    {{0x8769, IfdId::panaRawId}, newTiffSubIfd<IfdId::exifId>},
+    {{0x8825, IfdId::panaRawId}, newTiffSubIfd<IfdId::gpsId>},
+    //        {{    0x0111, IfdId::panaRawId,        newTiffImageData<0x0117, IfdId::panaRawId>       },
+    //        {{    0x0117, IfdId::panaRawId,        newTiffImageSize<0x0111, IfdId::panaRawId>       },
+    {{Tag::next, IfdId::panaRawId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::panaRawId}, newTiffEntry},
 
     // Casio makernote
-    {Tag::next, IfdId::casioId, ignoreTiffComponent},
-    {Tag::all, IfdId::casioId, newTiffEntry},
+    {{Tag::next, IfdId::casioId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::casioId}, newTiffEntry},
 
     // Casio2 makernote
-    {Tag::next, IfdId::casio2Id, ignoreTiffComponent},
-    {Tag::all, IfdId::casio2Id, newTiffEntry},
+    {{Tag::next, IfdId::casio2Id}, ignoreTiffComponent},
+    {{Tag::all, IfdId::casio2Id}, newTiffEntry},
 
     // -----------------------------------------------------------------------
     // Tags which are not de/encoded
-    {Tag::next, IfdId::ignoreId, ignoreTiffComponent},
-    {Tag::all, IfdId::ignoreId, newTiffEntry}};
+    {{Tag::next, IfdId::ignoreId}, ignoreTiffComponent},
+    {{Tag::all, IfdId::ignoreId}, newTiffEntry}};
 
 // TIFF mapping table for special decoding and encoding requirements
 const TiffMappingInfo TiffMapping::tiffMappingInfo_[] = {
@@ -1808,11 +1808,18 @@ bool TiffTreeStruct::operator==(const TiffTreeStruct::Key& key) const {
 
 TiffComponent::UniquePtr TiffCreator::create(uint32_t extendedTag, IfdId group) {
   auto tag = static_cast<uint16_t>(extendedTag & 0xffff);
-  const TiffGroupStruct* ts = find(tiffGroupStruct_, TiffGroupStruct::Key(extendedTag, group));
-  if (ts && ts->newTiffCompFct_)
-    return ts->newTiffCompFct_(tag, group);
+  auto i = tiffGroupTable_.find(TiffGroupKey(extendedTag, group));
+  // If the lookup failed then try again with Tag::all.
+  if (i == tiffGroupTable_.end()) {
+    i = tiffGroupTable_.find(TiffGroupKey(Tag::all, group));
+  }
+  if (i != tiffGroupTable_.end()) {
+    if (i->second) {
+      return i->second(tag, group);
+    }
+  }
 #ifdef EXIV2_DEBUG_MESSAGES
-  if (!ts)
+  if (i == tiffGroupTable_.end())
     std::cerr << "Warning: No TIFF structure entry found for ";
   else
     std::cerr << "Warning: No TIFF component creator found for ";

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -146,29 +146,13 @@ struct TiffImgTagStruct {
   IfdId group_;   //!< Group that contains the image tag
 };                // struct TiffImgTagStruct
 
+typedef std::pair<uint32_t, IfdId> TiffGroupKey;
+
 /*!
   @brief Data structure used as a row (element) of a table (array)
          defining the TIFF component used for each tag in a group.
  */
-struct TiffGroupStruct {
-  //! Search key for TIFF group structure.
-  using Key = std::pair<uint32_t, IfdId>;
-
-  //! Comparison operator to compare a TiffGroupStruct with a TiffGroupStruct::Key
-  bool operator==(const Key& key) const {
-    auto [e, g] = key;
-    return g == group_ && (Tag::all == extendedTag_ || e == extendedTag_);
-  }
-  //! Return the tag corresponding to the extended tag
-  [[nodiscard]] uint16_t tag() const {
-    return static_cast<uint16_t>(extendedTag_ & 0xffff);
-  }
-
-  // DATA
-  uint32_t extendedTag_;           //!< Tag (32 bit so that it can contain special tags)
-  IfdId group_;                    //!< Group that contains the tag
-  NewTiffCompFct newTiffCompFct_;  //!< Function to create the correct TIFF component
-};
+typedef std::map<TiffGroupKey, NewTiffCompFct> TiffGroupTable;
 
 /*!
   @brief Data structure used as a row of the table which describes TIFF trees.
@@ -216,8 +200,8 @@ class TiffCreator {
   static void getPath(TiffPath& tiffPath, uint32_t extendedTag, IfdId group, uint32_t root);
 
  private:
-  static const TiffTreeStruct tiffTreeStruct_[];    //<! TIFF tree structure
-  static const TiffGroupStruct tiffGroupStruct_[];  //<! TIFF group structure
+  static const TiffTreeStruct tiffTreeStruct_[];  //<! TIFF tree structure
+  static const TiffGroupTable tiffGroupTable_;    //<! TIFF group structure
 
 };  // class TiffCreator
 

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -5,6 +5,7 @@
 
 // *****************************************************************************
 // included header files
+#include <unordered_map>
 #include "image.hpp"
 #include "tiffcomposite_int.hpp"
 #include "tifffwd_int.hpp"
@@ -146,13 +147,19 @@ struct TiffImgTagStruct {
   IfdId group_;   //!< Group that contains the image tag
 };                // struct TiffImgTagStruct
 
-typedef std::pair<uint32_t, IfdId> TiffGroupKey;
+using TiffGroupKey = std::pair<uint32_t, IfdId>;
+
+struct TiffGroupKey_hash {
+  std::size_t operator()(const TiffGroupKey& pair) const {
+    return std::hash<uint64_t>{}(static_cast<uint64_t>(pair.first) << 32 | static_cast<uint64_t>(pair.second));
+  }
+};
 
 /*!
   @brief Data structure used as a row (element) of a table (array)
          defining the TIFF component used for each tag in a group.
  */
-typedef std::map<TiffGroupKey, NewTiffCompFct> TiffGroupTable;
+using TiffGroupTable = std::unordered_map<TiffGroupKey, NewTiffCompFct, TiffGroupKey_hash>;
 
 /*!
   @brief Data structure used as a row of the table which describes TIFF trees.


### PR DESCRIPTION
OSS-Fuzz reported a [timeout](https://oss-fuzz.com/testcase-detail/5382480668000256). It's not serious problem - just a moderately large file that's a bit slow to process. But I noticed that it's spending a lot of time in this line of code:

https://github.com/Exiv2/exiv2/blob/ee5dae4dddef48bed6d9ed4859680f91e7ff83ee/src/tiffimage_int.cpp#L1811

It's doing a linear search of a 358-element array, which is a bit slow. This PR replaces the array with a `std::map`, which improves the running time on this particular file by approximately 10%.

poc: ![poc](https://user-images.githubusercontent.com/4358136/182275820-bc7cc36b-ea8b-4401-9482-caaa3c29a16e.jpg)

```bash
time exiv2 poc.jpg
```