### PR TITLE
revert std::function back to function pointers

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -325,8 +325,8 @@ int Print::printTag(const Exiv2::ExifData& exifData, const std::string& key, con
   return rc;
 }  // Print::printTag
 
-int Print::printTag(const Exiv2::ExifData& exifData, const EasyAccessFct& easyAccessFct, const std::string& label,
-                    const EasyAccessFct& easyAccessFctFallback) const {
+int Print::printTag(const Exiv2::ExifData& exifData, EasyAccessFct easyAccessFct, const std::string& label,
+                    EasyAccessFct easyAccessFctFallback) const {
   int rc = 0;
   if (!label.empty()) {
     printLabel(label);

--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -157,14 +157,14 @@ class Print : public Task {
    */
   int printTag(const Exiv2::ExifData& exifData, const std::string& key, const std::string& label = "") const;
   //! Type for an Exiv2 Easy access function
-  using EasyAccessFct = std::function<Exiv2::ExifData::const_iterator(const Exiv2::ExifData& ed)>;
+  using EasyAccessFct = Exiv2::ExifData::const_iterator (*)(const Exiv2::ExifData&);
   /*!
     @brief Print one summary line with a label (if provided) and requested
            data. A line break is printed only if a label is provided.
     @return 1 if a line was written, 0 if the information was not found.
    */
-  int printTag(const Exiv2::ExifData& exifData, const EasyAccessFct& easyAccessFct, const std::string& label = "",
-               const EasyAccessFct& easyAccessFctFallback = nullptr) const;
+  int printTag(const Exiv2::ExifData& exifData, EasyAccessFct easyAccessFct, const std::string& label = "",
+               EasyAccessFct easyAccessFctFallback = nullptr) const;
 
  private:
   std::string path_;

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -10,8 +10,6 @@
 #include "metadatum.hpp"
 #include "properties.hpp"
 
-#include <functional>
-
 // *****************************************************************************
 // namespace extensions
 namespace Exiv2 {
@@ -310,7 +308,7 @@ class EXIV2API XmpParser {
     @param pLockData Pointer to the pLockData passed to initialize()
     @param lockUnlock Indicates whether to lock (true) or unlock (false)
    */
-  using XmpLockFct = std::function<void(void* pLockData, bool lockUnlock)>;
+  using XmpLockFct = void (*)(void* pLockData, bool lockUnlock);
 
   /*!
     @brief Initialize the XMP Toolkit.

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -5,7 +5,7 @@
 #include <iomanip>
 #include <iostream>
 
-using EasyAccessFct = std::function<Exiv2::ExifData::const_iterator(const Exiv2::ExifData&)>;
+using EasyAccessFct = Exiv2::ExifData::const_iterator (*)(const Exiv2::ExifData&);
 using EasyAccess = std::pair<const char*, EasyAccessFct>;
 
 static const EasyAccess easyAccess[] = {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1526,7 +1526,7 @@ bool asciiToUtf8(std::string& /*str*/) {
   return true;
 }
 
-using ConvFct = std::function<bool(std::string&)>;
+using ConvFct = bool (*)(std::string&);
 
 struct ConvFctList {
   bool operator==(const std::pair<const char*, const char*>& fromTo) const {

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -26,10 +26,10 @@ using CrwSubDir = std::pair<uint16_t, uint16_t>;
 // type definitions
 
 //! Function pointer for functions to decode Exif tags from a CRW entry
-using CrwDecodeFct = std::function<void(const CiffComponent&, const CrwMapping*, Image&, ByteOrder)>;
+using CrwDecodeFct = void (*)(const CiffComponent&, const CrwMapping*, Image&, ByteOrder);
 
 //! Function pointer for functions to encode CRW entries from Exif tags
-using CrwEncodeFct = std::function<void(const Image&, const CrwMapping*, CiffHeader*)>;
+using CrwEncodeFct = void (*)(const Image&, const CrwMapping*, CiffHeader*);
 
 //! Stack to hold a path of CRW directories
 using CrwDirs = std::stack<CrwSubDir>;
@@ -505,8 +505,8 @@ struct CrwMapping {
       size_(size),
       tag_(tag),
       ifdId_(ifdId),
-      toExif_(std::move(toExif)),
-      fromExif_(std::move(fromExif)) {
+      toExif_(toExif),
+      fromExif_(fromExif) {
   }
   //@}
 

--- a/src/makernote_int.hpp
+++ b/src/makernote_int.hpp
@@ -8,8 +8,6 @@
 #include "tags_int.hpp"
 #include "types.hpp"
 
-#include <functional>
-
 // namespace extensions
 namespace Exiv2::Internal {
 class IoWrapper;
@@ -30,10 +28,10 @@ std::string readExiv2Config(const std::string& section, const std::string& value
 // class definitions
 
 //! Type for a pointer to a function creating a makernote (image)
-using NewMnFct = std::function<TiffComponent*(uint16_t, IfdId, IfdId, const byte*, size_t, ByteOrder)>;
+using NewMnFct = TiffComponent* (*)(uint16_t, IfdId, IfdId, const byte*, size_t, ByteOrder);
 
 //! Type for a pointer to a function creating a makernote (group)
-using NewMnFct2 = std::function<TiffComponent*(uint16_t tag, IfdId group, IfdId mnGroup)>;
+using NewMnFct2 = TiffComponent* (*)(uint16_t tag, IfdId group, IfdId mnGroup);
 
 //! Makernote registry structure
 struct TiffMnRegistry {

--- a/src/tifffwd_int.hpp
+++ b/src/tifffwd_int.hpp
@@ -9,7 +9,6 @@
 #include "types.hpp"
 
 // + standard includes
-#include <functional>
 #include <stack>
 
 // *****************************************************************************
@@ -62,17 +61,17 @@ using EncoderFct = void (TiffEncoder::*)(TiffEntryBase*, const Exifdatum*);
 /*!
   @brief Type for a function pointer for a function to decode a TIFF component.
  */
-using FindDecoderFct = std::function<DecoderFct(const std::string& make, uint32_t extendedTag, IfdId group)>;
+using FindDecoderFct = DecoderFct (*)(const std::string& make, uint32_t extendedTag, IfdId group);
 /*!
   @brief Type for a function pointer for a function to encode a TIFF component.
  */
-using FindEncoderFct = std::function<EncoderFct(const std::string& make, uint32_t extendedTag, IfdId group)>;
+using FindEncoderFct = EncoderFct (*)(const std::string& make, uint32_t extendedTag, IfdId group);
 /*!
   @brief Type for a function pointer for a function to create a TIFF component.
          Use TiffComponent::UniquePtr, it is not used in this declaration only
          to reduce dependencies.
  */
-using NewTiffCompFct = std::function<std::unique_ptr<TiffComponent>(uint16_t tag, IfdId group)>;
+using NewTiffCompFct = std::unique_ptr<TiffComponent> (*)(uint16_t tag, IfdId group);
 
 //! Stack to hold a path from the TIFF root element to a TIFF entry
 using TiffPath = std::stack<TiffPathItem>;

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1363,7 +1363,7 @@ const TiffTreeTable TiffCreator::tiffTreeTable_ = {
   Each entry of the table defines for a particular tag and group combination
   the corresponding TIFF component create function.
  */
-#define ignoreTiffComponent 0
+#define ignoreTiffComponent nullptr
 const TiffGroupTable TiffCreator::tiffGroupTable_ = {
     // ext. tag  group             create function
     //---------  ----------------- -----------------------------------------
@@ -1987,7 +1987,7 @@ ByteOrder TiffParserWorker::decode(ExifData& exifData, IptcData& iptcData, XmpDa
 
   auto rootDir = parse(pData, size, root, pHeader);
   if (rootDir) {
-    TiffDecoder decoder(exifData, iptcData, xmpData, rootDir.get(), std::move(findDecoderFct));
+    TiffDecoder decoder(exifData, iptcData, xmpData, rootDir.get(), findDecoderFct);
     rootDir->accept(decoder);
   }
   return pHeader->byteOrder();
@@ -1996,7 +1996,7 @@ ByteOrder TiffParserWorker::decode(ExifData& exifData, IptcData& iptcData, XmpDa
 
 WriteMethod TiffParserWorker::encode(BasicIo& io, const byte* pData, size_t size, const ExifData& exifData,
                                      const IptcData& iptcData, const XmpData& xmpData, uint32_t root,
-                                     const FindEncoderFct& findEncoderFct, TiffHeaderBase* pHeader,
+                                     FindEncoderFct findEncoderFct, TiffHeaderBase* pHeader,
                                      OffsetWriter* pOffsetWriter) {
   /*
      1) parse the binary image, if one is provided, and

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -222,7 +222,7 @@ class TiffParserWorker {
    */
   static WriteMethod encode(BasicIo& io, const byte* pData, size_t size, const ExifData& exifData,
                             const IptcData& iptcData, const XmpData& xmpData, uint32_t root,
-                            const FindEncoderFct& findEncoderFct, TiffHeaderBase* pHeader, OffsetWriter* pOffsetWriter);
+                            FindEncoderFct findEncoderFct, TiffHeaderBase* pHeader, OffsetWriter* pOffsetWriter);
 
  private:
   /*!

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -185,11 +185,7 @@ void TiffCopier::visitBinaryElement(TiffBinaryElement* object) {
 
 TiffDecoder::TiffDecoder(ExifData& exifData, IptcData& iptcData, XmpData& xmpData, TiffComponent* pRoot,
                          FindDecoderFct findDecoderFct) :
-    exifData_(exifData),
-    iptcData_(iptcData),
-    xmpData_(xmpData),
-    pRoot_(pRoot),
-    findDecoderFct_(std::move(findDecoderFct)) {
+    exifData_(exifData), iptcData_(iptcData), xmpData_(xmpData), pRoot_(pRoot), findDecoderFct_(findDecoderFct) {
   // #1402 Fujifilm RAF. Search for the make
   // Find camera make in existing metadata (read from the JPEG)
   ExifKey key("Exif.Image.Make");
@@ -452,7 +448,7 @@ TiffEncoder::TiffEncoder(ExifData exifData, const IptcData& iptcData, const XmpD
     pRoot_(pRoot),
     isNewImage_(isNewImage),
     pPrimaryGroups_(pPrimaryGroups),
-    findEncoderFct_(std::move(findEncoderFct)) {
+    findEncoderFct_(findEncoderFct) {
   byteOrder_ = pHeader->byteOrder();
   origByteOrder_ = byteOrder_;
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -232,8 +232,7 @@ Exiv2::XmpKey::UniquePtr makeXmpKey(const std::string& schemaNs, const std::stri
 //! Helper class used to serialize critical sections
 class AutoLock {
  public:
-  AutoLock(Exiv2::XmpParser::XmpLockFct xmpLockFct, void* pLockData) :
-      xmpLockFct_(std::move(xmpLockFct)), pLockData_(pLockData) {
+  AutoLock(Exiv2::XmpParser::XmpLockFct xmpLockFct, void* pLockData) : xmpLockFct_(xmpLockFct), pLockData_(pLockData) {
     if (xmpLockFct_)
       xmpLockFct_(pLockData_, true);
   }
@@ -515,7 +514,7 @@ void* XmpParser::pLockData_ = nullptr;
 #ifdef EXV_HAVE_XMP_TOOLKIT
 bool XmpParser::initialize(XmpParser::XmpLockFct xmpLockFct, void* pLockData) {
   if (!initialized_) {
-    xmpLockFct_ = std::move(xmpLockFct);
+    xmpLockFct_ = xmpLockFct;
     pLockData_ = pLockData;
     initialized_ = SXMPMeta::Initialize();
 #ifdef EXV_ADOBE_XMPSDK


### PR DESCRIPTION
The former has too much overhead. No point in it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>