### PR TITLE
manual replacement of [0] with front()

### DIFF
--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -553,7 +553,7 @@ uint32_t PsdImage::writeIptcData(const IptcData& iptcData, BasicIo& out) {
       std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_IPTC_NAA << "\n";
       std::cerr << std::dec << "Writing IPTC_NAA: size: " << rawIptc.size() << "\n";
 #endif
-      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
+      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, kPhotoshopResourceID_IPTC_NAA, bigEndian);
       if (out.write(buf, 2) != 2)
@@ -598,7 +598,7 @@ uint32_t PsdImage::writeExifData(const ExifData& exifData, BasicIo& out) {
       std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_ExifInfo << "\n";
       std::cerr << std::dec << "Writing ExifInfo: size: " << blob.size() << "\n";
 #endif
-      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
+      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, kPhotoshopResourceID_ExifInfo, bigEndian);
       if (out.write(buf, 2) != 2)
@@ -645,7 +645,7 @@ uint32_t PsdImage::writeXmpData(const XmpData& xmpData, BasicIo& out) const {
     std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_XMPPacket << "\n";
     std::cerr << std::dec << "Writing XMPPacket: size: " << xmpPacket.size() << "\n";
 #endif
-    if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
+    if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
       throw Error(ErrorCode::kerImageWriteFailed);
     us2Data(buf, kPhotoshopResourceID_XMPPacket, bigEndian);
     if (out.write(buf, 2) != 2)


### PR DESCRIPTION
Avoids implicit array decay.

Signed-off-by: Rosen Penev <rosenp@gmail.com>