### PR TITLE
Add more MIME type mappings for TIFF-based raws

### DIFF
--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -83,8 +83,11 @@ namespace Exiv2 {
 
     //! List of TIFF compression to MIME type mappings
     MimeTypeList mimeTypeList[] = {
+        { 32767, "image/x-sony-arw"    },
+        { 32769, "image/x-epson-erf"   },
         { 32770, "image/x-samsung-srw" },
         { 34713, "image/x-nikon-nef"   },
+        { 65000, "image/x-kodak-dcr"   },
         { 65535, "image/x-pentax-pef"  }
     };
 


### PR DESCRIPTION
Now matches known raw file compression tag values in https://github.com/Exiv2/exiv2/blob/fa94372e6e8b9f8d62d51a7f22b647a6ddedde23/src/tags_int.cpp#L242-L277

@neheb Please also include in your recent https://github.com/Exiv2/exiv2/pull/2332 for main. 

Edit: fixes #2260