### PR TITLE
Avoid potential integer overflow in QuickTimeVideo::userDataDecoder

### DIFF
--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -803,7 +803,7 @@ void QuickTimeVideo::userDataDecoder(size_t size_external) {
 
     tv = find(userDataReferencetags, Exiv2::toString(buf.data()));
 
-    if (size == 0 || (size - 12) <= 0)
+    if (size <= 12)
       break;
 
     else if (equalsQTimeTag(buf, "DcMD") || equalsQTimeTag(buf, "NCDT"))


### PR DESCRIPTION
I'm worried about what will happen if `size` is between 1 and 11. I think it could cause an integer overflow.