### PR TITLE
Use getULong to read unsigned numbers

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -184,8 +184,8 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 
   // The box length is encoded as a uint32_t by default, but the special value 1 means
   // that it's a uint64_t.
-  uint64_t box_length = getLong(reinterpret_cast<byte*>(&hdrbuf[0]), endian_);
-  uint32_t box_type = getLong(reinterpret_cast<byte*>(&hdrbuf[sizeof(uint32_t)]), endian_);
+  uint64_t box_length = getULong(reinterpret_cast<byte*>(&hdrbuf[0]), endian_);
+  uint32_t box_type = getULong(reinterpret_cast<byte*>(&hdrbuf[sizeof(uint32_t)]), endian_);
   bool bLF = true;
 
   if (bTrace) {
@@ -265,7 +265,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     // 8.11.6.2
     case TAG_infe: {  // .__._.__hvc1_ 2 0 0 1 0 1 0 0 104 118 99 49 0
       enforce(data.size() - skip >= 8, Exiv2::ErrorCode::kerCorruptedMetadata);
-      /* getLong (data.pData_+skip,endian_) ; */ skip += 4;
+      /* getULong (data.pData_+skip,endian_) ; */ skip += 4;
       uint16_t ID = data.read_uint16(skip, endian_);
       skip += 2;
       /* getShort(data.pData_+skip,endian_) ; */ skip += 2;  // protection

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -77,8 +77,8 @@ void BmpImage::readMetadata() {
   */
   byte buf[26];
   if (io_->read(buf, sizeof(buf)) == sizeof(buf)) {
-    pixelWidth_ = getLong(buf + 18, littleEndian);
-    pixelHeight_ = getLong(buf + 22, littleEndian);
+    pixelWidth_ = getULong(buf + 18, littleEndian);
+    pixelHeight_ = getULong(buf + 22, littleEndian);
   }
 }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -150,8 +150,8 @@ void Jp2Image::readMetadata() {
   while (io_->read(reinterpret_cast<byte*>(&box), boxHSize) == boxHSize) {
     boxes_check(boxesCount++, boxem);
     const size_t position = io_->tell();
-    box.length = getLong(reinterpret_cast<byte*>(&box.length), bigEndian);
-    box.type = getLong(reinterpret_cast<byte*>(&box.type), bigEndian);
+    box.length = getULong(reinterpret_cast<byte*>(&box.length), bigEndian);
+    box.type = getULong(reinterpret_cast<byte*>(&box.type), bigEndian);
 #ifdef EXIV2_DEBUG_MESSAGES
     std::cout << "Exiv2::Jp2Image::readMetadata: "
               << "Position: " << position << " box type: " << toAscii(box.type) << " length: " << box.length
@@ -193,8 +193,8 @@ void Jp2Image::readMetadata() {
 
         while (io_->read(reinterpret_cast<byte*>(&subBox), boxHSize) == boxHSize && subBox.length) {
           boxes_check(boxesCount++, boxem);
-          subBox.length = getLong(reinterpret_cast<byte*>(&subBox.length), bigEndian);
-          subBox.type = getLong(reinterpret_cast<byte*>(&subBox.type), bigEndian);
+          subBox.length = getULong(reinterpret_cast<byte*>(&subBox.length), bigEndian);
+          subBox.type = getULong(reinterpret_cast<byte*>(&subBox.type), bigEndian);
           if (subBox.length > io_->size()) {
             throw Error(ErrorCode::kerCorruptedMetadata);
           }
@@ -242,8 +242,8 @@ void Jp2Image::readMetadata() {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "Exiv2::Jp2Image::readMetadata: Ihdr data found" << std::endl;
 #endif
-            ihdr.imageHeight = getLong(reinterpret_cast<byte*>(&ihdr.imageHeight), bigEndian);
-            ihdr.imageWidth = getLong(reinterpret_cast<byte*>(&ihdr.imageWidth), bigEndian);
+            ihdr.imageHeight = getULong(reinterpret_cast<byte*>(&ihdr.imageHeight), bigEndian);
+            ihdr.imageWidth = getULong(reinterpret_cast<byte*>(&ihdr.imageWidth), bigEndian);
             ihdr.componentCount = getShort(reinterpret_cast<byte*>(&ihdr.componentCount), bigEndian);
             enforce(ihdr.c == 7, ErrorCode::kerCorruptedMetadata);
 
@@ -418,8 +418,8 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
     while (box.length && box.type != kJp2BoxTypeClose &&
            io_->read(reinterpret_cast<byte*>(&box), boxHSize) == boxHSize) {
       const size_t position = io_->tell();
-      box.length = getLong(reinterpret_cast<byte*>(&box.length), bigEndian);
-      box.type = getLong(reinterpret_cast<byte*>(&box.type), bigEndian);
+      box.length = getULong(reinterpret_cast<byte*>(&box.length), bigEndian);
+      box.type = getULong(reinterpret_cast<byte*>(&box.type), bigEndian);
       enforce(box.length <= boxHSize + io_->size() - io_->tell(), ErrorCode::kerCorruptedMetadata);
 
       if (bPrint) {
@@ -456,8 +456,8 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
                  io_->tell() < position + box.length)  // don't read beyond the box!
           {
             const size_t address = io_->tell() - boxHSize;
-            subBox.length = getLong(reinterpret_cast<byte*>(&subBox.length), bigEndian);
-            subBox.type = getLong(reinterpret_cast<byte*>(&subBox.type), bigEndian);
+            subBox.length = getULong(reinterpret_cast<byte*>(&subBox.length), bigEndian);
+            subBox.type = getULong(reinterpret_cast<byte*>(&subBox.type), bigEndian);
 
             if (subBox.length < boxHSize || subBox.length > io_->size() - io_->tell()) {
               throw Error(ErrorCode::kerCorruptedMetadata);
@@ -603,7 +603,7 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
   size_t outlen = boxHSize;                                  // now many bytes have we written to output?
   size_t inlen = boxHSize;                                   // how many bytes have we read from boxBuf?
   enforce(boxHSize <= output.size(), ErrorCode::kerCorruptedMetadata);
-  uint32_t length = getLong(boxBuf.c_data(0), bigEndian);
+  uint32_t length = getULong(boxBuf.c_data(0), bigEndian);
   enforce(length <= output.size(), ErrorCode::kerCorruptedMetadata);
   uint32_t count = boxHSize;
   bool bWroteColor = false;
@@ -615,8 +615,8 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
     Internal::Jp2BoxHeader newBox = subBox;
 
     if (count < length) {
-      subBox.length = getLong(boxBuf.c_data(count), bigEndian);
-      subBox.type = getLong(boxBuf.c_data(count + 4), bigEndian);
+      subBox.length = getULong(boxBuf.c_data(count), bigEndian);
+      subBox.type = getULong(boxBuf.c_data(count + 4), bigEndian);
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Jp2Image::encodeJp2Header subbox: " << toAscii(subBox.type) << " length = " << subBox.length
                 << std::endl;

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1120,7 +1120,7 @@ void TiffReader::visitDirectory(TiffDirectory* object) {
       return;
     }
     TiffComponent::UniquePtr tc;
-    uint32_t next = getLong(p, byteOrder());
+    uint32_t next = getULong(p, byteOrder());
     if (next) {
       tc = TiffCreator::create(Tag::next, object->group());
 #ifndef SUPPRESS_WARNINGS
@@ -1152,7 +1152,7 @@ void TiffReader::visitSubIfd(TiffSubIfd* object) {
     if (object->group() == IfdId::ifd1Id)
       maxi = 1;
     for (uint32_t i = 0; i < object->count(); ++i) {
-      uint32_t offset = getLong(object->pData() + 4 * i, byteOrder());
+      uint32_t offset = getULong(object->pData() + 4 * i, byteOrder());
       if (baseOffset() + offset > size_) {
 #ifndef SUPPRESS_WARNINGS
         EXV_ERROR << "Directory " << groupName(object->group()) << ", entry 0x" << std::setw(4) << std::setfill('0')
@@ -1271,7 +1271,7 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
     throw Error(ErrorCode::kerArithmeticOverflow);
   }
   size_t size = typeSize * count;
-  uint32_t offset = getLong(p, byteOrder());
+  uint32_t offset = getULong(p, byteOrder());
   byte* pData = p;
   if (size > 4 && (baseOffset() + offset >= size_ || baseOffset() + offset <= 0)) {
     // #1143


### PR DESCRIPTION
`getLong` returns a signed number. It's better to use `getULong` when reading an unsigned value.