### PR TITLE
Fix bmff exception; Bump Conan version

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/on_PR_linux_special_buils.yml
+++ b/.github/workflows/on_PR_linux_special_buils.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |
@@ -63,7 +63,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind ninja-build
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |
@@ -100,7 +100,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |
@@ -136,7 +136,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install valgrind doxygen graphviz gettext
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.51.0"
+          pip.exe install "conan==1.52.0"
           conan profile new --detect default
           conan profile update settings.build_type=${{matrix.build_type}} default
           conan profile update settings.compiler="Visual Studio" default

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Conan & Common config
         run: |
-          pip.exe install "conan==1.51.0"
+          pip.exe install "conan==1.52.0"
           conan config install https://github.com/conan-io/conanclientcert.git
           conan profile new --detect default
           conan profile show default
@@ -77,7 +77,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get install ninja-build
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan
         run: |

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          pip3 install conan==1.51.0
+          pip3 install conan==1.52.0
 
       - name: Conan common config
         run: |

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -711,7 +711,7 @@ namespace Exiv2
     void BmffImage::writeMetadata()
     {
         // bmff files are read-only
-        throw(Error(kerInvalidSettingForImage, "Image comment", "BMFF"));
+        throw(Error(kerWritingImageFormatUnsupported, "BMFF"));
     }  // BmffImage::writeMetadata
 
     // *************************************************************************


### PR DESCRIPTION
- This is a partial backport of #2364. The new exceptions in `::setExifData()`/`::setIptcData()`/`::setXmpData()` are not included as they could change the control flow of the maintenance branch for the user.
- Conan change is a backport of #2361.
- Closes #2350.
