### PR TITLE
Fix bug in (unused) non-mmap code

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -203,6 +203,7 @@ int FileIo::munmap() {
     CloseHandle(p_->hFile_);
     p_->hFile_ = 0;
 #else
+#error Platforms without mmap are not supported. See https://github.com/Exiv2/exiv2/issues/2380
     if (p_->isWriteable_) {
       seek(0, BasicIo::beg);
       write(p_->pMappedArea_, p_->mappedLength_);
@@ -275,6 +276,7 @@ byte* FileIo::mmap(bool isWriteable) {
   }
   p_->pMappedArea_ = static_cast<byte*>(rc);
 #else
+#error Platforms without mmap are not supported. See https://github.com/Exiv2/exiv2/issues/2380
   // Workaround for platforms without mmap: Read the file into memory
   byte* buf = new byte[p_->mappedLength_];
   const long offset = std::ftell(p_->fp_);


### PR DESCRIPTION
Fixes: #2380 

We have some `#ifdef`-ed fallback code for when `EXV_HAVE_MMAP` is undefined. We don't test that code because all realistic platforms have `mmap`. It turns out that the fallback code doesn't work. This fixes it. I have tested it locally, but I don't think it's worth adding a test for it, because we don't expect anybody to build exiv2 like this.