### PR TITLE
Fix "Windows MSYS2 UCRT64/Debug/Shared" build

### DIFF
--- a/tests/bash_tests/utils.py
+++ b/tests/bash_tests/utils.py
@@ -343,7 +343,7 @@ class HttpServer:
         log.info('Starting HTTP server ...')
         self.proc = multiprocessing.Process(target=self._start, name=str(self))
         self.proc.start()
-        time.sleep(2)
+        time.sleep(5)
         try:
             with request.urlopen('http://127.0.0.1:{}'.format(self.port), timeout=3) as f:
                 if f.status != 200:


### PR DESCRIPTION
Build occasionally fails in `io_test` (`bashtest`) when using the server. Increase sleep timeout to prevent race condition.