### PR TITLE
Enable Workflow dispatch on Windows CI jobs

### DIFF
--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "*.md"
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
I would like to enable the possibility of triggering such Windows CI jobs without needing to create a PR, with the aim of trying to fix the current issue we have with the cygwin builds. The idea is to just trigger such specific job in isolation. When a PR is created, dozens of CI jobs are dispatched and I do not want to wait for all of them to finish when I am just trying to fix the Windows issue.

