### PR TITLE
Update ubuntu-latest tag to ubuntu-22.04

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -11,7 +11,7 @@ on:
       - "*.md"
 jobs:
   Fuzzing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Build Fuzzers
       id: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -13,7 +13,7 @@ permissions: read-all
 
 jobs:
   codesee:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     name: Analyze the repo with CodeSee
     steps:

--- a/.github/workflows/nightly_Linux_distributions.yml
+++ b/.github/workflows/nightly_Linux_distributions.yml
@@ -14,7 +14,7 @@ name: Nightly - Linux distributions
 
 jobs:
   distros:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/on_PR_linux_fuzz.yml
+++ b/.github/workflows/on_PR_linux_fuzz.yml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   Linux:
-    name: 'Ubuntu 20.04 - clang/libFuzzer'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - clang/libFuzzer'
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -36,23 +36,23 @@ jobs:
 
       - name: Run Conan
         run: |
-          mkdir build && cd build
+          mkdir build-base_linux && cd build-base_linux
           conan profile list
           conan profile show default
           conan install .. -o webready=True --build missing
 
       - name: Build
         run: |
-          cmake --preset base_linux -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}}
-          cmake --build build --parallel
+          cmake --preset base_linux -S . -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}}
+          cmake --build build-base_linux --parallel
 
       - name: Install
         run: |
-          cd build
+          cd build-base_linux
           cmake --install . 
           tree install
 
       - name: Test
         run: |
-          cd build
+          cd build-base_linux
           ctest --output-on-failure

--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   Linux:
-    name: 'Ubuntu 20.04 - GCC, BuildType:${{matrix.build_type}}, SHARED:${{matrix.shared_libraries}}'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC, BuildType:${{matrix.build_type}}, SHARED:${{matrix.shared_libraries}}'
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -25,7 +25,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          sudo apt-get install ninja-build
+          sudo apt-get install ninja-build tree
           pip3 install conan==1.54.0
 
       - name: Conan common config

--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   special_debugRelease:
-    name: 'Ubuntu 20.04 - GCC - Debug+Coverage'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Debug+Coverage'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -61,8 +61,8 @@ jobs:
           ./codecov -f coverage.xml
 
   special_releaseValgrind:
-    name: 'Ubuntu 20.04 - GCC - Release+Valgrind'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Release+Valgrind'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -96,8 +96,8 @@ jobs:
 
 
   special_releaseSanitizers:
-    name: 'Ubuntu 20.04 - GCC - Release+Sanitizers'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Release+Sanitizers'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -130,8 +130,8 @@ jobs:
           ctest --output-on-failure
 
   special_allEnabled:
-    name: 'Ubuntu 20.04 - GCC - All Options Enabled + Documentation'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - All Options Enabled + Documentation'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on_PR_linux_staticAnalysis.yml
+++ b/.github/workflows/on_PR_linux_staticAnalysis.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   special_pvsStudio:
-    name: 'Ubuntu 20.04 - GCC - Static Analyzer: PVS-Studio'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Static Analyzer: PVS-Studio'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -64,8 +64,8 @@ jobs:
           ctest --output-on-failure
 
   Linux:
-    name: 'Ubuntu 20.04 - GCC - Arch:x64 BuildType:Release - SHARED'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Arch:x64 BuildType:Release - SHARED'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on_push_ExtraJobsForMain.yml
+++ b/.github/workflows/on_push_ExtraJobsForMain.yml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   special_debugRelease:
-    name: 'Ubuntu 20.04 - GCC - Debug+Coverage'
-    runs-on: ubuntu-latest
+    name: 'Ubuntu 22.04 - GCC - Debug+Coverage'
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on_push_clang_format.yml
+++ b/.github/workflows/on_push_clang_format.yml
@@ -5,7 +5,7 @@ concurrency:
 on: [push, pull_request]
 jobs:
   clang-format-checking:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: DoozyX/clang-format-lint-action@v0.14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   Linux:
     name: 'Build Linux Release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -152,7 +152,7 @@ jobs:
 
   publish:
     needs: [Linux, macOS, Windows]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Everytime a CI service such a GitHub actions update the images corresponding to their 'latest' tags, pipelines tend to have some hipcups due to changes in the distribution default packages.

By fixing the images to a specific one, we should be more resilient to changes in the Github actions environment.

Fixes #2438 