### PR TITLE
Prefer writing PNG eXIf chunk

### DIFF
--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -321,14 +321,12 @@ std::string PngChunk::makeMetadataChunk(const std::string& metadata, MetadataId 
   switch (type) {
     case mdComment:
       return makeUtf8TxtChunk("Description", metadata, true);
-    case mdExif:
-      rawProfile = writeRawProfile(metadata, "exif");
-      return makeAsciiTxtChunk("Raw profile type exif", rawProfile, true);
     case mdIptc:
       rawProfile = writeRawProfile(metadata, "iptc");
       return makeAsciiTxtChunk("Raw profile type iptc", rawProfile, true);
     case mdXmp:
       return makeUtf8TxtChunk("XML:com.adobe.xmp", metadata, false);
+    case mdExif:
     case mdIccProfile:
     case mdNone:
       return {};

--- a/test/data/test_reference_files/icc-test.out
+++ b/test/data/test_reference_files/icc-test.out
@@ -308,152 +308,152 @@ STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
       33 | iTXt  |      31 | Description.....x.KLJNIMK..... | 0xc1fefec8
-      76 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8549 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9197 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
- 1168394 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
- 1175562 | gAMA  |       4 | ....                           | 0x0bfc6105
- 1175578 | bKGD  |       6 | ......                         | 0xa0bda793
- 1175596 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
- 1175617 | tIME  |       7 | ......2                        | 0x582d32e4
- 1175636 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
- 1175926 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
- 1184130 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
- 1192334 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
- 1200538 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
- 1208742 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
- 1215927 | IEND  |       0 |                                | 0xae426082
+      76 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8496 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9144 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
+ 1168341 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+ 1175509 | gAMA  |       4 | ....                           | 0x0bfc6105
+ 1175525 | bKGD  |       6 | ......                         | 0xa0bda793
+ 1175543 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+ 1175564 | tIME  |       7 | ......2                        | 0x582d32e4
+ 1175583 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+ 1175873 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+ 1184077 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+ 1192281 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+ 1200485 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+ 1208689 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+ 1215874 | IEND  |       0 |                                | 0xae426082
 abcdefg
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
-      33 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8506 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9154 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
- 1168351 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
- 1175519 | gAMA  |       4 | ....                           | 0x0bfc6105
- 1175535 | bKGD  |       6 | ......                         | 0xa0bda793
- 1175553 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
- 1175574 | tIME  |       7 | ......2                        | 0x582d32e4
- 1175593 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
- 1175883 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
- 1184087 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
- 1192291 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
- 1200495 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
- 1208699 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
- 1215884 | IEND  |       0 |                                | 0xae426082
+      33 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8453 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9101 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
+ 1168298 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+ 1175466 | gAMA  |       4 | ....                           | 0x0bfc6105
+ 1175482 | bKGD  |       6 | ......                         | 0xa0bda793
+ 1175500 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+ 1175521 | tIME  |       7 | ......2                        | 0x582d32e4
+ 1175540 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+ 1175830 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+ 1184034 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+ 1192238 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+ 1200442 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+ 1208646 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+ 1215831 | IEND  |       0 |                                | 0xae426082
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
-      33 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8506 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9154 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
- 1168351 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
- 1175519 | gAMA  |       4 | ....                           | 0x0bfc6105
- 1175535 | bKGD  |       6 | ......                         | 0xa0bda793
- 1175553 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
- 1175574 | tIME  |       7 | ......2                        | 0x582d32e4
- 1175593 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
- 1175883 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
- 1184087 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
- 1192291 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
- 1200495 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
- 1208699 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
- 1215884 | IEND  |       0 |                                | 0xae426082
+      33 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8453 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9101 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
+ 1168298 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+ 1175466 | gAMA  |       4 | ....                           | 0x0bfc6105
+ 1175482 | bKGD  |       6 | ......                         | 0xa0bda793
+ 1175500 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+ 1175521 | tIME  |       7 | ......2                        | 0x582d32e4
+ 1175540 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+ 1175830 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+ 1184034 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+ 1192238 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+ 1200442 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+ 1208646 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+ 1215831 | IEND  |       0 |                                | 0xae426082
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
       33 | iTXt  |      31 | Description.....x.KLJNIMK..... | 0xc1fefec8
-      76 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8549 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9197 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
- 1168394 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
- 1175562 | gAMA  |       4 | ....                           | 0x0bfc6105
- 1175578 | bKGD  |       6 | ......                         | 0xa0bda793
- 1175596 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
- 1175617 | tIME  |       7 | ......2                        | 0x582d32e4
- 1175636 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
- 1175926 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
- 1184130 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
- 1192334 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
- 1200538 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
- 1208742 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
- 1215927 | IEND  |       0 |                                | 0xae426082
+      76 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8496 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9144 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
+ 1168341 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+ 1175509 | gAMA  |       4 | ....                           | 0x0bfc6105
+ 1175525 | bKGD  |       6 | ......                         | 0xa0bda793
+ 1175543 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+ 1175564 | tIME  |       7 | ......2                        | 0x582d32e4
+ 1175583 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+ 1175873 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+ 1184077 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+ 1192281 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+ 1200485 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+ 1208689 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+ 1215874 | IEND  |       0 |                                | 0xae426082
 abcdefg
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
-      33 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8506 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9154 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
- 1168351 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
- 1175519 | gAMA  |       4 | ....                           | 0x0bfc6105
- 1175535 | bKGD  |       6 | ......                         | 0xa0bda793
- 1175553 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
- 1175574 | tIME  |       7 | ......2                        | 0x582d32e4
- 1175593 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
- 1175883 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
- 1184087 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
- 1192291 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
- 1200495 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
- 1208699 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
- 1215884 | IEND  |       0 |                                | 0xae426082
+      33 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8453 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9101 | iCCP  | 1159185 | ICC profile..x...uP.[..9@.HB.D | 0xd3dbe519
+ 1168298 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+ 1175466 | gAMA  |       4 | ....                           | 0x0bfc6105
+ 1175482 | bKGD  |       6 | ......                         | 0xa0bda793
+ 1175500 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+ 1175521 | tIME  |       7 | ......2                        | 0x582d32e4
+ 1175540 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+ 1175830 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+ 1184034 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+ 1192238 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+ 1200442 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+ 1208646 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+ 1215831 | IEND  |       0 |                                | 0xae426082
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
-      33 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8506 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9154 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
-    9459 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
-   16627 | gAMA  |       4 | ....                           | 0x0bfc6105
-   16643 | bKGD  |       6 | ......                         | 0xa0bda793
-   16661 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
-   16682 | tIME  |       7 | ......2                        | 0x582d32e4
-   16701 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
-   16991 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
-   25195 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
-   33399 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
-   41603 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
-   49807 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
-   56992 | IEND  |       0 |                                | 0xae426082
+      33 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8453 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9101 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
+    9406 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+   16574 | gAMA  |       4 | ....                           | 0x0bfc6105
+   16590 | bKGD  |       6 | ......                         | 0xa0bda793
+   16608 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+   16629 | tIME  |       7 | ......2                        | 0x582d32e4
+   16648 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+   16938 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+   25142 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+   33346 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+   41550 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+   49754 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+   56939 | IEND  |       0 |                                | 0xae426082
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
       33 | iTXt  |      31 | Description.....x.KLJNIMK..... | 0xc1fefec8
-      76 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8549 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9197 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
-    9502 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
-   16670 | gAMA  |       4 | ....                           | 0x0bfc6105
-   16686 | bKGD  |       6 | ......                         | 0xa0bda793
-   16704 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
-   16725 | tIME  |       7 | ......2                        | 0x582d32e4
-   16744 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
-   17034 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
-   25238 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
-   33442 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
-   41646 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
-   49850 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
-   57035 | IEND  |       0 |                                | 0xae426082
+      76 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8496 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9144 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
+    9449 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+   16617 | gAMA  |       4 | ....                           | 0x0bfc6105
+   16633 | bKGD  |       6 | ......                         | 0xa0bda793
+   16651 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+   16672 | tIME  |       7 | ......2                        | 0x582d32e4
+   16691 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+   16981 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+   25185 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+   33389 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+   41593 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+   49797 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+   56982 | IEND  |       0 |                                | 0xae426082
 abcdefg
 STRUCTURE OF PNG FILE: ReaganLargePng.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ............                   | 0x8cf910c3
-      33 | zTXt  |    8461 | Raw profile type exif..x...iv. | 0x91fbf6a0
-    8506 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
-    9154 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
-    9459 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
-   16627 | gAMA  |       4 | ....                           | 0x0bfc6105
-   16643 | bKGD  |       6 | ......                         | 0xa0bda793
-   16661 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
-   16682 | tIME  |       7 | ......2                        | 0x582d32e4
-   16701 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
-   16991 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
-   25195 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
-   33399 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
-   41603 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
-   49807 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
-   56992 | IEND  |       0 |                                | 0xae426082
+      33 | eXIf  |    8408 | II*..........................  | 0x81634e71
+    8453 | zTXt  |     636 | Raw profile type iptc..x..TKn. | 0x4e5178d3
+    9101 | iCCP  |     293 | ICC profile..x.c``2ptqre.``..+ | 0x7d41600b
+    9406 | iTXt  |    7156 | XML:com.adobe.xmp.....<?xpacke | 0x8d6d70ba
+   16574 | gAMA  |       4 | ....                           | 0x0bfc6105
+   16590 | bKGD  |       6 | ......                         | 0xa0bda793
+   16608 | pHYs  |       9 | ...#...#.                      | 0x78a53f76
+   16629 | tIME  |       7 | ......2                        | 0x582d32e4
+   16648 | zTXt  |     278 | Comment..x.}..n.@....O..5..h.. | 0xdb1dfff5
+   16938 | IDAT  |    8192 | x...k.%.u%....D......GWW...ER. | 0x929ed75c
+   25142 | IDAT  |    8192 | .F('.T)/....D"]..."2 '(...D%.. | 0x52c572c0
+   33346 | IDAT  |    8192 | y-.....>....3..p.....$....E.Bj | 0x65a90ffb
+   41550 | IDAT  |    8192 | ....S....?..G.....G........... | 0xf44da161
+   49754 | IDAT  |    7173 | .evl...3K..j.S.....x......Z .D | 0xbe6d3574
+   56939 | IEND  |       0 |                                | 0xae426082
 45ed3c125cc6041b37b44ee4cb881cd8
 45ed3c125cc6041b37b44ee4cb881cd8
 50b9125494306a6fc1b7c4f2a1a8d49d

--- a/test/data/test_reference_files/png-test.out
+++ b/test/data/test_reference_files/png-test.out
@@ -57,12 +57,12 @@ STRUCTURE OF PNG FILE: 1343_exif.png
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | .......d....                   | 0x4ce4e85c
       33 | iTXt  |      39 | Description.....x.K.H.KOMQH... | 0xe0a1c8ce
-      84 | zTXt  |     145 | Raw profile type exif..x.U.... | 0x2f6d89e8
-     241 | sRGB  |       1 |                                | 0xaece1ce9
-     254 | gAMA  |       4 | ....                           | 0x0bfc6105
-     270 | pHYs  |       9 | .........                      | 0xc76fa864
-     291 | IDAT  |     257 | x^..1..0......t.....h......z.. | 0x64465429
-     560 | IEND  |       0 |                                | 0xae426082
+      84 | eXIf  |     108 | II*...............J..........  | 0xe863fbc7
+     204 | sRGB  |       1 |                                | 0xaece1ce9
+     217 | gAMA  |       4 | ....                           | 0x0bfc6105
+     233 | pHYs  |       9 | .........                      | 0xc76fa864
+     254 | IDAT  |     257 | x^..1..0......t.....h......z.. | 0x64465429
+     523 | IEND  |       0 |                                | 0xae426082
 changed comment
 Exif.Image.ImageDescription                  Ascii      17  Can you read me?
 Exif.Image.XResolution                       Rational    1  72


### PR DESCRIPTION
Resolves https://github.com/Exiv2/exiv2/issues/2250

We still support reading the (unregistered) legacy text chunks, but always write out the eXIf chunk added to the PNG spec (as Exiftool does).