### PR TITLE
Silence unused parameter warning when EXV_ENABLE_INIH is undefined

### DIFF
--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -80,7 +80,8 @@ std::string getExiv2ConfigPath() {
   return (currentPath / inifile).string();
 }
 
-std::string readExiv2Config(const std::string& section, const std::string& value, const std::string& def) {
+std::string readExiv2Config([[maybe_unused]] const std::string& section, [[maybe_unused]] const std::string& value,
+                            const std::string& def) {
   std::string result = def;
 
 #ifdef EXV_ENABLE_INIH


### PR DESCRIPTION
Follow-up to #2465: the OSS-Fuzz build is now failing due to a compiler warning because two of the parameters are unused. This silences the warnings.