### PR TITLE
Remove use of 'register' storage class keyword

### DIFF
--- a/contrib/organize/MD5.cpp
+++ b/contrib/organize/MD5.cpp
@@ -153,7 +153,7 @@ MD5Final(md5byte digest[16], struct MD5_CTX *ctx)
 void
 MD5Transform(UWORD32 buf[4], UWORD32 const in[16])
 {
-	register UWORD32 a, b, c, d;
+	UWORD32 a, b, c, d;
 
 	a = buf[0];
 	b = buf[1];

--- a/xmpsdk/src/MD5.cpp
+++ b/xmpsdk/src/MD5.cpp
@@ -153,7 +153,7 @@ MD5Final(md5byte digest[16], struct MD5_CTX *ctx)
 void
 MD5Transform(UWORD32 buf[4], UWORD32 const in[16])
 {
-	register UWORD32 a, b, c, d;
+	UWORD32 a, b, c, d;
 
 	a = buf[0];
 	b = buf[1];


### PR DESCRIPTION
It is gone from c++17 and newer std, latest clang/gcc are now defaulting to c++17

Signed-off-by: Khem Raj <raj.khem@gmail.com>