### PR TITLE
use gnu_printf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,11 +158,6 @@ endif()
 # Other library target properties
 # ---------------------------------------------------------
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-    # Do not check format overflows on this file, to skip a false positive warning
-    set_source_files_properties(value.cpp PROPERTIES COMPILE_FLAGS -Wno-format-overflow)
-endif()
-
 set_target_properties( exiv2lib PROPERTIES
     VERSION       ${PROJECT_VERSION}
     SOVERSION     ${PROJECT_VERSION_MINOR}

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -12,7 +12,9 @@
 #include <ostream>  // for ostream, basic_ostream::put
 #include <string>
 
-#if (defined(__GNUG__) || defined(__GNUC__)) || defined(__clang__)
+#if defined(__MINGW32__)
+#define ATTRIBUTE_FORMAT_PRINTF __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 0)))
+#elif defined(__GNUC__)
 #define ATTRIBUTE_FORMAT_PRINTF __attribute__((format(printf, 1, 0)))
 #else
 #define ATTRIBUTE_FORMAT_PRINTF


### PR DESCRIPTION
Fixes warning under MinGW:

warning: unknown conversion type character 'z' in format [-Wformat=]

Signed-off-by: Rosen Penev <rosenp@gmail.com>