### PR TITLE
fix C++20 deprecation warning

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -422,7 +422,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
           enforce(data.size() - skip >= (version > 2u ? 4u : 2u), Exiv2::ErrorCode::kerCorruptedMetadata);
           enforce(data.size() - skip >= step, Exiv2::ErrorCode::kerCorruptedMetadata);
           uint32_t ID = version > 2 ? data.read_uint32(skip, endian_) : data.read_uint16(skip, endian_);
-          auto offset = [=] {
+          auto offset = [this, &data, skip, step] {
             if (step == 14 || step == 16)
               return data.read_uint32(skip + step - 8, endian_);
             if (step == 18)


### PR DESCRIPTION
Capturing this with = is deprecated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>