### PR TITLE
Export QuickTimeVideo

### DIFF
--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -33,10 +33,13 @@
 // included header files
 #include "image.hpp"
 
+// *****************************************************************************
+// namespace extensions
 namespace Exiv2 {
 
 // *****************************************************************************
 // class definitions
+
 /*!
   @brief Class to access ASF video files.
  */
@@ -56,7 +59,10 @@ class EXIV2API AsfVideo : public Image {
         method to get a temporary reference.
    */
   explicit AsfVideo(BasicIo::UniquePtr io);
+  //@}
 
+  //! @name NOT Implemented
+  //@{
   //! Copy constructor
   AsfVideo(const AsfVideo&) = delete;
   //! Assignment operator
@@ -71,7 +77,7 @@ class EXIV2API AsfVideo : public Image {
 
   //! @name Accessors
   //@{
-  std::string mimeType() const override;
+  [[nodiscard]] std::string mimeType() const override;
   //@}
  private:
   static constexpr size_t ASF_TAG_SIZE = 0x4;

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -116,7 +116,10 @@ class EXIV2API MatroskaVideo : public Image {
         method to get a temporary reference.
    */
   explicit MatroskaVideo(BasicIo::UniquePtr io);
+  //@}
 
+  //! @name NOT Implemented
+  //@{
   //! Copy constructor
   MatroskaVideo(const MatroskaVideo&) = delete;
   //! Assignment operator
@@ -184,6 +187,10 @@ class EXIV2API MatroskaVideo : public Image {
 };  // class MatroskaVideo
 
 // *****************************************************************************
+// template, inline and free functions
+
+// These could be static private functions on Image subclasses but then
+// ImageFactory needs to be made a friend.
 /*!
   @brief Create a new MatroskaVideo instance and return an auto-pointer to it.
       Caller owns the returned object and the auto-pointer ensures that

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -17,8 +17,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef QUICKTIMEVIDEO_HPP
-#define QUICKTIMEVIDEO_HPP
+#ifndef QUICKTIMEVIDEO_HPP_
+#define QUICKTIMEVIDEO_HPP_
 
 // *****************************************************************************
 #include "exiv2lib_export.h"
@@ -37,7 +37,7 @@ namespace Exiv2 {
 /*!
   @brief Class to access QuickTime video files.
  */
-class QuickTimeVideo : public Image {
+class EXIV2API QuickTimeVideo : public Image {
  public:
   //! @name Creators
   //@{
@@ -52,7 +52,7 @@ class QuickTimeVideo : public Image {
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
    */
-  QuickTimeVideo(BasicIo::UniquePtr io);
+  explicit QuickTimeVideo(BasicIo::UniquePtr io);
   //@}
 
   //! @name NOT Implemented
@@ -71,7 +71,7 @@ class QuickTimeVideo : public Image {
 
   //! @name Accessors
   //@{
-  std::string mimeType() const override;
+  [[nodiscard]] std::string mimeType() const override;
   //@}
 
  protected:
@@ -227,11 +227,11 @@ class QuickTimeVideo : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool create);
+EXIV2API Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool create);
 
 //! Check if the file iIo is a Quick Time Video.
-bool isQTimeType(BasicIo& iIo, bool advance);
+EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);
 
 }  // namespace Exiv2
 
-#endif  // QUICKTIMEVIDEO_HPP
+#endif  // QUICKTIMEVIDEO_HPP_

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -14,11 +14,11 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * asize_t with this program; if not, write to the Free Software
+ * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, 5th Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef RIFFVIDEO_HPP
-#define RIFFVIDEO_HPP
+#ifndef RIFFVIDEO_HPP_
+#define RIFFVIDEO_HPP_
 
 // *****************************************************************************
 #include "exiv2lib_export.h"
@@ -53,12 +53,14 @@ class EXIV2API RiffVideo : public Image {
         method to get a temporary reference.
    */
   explicit RiffVideo(BasicIo::UniquePtr io);
+  //@}
 
+  //! @name NOT Implemented
+  //@{
   //! Copy constructor
   RiffVideo(const RiffVideo&) = delete;
   //! Assignment operator
   RiffVideo& operator=(const RiffVideo&) = delete;
-
   //@}
 
   //! @name Manipulators
@@ -204,4 +206,4 @@ EXIV2API bool isRiffType(BasicIo& iIo, bool advance);
 
 }  // namespace Exiv2
 
-#endif  // RIFFVIDEO_HPP
+#endif  // RIFFVIDEO_HPP_


### PR DESCRIPTION
Explicitly export QuickTimeVideo, so it is exported on Windows/MSVC as well.

Also clean up/synchronize other video public headers