### PR TITLE
fuzz issue : check that block is not corrupted before decoding

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -254,6 +254,10 @@ AsfVideo::HeaderReader::HeaderReader(BasicIo::UniquePtr& io) : IdBuf_(GUID) {
 void AsfVideo::decodeBlock() {
   Internal::enforce(GUID + QWORD + io_->tell() <= io_->size(), Exiv2::ErrorCode::kerCorruptedMetadata);
   HeaderReader objectHeader(io_);
+#ifdef EXIV2_DEBUG_MESSAGES
+  EXV_INFO << "decodeBlock = " << GUIDTag(objectHeader.getId().data()).to_string()
+           << "\tsize= " << objectHeader.getSize() << "\t " << io_->tell() << "/" << io_->size() << std::endl;
+#endif
   Internal::enforce(objectHeader.getSize() + io_->tell() <= io_->size(), Exiv2::ErrorCode::kerCorruptedMetadata);
   auto tag = GUIDReferenceTags.find(GUIDTag(objectHeader.getId().data()));
 
@@ -483,7 +487,8 @@ void AsfVideo::fileProperties() {
   xmpData()["Xmp.video.SendDuration"] = readQWORDTag(io_);
   xmpData()["Xmp.video.Preroll"] = readQWORDTag(io_);
 
-  io_->seek(io_->tell() + DWORD + DWORD + DWORD, BasicIo::beg);
+  io_->seek(io_->tell() + DWORD + DWORD + DWORD,
+            BasicIo::beg);  // ignore Flags, Minimum Data Packet Size and Maximum Data Packet Size
   xmpData()["Xmp.video.MaxBitRate"] = readDWORDTag(io_);
 }  // AsfVideo::fileProperties
 


### PR DESCRIPTION
Fixing the issue faced here : https://github.com/Exiv2/exiv2/issues/2450#issuecomment-1427695015
We should throw exception when the size of the block is higher than the size of the file