### PR TITLE
asfvideo fuzz issue : nb_headers should not exceed the max value of uint32

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -294,6 +294,7 @@ void AsfVideo::decodeHeader() {
   io_->read(nbHeadersBuf.data(), DWORD);
 
   uint32_t nb_headers = Exiv2::getULong(nbHeadersBuf.data(), littleEndian);
+  Internal::enforce(nb_headers < std::numeric_limits<uint32_t>::max(), Exiv2::ErrorCode::kerCorruptedMetadata);
   io_->seekOrThrow(io_->tell() + BYTE * 2, BasicIo::beg,
                    ErrorCode::kerFailedToReadImageData);  // skip two reserved tags
   for (uint32_t i = 0; i < nb_headers; i++) {


### PR DESCRIPTION
fixing error faced here : https://github.com/Exiv2/exiv2/issues/2450#issuecomment-1453396653
```
./bin/exiv2  -p x ~/Downloads/pocs/crash-8c3b9114184273407e8bbc52579ac881606e60b0
Exiv2 exception in print action for file /home/mohamed.chebbi@devel.iress.com.au/Downloads/pocs/crash-8c3b9114184273407e8bbc52579ac881606e60b0:
corrupted image metadata

```