### PR TITLE
Convert tail-recursion to loop to avoid stack exhaustion

### DIFF
--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -456,17 +456,14 @@ void RiffVideo::readChunk(HeaderReader& header_) {
 }
 
 void RiffVideo::decodeBlocks() {
-  HeaderReader header(io_);
-  if (equal(header.getId(), CHUNK_ID_LIST)) {
-    readList(header);
-  } else {
-    readChunk(header);
-  }
-
-  if (!io_->eof() && io_->tell() < io_->size()) {
-    decodeBlocks();
-  }
-
+  do {
+    HeaderReader header(io_);
+    if (equal(header.getId(), CHUNK_ID_LIST)) {
+      readList(header);
+    } else {
+      readChunk(header);
+    }
+  } while (!io_->eof() && io_->tell() < io_->size());
 }  // RiffVideo::decodeBlock
 
 void RiffVideo::readAviHeader() {


### PR DESCRIPTION
This fixes an OSS-Fuzz issue: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56746

This call to `decodeBlocks` is a tail-recursion, so it can be converted to a loop:

https://github.com/Exiv2/exiv2/blob/1697417c27b81c68a56f9af470e75ffad629346c/src/riffvideo.cpp#L466-L468