### PR TITLE
Minor refactorings to stop UBSAN from complaining

### DIFF
--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -295,7 +295,6 @@ void TiffImageEntry::setStrips(const Value* pSize, const byte* pData, size_t siz
   }
   for (size_t i = 0; i < pValue()->count(); ++i) {
     const size_t offset = pValue()->toUint32(i);
-    const byte* pStrip = pData + baseOffset + offset;
     const size_t size = pSize->toUint32(i);
 
     if (size > sizeData || offset > sizeData - size || baseOffset > sizeData - size - offset) {
@@ -304,6 +303,7 @@ void TiffImageEntry::setStrips(const Value* pSize, const byte* pData, size_t siz
                   << tag() << ": Strip " << std::dec << i << " is outside of the data area; ignored.\n";
 #endif
     } else if (size != 0) {
+      const byte* pStrip = pData + baseOffset + offset;
       strips_.emplace_back(pStrip, size);
     }
   }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -1316,7 +1316,7 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
                   << size
                   << ", exceeds buffer size by "
                   // cast to make MSVC happy
-                  << static_cast<size_t>(pData + size - pLast_) << " Bytes; truncating the entry\n";
+                  << size - static_cast<size_t>(pLast_ - pData) << " Bytes; truncating the entry\n";
 #endif
         size = 0;
       }


### PR DESCRIPTION
Fixes: #2539

UBSAN is complaining because there's an integer overflow in a pointer addition. In both cases, it's harmless because the pointer is never dereferenced. I've refactored the code to stop the overflow from happening.