### PR TITLE
meson: compile convert.cpp separately, with just iconv

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,9 +85,9 @@ if zlib_dep.found()
 endif
 
 if meson.version().version_compare('>= 0.60') and host_machine.system() != 'freebsd'
-  iconv_dep = dependency('iconv', disabler: true, required: get_option('iconv'))
+  iconv_dep = dependency('iconv', required: get_option('iconv'))
 else
-  iconv_dep = dependency('', disabler: true, required: false)
+  iconv_dep = dependency('', required: false)
 endif
 if iconv_dep.found()
   deps += iconv_dep
@@ -124,7 +124,6 @@ base_lib = files(
   'src/basicio.cpp',
   'src/bmffimage.cpp',
   'src/bmpimage.cpp',
-  'src/convert.cpp',
   'src/cr2image.cpp',
   'src/crwimage.cpp',
   'src/datasets.cpp',
@@ -289,6 +288,20 @@ exiv2int_dep = declare_dependency(
   link_with: exiv2int,
 )
 
+# This is compiled separately, because there are multiple sources for iconv
+# (methods "builtin" and "system") and it's possible to have the include
+# directory from one dependency leak over and force the system iconv to be used
+# instead of the builtin one. This causes miscompilation.
+convertlib = static_library(
+  '_convert',
+  'src/convert.cpp',
+  cpp_args: cargs,
+  gnu_symbol_visibility: 'hidden',
+  dependencies: iconv_dep,
+  include_directories: [depinc, libinc],
+  build_by_default: false,
+)
+
 exiv2 = library(
   'exiv2',
   base_lib,
@@ -296,6 +309,7 @@ exiv2 = library(
   cpp_args: cargs,
   version: meson.project_version(),
   gnu_symbol_visibility: 'hidden',
+  link_with: convertlib,
   dependencies: [deps, exiv2int_dep],
   include_directories: libinc,
   install: true,


### PR DESCRIPTION
Compiling this file with all dependencies as part of the main library causes it to have the include directories of all dependencies, but iconv is a bit of a special case: it can have a libc builtin or an external library version. The external library might be installed to the same directory as other dependencies, for example on FreeBSD -- but if exiv2 is not supposed to be built with GNU libiconv, then it will expect to see the libc builtin.

The leaky include directories means that iconv.h gets pulled in from the GNU libiconv version instead, though, which then forces -liconv to be necessary for no reason.

There are two general solutions to ensuring that everything links correctly:

- expect exiv2 to be built with *global* -I/usr/local/include -L/usr/local/lib thus forcing the use of GNU libiconv

- carefully compiling the iconv support without any other dependencies

Let's do the latter since it allows for more choice and is easier to enforce.

/cc @neheb 