### PR TITLE
Add Sony ZV-E1 ID

### DIFF
--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -431,7 +431,8 @@ constexpr TagDetails sonyModelId[] = {{0, N_("Multiple camera models")},
                                       {388, "ILCE-7M4"},
                                       {389, "ZV-1F"},
                                       {390, "ILCE-7RM5"},
-                                      {391, "ILME-FX30"}};
+                                      {391, "ILME-FX30"},
+                                      {393, "ZV-E1"}};
 
 //! Lookup table to translate Sony creative style (main group) values to readable labels
 constexpr StringTagDetails sonyCreativeStyleStd[] = {{"AdobeRGB", N_("Adobe RGB")},


### PR DESCRIPTION
@boardhead Found in [recent DPReview sample.](https://www.dpreview.com/sample-galleries/0639295760/sony-zv-e1-pre-production-sample-gallery-dpreview-tv)
```
SonyModelID                     : Unknown (393)
```