### PR TITLE
clang-tidy: remove const from data members

### DIFF
--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -1264,7 +1264,7 @@ bool parseCmdFiles(ModifyCmds& modifyCmds, const Params::CmdFiles& cmdFiles) {
       while (bStdin ? std::getline(std::cin, line) : std::getline(file, line)) {
         ModifyCmd modifyCmd;
         if (parseLine(modifyCmd, line, ++num)) {
-          modifyCmds.push_back(modifyCmd);
+          modifyCmds.push_back(std::move(modifyCmd));
         }
       }
     } catch (const Exiv2::Error& error) {
@@ -1281,7 +1281,7 @@ bool parseCmdLines(ModifyCmds& modifyCmds, const Params::CmdLines& cmdLines) {
     for (auto&& line : cmdLines) {
       ModifyCmd modifyCmd;
       if (parseLine(modifyCmd, line, ++num)) {
-        modifyCmds.push_back(modifyCmd);
+        modifyCmds.push_back(std::move(modifyCmd));
       }
     }
     return true;

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -116,7 +116,7 @@ class EXIV2API BmffImage : public Image {
   [[nodiscard]] uint32_t pixelHeight() const override;
   //@}
 
-  const Exiv2::ByteOrder endian_{Exiv2::bigEndian};
+  static constexpr Exiv2::ByteOrder endian_{Exiv2::bigEndian};
 
  private:
   void openOrThrow();

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -120,7 +120,7 @@ class EXIV2API LogMsg {
   // The log handler in use
   static Handler handler_;
   // The type of this log message
-  const Level msgType_;
+  Level msgType_;
   // Holds the log message until it is passed to the message handler
   std::ostringstream os_;
 
@@ -284,12 +284,12 @@ class EXIV2API Error : public std::exception {
   //@}
 
   // DATA
-  const ErrorCode code_;    //!< Error code
-  const std::string arg1_;  //!< First argument
-  const std::string arg2_;  //!< Second argument
-  const std::string arg3_;  //!< Third argument
-  std::string msg_;         //!< Complete error message
-};                          // class BasicError
+  ErrorCode code_;    //!< Error code
+  std::string arg1_;  //!< First argument
+  std::string arg2_;  //!< Second argument
+  std::string arg3_;  //!< Third argument
+  std::string msg_;   //!< Complete error message
+};
 
 //! %Error output operator
 inline std::ostream& operator<<(std::ostream& os, const Error& error) {

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -660,7 +660,7 @@ class EXIV2API BlockMap {
   blockType_e type_{bNone};
   byte* data_{nullptr};
   size_t size_{0};
-};  // class BlockMap
+};
 
 void MemIo::Impl::reserve(size_t wcount) {
   const size_t need = wcount + idx_;
@@ -1058,8 +1058,7 @@ class RemoteIo::Impl {
     @throw Error if it fails.
    */
   virtual size_t populateBlocks(size_t lowBlock, size_t highBlock);
-
-};  // class RemoteIo::Impl
+};
 
 RemoteIo::Impl::Impl(const std::string& url, size_t blockSize) :
     path_(url), blockSize_(blockSize), protocol_(fileProtocol(url)) {
@@ -1575,7 +1574,7 @@ class CurlIo::CurlImpl : public Impl {
   CurlImpl& operator=(const CurlImpl&) = delete;  //!< Assignment
  private:
   long timeout_;  //!< The number of seconds to wait while trying to connect.
-};                // class RemoteIo::Impl
+};
 
 CurlIo::CurlImpl::CurlImpl(const std::string& url, size_t blockSize) : Impl(url, blockSize), curl_(curl_easy_init()) {
   if (!curl_) {

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -423,7 +423,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
           Internal::enforce(data.size() - skip >= (version > 2u ? 4u : 2u), Exiv2::ErrorCode::kerCorruptedMetadata);
           Internal::enforce(data.size() - skip >= step, Exiv2::ErrorCode::kerCorruptedMetadata);
           uint32_t ID = version > 2 ? data.read_uint32(skip, endian_) : data.read_uint16(skip, endian_);
-          auto offset = [this, &data, skip, step] {
+          auto offset = [&data, skip, step] {
             if (step == 14 || step == 16)
               return data.read_uint32(skip + step - 8, endian_);
             if (step == 18)

--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -49,7 +49,7 @@ class Cr2Header : public TiffHeaderBase {
   // DATA
   uint32_t offset2_{0x00000000};             //!< Bytes 12-15 from the header
   static constexpr auto cr2sig_ = "CR\2\0";  //!< Signature for CR2 type TIFF
-};                                           // class Cr2Header
+};
 
 }  // namespace Exiv2::Internal
 

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -71,7 +71,7 @@ struct binaryToStringHelper {
   // invoke:
   // binaryToString(makeSlice(buf, 0, n));
   // <- buf_ would be now dangling, were it a reference
-  const Slice<T> buf_;
+  Slice<T> buf_;
 };
 
 /*!

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -88,7 +88,7 @@ class TiffPathItem {
   // DATA
   uint32_t extendedTag_;
   IfdId group_;
-};  // class TiffPathItem
+};
 
 /*!
   @brief Simple IO wrapper to ensure that the header is only written if there is
@@ -139,7 +139,7 @@ class IoWrapper {
   size_t size_;              //! Size of the header data.
   bool wroteHeader_{false};  //! Indicates if the header has been written.
   OffsetWriter* pow_;        //! Pointer to an offset-writer, if any, or 0
-};                           // class IoWrapper
+};
 
 /*!
   @brief Interface class for components of a TIFF directory hierarchy
@@ -336,8 +336,7 @@ class TiffComponent {
     a memory buffer. The buffer is allocated and freed outside of this class.
    */
   byte* pStart_{};
-
-};  // class TiffComponent
+};
 
 //! TIFF mapping table for functions to decode special cases
 struct TiffMappingInfo {
@@ -561,7 +560,7 @@ class TiffEntryBase : public TiffComponent {
   // TiffEntryBase has a clone method, which could lead to the DataBuf
   // having multiple owners.
   std::shared_ptr<DataBuf> storage_;
-};  // class TiffEntryBase
+};
 
 /*!
   @brief A standard TIFF IFD entry.
@@ -586,8 +585,7 @@ class TiffEntry : public TiffEntryBase {
   //@{
   [[nodiscard]] TiffEntry* doClone() const override;
   //@}
-
-};  // class TiffEntry
+};
 
 /*!
   @brief Interface for a standard TIFF IFD entry consisting of a value
@@ -633,10 +631,9 @@ class TiffDataEntryBase : public TiffEntryBase {
 
  private:
   // DATA
-  const uint16_t szTag_;  //!< Tag of the entry with the size
-  const IfdId szGroup_;   //!< Group of the entry with the size
-
-};  // class TiffDataEntryBase
+  uint16_t szTag_;  //!< Tag of the entry with the size
+  IfdId szGroup_;   //!< Group of the entry with the size
+};
 
 /*!
   @brief A standard TIFF IFD entry consisting of a value which is an offset
@@ -700,8 +697,7 @@ class TiffDataEntry : public TiffDataEntryBase {
   // DATA
   byte* pDataArea_{};      //!< Pointer to the data area (never alloc'd)
   size_t sizeDataArea_{};  //!< Size of the data area
-
-};  // class TiffDataEntry
+};
 
 /*!
   @brief A standard TIFF IFD entry consisting of a value which is an array
@@ -771,8 +767,7 @@ class TiffImageEntry : public TiffDataEntryBase {
 
   // DATA
   Strips strips_;  //!< Image strips data (never alloc'd) and sizes
-
-};  // class TiffImageEntry
+};
 
 /*!
   @brief A TIFF IFD entry containing the size of a data area of a related
@@ -817,10 +812,9 @@ class TiffSizeEntry : public TiffEntryBase {
 
  private:
   // DATA
-  const uint16_t dtTag_;  //!< Tag of the entry with the data area
-  const IfdId dtGroup_;   //!< Group of the entry with the data area
-
-};  // class TiffSizeEntry
+  uint16_t dtTag_;  //!< Tag of the entry with the data area
+  IfdId dtGroup_;   //!< Group of the entry with the data area
+};
 
 /*!
   @brief This class models a TIFF directory (%Ifd). It is a composite
@@ -924,10 +918,9 @@ class TiffDirectory : public TiffComponent {
 
   // DATA
   Components components_;   //!< List of components in this directory
-  const bool hasNext_;      //!< True if the directory has a next pointer
+  bool hasNext_;            //!< True if the directory has a next pointer
   TiffComponent* pNext_{};  //!< Pointer to the next IFD
-
-};  // class TiffDirectory
+};
 
 /*!
   @brief This class models a TIFF sub-directory (sub-IFD). A sub-IFD
@@ -1001,8 +994,7 @@ class TiffSubIfd : public TiffEntryBase {
   // DATA
   IfdId newGroup_;  //!< Start of the range of group numbers for the sub-IFDs
   Ifds ifds_;       //!< The subdirectories
-
-};  // class TiffSubIfd
+};
 
 /*!
   @brief This class is the basis for Makernote support in TIFF. It contains
@@ -1073,8 +1065,7 @@ class TiffMnEntry : public TiffEntryBase {
   // DATA
   IfdId mnGroup_;        //!< New group for concrete mn
   TiffComponent* mn_{};  //!< The Makernote
-
-};  // class TiffMnEntry
+};
 
 /*!
   @brief Tiff IFD Makernote. This is a concrete class suitable for all
@@ -1224,8 +1215,7 @@ class TiffIfdMakernote : public TiffComponent {
   TiffDirectory ifd_;                           //!< Makernote IFD
   size_t mnOffset_{};                           //!< Makernote offset
   ByteOrder imageByteOrder_{invalidByteOrder};  //!< Byte order for the image
-
-};  // class TiffIfdMakernote
+};
 
 /*!
   @brief Function pointer type for a function to determine which cfg + def
@@ -1272,9 +1262,9 @@ struct ArrayCfg {
 
 //! Combination of array configuration and definition for arrays
 struct ArraySet {
-  const ArrayCfg cfg_;    //!< Binary array configuration
-  const ArrayDef* def_;   //!< Binary array definition array
-  const size_t defSize_;  //!< Size of the array definition array
+  ArrayCfg cfg_;         //!< Binary array configuration
+  const ArrayDef* def_;  //!< Binary array definition array
+  size_t defSize_;       //!< Size of the array definition array
 };
 
 /*!
@@ -1396,19 +1386,19 @@ class TiffBinaryArray : public TiffEntryBase {
 
  private:
   // DATA
-  const CfgSelFct cfgSelFct_{};  //!< Pointer to a function to determine which cfg to use (may be 0)
-  const ArraySet* arraySet_{};   //!< Pointer to the array set, if any (may be 0)
-  const ArrayCfg* arrayCfg_{};   //!< Pointer to the array configuration (must not be 0, except for
-                                 //!< unrecognized complex binary arrays)
-  const ArrayDef* arrayDef_{};   //!< Pointer to the array definition (may be 0)
-  size_t defSize_{};             //!< Size of the array definition array (may be 0)
-  size_t setSize_{};             //!< Size of the array set (may be 0)
-  Components elements_;          //!< List of elements in this composite
-  byte* origData_{};             //!< Pointer to the original data buffer (unencrypted)
-  size_t origSize_{};            //!< Size of the original data buffer
-  TiffComponent* pRoot_{};       //!< Pointer to the root component of the TIFF tree. (Only used for intrusive writing.)
-  bool decoded_{};               //!< Flag to indicate if the array was decoded
-};                               // class TiffBinaryArray
+  CfgSelFct cfgSelFct_{};       //!< Pointer to a function to determine which cfg to use (may be 0)
+  const ArraySet* arraySet_{};  //!< Pointer to the array set, if any (may be 0)
+  const ArrayCfg* arrayCfg_{};  //!< Pointer to the array configuration (must not be 0, except for
+                                //!< unrecognized complex binary arrays)
+  const ArrayDef* arrayDef_{};  //!< Pointer to the array definition (may be 0)
+  size_t defSize_{};            //!< Size of the array definition array (may be 0)
+  size_t setSize_{};            //!< Size of the array set (may be 0)
+  Components elements_;         //!< List of elements in this composite
+  byte* origData_{};            //!< Pointer to the original data buffer (unencrypted)
+  size_t origSize_{};           //!< Size of the original data buffer
+  TiffComponent* pRoot_{};      //!< Pointer to the root component of the TIFF tree. (Only used for intrusive writing.)
+  bool decoded_{};              //!< Flag to indicate if the array was decoded
+};
 
 /*!
   @brief Element of a TiffBinaryArray.
@@ -1483,8 +1473,7 @@ class TiffBinaryElement : public TiffEntryBase {
   // DATA
   ArrayDef elDef_{0, ttUndefined, 0};        //!< The array element definition
   ByteOrder elByteOrder_{invalidByteOrder};  //!< Byte order to read/write the element
-
-};  // class TiffBinaryElement
+};
 
 // *****************************************************************************
 // template, inline and free functions

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -98,12 +98,11 @@ class TiffHeaderBase {
 
  private:
   // DATA
-  const uint16_t tag_;   //!< Tag to identify the buffer as TIFF data
-  const uint32_t size_;  //!< Size of the header
+  uint16_t tag_;         //!< Tag to identify the buffer as TIFF data
+  uint32_t size_;        //!< Size of the header
   ByteOrder byteOrder_;  //!< Applicable byte order
   uint32_t offset_;      //!< Offset to the start of the root dir
-
-};  // class TiffHeaderBase
+};
 
 //! Convenience function to check if tag, group is in the list of TIFF image tags.
 bool isTiffImageTag(uint16_t tag, IfdId group);
@@ -126,7 +125,7 @@ class TiffHeader : public TiffHeaderBase {
  private:
   // DATA
   bool hasImageTags_;  //!< Indicates if image tags are supported
-};                     // class TiffHeader
+};
 
 /*!
   @brief Data structure used to list image tags for TIFF and TIFF-like images.
@@ -175,8 +174,7 @@ class TiffCreator {
  private:
   static const TiffTreeTable tiffTreeTable_;    ///< TIFF tree structure
   static const TiffGroupTable tiffGroupTable_;  ///< TIFF group structure
-
-};  // class TiffCreator
+};
 
 /*!
   @brief Stateless parser class for data in TIFF format. Images use this
@@ -245,8 +243,7 @@ class TiffParserWorker {
     @return List of primary groups which is populated
    */
   static PrimaryGroups findPrimaryGroups(TiffComponent* pSourceDir);
-
-};  // class TiffParserWorker
+};
 
 /*!
   @brief Table of TIFF decoding and encoding functions and find functions.
@@ -287,8 +284,7 @@ class TiffMapping {
 
  private:
   static const TiffMappingInfo tiffMappingInfo_[];  ///< TIFF mapping table
-
-};  // class TiffMapping
+};
 
 /*!
   @brief Class to insert pointers or offsets to computed addresses at

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -668,7 +668,7 @@ class TiffReader : public TiffVisitor {
 
   // DATA
   const byte* pData_;      //!< Pointer to the memory buffer
-  const size_t size_;      //!< Size of the buffer
+  size_t size_;            //!< Size of the buffer
   const byte* pLast_;      //!< Pointer to the last byte
   TiffComponent* pRoot_;   //!< Root element of the composite
   TiffRwState* pState_;    //!< Pointer to the state in effect (origState_ or mnState_)
@@ -678,7 +678,7 @@ class TiffReader : public TiffVisitor {
   IdxSeq idxSeq_;          //!< Sequences for group, used for the entry's idx
   PostList postList_;      //!< List of components with deferred reading
   bool postProc_{false};   //!< True in postProcessList()
-};                         // class TiffReader
+};
 
 }  // namespace Internal
 }  // namespace Exiv2


### PR DESCRIPTION
Found with cppcoreguidelines-avoid-const-or-ref-data-members