### PR TITLE
meson: fix tests when zlib is disabled

### DIFF
--- a/unitTests/meson.build
+++ b/unitTests/meson.build
@@ -23,7 +23,6 @@ test_sources = files(
   'test_image_int.cpp',
   'test_jp2image.cpp',
   'test_jp2image_int.cpp',
-  'test_pngimage.cpp',
   'test_safe_op.cpp',
   'test_slice.cpp',
   'test_tiffheader.cpp',
@@ -36,6 +35,12 @@ if get_option('video')
     'test_asfvideo.cpp',
     'test_matroskavideo.cpp',
     'test_riffVideo.cpp',
+  )
+endif
+
+if zlib_dep.found()
+  test_sources += files(
+    'test_pngimage.cpp',
   )
 endif
 

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -22,7 +22,9 @@ TEST(TheImageFactory, createsInstancesForFewSupportedTypesInMemory) {
   EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg));
   EXPECT_NO_THROW(ImageFactory::create(ImageType::exv));
   EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf));
+#ifdef EXV_HAVE_LIBZ
   EXPECT_NO_THROW(ImageFactory::create(ImageType::png));
+#endif
 }
 
 TEST(TheImageFactory, cannotCreateInstancesForMostTypesInMemory) {
@@ -66,7 +68,9 @@ TEST(TheImageFactory, createsInstancesForFewSupportedTypesInFiles) {
   EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath));
   EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, filePath));
   EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath));
+#ifdef EXV_HAVE_LIBZ
   EXPECT_NO_THROW(ImageFactory::create(ImageType::png, filePath));
+#endif
 
   EXPECT_TRUE(fs::remove(filePath));
 }
@@ -116,9 +120,11 @@ TEST(TheImageFactory, loadInstancesDifferentImageTypes) {
   EXPECT_EQ(ImageType::tiff, ImageFactory::getType(imagePath));
   EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
 
+#ifdef EXV_HAVE_LIBZ
   imagePath = (testData / "exiv2-bug1074.png").string();
   EXPECT_EQ(ImageType::png, ImageFactory::getType(imagePath));
   EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+#endif
 
   imagePath = (testData / "BlueSquare.xmp").string();
   EXPECT_EQ(ImageType::xmp, ImageFactory::getType(imagePath));


### PR DESCRIPTION
This sometimes shows up in CI if zlib is not found.

As an aside, there's already a usage of #ifdef EXV_HAVE_LIBZ . Seems untested.