### PR TITLE
Extract XMP data from embedded JPEG preview inside RAF files

### DIFF
--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -268,6 +268,7 @@ void RafImage::readMetadata() {
     xmpData_ = jpg_img.xmpData();
     exifData_ = jpg_img.exifData();
     iptcData_ = jpg_img.iptcData();
+    comment_ = jpg_img.comment();
   } catch (const Exiv2::Error&) {
   }
 

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -260,13 +260,16 @@ void RafImage::readMetadata() {
   }
 
   // Retreive metadata from embedded JPEG preview image.
-  auto jpg_io = std::make_unique<Exiv2::MemIo>(jpg_buf.data(), jpg_buf.size());
-  auto jpg_img = JpegImage(std::move(jpg_io), false);
-  jpg_img.readMetadata();
-  setByteOrder(jpg_img.byteOrder());
-  xmpData_ = jpg_img.xmpData();
-  exifData_ = jpg_img.exifData();
-  iptcData_ = jpg_img.iptcData();
+  try {
+    auto jpg_io = std::make_unique<Exiv2::MemIo>(jpg_buf.data(), jpg_buf.size());
+    auto jpg_img = JpegImage(std::move(jpg_io), false);
+    jpg_img.readMetadata();
+    setByteOrder(jpg_img.byteOrder());
+    xmpData_ = jpg_img.xmpData();
+    exifData_ = jpg_img.exifData();
+    iptcData_ = jpg_img.iptcData();
+  } catch (const Exiv2::Error&) {
+  }
 
   exifData_["Exif.Image2.JPEGInterchangeFormat"] = getULong(jpg_img_offset, bigEndian);
   exifData_["Exif.Image2.JPEGInterchangeFormatLength"] = getULong(jpg_img_length, bigEndian);

--- a/tests/bugfixes/github/test_issue_857.py
+++ b/tests/bugfixes/github/test_issue_857.py
@@ -22,7 +22,7 @@ class OutOfMemoryInRafImageReadMetadata(metaclass=CaseMeta):
 $kerCorruptedMetadata
 """,
 """Exiv2 exception in print action for file $filename2:
-This does not look like a TIFF image
+$kerCorruptedMetadata
 """
 ]
     retval = [1,1]


### PR DESCRIPTION
The Fujifilm X-T5 camera stores in-camera rating for RAF images by using XMP. But the XMP data is not directly encoded into the RAF structure - instead it is attached as a second APP1 segment to the embedded JPEG preview file.

This patch extracts the JPEG preview and parses it like a standalone JPEG file.

fixes #2610 