### PR TITLE
meson: increase minimum version to 0.54.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'exiv2',
   'cpp',
   version: '1.0.0',
-  meson_version: '>=0.49.0',
+  meson_version: '>=0.54.1',
   default_options: ['warning_level=0', 'cpp_std=c++17'],
 )
 


### PR DESCRIPTION
0.54.1 fixed a bug with cmake config files which meson 1.1.0 warns on.