### PR TITLE
Bump minimum cmake and stop creating build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Minimum version imposed by Centos:8
-cmake_minimum_required( VERSION 3.11.0 )
+# Minimum version imposed by Ubuntu:20.04
+cmake_minimum_required( VERSION 3.16.3 )
 
 project(exiv2          # use TWEAK to categorize the build
     VERSION 1.00.0.9   # 1.00.0    = GM               (tagged and released)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,9 @@ Once you have a GitHub login:
 
 5. Configure the project and check that it builds (if not, please report a bug):
 
-        $ rm -rf build
-        $ mkdir build && cd build
-        $ cmake -DCMAKE_BUILD_TYPE=Release ..
-        $ cmake --build . --parallel
+        $ rm -r build
+        $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        $ cmake --build build --parallel
 
 6. Now, make your change(s), add tests for your changes, and commit each change:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Once you have a GitHub login:
 
 5. Configure the project and check that it builds (if not, please report a bug):
 
-        $ rm -r build
+        $ rm -rf build
         $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
         $ cmake --build build --parallel
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ You need [CMake](https://cmake.org/download/) to configure the Exiv2 project, an
 ## Build, Install, Use Exiv2 on a UNIX-like system
 
 ```bash
-$ cd ~/gnu/github/exiv2                     # Location of the project code
-$ mkdir build && cd build                   # Create a build directory
-$ cmake -DCMAKE_BUILD_TYPE=Release ..       # Configure the project with CMake
-$ cmake --build .                           # Compile the project
-$ ctest --verbose                           # Run tests
-$ cmake --install .                         # Run the install target (install library, public headers, application and CMake files)
+$ cd ~/gnu/github/exiv2                          # Location of the project code
+$ rm -r build                                    # Remove existing build directory
+$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release # Configure the project with CMake
+$ cmake --build build                            # Compile the project
+$ ctest --test-dir build --verbose               # Run tests
+$ sudo cmake --install build                     # Run the install target (install library, public headers, application and CMake files)
 ```
 
 This will install the library into the "standard locations".  The library will be installed in `/usr/local/lib`, executables (including the exiv2 command-line program) in `/usr/local/bin/` and header files in `/usr/local/include/exiv2`. The target directory for the installation can be modified by using the CMake option `-DCMAKE_INSTALL_PREFIX`. 
@@ -115,7 +115,7 @@ I don't know why anybody would uninstall Exiv2.
 ```bash
 $ cd ~/gnu/github/exiv2  # location of the project code
 $ cd build
-$ cmake --build . --target uninstall
+$ cmake --build build --target uninstall
 ```
 
 These commands will run the `uninstall` target and remove all the files which were installed by the `install` target.
@@ -133,9 +133,9 @@ See [README-CONAN](README-CONAN.md) for more information about Conan.
 When you build, you may install with the following command.
 
 ```cmd
-> cmake --install .
+> cmake --install build
 ```
-This will create and copy the exiv2 build artefacts to `%ProgramFiles%/exiv2`. To be able to run the `exiv2` command line application from any terminal you should modify your path to include `%ProgramFiles%/exiv2/bin`.
+This will create and copy the exiv2 build artifacts to `%ProgramFiles%/exiv2`. To be able to run the `exiv2` command line application from any terminal you should modify your path to include `%ProgramFiles%/exiv2/bin`.
 
 [TOC](#TOC)
 <div id="CMakePresets">
@@ -489,7 +489,7 @@ Additionally, you will require an additional build step to actually build the do
 
 ```bash
 $ cmake ..options.. -DEXIV2_BUILD_DOC=ON
-$ cmake --build . --target doc
+$ cmake --build build --target doc
 ```
 
 To build the documentation, you must install the following products:
@@ -547,15 +547,14 @@ Create and build exiv2 for your platform.
 
 ```bash
 $ git clone https://github.com/exiv2/exiv2
-$ mkdir -p exiv2/build
-$ cd       exiv2/build
-$ cmake .. -G "Unix Makefiles" -DEXIV2_TEAM_PACKAGING=ON
+$ cd exiv2
+$ cmake -S . -B build -G "Unix Makefiles" -DEXIV2_TEAM_PACKAGING=ON
 ...
 -- Build files have been written to: .../build
-$ cmake --build . --config Release
+$ cmake --build build --config Release
 ...
 [100%] Built target addmoddel
-$ cmake --build . --target package
+$ cmake --build build --target package
 ...
 CPack: - package: /path/to/exiv2/build/exiv2-0.27.1-Linux.tar.gz generated.
 ```
@@ -563,7 +562,7 @@ CPack: - package: /path/to/exiv2/build/exiv2-0.27.1-Linux.tar.gz generated.
 2) Source Package
 
 ```bash
-$ cmake --build . --target package_source
+$ cmake --build build --target package_source
 Run CPack packaging tool for source...
 ...
 CPack: - package: /path/to/exiv2/build/exiv2-0.27.1-Source.tar.gz generated.
@@ -580,10 +579,8 @@ In general to generate a debug library, you should use the *CMake* option `-DCMA
 
 ```bash
 $ cd <exiv2dir>
-$ mkdir build
-$ cd build
-$ cmake .. -G "Unix Makefiles" "-DCMAKE_BUILD_TYPE=Debug"
-$ cmake --build .
+$ cmake -S . -B build -G "Unix Makefiles" "-DCMAKE_BUILD_TYPE=Debug"
+$ cmake --build build
 
 ```
 
@@ -611,11 +608,11 @@ Those blocks of code are not compiled unless you define `EXIV2_DEBUG_MESSAGES`. 
 
 ```bash
 $ cd <exiv2dir> && cd build
-$ cmake -DCMAKE_CXX_FLAGS=-DEXIV2_DEBUG_MESSAGES ..
-$ cmake --build .
+$ cmake -S . -B build -DCMAKE_CXX_FLAGS=-DEXIV2_DEBUG_MESSAGES
+$ cmake --build build
 $ bin/exiv2 ...
 -- or --
-$ cmake --install .
+$ cmake --install build
 $ exiv2     ...
 ```
 
@@ -639,14 +636,14 @@ and runs on Windows, Mac and Linux.  It has excellent integration with CMake and
 add **`-DCMAKE_BUILD_TYPE=Debug`** to the CMake command.  It keeps build types in separate directories
 such as **`<exiv2dir>/cmake-build-debug`**.
 
-5) cmake --build . options **`--config Release|Debug`** and **`--target install`**
+5) cmake --build build options **`--config Release|Debug`** and **`--target install`**
 
 Visual Studio and Xcode can build debug or release builds without using the option **`-DCMAKE_BUILD_TYPE`** because the generated project files can build multiple types.  The option **`--config Debug`** can be specified on the CMake command-line to specify the build type.  Alternatively, if you prefer to build in the IDE, the UI provides options to select the configuration and target.
 
 With the Unix Makefile generator, the targets can be listed:
 
 ```bash
-$ cmake --build . --target help
+$ cmake --build build --target help
 The following are some of the valid targets for this Makefile:
 ... all (the default if no target is provided)
 ... clean
@@ -664,9 +661,9 @@ The following are some of the valid targets for this Makefile:
 
 ```bash
 $ cd <exiv2dir>
-$ rm -rf build ; mkdir build ; cd build
-$ cmake .. -DCMAKE_C_COMPILER=$(which clang) -DCMAKE_CXX_COMPILER=$(which clang++)
-$ cmake --build .
+$ rm -rf build
+$ cmake -S . -B build -DCMAKE_C_COMPILER=$(which clang) -DCMAKE_CXX_COMPILER=$(which clang++)
+$ cmake --build build
 ```
 
 **_OR_**
@@ -675,9 +672,9 @@ $ cmake --build .
 $ export CC=$(which clang)
 $ export CXX=$(which clang++)
 $ cd <exiv2dir>
-$ rm -rf build ; mkdir build ; cd build
-$ cmake ..
-$ cmake --build .
+$ rm -rf build
+$ cmake -S . -B build
+$ cmake --build build
 ```
 
 2) On macOS
@@ -705,12 +702,12 @@ To build with ccache, use the CMake option **-DBUILD\_WITH\_CCACHE=ON**
 
 ```bash
 $ cd <exiv2dir>
-$ mkdir build ; cd build ; cd build
-$ cmake .. -G "Unix Makefiles" -DBUILD_WITH_CCACHE=ON
-$ cmake --build .
+$ mkdir build
+$ cmake -S . -B build -G "Unix Makefiles" -DBUILD_WITH_CCACHE=ON
+$ cmake --build build
 # Build again to appreciate the performance gain
-$ cmake --build . --target clean
-$ cmake --build .
+$ cmake --build build --target clean
+$ cmake --build build
 ```
 
 Due to the way in which ccache is installed in Fedora (and other Linux distros), ccache effectively replaces the compiler.  A default build or **-DBUILD\_WITH\_CCACHE=OFF** is not effective and the environment variable CCACHE_DISABLE is required to disable ccache. [https://github.com/Exiv2/exiv2/issues/361](https://github.com/Exiv2/exiv2/issues/361)
@@ -955,13 +952,13 @@ For new bug reports, feature requests and support:  Please open an issue in Gith
 
 # Test Suite
 
-You execute the Test Suite using CTest with the command `$ ctest`.
+You execute the Test Suite using CTest with the command `$ ctest --test-dir build`.
 
 The build creates 6 tests: bashTests, bugfixTests, lensTests, tiffTests, unitTests and versionTests.  You can run all tests or a subset. To list all available tests, execute ctest with the `-N` or `--show-only` option, which disables execution:
 
 ```bash
-.../main/build $ ctest -N
-Test project ...main/build
+.../exiv2/ $ ctest --test-dir build --show-only
+Test project ...main/exiv2
   Test #1: bashTests
   Test #2: bugfixTests
   Test #3: lensTests
@@ -970,16 +967,16 @@ Test project ...main/build
   Test #6: unitTests
 
 Total Tests: 6
-.../main/build $
+.../exiv2 $
 ```
 
 ctest provides many option and the following show common use-case scenarios:
 
 ```bash
-$ ctest                              # run all tests and display summary
-$ ctest --output-on-failure          # run all tests and output failures
-$ ctest -R bugfix                    # run only bugfixTests and display summary
-$ ctest -R bugfix --verbose          # run only bugfixTests and display all output
+$ ctest --test-dir build                             # run all tests and display summary
+$ ctest --test-dir build --output-on-failure         # run all tests and output failures
+$ ctest --test-dir build-R bugfix                    # run only bugfixTests and display summary
+$ ctest --test-dir build -R bugfix --verbose         # run only bugfixTests and display all output
 ```
 
 Except for the `unitTests`,  CMake needs to find a python3 interpreter in the system to be able to run the rest of the test targets with CTest:
@@ -1025,11 +1022,11 @@ The Variable EXIV2\_PORT or EXIV2\_HTTP can be set to None to skip http tests.  
 You can run tests directly from the build:
 
 ```bash
-$ cmake .. -G "Unix Makefiles" -DEXIV2_BUILD_UNIT_TESTS=ON 
+$ cmake -S . -B build -G "Unix Makefiles" -DEXIV2_BUILD_UNIT_TESTS=ON 
 ... lots of output and build summary ...
-$ cmake --build .
+$ cmake --build build
 ... lots of output ...
-$ ctest
+$ ctest --test-dir build
 ... test summary ...
 $
 ```
@@ -1038,13 +1035,13 @@ You can run individual tests in the `test` directory.  **Caution:** If you build
 
 ```bash
 $ cd <exiv2dir>/build
-$ ctest -R bash --verbose
+$ ctest --test-dir build -R bash --verbose
 addmoddel_test (testcases.TestCases) ... ok
 ....
 Ran 176 tests in 9.526s
 OK (skipped=6)
 
-$ ctest -R bugfix --verbose
+$ ctest --test-dir build -R bugfix --verbose
 ... lots of output ...
 test_run (tiff_test.test_tiff_test_program.TestTiffTestProg) ... ok
 ----------------------------------------------------------------------
@@ -1069,14 +1066,14 @@ You can execute the test suite in a similar manner to that described for UNIX-li
 
 ```cmd
 > cd <exiv2dir>/build
-> ctest -C Release
-> ctest -C Release -R bugfix --verbose
+> ctest --test-dir build -C Release
+> ctest --test-dir build -C Release -R bugfix --verbose
 ```
 Visual Studio can build different configs as follows:
 
 ```cmd
-> cmake --build . --config Release        # or Debug or MinSizeRel or RelWithDebInfo
-> ctest -C Release
+> cmake --build build --config Release        # or Debug or MinSizeRel or RelWithDebInfo
+> ctest --test-dir build -C Release
 ```
 The default for **CMake** config option `--config` is `Release`.  **ctest** does not have a default for config option `-C`.
 
@@ -1088,19 +1085,18 @@ As a summary, the procedure is:
 
 ```
 c:\...\exiv2>mkdir build
-c:\...\exiv2>cd build
-c:\...\exiv2\build>conan install .. --build missing --profile msvc2019Release
-c:\...\exiv2\build>cmake .. -DEXIV2_BUILD_UNIT_TESTS=ON -G "Visual Studio 16 2019"
-c:\...\exiv2\build>cmake --build . --config Release
+c:\...\exiv2\build>conan install . --build missing --profile msvc2019Release
+c:\...\exiv2\build>cmake -S . B build -DEXIV2_BUILD_UNIT_TESTS=ON -G "Visual Studio 16 2019"
+c:\...\exiv2\build>cmake --build build --config Release
 ... lots of output from compiler and linker ...
-c:\...\exiv2\build>ctest -C Release
+c:\...\exiv2\build>ctest --test-dir build -C Release
 ```
 
 If you wish to use an environment variables, use set:
 
 ```
 set EXIV2_PORT=54321
-ctest -C Release --verbose -R bash
+ctest --test-dir build -C Release --verbose -R bash
 set EXIV2_PORT=
 ```
 
@@ -1133,14 +1129,14 @@ You can run the bugfix tests from the build directory:
 
 ```bash
 $ cd <exiv2dir>/build
-$ ctest -R bugfix  
+$ ctest --test-dir build -R bugfix  
 ```
 
 If you wish to run in verbose mode:
 
 ```bash
 $ cd <exiv2dir>/build
-$ ctest -R bugfix --verbose
+$ ctest --test-dir build -R bugfix --verbose
 ```
 
 The bugfix tests are stored in directory tests/ and you can run them all with the command:
@@ -1161,8 +1157,8 @@ $ python3 runner.py --verbose bugfixes/redmine/test_issue_841.py  # or $(find . 
 You may wish to get a brief summary of failures with commands such as:
 
 ```bash
-$ cd <exiv2dir>/build
-$ ctest -R bugfix --verbose 2>&1 | grep FAIL
+$ cd <exiv2dir>
+$ ctest --test-dir build -R bugfix --verbose 2>&1 | grep FAIL
 ```
 
 [TOC](#TOC)
@@ -1179,9 +1175,9 @@ To build the fuzzers:
 
 ```bash
 $ cd <exiv2dir>
-$ rm -rf build-fuzz ; mkdir build-fuzz ; cd build-fuzz
-$ cmake .. -DCMAKE_CXX_COMPILER=$(which clang++) -DEXIV2_BUILD_FUZZ_TESTS=ON -DEXIV2_TEAM_USE_SANITIZERS=ON
-$ cmake --build .
+$ rm -rf build-fuzz
+$ cmake -S . -B build-fuzz -DCMAKE_CXX_COMPILER=$(which clang++) -DEXIV2_BUILD_FUZZ_TESTS=ON -DEXIV2_TEAM_USE_SANITIZERS=ON
+$ cmake --build build-fuzz
 ```
 
 To execute a fuzzer:
@@ -1230,9 +1226,8 @@ $ mkdir -p ~/gnu/github/exiv2
 $ cd ~/gnu/github/exiv2
 $ git clone https://github.com/exiv2/exiv2
 $ cd exiv2
-$ mkdir build ; cd build ;
-$ cmake .. -G "Unix Makefiles"
-$ make
+$ cmake -S . -B build -G "Unix Makefiles"
+$ cmake --build build
 ```
 
 [TOC](#TOC)
@@ -1274,8 +1269,8 @@ mkdir -p ~/gnu/github/exiv2
 cd       ~/gnu/github/exiv2
 git clone https://github.com/exiv2/exiv2
 cd exiv2
-mkdir build && cd build
-cmake -G Ninja
+cmake -S . -B build
+      -G Ninja
       -DCMAKE_CXX_FLAGS=-Wno-deprecated
       -DCMAKE_BUILD_TYPE=Release
       -DBUILD_SHARED_LIBS=ON
@@ -1286,7 +1281,7 @@ cmake -G Ninja
       -DEXIV2_BUILD_UNIT_TESTS=ON
       ..
 
-cmake --build .
+cmake --build build
 ```
 
 The binaries generated at this point can be executed from the MSYS2 UCRT64 terminal, but they will not run from a Windows Command Prompt or PowerShell. The reason is that the MSYS2 UCRT64 terminal is properly configured to find some needed DLLs. In case you want to be able to run the generated **exiv2** binary from any Windows terminal, you'll need to deploy the needed DLLs with the application.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ You need [CMake](https://cmake.org/download/) to configure the Exiv2 project, an
 
 ```bash
 $ cd ~/gnu/github/exiv2                          # Location of the project code
-$ rm -r build                                    # Remove existing build directory
 $ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release # Configure the project with CMake
 $ cmake --build build                            # Compile the project
 $ ctest --test-dir build --verbose               # Run tests

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ I don't know why anybody would uninstall Exiv2.
 
 ```bash
 $ cd ~/gnu/github/exiv2  # location of the project code
-$ cd build
 $ cmake --build build --target uninstall
 ```
 
@@ -134,7 +133,7 @@ When you build, you may install with the following command.
 ```cmd
 > cmake --install build
 ```
-This will create and copy the exiv2 build artifacts to `%ProgramFiles%/exiv2`. To be able to run the `exiv2` command line application from any terminal you should modify your path to include `%ProgramFiles%/exiv2/bin`.
+This will create and copy the exiv2 build artefacts to `%ProgramFiles%/exiv2`. To be able to run the `exiv2` command line application from any terminal you should modify your path to include `%ProgramFiles%/exiv2/bin`.
 
 [TOC](#TOC)
 <div id="CMakePresets">
@@ -606,7 +605,7 @@ Exiv2 respects the symbol `NDEBUG` which is set only for Release builds. There a
 Those blocks of code are not compiled unless you define `EXIV2_DEBUG_MESSAGES`. They are provided for additional debugging information. For example, if you are interested in additional output from webpimage.cpp, you can update your build as follows:
 
 ```bash
-$ cd <exiv2dir> && cd build
+$ cd <exiv2dir>
 $ cmake -S . -B build -DCMAKE_CXX_FLAGS=-DEXIV2_DEBUG_MESSAGES
 $ cmake --build build
 $ bin/exiv2 ...
@@ -701,7 +700,6 @@ To build with ccache, use the CMake option **-DBUILD\_WITH\_CCACHE=ON**
 
 ```bash
 $ cd <exiv2dir>
-$ mkdir build
 $ cmake -S . -B build -G "Unix Makefiles" -DBUILD_WITH_CCACHE=ON
 $ cmake --build build
 # Build again to appreciate the performance gain
@@ -1033,7 +1031,7 @@ $
 You can run individual tests in the `test` directory.  **Caution:** If you build in a directory other than \<exiv2dir\>/build, you must set EXIV2\_BINDIR to run tests from the `test` directory.
 
 ```bash
-$ cd <exiv2dir>/build
+$ cd <exiv2dir>
 $ ctest --test-dir build -R bash --verbose
 addmoddel_test (testcases.TestCases) ... ok
 ....
@@ -1064,7 +1062,7 @@ $
 You can execute the test suite in a similar manner to that described for UNIX-like systems.  You _**must**_ provide the `-C` config option to ctest for Visual Studio builds.  
 
 ```cmd
-> cd <exiv2dir>/build
+> cd <exiv2dir>
 > ctest --test-dir build -C Release
 > ctest --test-dir build -C Release -R bugfix --verbose
 ```
@@ -1083,7 +1081,6 @@ You can build with Visual Studio using Conan.  The is described in detail in [RE
 As a summary, the procedure is:
 
 ```
-c:\...\exiv2>mkdir build
 c:\...\exiv2\build>conan install . --build missing --profile msvc2019Release
 c:\...\exiv2\build>cmake -S . B build -DEXIV2_BUILD_UNIT_TESTS=ON -G "Visual Studio 16 2019"
 c:\...\exiv2\build>cmake --build build --config Release
@@ -1127,14 +1124,14 @@ $ popd
 You can run the bugfix tests from the build directory:
 
 ```bash
-$ cd <exiv2dir>/build
+$ cd <exiv2dir>
 $ ctest --test-dir build -R bugfix  
 ```
 
 If you wish to run in verbose mode:
 
 ```bash
-$ cd <exiv2dir>/build
+$ cd <exiv2dir>
 $ ctest --test-dir build -R bugfix --verbose
 ```
 


### PR DESCRIPTION
This upgrades the cmake version to match the version Ubuntu 20.04 now that Ubuntu 18.04 is EOL. 

I updated the build instructions to use the method that doesn't require you to delete, create and change directories into a build directory to compile and test the code. The other advantage is you can now have multiple build directories while continuing to work in the same root directory. 

Closes https://github.com/Exiv2/exiv2/issues/2617