### PR TITLE
Adapt for NetBSD iconv() prototype change

### DIFF
--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -29,7 +29,17 @@
 
 /* Define to `const' or to empty, depending on the second argument of `iconv'. */
 #cmakedefine ICONV_ACCEPTS_CONST_INPUT
-#if defined(ICONV_ACCEPTS_CONST_INPUT) || defined(__NetBSD__)
+
+#if defined(__NetBSD__)
+#include <sys/param.h>
+#if __NetBSD_Prereq__(9,99,17)
+#define NETBSD_POSIX_ICONV 1
+#else
+#define NETBSD_POSIX_ICONV 0
+#endif
+#endif
+
+#if defined(ICONV_ACCEPTS_CONST_INPUT) || (defined(__NetBSD__) && !NETBSD_POSIX_ICONV)
 #define EXV_ICONV_CONST const
 #else
 #define EXV_ICONV_CONST


### PR DESCRIPTION
Between NetBSD 9 and the (to-be-released soon) NetBSD 10, the `iconv()` prototype was adapted to follow POSIX.
This patch makes exiv2 compile on NetBSD 9 and 10 cleanly.