### PR TITLE
Sort and remove duplicates in apt dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ Update your system and install the build tools and dependencies (zlib, expat, gt
 
 ```bash
 $ sudo apt --yes update
-$ sudo apt install --yes build-essential git clang ccache python3 libxml2-utils cmake python3 libexpat1-dev libz-dev zlib1g-dev libbrotli-dev libssh-dev libcurl4-openssl-dev libgtest-dev google-mock libinih-dev
+$ sudo apt install --yes build-essential ccache clang cmake git google-mock libbrotli-dev libcurl4-openssl-dev libexpat1-dev libgtest-dev libinih-dev libssh-dev libxml2-utils libz-dev python3 zlib1g-dev
 ```
 
 For users of other platforms, the script <exiv2dir>/ci/install_dependencies.sh has code used to configure many platforms.  The code in that file is a useful guide to configuring your platform.


### PR DESCRIPTION
* python3 was duplicated
* sorting them makes it easier to spot duplicates

 Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)