### PR TITLE
Allow c_data() to return zero byte buffer

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -173,7 +173,7 @@ byte* Exiv2::DataBuf::data(size_t offset) {
 }
 
 const byte* Exiv2::DataBuf::c_data(size_t offset) const {
-  if (pData_.empty()) {
+  if (pData_.empty() || offset == pData_.size()) {
     return nullptr;
   }
   if (offset > pData_.size()) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -176,7 +176,7 @@ const byte* Exiv2::DataBuf::c_data(size_t offset) const {
   if (pData_.empty()) {
     return nullptr;
   }
-  if (offset >= pData_.size()) {
+  if (offset > pData_.size()) {
     throw std::out_of_range("Overflow in Exiv2::DataBuf::c_data");
   }
   return &pData_[offset];

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -49,8 +49,8 @@ TEST(DataBuf, canBeConstructedFromExistingData) {
 TEST(DataBuf, tryingToAccessTooFarElementThrows) {
   const std::array<byte, 4> data{'h', 'o', 'l', 'a'};
   DataBuf instance(data.data(), data.size());
-  ASSERT_THROW([[maybe_unused]] auto d = instance.data(4), std::out_of_range);
-  ASSERT_THROW([[maybe_unused]] auto d = instance.c_data(4), std::out_of_range);
+  ASSERT_THROW([[maybe_unused]] auto d = instance.data(5), std::out_of_range);
+  ASSERT_THROW([[maybe_unused]] auto d = instance.c_data(5), std::out_of_range);
 }
 
 TEST(DataBuf, readUintFunctionsWorksOnExistingData) {


### PR DESCRIPTION
This reverts a change that was made in #2209. I [argued at the time](https://github.com/Exiv2/exiv2/pull/2209#discussion_r857744958) that it was a bad idea. Since then it has caused at least two bugs that I'm aware of: #2565, #2650.