### PR TITLE
Fuzz Metadata::print() with nullptr parameter

### DIFF
--- a/fuzz/fuzz-read-print-write.cpp
+++ b/fuzz/fuzz-read-print-write.cpp
@@ -21,12 +21,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     image->readMetadata();
     for (auto& md : image->exifData()) {
+      md.print();
       md.print(&image->exifData());
     }
     for (auto& md : image->iptcData()) {
+      md.print();
       md.print(&image->exifData());
     }
     for (auto& md : image->xmpData()) {
+      md.print();
       md.print(&image->exifData());
     }
 


### PR DESCRIPTION
This should prevent issues like #2638 and #2649 from happening again.