### PR TITLE
FreeBSD Fix getLoadedLibraries() crash

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -140,8 +140,7 @@ static std::vector<std::string> getLoadedLibraries() {
     pushPath(path, libs, paths);
   }
 #elif defined(__FreeBSD__)
-  // this code seg-faults when called from an SSH script! (security?)
-  if (isatty(STDIN_FILENO)) {
+  {
     unsigned int n;
     struct procstat* procstat = procstat_open_sysctl();
     struct kinfo_proc* procs = procstat ? procstat_getprocs(procstat, KERN_PROC_PID, getpid(), &n) : nullptr;
@@ -149,8 +148,10 @@ static std::vector<std::string> getLoadedLibraries() {
     if (files) {
       filestat* entry;
       STAILQ_FOREACH(entry, files, next) {
-        std::string path(entry->fs_path);
-        pushPath(path, libs, paths);
+        if (entry && PS_FST_TYPE_VNODE == entry->fs_type && entry->fs_path) {
+          std::string path(entry->fs_path);
+          pushPath(path, libs, paths);
+        }
       }
     }
     // free resources


### PR DESCRIPTION
FreeBSD's getLoadedLibraries() uses libprocstat(3) to obtain the list of mapped files (libraries). However, the list obtained from procstat_getfiles() does not only return regular files, but might also return anonymous objects that have no entry->fs_path. 

Motivation: With exiv2 v0.28, I had also observed crashes with a real TTY, and the entry->fs_path dereference would crash, even if it was only for a test "non-null", so we need something more thorough.

Add a check to only consider entry types of type VNODE (actual file system entries), and also make sure that entry->fs_path is defined (i.e. non-null) so we don't pass a nullptr to the std::string(const char *) constructor when we are reading corrupt data. std::string((const char *)0) on FreeBSD 13.2 - calls strlen() and crashes there.