### PR TITLE
avoid newer clang-format issue

### DIFF
--- a/.github/workflows/on_push_clang_format.yml
+++ b/.github/workflows/on_push_clang_format.yml
@@ -13,5 +13,4 @@ jobs:
           source: '.'
           exclude: './xmpsdk ./contrib'
           extensions: 'c,h,cpp,hpp'
-          clangFormatVersion: 12
           style: file

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -62,10 +62,14 @@ class Options {
   virtual ~Options() = default;
 };
 
-enum { resultOK = 0, resultSyntaxError, resultSelectFailed };
+enum {
+  resultOK = 0,
+  resultSyntaxError,
+  resultSelectFailed,
+};
 
-enum  // keyword indices
-{
+// keyword indices
+enum {
   kwHELP = 0,
   kwVERSION,
   kwDST,
@@ -75,13 +79,10 @@ enum  // keyword indices
   kwADJUST,
   kwTZ,
   kwDELTA,
-  kwMAX  // manages keyword array
-  ,
-  kwNEEDVALUE  // bogus keywords for error reporting
-  ,
-  kwSYNTAX  // -- ditto --
-  ,
-  kwNOVALUE = -kwVERBOSE  // keywords <= kwNOVALUE are flags (no value needed)
+  kwMAX,                   // manages keyword array
+  kwNEEDVALUE,             // bogus keywords for error reporting
+  kwSYNTAX,                // -- ditto --
+  kwNOVALUE = -kwVERBOSE,  // keywords <= kwNOVALUE are flags (no value needed)
 };
 
 // file types supported
@@ -625,10 +626,13 @@ int getFileType(std::string& path, Options& options) {
   return getFileType(path.c_str(), options);
 }
 int getFileType(const char* path, Options& options) {
-  return readXML(path, options)     ? typeXML
-         : readDir(path, options)   ? typeDirectory
-         : readImage(path, options) ? typeImage
-                                    : readFile(path, options);
+  if (readXML(path, options))
+    return typeXML;
+  if (readDir(path, options))
+    return typeDirectory;
+  if (readImage(path, options))
+    return typeImage;
+  return readFile(path, options);
 }
 
 int version(const char* program) {

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -360,9 +360,8 @@ void Jp2Image::readMetadata() {
         break;
       }
 
-      default: {
+      default:
         break;
-      }
     }
     lastBoxTypeRead = box.type;
 

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -302,9 +302,8 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       break;
     }
 
-    default: {
+    default:
       break;
-    }
   }
 }  // PsdImage::readResourceBlock
 

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -1004,7 +1004,20 @@ void printNode(const std::string& schemaNs, const std::string& propPath, const s
     std::cout << "ashisabsals\n"
               << "lcqqtrgqlai\n";
   }
-  enum { alia = 0, sche, hasq, isqu, stru, arra, abag, aseq, aalt, lang, simp, len };
+  enum {
+    alia = 0,
+    sche,
+    hasq,
+    isqu,
+    stru,
+    arra,
+    abag,
+    aseq,
+    aalt,
+    lang,
+    simp,
+    len,
+  };
 
   std::string opts(len, '.');
   if (XMP_PropIsAlias(opt))


### PR DESCRIPTION
More readable anyway.

Also remove specific version. Problems have been fixed already. All versions should work the same now.