### PR TITLE
github CI: remove msvcrt

### DIFF
--- a/.github/workflows/on_PR_meson.yaml
+++ b/.github/workflows/on_PR_meson.yaml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         deps: ['enabled', 'disabled']
-        platform: ['MINGW32', 'MINGW64', 'UCRT64', 'CLANG32', 'CLANG64']
+        platform: ['UCRT64', 'CLANG32', 'CLANG64']
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
msvcrt support was effectively killed when wstring support was removed. No need to test for it.