### PR TITLE
optimize toAscii function with early exit

### DIFF
--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -100,9 +100,10 @@ Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create) : Image(ImageType::jp2, m
 // Obtains the ascii version from the box.type
 std::string Jp2Image::toAscii(uint32_t n) {
   const auto p = reinterpret_cast<const char*>(&n);
+  if (isBigEndianPlatform())
+    return std::string(p, p + 4);
   std::string result(p, p + 4);
-  if (!isBigEndianPlatform())
-    std::reverse(result.begin(), result.end());
+  std::reverse(result.begin(), result.end());
   return result;
 }
 


### PR DESCRIPTION
GCC is able to see that the branch is useless as it can be done at compile time. Produces shorter assembly with both -O2 and -O3.

https://godbolt.org/z/ejhfxh8Tx