### PR TITLE
optimize toAscii

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -87,13 +87,11 @@ std::string BmffImage::toAscii(uint32_t n) {
   std::string result(p, p + 4);
   if (!isBigEndianPlatform())
     std::reverse(result.begin(), result.end());
-  std::transform(result.begin(), result.end(), result.begin(), [](char c) {
-    if (32 <= c && c < 127)
-      return c;  // only allow 7-bit printable ascii
-    if (c == 0)
-      return '_';  // show 0 as _
-    return '.';    // others .
-  });
+  // show 0 as _
+  std::replace(result.begin(), result.end(), '\0', '_');
+  // show non 7-bit printable ascii as .
+  std::replace_if(
+      result.begin(), result.end(), [](char c) { return c < 32 || c > 126; }, '.');
   return result;
 }
 

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -84,16 +84,16 @@ BmffImage::BmffImage(BasicIo::UniquePtr io, bool /* create */) :
 
 std::string BmffImage::toAscii(uint32_t n) {
   const auto p = reinterpret_cast<const char*>(&n);
-  std::string result(4, '.');
-  std::transform(p, p + 4, result.begin(), [](char c) {
+  std::string result(p, p + 4);
+  if (!isBigEndianPlatform())
+    std::reverse(result.begin(), result.end());
+  std::transform(result.begin(), result.end(), result.begin(), [](char c) {
     if (32 <= c && c < 127)
       return c;  // only allow 7-bit printable ascii
     if (c == 0)
       return '_';  // show 0 as _
     return '.';    // others .
   });
-  if (!isBigEndianPlatform())
-    std::reverse(result.begin(), result.end());
   return result;
 }
 


### PR DESCRIPTION
Construct string in lambda to help the compiler optimize the generated code. Also replace transform with normal loop.