### PR TITLE
asf: fix GUID reading on big endian platforms

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -55,6 +55,11 @@ AsfVideo::GUIDTag::GUIDTag(const uint8_t* bytes) {
   memcpy(&data2_, bytes + DWORD, WORD);
   memcpy(&data3_, bytes + DWORD + WORD, WORD);
   std::copy(bytes + QWORD, bytes + 2 * QWORD, data4_.begin());
+  if (isBigEndianPlatform()) {
+    data1_ = byteSwap(data1_, true);
+    data2_ = byteSwap(data2_, true);
+    data3_ = byteSwap(data3_, true);
+  }
 }
 
 std::string AsfVideo::GUIDTag::to_string() {


### PR DESCRIPTION
Setting the initial parts (`data1_`, `data2_`, `data3_`) from the bytes directly using `memcpy()` means that they will be interpreted depending on the platform endianness. For example, the initial 4 bytes of the ASF header are `0x30`, `0x26`, `0xB2`, `0x75`, which will be read as `0x3026B275` on big endian platofrms, never matching the actual GUID (`0x75B22630`), which is always specified in little endian format.

Hence, when reading a GUID from data, make sure to turn the GUID parts to little endian. This fixes the reading of ASF files on big endian platforms.

Fixes commit bed8d3d93cc99cc294bdd895d797e8cd296da130