### PR TITLE
replace reinterpret_cast with memcpy

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -51,9 +51,9 @@ AsfVideo::GUIDTag::GUIDTag(unsigned int data1, unsigned short data2, unsigned sh
 }
 
 AsfVideo::GUIDTag::GUIDTag(const uint8_t* bytes) {
-  memcpy(&data1_, bytes, DWORD);
-  memcpy(&data2_, bytes + DWORD, WORD);
-  memcpy(&data3_, bytes + DWORD + WORD, WORD);
+  std::copy_n(bytes, DWORD, reinterpret_cast<uint8_t*>(&data1_));
+  std::copy_n(bytes + DWORD, WORD, reinterpret_cast<uint8_t*>(&data2_));
+  std::copy_n(bytes + DWORD + WORD, WORD, reinterpret_cast<uint8_t*>(&data3_));
   std::copy(bytes + QWORD, bytes + 2 * QWORD, data4_.begin());
 }
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -874,7 +874,7 @@ void append(Blob& blob, const byte* buf, size_t len) {
       blob.reserve(size + 65536);
     }
     blob.resize(size + len);
-    std::memcpy(&blob[size], buf, len);
+    std::copy_n(buf, len, &blob[size]);
   }
 }  // append
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -598,7 +598,7 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
   while (count < length && !bWroteColor) {
     Internal::enforce(boxHSize <= length - count, ErrorCode::kerCorruptedMetadata);
     Internal::Jp2BoxHeader subBox;
-    memcpy(&subBox, boxBuf.c_data(count), boxHSize);
+    std::copy_n(boxBuf.c_data(count), boxHSize, reinterpret_cast<byte*>(&subBox));
     Internal::Jp2BoxHeader newBox = subBox;
 
     if (count < length) {

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -732,7 +732,7 @@ void JpegBase::doWriteMetadata(BasicIo& outIo) {
           if (exifSize > 0xffff - 8)
             throw Error(ErrorCode::kerTooLargeJpegSegment, "Exif");
           us2Data(tmpBuf.data() + 2, static_cast<uint16_t>(exifSize + 8), bigEndian);
-          std::memcpy(tmpBuf.data() + 4, exifId_, 6);
+          std::copy_n(exifId_, 6, tmpBuf.data() + 4);
           if (outIo.write(tmpBuf.data(), 10) != 10)
             throw Error(ErrorCode::kerImageWriteFailed);
 
@@ -759,7 +759,7 @@ void JpegBase::doWriteMetadata(BasicIo& outIo) {
         if (xmpPacket_.size() > 0xffff - 31)
           throw Error(ErrorCode::kerTooLargeJpegSegment, "XMP");
         us2Data(tmpBuf.data() + 2, static_cast<uint16_t>(xmpPacket_.size() + 31), bigEndian);
-        std::memcpy(tmpBuf.data() + 4, xmpId_, 29);
+        std::copy_n(xmpId_, 29, tmpBuf.data() + 4);
         if (outIo.write(tmpBuf.data(), 33) != 33)
           throw Error(ErrorCode::kerImageWriteFailed);
 
@@ -835,7 +835,7 @@ void JpegBase::doWriteMetadata(BasicIo& outIo) {
           tmpBuf[0] = 0xff;
           tmpBuf[1] = app13_;
           us2Data(tmpBuf.data() + 2, static_cast<uint16_t>(chunkSize + 16), bigEndian);
-          std::memcpy(tmpBuf.data() + 4, Photoshop::ps3Id_, 14);
+          std::copy_n(Photoshop::ps3Id_, 14, tmpBuf.data() + 4);
           if (outIo.write(tmpBuf.data(), 18) != 18)
             throw Error(ErrorCode::kerImageWriteFailed);
           if (outIo.error())

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -179,7 +179,7 @@ void PgfImage::doWriteMetadata(BasicIo& outIo) {
   // Write new Header size.
   auto newHeaderSize = static_cast<uint32_t>(header.size() + imgSize);
   DataBuf buffer(4);
-  *reinterpret_cast<uint32_t*>(buffer.data()) = newHeaderSize;
+  std::copy_n(&newHeaderSize, sizeof(uint32_t), buffer.data());
   byteSwap_(buffer, 0, bSwap_);
   if (outIo.write(buffer.c_data(), 4) != 4)
     throw Error(ErrorCode::kerImageWriteFailed);

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -534,7 +534,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
       throw Error(ErrorCode::kerInputDataReadFailed);
 
     char szChunk[5];
-    memcpy(szChunk, cheaderBuf.c_data(4), 4);
+    std::copy_n(cheaderBuf.c_data(4), 4, szChunk);
     szChunk[4] = 0;
 
     if (!strcmp(szChunk, "IEND")) {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -386,7 +386,7 @@ bool TiffBinaryArray::updOrigDataBuf(const byte* pData, size_t size) {
     return false;
   if (origData_ == pData)
     return true;
-  memcpy(origData_, pData, origSize_);
+  std::copy_n(pData, origSize_, origData_);
   return true;
 }
 

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -780,7 +780,7 @@ void TiffEncoder::encodeDataEntry(TiffDataEntry* object, const Exifdatum* datum)
 #endif
       DataBuf buf = object->pValue()->dataArea();
       if (!buf.empty()) {
-        memcpy(object->pDataArea_, buf.c_data(), buf.size());
+        std::copy_n(buf.c_data(), buf.size(), object->pDataArea_);
         if (object->sizeDataArea_ > buf.size()) {
           memset(object->pDataArea_ + buf.size(), 0x0, object->sizeDataArea_ - buf.size());
         }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -801,7 +801,7 @@ size_t DateValue::copy(byte* buf, ByteOrder /*byteOrder*/) const {
   // sprintf wants to add the null terminator, so use oversized buffer
   char temp[9];
   auto wrote = static_cast<size_t>(snprintf(temp, sizeof(temp), "%04d%02d%02d", date_.year, date_.month, date_.day));
-  std::memcpy(buf, temp, wrote);
+  std::copy_n(temp, wrote, buf);
   return wrote;
 }
 
@@ -929,7 +929,7 @@ size_t TimeValue::copy(byte* buf, ByteOrder /*byteOrder*/) const {
                                                   plusMinus, abs(time_.tzHour), abs(time_.tzMinute)));
 
   Internal::enforce(wrote == 11, Exiv2::ErrorCode::kerUnsupportedTimeFormat);
-  std::memcpy(buf, temp, wrote);
+  std::copy_n(temp, wrote, buf);
   return wrote;
 }
 


### PR DESCRIPTION
On mips64, this throws a cast-align warning. Silence it.