### PR TITLE
tests: do not hardcode ENOENT

### DIFF
--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -39,7 +39,7 @@ TEST(strError, returnSuccessAfterClosingFile) {
 
 TEST(strError, returnNoSuchFileOrDirectoryWhenTryingToOpenNonExistingFile) {
   std::ifstream auxFile("nonExistingFile");
-  ASSERT_STREQ("No such file or directory (errno = 2)", strError().c_str());
+  ASSERT_TRUE(Internal::contains(strError(), "No such file or directory (errno = "));
 }
 
 TEST(strError, doNotRecognizeUnknownError) {


### PR DESCRIPTION
The actual values of errno constants are not specified in POSIX, and left as implementation details; hence, tweak the check for the `ENOENT` description to not check for the actual value.

In particular, this fixes the tests on GNU/Hurd, as its POSIX errnos do not start from 1.