### PR TITLE
Add a cmake config file export

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(exiv2 REQUIRED CONFIG NAMES exiv2)    # search ${CMAKE_INSTALL_PREFIX}/lib/cmake/exiv2/
 add_executable(exifprint ../samples/exifprint.cpp) # Create exifprint target
-target_link_libraries(exifprint PRIVATE exiv2lib)  # link exiv2lib
+target_link_libraries(exifprint PRIVATE Exiv2::exiv2lib)  # link exiv2lib
 EOF
 $ cmake .                                          # generate the makefile
 $ cmake --build .                                  # build the code

--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -3,7 +3,9 @@
 cmake_minimum_required(VERSION 3.16.3)
 include(CMakeFindDependencyMacro)
 
-find_dependency(ZLIB REQUIRED)
+if(@EXIV2_ENABLE_PNG@) # if(EXIV2_ENABLE_PNG)
+  find_dependency(ZLIB REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/exiv2Export.cmake")
 

--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+cmake_minimum_required(VERSION 3.16.3)
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/exiv2Export.cmake")
+
+check_required_components(exiv2)

--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.5)
 include(CMakeFindDependencyMacro)
 
 if(@EXIV2_ENABLE_PNG@) # if(EXIV2_ENABLE_PNG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library( exiv2lib
     ${PUBLIC_HEADERS}
     $<TARGET_OBJECTS:exiv2lib_int>
 )
+add_library(Exiv2::exiv2lib ALIAS exiv2lib)
 
 generate_export_header(exiv2lib
     EXPORT_MACRO_NAME EXIV2API
@@ -300,7 +301,7 @@ install(FILES
 
 install(EXPORT exiv2Export 
     DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2"
-    NAMESPACE exiv2::
+    NAMESPACE Exiv2::
 )
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -283,10 +283,13 @@ set(requires_private_for_pc_file "${requires_private_string}" PARENT_SCOPE)
 
 write_basic_package_version_file(exiv2ConfigVersion.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS exiv2lib EXPORT exiv2Config
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+install(TARGETS exiv2lib EXPORT exiv2Export)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ../cmake/exiv2Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake
+  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2"
 )
 
 install(FILES
@@ -295,7 +298,14 @@ install(FILES
     ${CMAKE_BINARY_DIR}/exiv2lib_export.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
-install(EXPORT exiv2Config DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2")
+install(EXPORT exiv2Export 
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2"
+    NAMESPACE exiv2::
+)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exiv2ConfigVersion.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2")
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/exiv2ConfigVersion.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2")
 


### PR DESCRIPTION
This is an example of the path forward for #2687 . More work will be required for all the dependencies, and propagating the build options such as `EXIV2_ENABLE_PNG` to add/remove find_dependency calls. 

Edit: All actions are complete in scope of the original issue. 

Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/)