### PR TITLE
Make FindInih also make finding reader required

### DIFF
--- a/cmake/Findinih.cmake
+++ b/cmake/Findinih.cmake
@@ -22,7 +22,7 @@ mark_as_advanced(inih_LIBRARY)
 mark_as_advanced(inih_inireader_INCLUDE_DIR)
 mark_as_advanced(inih_inireader_LIBRARY)
 
-find_package_handle_standard_args(inih REQUIRED_VARS inih_LIBRARY inih_INCLUDE_DIR inih_inireader_INCLUDE_DIR)
+find_package_handle_standard_args(inih REQUIRED_VARS inih_LIBRARY inih_INCLUDE_DIR inih_inireader_INCLUDE_DIR inih_inireader_LIBRARY)
 
 if(NOT inih_FOUND)
   message(FATAL_ERROR "inih library not found")

--- a/cmake/Findinih.cmake
+++ b/cmake/Findinih.cmake
@@ -22,7 +22,7 @@ mark_as_advanced(inih_LIBRARY)
 mark_as_advanced(inih_inireader_INCLUDE_DIR)
 mark_as_advanced(inih_inireader_LIBRARY)
 
-find_package_handle_standard_args(inih REQUIRED_VARS inih_LIBRARY inih_INCLUDE_DIR)
+find_package_handle_standard_args(inih REQUIRED_VARS inih_LIBRARY inih_INCLUDE_DIR inih_inireader_INCLUDE_DIR)
 
 if(NOT inih_FOUND)
   message(FATAL_ERROR "inih library not found")


### PR DESCRIPTION
* Fixes issue on alpine where inih-dev is installed without inih-inireader-dev
* https://github.com/Exiv2/exiv2/pull/2443#issuecomment-1648144243

Since inih [doesn't support CMake](https://github.com/benhoyt/inih/issues/133), this module must be maintained here.

Note: This work was done on behalf of[ AeroVironment Inc.](https://www.avinc.com/) 