### PR TITLE
Allow building Exiv2 0.27 with C++17 compiler

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -55,7 +55,11 @@ namespace Exiv2 {
     class EXIV2API BasicIo {
     public:
         //! BasicIo auto_ptr type
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<BasicIo> AutoPtr;
+#else
         typedef std::auto_ptr<BasicIo> AutoPtr;
+#endif
 
         //! Seek starting positions
         enum Position { beg, cur, end };
@@ -521,7 +525,11 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Impl> p_;
+#else
         std::auto_ptr<Impl> p_;
+#endif
 
     }; // class FileIo
 
@@ -721,7 +729,11 @@ namespace Exiv2 {
 
         // Pimpl idiom
         class Impl;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Impl> p_;
+#else
         std::auto_ptr<Impl> p_;
+#endif
 
     }; // class MemIo
 

--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -105,4 +105,11 @@ typedef int pid_t;
   using auto_ptr = std::unique_ptr<T>;
 #endif
 
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+# define EXV_NO_AUTO_PTR
+# define EXV_NO_AUTO_PTR_MOVE(x) std::move(x)
+#else
+# define EXV_NO_AUTO_PTR_MOVE(x) (x)
+#endif
+
 #endif // _CONFIG_H_

--- a/include/exiv2/datasets.hpp
+++ b/include/exiv2/datasets.hpp
@@ -275,7 +275,11 @@ namespace Exiv2 {
     class EXIV2API IptcKey : public Key {
     public:
         //! Shortcut for an %IptcKey auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<IptcKey> AutoPtr;
+#else
         typedef std::auto_ptr<IptcKey> AutoPtr;
+#endif
 
         //! @name Creators
         //@{

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -78,7 +78,11 @@ namespace Exiv2 {
     class EXIV2API Image {
     public:
         //! Image auto_ptr type
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Image> AutoPtr;
+#else
         typedef std::auto_ptr<Image> AutoPtr;
+#endif
 
         //! @name Creators
         //@{

--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -44,7 +44,11 @@ namespace Exiv2 {
     class EXIV2API Key {
     public:
         //! Shortcut for a %Key auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Key> AutoPtr;
+#else
         typedef std::auto_ptr<Key> AutoPtr;
+#endif
 
         //! @name Creators
         //@{

--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -231,7 +231,11 @@ namespace Exiv2 {
     {
     public:
         //! Shortcut for an %XmpKey auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<XmpKey> AutoPtr;
+#else
         typedef std::auto_ptr<XmpKey> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -294,7 +298,11 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Impl> p_;
+#else
         std::auto_ptr<Impl> p_;
+#endif
 
     };  // class XmpKey
 

--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -140,7 +140,11 @@ namespace Exiv2 {
     class EXIV2API ExifKey : public Key {
     public:
         //! Shortcut for an %ExifKey auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<ExifKey> AutoPtr;
+#else
         typedef std::auto_ptr<ExifKey> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -214,7 +218,11 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Impl> p_;
+#else
         std::auto_ptr<Impl> p_;
+#endif
 
     }; // class ExifKey
 

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -51,7 +51,11 @@ namespace Exiv2 {
     class EXIV2API Value {
     public:
         //! Shortcut for a %Value auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Value> AutoPtr;
+#else
         typedef std::auto_ptr<Value> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -253,7 +257,11 @@ namespace Exiv2 {
     class EXIV2API DataValue : public Value {
     public:
         //! Shortcut for a %DataValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<DataValue> AutoPtr;
+#else
         typedef std::auto_ptr<DataValue> AutoPtr;
+#endif
 
         explicit DataValue(TypeId typeId =undefined);
 
@@ -335,7 +343,11 @@ namespace Exiv2 {
     class EXIV2API StringValueBase : public Value {
     public:
         //! Shortcut for a %StringValueBase auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<StringValueBase> AutoPtr;
+#else
         typedef std::auto_ptr<StringValueBase> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -417,7 +429,11 @@ namespace Exiv2 {
     class EXIV2API StringValue : public StringValueBase {
     public:
         //! Shortcut for a %StringValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<StringValue> AutoPtr;
+#else
         typedef std::auto_ptr<StringValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -449,7 +465,11 @@ namespace Exiv2 {
     class EXIV2API AsciiValue : public StringValueBase {
     public:
         //! Shortcut for a %AsciiValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<AsciiValue> AutoPtr;
+#else
         typedef std::auto_ptr<AsciiValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -537,7 +557,11 @@ namespace Exiv2 {
         }; // class CharsetInfo
 
         //! Shortcut for a %CommentValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<CommentValue> AutoPtr;
+#else
         typedef std::auto_ptr<CommentValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -624,7 +648,11 @@ namespace Exiv2 {
     class EXIV2API XmpValue : public Value {
     public:
         //! Shortcut for a %XmpValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<XmpValue> AutoPtr;
+#else
         typedef std::auto_ptr<XmpValue> AutoPtr;
+#endif
 
         //! XMP array types.
         enum XmpArrayType { xaNone, xaAlt, xaBag, xaSeq };
@@ -715,7 +743,11 @@ namespace Exiv2 {
     class EXIV2API XmpTextValue : public XmpValue {
     public:
         //! Shortcut for a %XmpTextValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<XmpTextValue> AutoPtr;
+#else
         typedef std::auto_ptr<XmpTextValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -797,7 +829,11 @@ namespace Exiv2 {
     class EXIV2API XmpArrayValue : public XmpValue {
     public:
         //! Shortcut for a %XmpArrayValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<XmpArrayValue> AutoPtr;
+#else
         typedef std::auto_ptr<XmpArrayValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -890,7 +926,11 @@ namespace Exiv2 {
     class EXIV2API LangAltValue : public XmpValue {
     public:
         //! Shortcut for a %LangAltValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<LangAltValue> AutoPtr;
+#else
         typedef std::auto_ptr<LangAltValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -978,7 +1018,11 @@ namespace Exiv2 {
     class EXIV2API DateValue : public Value {
     public:
         //! Shortcut for a %DateValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<DateValue> AutoPtr;
+#else
         typedef std::auto_ptr<DateValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -1079,7 +1123,11 @@ namespace Exiv2 {
     class EXIV2API TimeValue : public Value {
     public:
         //! Shortcut for a %TimeValue auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<TimeValue> AutoPtr;
+#else
         typedef std::auto_ptr<TimeValue> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -1235,7 +1283,11 @@ namespace Exiv2 {
     class ValueType : public Value {
     public:
         //! Shortcut for a %ValueType\<T\> auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<ValueType<T> > AutoPtr;
+#else
         typedef std::auto_ptr<ValueType<T> > AutoPtr;
+#endif
 
         //! @name Creators
         //@{

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -146,7 +146,11 @@ namespace Exiv2 {
     private:
         // Pimpl idiom
         struct Impl;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Impl> p_;
+#else
         std::auto_ptr<Impl> p_;
+#endif
 
     }; // class Xmpdatum
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -223,7 +223,11 @@ namespace Action {
             Task* t = i->second;
             return t->clone();
         }
+#ifdef EXV_NO_AUTO_PTR
+        return Task::AutoPtr(nullptr);
+#else
         return Task::AutoPtr(0);
+#endif
     } // TaskFactory::create
 
     Print::~Print()
@@ -1987,7 +1991,7 @@ namespace {
         if ( bStdin )  Params::instance().getStdin(stdIn);
         Exiv2::BasicIo::AutoPtr ioStdin = Exiv2::BasicIo::AutoPtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
 
-        Exiv2::Image::AutoPtr sourceImage = bStdin ? Exiv2::ImageFactory::open(ioStdin) : Exiv2::ImageFactory::open(source);
+        Exiv2::Image::AutoPtr sourceImage = bStdin ? Exiv2::ImageFactory::open(EXV_NO_AUTO_PTR_MOVE(ioStdin)) : Exiv2::ImageFactory::open(source);
         assert(sourceImage.get() != 0);
         sourceImage->readMetadata();
 

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -65,7 +65,11 @@ namespace Action {
     class Task {
     public:
         //! Shortcut for an auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Task> AutoPtr;
+#else
         typedef std::auto_ptr<Task> AutoPtr;
+#endif
         //! Contructor.
         Task() : binary_(false) {}
         //! Virtual destructor.
@@ -163,7 +167,11 @@ namespace Action {
     public:
         virtual ~Print();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Print> AutoPtr;
+#else
         typedef std::auto_ptr<Print> AutoPtr;
+#endif
         AutoPtr clone() const;
 
         //! Print the Jpeg comment
@@ -219,7 +227,11 @@ namespace Action {
     public:
         virtual ~Rename();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Rename> AutoPtr;
+#else
         typedef std::auto_ptr<Rename> AutoPtr;
+#endif
         AutoPtr clone() const;
 
     private:
@@ -231,7 +243,11 @@ namespace Action {
     public:
         virtual ~Adjust();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Adjust> AutoPtr;
+#else
         typedef std::auto_ptr<Adjust> AutoPtr;
+#endif
         AutoPtr clone() const;
 
     private:
@@ -254,7 +270,11 @@ namespace Action {
     public:
         virtual ~Erase();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Erase> AutoPtr;
+#else
         typedef std::auto_ptr<Erase> AutoPtr;
+#endif
         AutoPtr clone() const;
 
         /*!
@@ -296,7 +316,11 @@ namespace Action {
     public:
         virtual ~Extract();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Extract> AutoPtr;
+#else
         typedef std::auto_ptr<Extract> AutoPtr;
+#endif
         AutoPtr clone() const;
 
         /*!
@@ -335,7 +359,11 @@ namespace Action {
     public:
         virtual ~Insert();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Insert> AutoPtr;
+#else
         typedef std::auto_ptr<Insert> AutoPtr;
+#endif
         AutoPtr clone() const;
 
         /*!
@@ -376,7 +404,11 @@ namespace Action {
     public:
         virtual ~Modify();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Modify> AutoPtr;
+#else
         typedef std::auto_ptr<Modify> AutoPtr;
+#endif
         AutoPtr clone() const;
         Modify() {}
         //! Apply modification commands to the \em pImage, return 0 if successful.
@@ -409,7 +441,11 @@ namespace Action {
     public:
         virtual ~FixIso();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<FixIso> AutoPtr;
+#else
         typedef std::auto_ptr<FixIso> AutoPtr;
+#endif
         AutoPtr clone() const;
 
     private:
@@ -427,7 +463,11 @@ namespace Action {
     public:
         virtual ~FixCom();
         virtual int run(const std::string& path);
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<FixCom> AutoPtr;
+#else
         typedef std::auto_ptr<FixCom> AutoPtr;
+#endif
         AutoPtr clone() const;
 
     private:

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -292,7 +292,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     AsfVideo::AsfVideo(BasicIo::AutoPtr io)
-        : Image(ImageType::asf, mdNone, io)
+        : Image(ImageType::asf, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // AsfVideo::AsfVideo
 
@@ -787,7 +787,7 @@ namespace Exiv2 {
 
     Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new AsfVideo(io));
+        Image::AutoPtr image(new AsfVideo(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -97,7 +97,7 @@ namespace Exiv2
     }
 
     BmffImage::BmffImage(BasicIo::AutoPtr io, bool /* create */)
-    : Image(ImageType::bmff, mdExif | mdIptc | mdXmp, io)
+    : Image(ImageType::bmff, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     , endian_(Exiv2::bigEndian)
     {
         pixelWidth_    = 0;
@@ -723,7 +723,7 @@ namespace Exiv2
     // free functions
     Image::AutoPtr newBmffInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new BmffImage(io, create));
+        Image::AutoPtr image(new BmffImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -41,7 +41,7 @@
 // class member definitions
 namespace Exiv2
 {
-    BmpImage::BmpImage(BasicIo::AutoPtr io) : Image(ImageType::bmp, mdNone, io)
+    BmpImage::BmpImage(BasicIo::AutoPtr io) : Image(ImageType::bmp, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     }
 
@@ -122,7 +122,7 @@ namespace Exiv2
     // free functions
     Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new BmpImage(io));
+        Image::AutoPtr image(new BmpImage(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -47,7 +47,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     Cr2Image::Cr2Image(BasicIo::AutoPtr io, bool /*create*/)
-        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // Cr2Image::Cr2Image
 
@@ -183,7 +183,11 @@ namespace Exiv2 {
                      ed.end());
         }
 
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
+#else
         std::auto_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
+#endif   
         OffsetWriter offsetWriter;
         offsetWriter.setOrigin(OffsetWriter::cr2RawIfdOffset, Cr2Header::offset2addr(), byteOrder);
         return TiffParserWorker::encode(io,
@@ -202,7 +206,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newCr2Instance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new Cr2Image(io, create));
+        Image::AutoPtr image(new Cr2Image(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -53,7 +53,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     CrwImage::CrwImage(BasicIo::AutoPtr io, bool /*create*/)
-        : Image(ImageType::crw, mdExif | mdComment, io)
+        : Image(ImageType::crw, mdExif | mdComment, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // CrwImage::CrwImage
 
@@ -185,7 +185,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newCrwInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new CrwImage(io, create));
+        Image::AutoPtr image(new CrwImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -201,7 +201,7 @@ namespace Exiv2 {
 
     void CiffComponent::add(AutoPtr component)
     {
-        doAdd(component);
+        doAdd(EXV_NO_AUTO_PTR_MOVE(component));
     }
 
     void CiffEntry::doAdd(AutoPtr /*component*/)
@@ -340,7 +340,7 @@ namespace Exiv2 {
             }
             m->setDir(this->tag());
             m->read(pData, size, o, byteOrder);
-            add(m);
+            add(EXV_NO_AUTO_PTR_MOVE(m));
             o += 10;
         }
     }  // CiffDirectory::readDirectory
@@ -712,7 +712,7 @@ namespace Exiv2 {
                 // Directory doesn't exist yet, add it
                 m_ = AutoPtr(new CiffDirectory(csd.crwDir_, csd.parent_));
                 cc_ = m_.get();
-                add(m_);
+                add(EXV_NO_AUTO_PTR_MOVE(m_));
             }
             // Recursive call to next lower level directory
             cc_ = cc_->add(crwDirs, crwTagId);
@@ -729,7 +729,7 @@ namespace Exiv2 {
                 // Tag doesn't exist yet, add it
                 m_ = AutoPtr(new CiffEntry(crwTagId, tag()));
                 cc_ = m_.get();
-                add(m_);
+                add(EXV_NO_AUTO_PTR_MOVE(m_));
             }
         }
         return cc_;

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -84,7 +84,11 @@ namespace Exiv2 {
     class CiffComponent {
     public:
         //! CiffComponent auto_ptr type
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<CiffComponent> AutoPtr;
+#else
         typedef std::auto_ptr<CiffComponent> AutoPtr;
+#endif
         //! Container type to hold all metadata
         typedef std::vector<CiffComponent*> Components;
 
@@ -428,7 +432,11 @@ namespace Exiv2 {
     class CiffHeader {
     public:
         //! CiffHeader auto_ptr type
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<CiffHeader> AutoPtr;
+#else
         typedef std::auto_ptr<CiffHeader> AutoPtr;
+#endif
 
         //! @name Creators
         //@{

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1076,7 +1076,7 @@ namespace Exiv2
 {
 
     EpsImage::EpsImage(BasicIo::AutoPtr io, bool create)
-            : Image(ImageType::eps, mdXmp, io)
+            : Image(ImageType::eps, mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
         //LogMsg::setLevel(LogMsg::debug);
         if (create) {
@@ -1153,7 +1153,7 @@ namespace Exiv2
     // free functions
     Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new EpsImage(io, create));
+        Image::AutoPtr image(new EpsImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -81,7 +81,11 @@ namespace {
     class Thumbnail {
     public:
         //! Shortcut for a %Thumbnail auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Thumbnail> AutoPtr;
+#else
         typedef std::auto_ptr<Thumbnail> AutoPtr;
+#endif
 
         //! @name Creators
         //@{
@@ -124,7 +128,11 @@ namespace {
     class TiffThumbnail : public Thumbnail {
     public:
         //! Shortcut for a %TiffThumbnail auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<TiffThumbnail> AutoPtr;
+#else
         typedef std::auto_ptr<TiffThumbnail> AutoPtr;
+#endif
 
         //! @name Manipulators
         //@{
@@ -148,7 +156,11 @@ namespace {
     class JpegThumbnail : public Thumbnail {
     public:
         //! Shortcut for a %JpegThumbnail auto pointer.
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<JpegThumbnail> AutoPtr;
+#else
         typedef std::auto_ptr<JpegThumbnail> AutoPtr;
+#endif
 
         //! @name Manipulators
         //@{
@@ -193,10 +205,15 @@ namespace Exiv2 {
     template<typename T>
     Exiv2::Exifdatum& setValue(Exiv2::Exifdatum& exifDatum, const T& value)
     {
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<Exiv2::ValueType<T> > v
+            = std::unique_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
+#else
         std::auto_ptr<Exiv2::ValueType<T> > v
             = std::auto_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
+#endif
         v->value_.push_back(value);
-        exifDatum.value_ = v;
+        exifDatum.value_ = EXV_NO_AUTO_PTR_MOVE(v);
         return exifDatum;
     }
 
@@ -434,7 +451,11 @@ namespace Exiv2 {
 
     Value::AutoPtr Exifdatum::getValue() const
     {
+#ifdef EXV_NO_AUTO_PTR
+        return value_.get() == 0 ? Value::AutoPtr(nullptr) : value_->clone();
+#else
         return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
+#endif
     }
 
     long Exifdatum::sizeDataArea() const
@@ -742,7 +763,11 @@ namespace Exiv2 {
 
         // Encode and check if the result fits into a JPEG Exif APP1 segment
         MemIo mio1;
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
+#else
         std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
+#endif
         WriteMethod wm = TiffParserWorker::encode(mio1,
                                                   pData,
                                                   size,

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -37,7 +37,7 @@
 namespace Exiv2 {
 
     GifImage::GifImage(BasicIo::AutoPtr io)
-        : Image(ImageType::gif, mdNone, io)
+        : Image(ImageType::gif, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // GifImage::GifImage
 
@@ -100,7 +100,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newGifInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new GifImage(io));
+        Image::AutoPtr image(new GifImage(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -201,7 +201,11 @@ namespace Exiv2 {
 
     Value::AutoPtr Iptcdatum::getValue() const
     {
+#ifdef EXV_NO_AUTO_PTR
+        return value_.get() == 0 ? Value::AutoPtr(nullptr) : value_->clone();
+#else
         return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
+#endif
     }
 
     const Value& Iptcdatum::value() const
@@ -228,7 +232,7 @@ namespace Exiv2 {
     {
         UShortValue::AutoPtr v(new UShortValue);
         v->value_.push_back(value);
-        value_ = v;
+        value_ = EXV_NO_AUTO_PTR_MOVE(v);
         return *this;
     }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -84,7 +84,7 @@ const unsigned char Jp2Blank[] = {
 // class member definitions
 namespace Exiv2
 {
-    Jp2Image::Jp2Image(BasicIo::AutoPtr io, bool create) : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, io)
+    Jp2Image::Jp2Image(BasicIo::AutoPtr io, bool create) : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
         if (create) {
             if (io_->open() == 0) {
@@ -952,7 +952,7 @@ namespace Exiv2
     // free functions
     Image::AutoPtr newJp2Instance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new Jp2Image(io, create));
+        Image::AutoPtr image(new Jp2Image(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -318,7 +318,7 @@ namespace Exiv2 {
 
     JpegBase::JpegBase(int type, BasicIo::AutoPtr io, bool create,
                        const byte initData[], long dataSize)
-        : Image(type, mdExif | mdIptc | mdXmp | mdComment, io)
+        : Image(type, mdExif | mdIptc | mdXmp | mdComment, EXV_NO_AUTO_PTR_MOVE(io))
     {
         if (create) {
             initImage(initData, dataSize);
@@ -1321,7 +1321,7 @@ namespace Exiv2 {
         0x11,0x03,0x11,0x00,0x3F,0x00,0xA0,0x00,0x0F,0xFF,0xD9 };
 
     JpegImage::JpegImage(BasicIo::AutoPtr io, bool create)
-        : JpegBase(ImageType::jpeg, io, create, blank_, sizeof(blank_))
+        : JpegBase(ImageType::jpeg, EXV_NO_AUTO_PTR_MOVE(io), create, blank_, sizeof(blank_))
     {
     }
 
@@ -1348,7 +1348,7 @@ namespace Exiv2 {
 
     Image::AutoPtr newJpegInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new JpegImage(io, create));
+        Image::AutoPtr image(new JpegImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }
@@ -1373,7 +1373,7 @@ namespace Exiv2 {
     const byte ExvImage::blank_[] = { 0xff,0x01,'E','x','i','v','2',0xff,0xd9 };
 
     ExvImage::ExvImage(BasicIo::AutoPtr io, bool create)
-        : JpegBase(ImageType::exv, io, create, blank_, sizeof(blank_))
+        : JpegBase(ImageType::exv, EXV_NO_AUTO_PTR_MOVE(io), create, blank_, sizeof(blank_))
     {
     }
 
@@ -1402,7 +1402,7 @@ namespace Exiv2 {
     Image::AutoPtr newExvInstance(BasicIo::AutoPtr io, bool create)
     {
         Image::AutoPtr image;
-        image = Image::AutoPtr(new ExvImage(io, create));
+        image = Image::AutoPtr(new ExvImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) image.reset();
         return image;
     }

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -472,7 +472,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     MatroskaVideo::MatroskaVideo(BasicIo::AutoPtr io)
-        : Image(ImageType::mkv, mdNone, io)
+        : Image(ImageType::mkv, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // MatroskaVideo::MatroskaVideo
 
@@ -732,7 +732,7 @@ namespace Exiv2 {
 
     Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new MatroskaVideo(io));
+        Image::AutoPtr image(new MatroskaVideo(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -40,7 +40,7 @@
 namespace Exiv2 {
 
     MrwImage::MrwImage(BasicIo::AutoPtr io, bool /*create*/)
-        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // MrwImage::MrwImage
 
@@ -155,7 +155,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newMrwInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new MrwImage(io, create));
+        Image::AutoPtr image(new MrwImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -44,7 +44,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     OrfImage::OrfImage(BasicIo::AutoPtr io, bool create)
-        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ io,create)
+        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ EXV_NO_AUTO_PTR_MOVE(io),create)
     {
         setTypeSupported(ImageType::orf, mdExif | mdIptc | mdXmp);
     } // OrfImage::OrfImage
@@ -189,7 +189,11 @@ namespace Exiv2 {
                      ed.end());
         }
 
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
+#else
         std::auto_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
+#endif
         return TiffParserWorker::encode(io,
                                         pData,
                                         size,
@@ -206,7 +210,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newOrfInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new OrfImage(io, create));
+        Image::AutoPtr image(new OrfImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -77,7 +77,7 @@ namespace Exiv2 {
     }
 
     PgfImage::PgfImage(BasicIo::AutoPtr io, bool create)
-            : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, io)
+            : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, EXV_NO_AUTO_PTR_MOVE(io))
             , bSwap_(isBigEndianPlatform())
     {
         if (create)
@@ -316,7 +316,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newPgfInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new PgfImage(io, create));
+        Image::AutoPtr image(new PgfImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good())
         {
             image.reset();

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -74,7 +74,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     PngImage::PngImage(BasicIo::AutoPtr io, bool create)
-            : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, io)
+            : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, EXV_NO_AUTO_PTR_MOVE(io))
     {
         if (create)
         {
@@ -745,7 +745,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newPngInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new PngImage(io, create));
+        Image::AutoPtr image(new PngImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good())
         {
             image.reset();

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -89,7 +89,11 @@ namespace {
         virtual ~Loader() {}
 
         //! Loader auto pointer
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<Loader> AutoPtr;
+#else
         typedef std::auto_ptr<Loader> AutoPtr;
+#endif
 
         //! Create a Loader subclass for requested id
         static AutoPtr create(PreviewId id, const Image &image);

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -118,7 +118,7 @@ enum {
 namespace Exiv2 {
 
     PsdImage::PsdImage(BasicIo::AutoPtr io)
-        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // PsdImage::PsdImage
 
@@ -685,7 +685,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newPsdInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new PsdImage(io));
+        Image::AutoPtr image(new PsdImage(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -602,7 +602,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     QuickTimeVideo::QuickTimeVideo(BasicIo::AutoPtr io)
-            : Image(ImageType::qtime, mdNone, io)
+            : Image(ImageType::qtime, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
             , timeScale_(1)
     {
     } // QuickTimeVideo::QuickTimeVideo
@@ -1625,7 +1625,7 @@ namespace Exiv2 {
 
 
     Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool /*create*/) {
-        Image::AutoPtr image(new QuickTimeVideo(io));
+        Image::AutoPtr image(new QuickTimeVideo(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -42,7 +42,7 @@
 namespace Exiv2 {
 
     RafImage::RafImage(BasicIo::AutoPtr io, bool /*create*/)
-        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // RafImage::RafImage
 
@@ -398,7 +398,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newRafInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new RafImage(io, create));
+        Image::AutoPtr image(new RafImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -497,7 +497,7 @@ namespace Exiv2 {
     using namespace Exiv2::Internal;
 
     RiffVideo::RiffVideo(BasicIo::AutoPtr io)
-            : Image(ImageType::riff, mdNone, io)
+            : Image(ImageType::riff, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // RiffVideo::RiffVideo
 
@@ -1300,7 +1300,7 @@ namespace Exiv2 {
 
     Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new RiffVideo(io));
+        Image::AutoPtr image(new RiffVideo(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -42,7 +42,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     Rw2Image::Rw2Image(BasicIo::AutoPtr io)
-        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, io)
+        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // Rw2Image::Rw2Image
 
@@ -240,7 +240,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newRw2Instance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new Rw2Image(io));
+        Image::AutoPtr image(new Rw2Image(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -37,7 +37,7 @@
 namespace Exiv2 {
 
     TgaImage::TgaImage(BasicIo::AutoPtr io)
-        : Image(ImageType::tga, mdNone, io)
+        : Image(ImageType::tga, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // TgaImage::TgaImage
 
@@ -122,7 +122,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newTgaInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new TgaImage(io));
+        Image::AutoPtr image(new TgaImage(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good())
         {
             image.reset();

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -381,7 +381,7 @@ namespace Exiv2 {
         }
         size_ = value->copy(pData_, byteOrder);
         assert(size_ == newSize);
-        setValue(value);
+        setValue(EXV_NO_AUTO_PTR_MOVE(value));
     } // TiffEntryBase::updateValue
 
     void TiffEntryBase::setValue(Value::AutoPtr value)
@@ -620,7 +620,7 @@ namespace Exiv2 {
         tp->setData(const_cast<byte*>(pData() + idx), sz);
         tp->setElDef(def);
         tp->setElByteOrder(cfg()->byteOrder_);
-        addChild(tc);
+        addChild(EXV_NO_AUTO_PTR_MOVE(tc));
         return sz;
     } // TiffBinaryArray::addElement
 
@@ -629,7 +629,7 @@ namespace Exiv2 {
                                           TiffComponent* const pRoot,
                                           TiffComponent::AutoPtr object)
     {
-        return doAddPath(tag, tiffPath, pRoot, object);
+        return doAddPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     } // TiffComponent::addPath
 
     TiffComponent* TiffComponent::doAddPath(uint16_t  /*tag*/,
@@ -671,7 +671,7 @@ namespace Exiv2 {
         if (tc == 0) {
             TiffComponent::AutoPtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
-                atc = object;
+                atc = EXV_NO_AUTO_PTR_MOVE(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
@@ -683,13 +683,13 @@ namespace Exiv2 {
             if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != 0) return 0;
 
             if (tpi.extendedTag() == Tag::next) {
-                tc = this->addNext(atc);
+                tc = this->addNext(EXV_NO_AUTO_PTR_MOVE(atc));
             }
             else {
-                tc = this->addChild(atc);
+                tc = this->addChild(EXV_NO_AUTO_PTR_MOVE(atc));
             }
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     } // TiffDirectory::doAddPath
 
     TiffComponent* TiffSubIfd::doAddPath(uint16_t tag,
@@ -716,15 +716,15 @@ namespace Exiv2 {
         }
         if (tc == 0) {
             if (tiffPath.size() == 1 && object.get() != 0) {
-                tc = addChild(object);
+                tc = addChild(EXV_NO_AUTO_PTR_MOVE(object));
             }
             else {
                 TiffComponent::AutoPtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
-                tc = addChild(atc);
+                tc = addChild(EXV_NO_AUTO_PTR_MOVE(atc));
             }
             setCount(static_cast<uint32_t>(ifds_.size()));
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     } // TiffSubIfd::doAddPath
 
     TiffComponent* TiffMnEntry::doAddPath(uint16_t tag,
@@ -746,7 +746,7 @@ namespace Exiv2 {
             mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
             assert(mn_);
         }
-        return mn_->addPath(tag, tiffPath, pRoot, object);
+        return mn_->addPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     } // TiffMnEntry::doAddPath
 
     TiffComponent* TiffIfdMakernote::doAddPath(uint16_t tag,
@@ -754,7 +754,7 @@ namespace Exiv2 {
                                                TiffComponent* const pRoot,
                                                TiffComponent::AutoPtr object)
     {
-        return ifd_.addPath(tag, tiffPath, pRoot, object);
+        return ifd_.addPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     }
 
     TiffComponent* TiffBinaryArray::doAddPath(uint16_t tag,
@@ -786,22 +786,22 @@ namespace Exiv2 {
         if (tc == 0) {
             TiffComponent::AutoPtr atc;
             if (tiffPath.size() == 1 && object.get() != 0) {
-                atc = object;
+                atc = EXV_NO_AUTO_PTR_MOVE(object);
             }
             else {
                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
             }
             assert(atc.get() != 0);
             assert(tpi.extendedTag() != Tag::next);
-            tc = addChild(atc);
+            tc = addChild(EXV_NO_AUTO_PTR_MOVE(atc));
             setCount(static_cast<uint32_t>(elements_.size()));
         }
-        return tc->addPath(tag, tiffPath, pRoot, object);
+        return tc->addPath(tag, tiffPath, pRoot, EXV_NO_AUTO_PTR_MOVE(object));
     } // TiffBinaryArray::doAddPath
 
     TiffComponent* TiffComponent::addChild(TiffComponent::AutoPtr tiffComponent)
     {
-        return doAddChild(tiffComponent);
+        return doAddChild(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
     } // TiffComponent::addChild
 
     TiffComponent* TiffComponent::doAddChild(AutoPtr /*tiffComponent*/)
@@ -828,14 +828,14 @@ namespace Exiv2 {
     {
         TiffComponent* tc = 0;
         if (mn_) {
-            tc =  mn_->addChild(tiffComponent);
+            tc =  mn_->addChild(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
         }
         return tc;
     } // TiffMnEntry::doAddChild
 
     TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::AutoPtr tiffComponent)
     {
-        return ifd_.addChild(tiffComponent);
+        return ifd_.addChild(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
     }
 
     TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::AutoPtr tiffComponent)
@@ -848,7 +848,7 @@ namespace Exiv2 {
 
     TiffComponent* TiffComponent::addNext(TiffComponent::AutoPtr tiffComponent)
     {
-        return doAddNext(tiffComponent);
+        return doAddNext(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
     } // TiffComponent::addNext
 
     TiffComponent* TiffComponent::doAddNext(AutoPtr /*tiffComponent*/)
@@ -870,14 +870,14 @@ namespace Exiv2 {
     {
         TiffComponent* tc = 0;
         if (mn_) {
-            tc = mn_->addNext(tiffComponent);
+            tc = mn_->addNext(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
         }
         return tc;
     } // TiffMnEntry::doAddNext
 
     TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::AutoPtr tiffComponent)
     {
-        return ifd_.addNext(tiffComponent);
+        return ifd_.addNext(EXV_NO_AUTO_PTR_MOVE(tiffComponent));
     }
 
     void TiffComponent::accept(TiffVisitor& visitor)

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -171,7 +171,11 @@ namespace Exiv2 {
     class TiffComponent {
     public:
         //! TiffComponent auto_ptr type
+#ifdef EXV_NO_AUTO_PTR
+        typedef std::unique_ptr<TiffComponent> AutoPtr;
+#else
         typedef std::auto_ptr<TiffComponent> AutoPtr;
+#endif
         //! Container type to hold all metadata
         typedef std::vector<TiffComponent*> Components;
 
@@ -197,10 +201,17 @@ namespace Exiv2 {
 
           @return A pointer to the newly added TIFF entry.
          */
+#ifdef EXV_NO_AUTO_PTR
+        TiffComponent* addPath(uint16_t tag,
+                               TiffPath& tiffPath,
+                               TiffComponent* const pRoot,
+                               AutoPtr object = nullptr);
+#else
         TiffComponent* addPath(uint16_t tag,
                                TiffPath& tiffPath,
                                TiffComponent* const pRoot,
                                AutoPtr object =AutoPtr(0));
+#endif
         /*!
           @brief Add a child to the component. Default is to do nothing.
           @param tiffComponent Auto pointer to the component to add.

--- a/src/tifffwd_int.hpp
+++ b/src/tifffwd_int.hpp
@@ -98,7 +98,11 @@ namespace Exiv2 {
              Use TiffComponent::AutoPtr, it is not used in this declaration only
              to reduce dependencies.
      */
+#ifdef EXV_NO_AUTO_PTR
+    typedef std::unique_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
+#else
     typedef std::auto_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
+#endif
 
     //! Stack to hold a path from the TIFF root element to a TIFF entry
     typedef std::stack<TiffPathItem> TiffPath;

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -68,7 +68,7 @@ namespace Exiv2 {
     using namespace Internal;
 
     TiffImage::TiffImage(BasicIo::AutoPtr io, bool /*create*/)
-        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, io),
+        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, EXV_NO_AUTO_PTR_MOVE(io)),
           pixelWidth_(0), pixelHeight_(0)
     {
     } // TiffImage::TiffImage
@@ -302,7 +302,11 @@ namespace Exiv2 {
                      ed.end());
         }
 
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
+#else
         std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
+#endif
         return TiffParserWorker::encode(io,
                                         pData,
                                         size,
@@ -319,7 +323,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newTiffInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new TiffImage(io, create));
+        Image::AutoPtr image(new TiffImage(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1675,7 +1675,11 @@ namespace Exiv2 {
     TiffComponent::AutoPtr TiffCreator::create(uint32_t extendedTag,
                                                IfdId    group)
     {
+#ifdef EXV_NO_AUTO_PTR
+        TiffComponent::AutoPtr tc(nullptr);
+#else
         TiffComponent::AutoPtr tc(0);
+#endif
         uint16_t tag = static_cast<uint16_t>(extendedTag & 0xffff);
         const TiffGroupStruct* ts = find(tiffGroupStruct_,
                                          TiffGroupStruct::Key(extendedTag, group));
@@ -1726,11 +1730,19 @@ namespace Exiv2 {
     )
     {
         // Create standard TIFF header if necessary
+#ifdef EXV_NO_AUTO_PTR
+        std::unique_ptr<TiffHeaderBase> ph;
+        if (!pHeader) {
+            ph = std::unique_ptr<TiffHeaderBase>(new TiffHeader);
+            pHeader = ph.get();
+        }
+#else
         std::auto_ptr<TiffHeaderBase> ph;
         if (!pHeader) {
             ph = std::auto_ptr<TiffHeaderBase>(new TiffHeader);
             pHeader = ph.get();
         }
+#endif  
         TiffComponent::AutoPtr rootDir = parse(pData, size, root, pHeader);
         if (0 != rootDir.get()) {
             TiffDecoder decoder(exifData,
@@ -1833,7 +1845,11 @@ namespace Exiv2 {
               TiffHeaderBase*    pHeader
     )
     {
+#ifdef EXV_NO_AUTO_PTR
+        if (pData == 0 || size == 0) return TiffComponent::AutoPtr(nullptr);
+#else
         if (pData == 0 || size == 0) return TiffComponent::AutoPtr(0);
+#endif
         if (!pHeader->read(pData, size) || pHeader->offset() >= size) {
             throw Error(kerNotAnImage, "TIFF");
         }

--- a/src/tiffimage_int.hpp
+++ b/src/tiffimage_int.hpp
@@ -249,8 +249,13 @@ namespace Exiv2 {
                  component creation function. If the pointer that is returned
                  is 0, then the TIFF entry should be ignored.
         */
+#ifdef EXV_NO_AUTO_PTR
+        static std::unique_ptr<TiffComponent> create(uint32_t extendedTag,
+                                                     IfdId    group);
+#else
         static std::auto_ptr<TiffComponent> create(uint32_t extendedTag,
                                                    IfdId    group);
+#endif
         /*!
           @brief Get the path, i.e., a list of extended tag and group pairs, from
                  the \em root TIFF element to the TIFF entry \em extendedTag and
@@ -342,12 +347,21 @@ namespace Exiv2 {
                            composite structure. If \em pData is 0 or \em size
                            is 0, the return value is a 0 pointer.
          */
+#ifdef EXV_NO_AUTO_PTR
+        static std::unique_ptr<TiffComponent> parse(
+            const byte*              pData,
+                  uint32_t           size,
+                  uint32_t           root,
+                  TiffHeaderBase*    pHeader
+        );
+#else
         static std::auto_ptr<TiffComponent> parse(
             const byte*              pData,
                   uint32_t           size,
                   uint32_t           root,
                   TiffHeaderBase*    pHeader
         );
+#endif
         /*!
           @brief Find primary groups in the source tree provided and populate
                  the list of primary groups.

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -214,7 +214,7 @@ namespace Exiv2 {
             // Assumption is that the corresponding TIFF entry doesn't exist
             TiffPath tiffPath;
             TiffCreator::getPath(tiffPath, object->tag(), object->group(), root_);
-            pRoot_->addPath(object->tag(), tiffPath, pRoot_, clone);
+            pRoot_->addPath(object->tag(), tiffPath, pRoot_, EXV_NO_AUTO_PTR_MOVE(clone));
 #ifdef EXIV2_DEBUG_MESSAGES
             ExifKey key(object->tag(), groupName(object->group()));
             std::cerr << "Copied " << key << "\n";
@@ -1371,7 +1371,7 @@ namespace Exiv2 {
             TiffComponent::AutoPtr tc = TiffCreator::create(tag, object->group());
             if (tc.get()) {
                 tc->setStart(p);
-                object->addChild(tc);
+                object->addChild(EXV_NO_AUTO_PTR_MOVE(tc));
             } else {
                EXV_WARNING << "Unable to handle tag " << tag << ".\n";
             }
@@ -1386,7 +1386,11 @@ namespace Exiv2 {
 #endif
                 return;
             }
+#ifdef EXV_NO_AUTO_PTR
+            TiffComponent::AutoPtr tc(nullptr);
+#else
             TiffComponent::AutoPtr tc(0);
+#endif
             uint32_t next = getLong(p, byteOrder());
             if (next) {
                 tc = TiffCreator::create(Tag::next, object->group());
@@ -1406,7 +1410,7 @@ namespace Exiv2 {
                     return;
                 }
                 tc->setStart(pData_ + baseOffset() + next);
-                object->addNext(tc);
+                object->addNext(EXV_NO_AUTO_PTR_MOVE(tc));
             }
         } // object->hasNext()
 
@@ -1448,7 +1452,7 @@ namespace Exiv2 {
                 TiffComponent::AutoPtr td(new TiffDirectory(object->tag(),
                                                             static_cast<IfdId>(object->newGroup_ + i)));
                 td->setStart(pData_ + baseOffset() + offset);
-                object->addChild(td);
+                object->addChild(EXV_NO_AUTO_PTR_MOVE(td));
             }
         }
 #ifndef SUPPRESS_WARNINGS
@@ -1642,7 +1646,7 @@ namespace Exiv2 {
         enforce(v.get() != NULL, kerCorruptedMetadata);
         v->read(pData, size, byteOrder());
 
-        object->setValue(v);
+        object->setValue(EXV_NO_AUTO_PTR_MOVE(v));
         object->setData(pData, size);
         object->setOffset(offset);
         object->setIdx(nextIdx(object->group()));
@@ -1740,7 +1744,7 @@ namespace Exiv2 {
         enforce(v.get() != NULL, kerCorruptedMetadata);
         v->read(pData, size, bo);
 
-        object->setValue(v);
+        object->setValue(EXV_NO_AUTO_PTR_MOVE(v));
         object->setOffset(0);
         object->setIdx(nextIdx(object->group()));
 

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -69,7 +69,7 @@ namespace Exiv2 {
     }
 
     WebPImage::WebPImage(BasicIo::AutoPtr io)
-    : Image(ImageType::webp, mdNone, io)
+    : Image(ImageType::webp, mdNone, EXV_NO_AUTO_PTR_MOVE(io))
     {
     } // WebPImage::WebPImage
 
@@ -733,7 +733,7 @@ namespace Exiv2 {
 
     Image::AutoPtr newWebPInstance(BasicIo::AutoPtr io, bool /*create*/)
     {
-        Image::AutoPtr image(new WebPImage(io));
+        Image::AutoPtr image(new WebPImage(EXV_NO_AUTO_PTR_MOVE(io)));
         if (!image->good()) {
             image.reset();
         }

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -421,7 +421,11 @@ namespace Exiv2 {
 
     Value::AutoPtr Xmpdatum::getValue() const
     {
+#ifdef EXV_NO_AUTO_PTR
+        return p_->value_.get() == 0 ? Value::AutoPtr(nullptr) : p_->value_->clone();
+#else
         return p_->value_.get() == 0 ? Value::AutoPtr(0) : p_->value_->clone();
+#endif
     }
 
     const Value& Xmpdatum::value() const

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -46,7 +46,7 @@ namespace Exiv2 {
 
 
     XmpSidecar::XmpSidecar(BasicIo::AutoPtr io, bool create)
-        : Image(ImageType::xmp, mdXmp, io)
+        : Image(ImageType::xmp, mdXmp, EXV_NO_AUTO_PTR_MOVE(io))
     {
         if (create) {
             if (io_->open() == 0) {
@@ -193,7 +193,7 @@ namespace Exiv2 {
     // free functions
     Image::AutoPtr newXmpInstance(BasicIo::AutoPtr io, bool create)
     {
-        Image::AutoPtr image(new XmpSidecar(io, create));
+        Image::AutoPtr image(new XmpSidecar(EXV_NO_AUTO_PTR_MOVE(io), create));
         if (!image->good()) {
             image.reset();
         }

--- a/xmpsdk/src/MD5.cpp
+++ b/xmpsdk/src/MD5.cpp
@@ -153,7 +153,11 @@ MD5Final(md5byte digest[16], struct MD5_CTX *ctx)
 void
 MD5Transform(UWORD32 buf[4], UWORD32 const in[16])
 {
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+	UWORD32 a, b, c, d;
+#else
 	register UWORD32 a, b, c, d;
+#endif
 
 	a = buf[0];
 	b = buf[1];


### PR DESCRIPTION
The only thing that is preventing this from happening is using `std::auto_ptr`. This PR introduces two compile definitions `EXV_NO_AUTO_PTR` (I looked at `BOOST_NO_AUTO_PTR` for inspiration) and `EXV_NO_AUTO_PTR_MOVE` which are defined only when compiling library with C++17 compiler flag. As far as I can tell there are no existing users of this library which are affected by this change: even using C++11 and C++14 compiler flag user will have the same behavior as before this PR, `std::auto_ptr` will be used. Looks not really nice, I know, but I think it is OK to have this on maintenance branch. I tested this changes locally with MSVC 192, gcc 10.4 and clang from android sdk r25c.