### PR TITLE
remove Exif.Photo.SceneCaptureType from easyaccess group sceneMode

### DIFF
--- a/src/easyaccess.cpp
+++ b/src/easyaccess.cpp
@@ -201,7 +201,6 @@ ExifData::const_iterator sceneMode(const ExifData& ed) {
       "Exif.Panasonic.SceneMode",
       "Exif.Pentax.PictureMode",
       "Exif.PentaxDng.PictureMode",
-      "Exif.Photo.SceneCaptureType",
   };
   return findMetadatum(ed, keys, std::size(keys));
 }

--- a/tests/bash_tests/test_easyaccess.py
+++ b/tests/bash_tests/test_easyaccess.py
@@ -455,7 +455,7 @@ ISO speed             (Exif.Photo.ISOSpeedRatings         ) : 12800
 Date & time original  (Exif.Photo.DateTimeOriginal        ) : 2020:12:11 19:05:49
 Flash bias            (                                   ) : 
 Exposure mode         (Exif.Photo.ExposureProgram         ) : Aperture priority
-Scene mode            (Exif.Photo.SceneCaptureType        ) : Standard
+Scene mode            (                                   ) : 
 Macro mode            (                                   ) : 
 Image quality         (Exif.Nikon3.Quality                ) : RAW    
 White balance         (Exif.Nikon3.WhiteBalance           ) : AUTO1       


### PR DESCRIPTION
Exif.Photo.SceneCaptureType is contained in two easyaccess groups, sceneCaptureType and sceneMode. It is the only tag contained in two groups. When it was added to sceneMode with commit 482cd93 in June 2010, it was already included in sceneCaptureType. So it seems to me, that at that point of time it was not remembered, that it was already in easyaccess. So for me it sounds logical, to have this tag only in sceneCaptureType and to remove it from sceneMode.
