### PR TITLE
clang-tidy: fix bad roundings

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1220,7 +1220,7 @@ class ValueType : public Value {
     const auto v = value_.at(n);
     if (static_cast<decltype(v)>(std::numeric_limits<I>::min()) <= v &&
         v <= static_cast<decltype(v)>(std::numeric_limits<I>::max())) {
-      return static_cast<I>(std::round(v));
+      return static_cast<I>(std::lround(v));
     }
     return 0;
   }

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2967,7 +2967,7 @@ std::ostream& CanonMakerNote::printSi0x0003(std::ostream& os, const Value& value
     // see also printSi0x0017
     std::ostringstream oss;
     oss.copyfmt(os);
-    auto res = static_cast<int>(100.0 * (static_cast<short>(value.toInt64()) / 32.0 + 5.0) + 0.5);
+    auto res = std::lround(100.0 * (static_cast<short>(value.toInt64()) / 32.0 + 5.0));
     os << std::fixed << std::setprecision(2) << res / 100.0;
     os.copyfmt(oss);
   }

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1731,8 +1731,8 @@ const TagInfo* Nikon3MakerNote::tagListLd4() {
 }
 
 std::ostream& Nikon3MakerNote::printIiIso(std::ostream& os, const Value& value, const ExifData*) {
-  double v = 100 * exp((value.toInt64() / 12.0 - 5) * log(2.0));
-  return os << static_cast<int>(v + 0.5);
+  auto v = std::lround(100.0 * std::exp((value.toInt64() / 12.0 - 5) * std::log(2.0)));
+  return os << v;
 }
 
 std::ostream& Nikon3MakerNote::print0x0002(std::ostream& os, const Value& value, const ExifData*) {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -784,7 +784,7 @@ size_t TiffBinaryArray::doCount() const {
     typeSize = 1;
   }
 
-  return static_cast<size_t>(static_cast<double>(size()) / typeSize + 0.5);
+  return std::lround(static_cast<double>(size()) / typeSize);
 }
 
 size_t TiffBinaryElement::doCount() const {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -622,7 +622,7 @@ Rational floatToRationalCast(float f) {
   } else {
     return {d > 0 ? 1 : -1, 0};
   }
-  const auto nom = static_cast<int32_t>(std::round(d * den));
+  const auto nom = static_cast<int32_t>(std::lround(d * den));
   const int32_t g = std::gcd(nom, den);
 
   return {nom / g, den / g};

--- a/test/data/test_reference_files/exiv2-bug1231a.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1231a.jpg.out
@@ -65,7 +65,7 @@ Exif.CanonCs.SRAWQuality                     Short       1  65535  (65535)
 Exif.Canon.CanonFlashInfo                    Short       4  0 0 0 0  0 0 0 0
 Exif.CanonSi.AutoISO                         Short       1  96  106.714
 Exif.CanonSi.ISOSpeed                        Short       1  192  200
-Exif.CanonSi.MeasuredEV                      Short       1  65241  -4.21
+Exif.CanonSi.MeasuredEV                      Short       1  65241  -4.22
 Exif.CanonSi.TargetAperture                  Short       1  116  F3.5
 Exif.CanonSi.TargetShutterSpeed              Short       1  0  1 s
 Exif.CanonSi.ExposureCompensation            Short       1  0  0

--- a/test/data/test_reference_files/exiv2-bug1231b.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1231b.jpg.out
@@ -65,7 +65,7 @@ Exif.CanonCs.SRAWQuality                     Short       1  65535  (65535)
 Exif.Canon.CanonFlashInfo                    Short       4  0 0 0 0  0 0 0 0
 Exif.CanonSi.AutoISO                         Short       1  96  106.714
 Exif.CanonSi.ISOSpeed                        Short       1  192  200
-Exif.CanonSi.MeasuredEV                      Short       1  65241  -4.21
+Exif.CanonSi.MeasuredEV                      Short       1  65241  -4.22
 Exif.CanonSi.TargetAperture                  Short       1  116  F3.5
 Exif.CanonSi.TargetShutterSpeed              Short       1  0  1 s
 Exif.CanonSi.ExposureCompensation            Short       1  0  0


### PR DESCRIPTION
Found with bugprone-incorrect-roundings