### PR TITLE
switch from custom stringFormat to fmtlib

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Install dependencies
       run: |
-        sudo eatmydata apt-get -y install libexpat1-dev zlib1g-dev libbrotli-dev libinih-dev
+        sudo eatmydata apt-get -y install libfmt-dev libexpat1-dev zlib1g-dev libbrotli-dev libinih-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja inih googletest
+          brew install ninja fmt inih googletest
 
       - name: Build
         run: |

--- a/.github/workflows/on_PR_mac_special_builds.yml
+++ b/.github/workflows/on_PR_mac_special_builds.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja inih googletest
+          brew install ninja fmt inih googletest
 
       - name: Build
         run: |

--- a/.github/workflows/on_PR_meson.yaml
+++ b/.github/workflows/on_PR_meson.yaml
@@ -115,6 +115,7 @@ jobs:
             cc:p
             cmake:p
             curl:p
+            fmt:p
             gtest:p
             libinih:p
             meson:p
@@ -126,6 +127,27 @@ jobs:
           meson setup "${{github.workspace}}/build" -Dauto_features=${{matrix.deps}} -Dwarning_level=3 -Dcpp_std=c++20
           meson compile -C "${{github.workspace}}/build" --verbose
           meson test -C "${{github.workspace}}/build" --verbose
+  MSYS:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: 'MSYS'
+          install: >-
+            cmake
+            gcc
+            meson
+            ninja
+            pkgconf
+      - name: Compile and Test
+        run: |
+          meson setup build -Dwarning_level=3 -Dcpp_std=gnu++20
+          meson compile -C build --verbose
+          meson test -C build --verbose
   MacOS:
     runs-on: macos-latest
     name: macOS-deps=${{matrix.deps}}
@@ -141,7 +163,7 @@ jobs:
 
       - name: Compile and Test
         run: |
-          meson setup "${{github.workspace}}/build" -Dauto_features=${{matrix.deps}} -Dwarning_level=3 -Dnls=disabled -Db_sanitize=address,undefined
+          meson setup "${{github.workspace}}/build" -Dauto_features=${{matrix.deps}} -Dwarning_level=3 -Dcpp_std=c++20 -Dnls=disabled -Db_sanitize=address,undefined
           meson compile -C "${{github.workspace}}/build" --verbose
           meson test -C "${{github.workspace}}/build" --verbose
   FreeBSD:
@@ -151,7 +173,7 @@ jobs:
       - uses: vmactions/freebsd-vm@v1
         with:
           prepare: |
-            pkg install -y cmake curl ninja meson gettext pkgconf googletest expat inih brotli
+            pkg install -y cmake curl ninja meson gettext pkgconf googletest expat inih brotli libfmt
           run: |
             meson setup "${{github.workspace}}/build" -Dwarning_level=3 -Dcpp_std=c++20
             meson compile -C "${{github.workspace}}/build" --verbose

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -115,6 +115,7 @@ jobs:
             libiconv:p
             libinih:p
             zlib:p
+            fmt:p
 
       - name: Build
         run: |
@@ -179,6 +180,7 @@ jobs:
           cmake --preset base_windows \
             -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
             -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}} \
+            -DCMAKE_CXX_STANDARD=20 \
             -DCONAN_AUTO_INSTALL=OFF \
             -DEXIV2_BUILD_SAMPLES=OFF \
             -DEXIV2_BUILD_UNIT_TESTS=OFF \

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja inih googletest
+          brew install ninja fmt inih googletest
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ endif()
 
 include_directories(${CMAKE_BINARY_DIR}) # Make the exv_conf.h file visible for the full project
 
+check_cxx_symbol_exists(__cpp_lib_format "format" HAVE_STD_FORMAT)
+if(NOT HAVE_STD_FORMAT)
+  find_package(fmt REQUIRED)
+endif()
+
 if(EXIV2_ENABLE_XMP)
   add_subdirectory(xmpsdk)
 endif()

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -41,46 +41,46 @@ distro_id=$(grep '^ID=' /etc/os-release|awk -F = '{print $2}'|sed 's/\"//g')
 
 case "$distro_id" in
     'fedora')
-        dnf -y --refresh install gcc-c++ clang cmake ninja-build expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel gmock-devel glibc-langpack-en inih-devel
+        dnf -y --refresh install gcc-c++ clang cmake ninja-build expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel gmock-devel glibc-langpack-en inih-devel fmt-devel
         ;;
 
     'debian')
         apt-get update
-        apt-get install -y cmake ninja-build g++ clang libexpat1-dev zlib1g-dev libbrotli-dev libssh-dev libcurl4-openssl-dev libgmock-dev libxml2-utils libinih-dev
+        apt-get install -y cmake ninja-build g++ clang libexpat1-dev zlib1g-dev libbrotli-dev libssh-dev libcurl4-openssl-dev libgmock-dev libxml2-utils libinih-dev libfmt-dev
         # debian_build_gtest
         ;;
 
     'arch')
         pacman --noconfirm -Syu
-        pacman --noconfirm --needed -S gcc clang cmake ninja expat zlib brotli libssh curl gtest libinih
+        pacman --noconfirm --needed -S gcc clang cmake ninja expat zlib brotli libssh curl gtest libinih fmt
         ;;
 
     'ubuntu')
         apt-get update
-        apt-get install -y cmake ninja-build g++ clang libexpat1-dev zlib1g-dev libbrotli-dev libssh-dev libcurl4-openssl-dev libgmock-dev libxml2-utils libinih-dev
+        apt-get install -y cmake ninja-build g++ clang libexpat1-dev zlib1g-dev libbrotli-dev libssh-dev libcurl4-openssl-dev libgmock-dev libxml2-utils libinih-dev libfmt-dev
         # debian_build_gtest
         ;;
 
     'alpine')
         apk update
-        apk add gcc g++ clang cmake samurai expat-dev zlib-dev brotli-dev libssh-dev curl-dev gtest gtest-dev gmock libintl gettext-dev libxml2-utils inih-dev inih-inireader-dev
+        apk add gcc g++ clang cmake samurai expat-dev zlib-dev brotli-dev libssh-dev curl-dev gtest gtest-dev gmock libintl gettext-dev libxml2-utils inih-dev inih-inireader-dev fmt-dev
         ;;
 
     'rhel')
         dnf clean all
-        dnf -y install gcc-c++ clang cmake ninja-build expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel inih-devel
+        dnf -y install gcc-c++ clang cmake ninja-build expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel inih-devel fmt-devel
         ;;
 
     'centos')
         dnf clean all
-        dnf -y install gcc-c++ clang cmake expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel git
+        dnf -y install gcc-c++ clang cmake expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel git fmt-devel
         dnf -y --enablerepo=crb install ninja-build meson
         centos_build_inih
         ;;
 
     'opensuse-tumbleweed')
         zypper --non-interactive refresh
-        zypper --non-interactive install gcc-c++ clang cmake ninja libexpat-devel zlib-devel libbrotli-devel libssh-devel libcurl-devel gmock libxml2-tools libinih-devel
+        zypper --non-interactive install gcc-c++ clang cmake ninja libexpat-devel zlib-devel libbrotli-devel libssh-devel libcurl-devel gmock libxml2-tools libinih-devel libfmt-devel
         ;;
     *)
         echo "Sorry, no predefined dependencies for your distribution $distro_id exist yet"

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -126,7 +126,9 @@ cmake_push_check_state()
 set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
 
 # All of our tests required C++17 or later
-set(CMAKE_CXX_STANDARD 17)
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 
 # Normalize and check the component list we were given
 set(want_components ${Filesystem_FIND_COMPONENTS})

--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -1,7 +1,9 @@
 # These flags applies to exiv2lib, the applications, and to the xmp code
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 17)
+if (NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,8 @@ class Exiv2Conan(ConanFile):
 
         self.requires('inih/55')
 
+        self.requires('fmt/10.1.1')
+
         if self.options.webready:
             self.requires('libcurl/7.85.0')
 

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -82,7 +82,7 @@ class EXIV2API AsfVideo : public Image {
     // Constructor to create a GUID object from a byte array
     explicit GUIDTag(const uint8_t* bytes);
 
-    std::string to_string();
+    std::string to_string() const;
 
     bool operator<(const GUIDTag& other) const;
   };

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   default_options: ['warning_level=0', 'cpp_std=c++17'],
 )
 
-cargs = []
+cargs = ['-D_GNU_SOURCE']
 cpp = meson.get_compiler('cpp')
 if host_machine.system() == 'windows' and get_option('default_library') != 'static'
   cargs += '-DEXIV2API=__declspec(dllexport)'
@@ -44,7 +44,7 @@ cdata.set('EXV_PACKAGE_VERSION', '@0@.@1@'.format(meson.project_version(), cdata
 cdata.set('EXV_PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), cdata.get('PROJECT_VERSION')))
 
 cdata.set('EXV_HAVE_STRERROR_R', cpp.has_function('strerror_r'))
-cdata.set('EXV_STRERROR_R_CHAR_P', not cpp.compiles('#include <string.h>\nint strerror_r(int,char*,size_t);int main(){}'))
+cdata.set('EXV_STRERROR_R_CHAR_P', not cpp.compiles('#define _GNU_SOURCE\n#include <string.h>\nint strerror_r(int,char*,size_t);int main(){}'))
 
 cdata.set('EXV_ENABLE_BMFF', get_option('bmff'))
 cdata.set('EXV_HAVE_LENSDATA', get_option('lensdata'))
@@ -53,6 +53,10 @@ cdata.set('EXV_ENABLE_VIDEO', get_option('video'))
 deps = []
 deps += cpp.find_library('ws2_32', required: host_machine.system() == 'windows')
 deps += cpp.find_library('procstat', required: host_machine.system() == 'freebsd')
+
+if not cpp.has_header_symbol('format', '__cpp_lib_format')
+  deps += dependency('fmt')
+endif
 
 if cpp.get_argument_syntax() == 'gcc' and cpp.version().version_compare('<9')
   if host_machine.system() == 'linux' and cpp.get_define('_LIBCPP_VERSION', prefix: '#include <new>') == ''

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,6 +251,12 @@ else()
   target_link_libraries(exiv2lib PRIVATE psapi ws2_32 shell32)
 endif()
 
+if(NOT HAVE_STD_FORMAT)
+  target_link_libraries(exiv2lib PRIVATE fmt::fmt)
+  target_link_libraries(exiv2lib_int PRIVATE fmt::fmt)
+  list(APPEND requires_private_list "fmt")
+endif()
+
 if(EXIV2_ENABLE_PNG)
   target_link_libraries(exiv2lib PRIVATE ZLIB::ZLIB)
   target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -12,6 +12,7 @@
 #include "error.hpp"
 #include "futils.hpp"
 #include "helper_functions.hpp"
+#include "image_int.hpp"
 #include "utils.hpp"
 // *****************************************************************************
 // class member definitions
@@ -58,24 +59,12 @@ AsfVideo::GUIDTag::GUIDTag(const uint8_t* bytes) {
   }
 }
 
-std::string AsfVideo::GUIDTag::to_string() {
-  // Convert each field of the GUID structure to a string
-  std::stringstream ss;
-  ss << std::hex << std::setw(8) << std::setfill('0') << data1_ << "-";
-  ss << std::hex << std::setw(4) << std::setfill('0') << data2_ << "-";
-  ss << std::hex << std::setw(4) << std::setfill('0') << data3_ << "-";
-
-  for (size_t i = 0; i < 8; i++) {
-    if (i == 2) {
-      ss << "-";
-    }
-    ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(data4_[i]);
-  }
-
+std::string AsfVideo::GUIDTag::to_string() const {
   // Concatenate all strings into a single string
   // Convert the string to uppercase
   // Example of output 399595EC-8667-4E2D-8FDB-98814CE76C1E
-  return Internal::upper(ss.str());
+  return stringFormat("{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}", data1_, data2_, data3_,
+                      data4_[0], data4_[1], data4_[2], data4_[3], data4_[4], data4_[5], data4_[6], data4_[7]);
 }
 
 bool AsfVideo::GUIDTag::operator<(const GUIDTag& other) const {

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -80,7 +80,7 @@ bool enableBMFF(bool) {
 }
 
 std::string Iloc::toString() const {
-  return Internal::stringFormat("ID = %u from,length = %u,%u", ID_, start_, length_);
+  return stringFormat("ID = {} from,length = {},{}", ID_, start_, length_);
 }
 
 BmffImage::BmffImage(BasicIo::UniquePtr io, bool /* create */, size_t max_box_depth) :
@@ -276,7 +276,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
   if (bTrace) {
     bLF = true;
     out << Internal::indent(depth) << "Exiv2::BmffImage::boxHandler: " << toAscii(box_type)
-        << Internal::stringFormat(" %8zd->%" PRIu64 " ", address, box_length);
+        << stringFormat(" {:8}->{} ", address, box_length);
   }
 
   if (box_length == 1) {
@@ -373,7 +373,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
         id = " *** XMP ***";
       }
       if (bTrace) {
-        out << Internal::stringFormat("ID = %3d ", ID) << name << " " << id;
+        out << stringFormat("ID = {:3} {} {}", ID, name, id);
       }
     } break;
 
@@ -451,8 +451,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
           uint32_t ldata = data.read_uint32(skip + step - 4, endian_);
           if (bTrace) {
             out << Internal::indent(depth)
-                << Internal::stringFormat("%8zd | %8zd |   ID | %4u | %6u,%6u", address + skip, step, ID, offset, ldata)
-                << '\n';
+                << stringFormat("{:8} | {:8} |   ID | {:4} | {:6},{:6}\n", address + skip, step, ID, offset, ldata);
           }
           // save data for post-processing in meta box
           if (offset && ldata && ID != unknownID_) {
@@ -470,7 +469,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       uint32_t height = data.read_uint32(skip, endian_);
       skip += 4;
       if (bTrace) {
-        out << "pixelWidth_, pixelHeight_ = " << Internal::stringFormat("%d, %d", width, height);
+        out << stringFormat("pixelWidth_, pixelHeight_ = {}, {}", width, height);
       }
       // HEIC files can have multiple ispe records
       // Store largest width/height
@@ -685,8 +684,8 @@ void BmffImage::parseCr3Preview(const DataBuf& data, std::ostream& out, bool bTr
     return "application/octet-stream";
   }();
   if (bTrace) {
-    out << Internal::stringFormat("width,height,size = %zu,%zu,%zu", nativePreview.width_, nativePreview.height_,
-                                  nativePreview.size_);
+    out << stringFormat("width,height,size = {},{},{}", nativePreview.width_, nativePreview.height_,
+                        nativePreview.size_);
   }
   nativePreviews_.push_back(std::move(nativePreview));
 }

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -386,7 +386,7 @@ std::string getProcessPath() {
       return "unknown";  // pathbuf not big enough
     auto path = fs::path(pathbuf);
 #elif defined(__sun__)
-    auto path = fs::read_symlink(Internal::stringFormat("/proc/%d/path/a.out", getpid()));
+    auto path = fs::read_symlink(stringFormat("/proc/{}/path/a.out", getpid()));
 #elif defined(__unix__)
     auto path = fs::read_symlink("/proc/self/exe");
 #endif

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -352,8 +352,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
       throw Error(ErrorCode::kerTiffDirectoryTooLarge);
 
     if (bFirst && bPrint) {
-      out << Internal::indent(depth) << Internal::stringFormat("STRUCTURE OF TIFF FILE (%c%c): ", c, c) << io.path()
-          << '\n';
+      out << Internal::indent(depth) << stringFormat("STRUCTURE OF TIFF FILE ({}{}): {}\n", c, c, io.path());
     }
 
     // Read the dictionary
@@ -433,11 +432,11 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
 
       if (bPrint) {
         const size_t address = start + 2 + (i * 12);
-        const std::string offsetString = bOffsetIsPointer ? Internal::stringFormat("%10u", offset) : "";
+        const std::string offsetString = bOffsetIsPointer ? stringFormat("{:9}", offset) : "";
 
         out << Internal::indent(depth)
-            << Internal::stringFormat("%8zu | %#06x %-28s |%10s |%9u |%10s | ", address, tag, tagName(tag).c_str(),
-                                      typeName(type), count, offsetString.c_str());
+            << stringFormat("{:8} | {:#06x} {:<28} | {:>9} | {:>8} | {:9} | ", address, tag, tagName(tag).c_str(),
+                            typeName(type), count, offsetString);
         if (isShortType(type)) {
           for (size_t k = 0; k < kount; k++) {
             out << sp << byteSwap2(buf, k * size, bSwap);

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -9,32 +9,6 @@
 #include <vector>
 
 namespace Exiv2::Internal {
-std::string stringFormat(const char* format, ...) {
-  std::string result;
-  std::vector<char> buffer;
-  size_t need = std::strlen(format) * 8;  // initial guess
-  int rc = -1;
-
-  // vsnprintf writes at most size (2nd parameter) bytes (including \0)
-  //           returns the number of bytes required for the formatted string excluding \0
-  // the following loop goes through:
-  // one iteration (if 'need' was large enough for the for formatted string)
-  // or two iterations (after the first call to vsnprintf we know the required length)
-  do {
-    buffer.resize(need + 1);
-    va_list args;            // variable arg list
-    va_start(args, format);  // args start after format
-    rc = vsnprintf(buffer.data(), buffer.size(), format, args);
-    va_end(args);  // free the args
-    if (rc > 0)
-      need = static_cast<size_t>(rc);
-  } while (buffer.size() <= need);
-
-  if (rc > 0)
-    result = std::string(buffer.data(), need);
-  return result;
-}
-
 [[nodiscard]] std::string indent(size_t i) {
   return std::string(2 * i, ' ');
 }

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -12,12 +12,14 @@
 #include <ostream>  // for ostream, basic_ostream::put
 #include <string>
 
-#if defined(__MINGW32__)
-#define ATTRIBUTE_FORMAT_PRINTF __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
-#elif defined(__GNUC__)
-#define ATTRIBUTE_FORMAT_PRINTF __attribute__((format(printf, 1, 2)))
+#if __has_include(<format>)
+#include <format>
+#endif
+#ifndef __cpp_lib_format
+#include <fmt/core.h>
+#define stringFormat fmt::format
 #else
-#define ATTRIBUTE_FORMAT_PRINTF
+#define stringFormat std::format
 #endif
 
 // *****************************************************************************
@@ -25,11 +27,6 @@
 namespace Exiv2::Internal {
 // *****************************************************************************
 // class definitions
-
-/*!
-  @brief format a string in the pattern of \em sprintf \em .
- */
-std::string stringFormat(const char* format, ...) ATTRIBUTE_FORMAT_PRINTF;
 
 /*!
  * @brief Helper struct for binary data output via @ref binaryToString.

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -413,8 +413,7 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
       Internal::enforce(box.length <= boxHSize + io_->size() - io_->tell(), ErrorCode::kerCorruptedMetadata);
 
       if (bPrint) {
-        out << Internal::stringFormat("%8zd | %8zd | ", position - boxHSize, static_cast<size_t>(box.length))
-            << toAscii(box.type) << "      | ";
+        out << stringFormat("{:8} | {:8} | {}      | ", position - boxHSize, box.length, toAscii(box.type));
         bLF = true;
         if (box.type == kJp2BoxTypeClose)
           lf(out, bLF);
@@ -456,8 +455,8 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
             DataBuf data(subBox.length - boxHSize);
             io_->read(data.data(), data.size());
             if (bPrint) {
-              out << Internal::stringFormat("%8zu | %8u |  sub:", address, subBox.length) << toAscii(subBox.type)
-                  << " | " << Internal::binaryToString(makeSlice(data, 0, std::min<size_t>(30, data.size())));
+              out << stringFormat("{:8} | {:8} |  sub:{} | ", address, subBox.length, toAscii(subBox.type))
+                  << Internal::binaryToString(makeSlice(data, 0, std::min<size_t>(30, data.size())));
               bLF = true;
             }
 

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -329,7 +329,7 @@ void JpegBase::readMetadata() {
 
 #define REPORT_MARKER                                 \
   if ((option == kpsBasic || option == kpsRecursive)) \
-  out << Internal::stringFormat("%8zd | 0xff%02x %-5s", io_->tell() - 2, marker, nm[marker].c_str())
+  out << stringFormat("{:8} | 0xff{:02x} {:<5}", io_->tell() - 2, marker, nm[marker].c_str())
 
 void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
   if (io_->open() != 0)
@@ -395,7 +395,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
       }
 
       if (bPrint && markerHasLength(marker))
-        out << Internal::stringFormat(" | %7d ", size);
+        out << stringFormat(" | {:7} ", size);
 
       // print signature for APPn
       if (marker >= app0_ && marker <= (app0_ | 0x0F)) {
@@ -470,7 +470,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
             enforce<std::out_of_range>(size >= 16, "Buffer too small to extract chunk information.");
             const int chunk = buf.read_uint8(2 + 12);
             const int chunks = buf.read_uint8(2 + 13);
-            out << Internal::stringFormat(" chunk %d/%d", chunk, chunks);
+            out << stringFormat(" chunk {}/{}", chunk, chunks);
           }
         }
 

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -256,10 +256,8 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
         enforce(bufRead == 4, ErrorCode::kerFailedToReadImageData);
         io_->seek(restore, BasicIo::beg);  // restore file pointer
 
-        out << Internal::stringFormat("%8d | %-5s |%8d | ", static_cast<uint32_t>(address), chType, dataOffset)
-            << dataString
-            << Internal::stringFormat(" | 0x%02x%02x%02x%02x", checksum[0], checksum[1], checksum[2], checksum[3])
-            << '\n';
+        out << stringFormat("{:8} | {:<5} |{:8} | {}", address, chType, dataOffset, dataString)
+            << stringFormat(" | 0x{:02x}{:02x}{:02x}{:02x}\n", checksum[0], checksum[1], checksum[2], checksum[3]);
       }
 
       // chunk type

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -150,12 +150,8 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     uint32_t jpg_img_off = Exiv2::getULong(jpg_img_offset, bigEndian);
     uint32_t jpg_img_len = Exiv2::getULong(jpg_img_length, bigEndian);
     {
-      std::stringstream j_off;
-      std::stringstream j_len;
-      j_off << jpg_img_off;
-      j_len << jpg_img_len;
-      out << Internal::indent(depth) << stringFormat(format, address, 4) << " JPEG offset : " << j_off.str() << '\n';
-      out << Internal::indent(depth) << stringFormat(format, address2, 4) << " JPEG length : " << j_len.str() << '\n';
+      out << Internal::indent(depth) << stringFormat(format, address, 4) << " JPEG offset : " << jpg_img_off << '\n';
+      out << Internal::indent(depth) << stringFormat(format, address2, 4) << " JPEG length : " << jpg_img_len << '\n';
     }
 
     // RAFs can carry the payload in one or two parts
@@ -170,14 +166,10 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       io_->readOrThrow(data, 4);
       meta_len[i] = Exiv2::getULong(data, bigEndian);
       {
-        std::stringstream c_off;
-        std::stringstream c_len;
-        c_off << meta_off[i];
-        c_len << meta_len[i];
-        out << Internal::indent(depth) << stringFormat(format, address, 4) << "meta offset" << i + 1 << " : "
-            << c_off.str() << '\n';
-        out << Internal::indent(depth) << stringFormat(format, address2, 4) << "meta length" << i + 1 << " : "
-            << c_len.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address, 4)
+            << stringFormat("meta offset{} : {}\n", i + 1, meta_off[i]);
+        out << Internal::indent(depth) << stringFormat(format, address2, 4)
+            << stringFormat("meta length{} : {}\n", i + 1, meta_len[i]);
       }
 
       address = io_->tell();
@@ -196,26 +188,16 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       io_->readOrThrow(data, 4);
       cfa_data[i] = Exiv2::getULong(data, bigEndian);
       {
-        std::stringstream c_off;
-        std::stringstream c_len;
-        std::stringstream c_comp;
-        std::stringstream c_size;
-        std::stringstream c_data;
-        c_off << cfa_off[i];
-        c_len << cfa_len[i];
-        c_comp << comp[i];
-        c_size << cfa_size[i];
-        c_data << cfa_data[i];
-        out << Internal::indent(depth) << stringFormat(format, address, 4U) << " CFA offset" << i + 1 << " : "
-            << c_off.str() << '\n';
-        out << Internal::indent(depth) << stringFormat(format, address2, 4U) << " CFA length" << i + 1 << " : "
-            << c_len.str() << '\n';
-        out << Internal::indent(depth) << stringFormat(format, address3, 4U) << "compression" << i + 1 << " : "
-            << c_comp.str() << '\n';
-        out << Internal::indent(depth) << stringFormat(format, address4, 4U) << "  CFA chunk" << i + 1 << " : "
-            << c_size.str() << '\n';
-        out << Internal::indent(depth) << stringFormat(format, address5, 4U) << "    unknown" << i + 1 << " : "
-            << c_data.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address, 4U)
+            << stringFormat(" CFA offset{} : {}\n", i + 1, cfa_off[i]);
+        out << Internal::indent(depth) << stringFormat(format, address2, 4U)
+            << stringFormat(" CFA length{} : {}\n", i + 1, cfa_len[i]);
+        out << Internal::indent(depth) << stringFormat(format, address3, 4U)
+            << stringFormat("compression{} : {}\n", i + 1, comp[i]);
+        out << Internal::indent(depth) << stringFormat(format, address4, 4U)
+            << stringFormat("  CFA chunk{} : {}\n", i + 1, cfa_size[i]);
+        out << Internal::indent(depth) << stringFormat(format, address5, 4U)
+            << stringFormat("    unknown{} : {}\n", i + 1, cfa_data[i]);
       }
     }
 

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -81,7 +81,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
   if (bPrint) {
     io_->seek(0, BasicIo::beg);  // rewind
     size_t address = io_->tell();
-    constexpr auto format = " %9zu | %9" PRIu32 " | ";
+    constexpr auto format = " {:9} | {:9} | ";
 
     {
       out << Internal::indent(depth) << "STRUCTURE OF RAF FILE: " << io().path() << '\n';
@@ -92,7 +92,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->readOrThrow(magicdata, 16);
     magicdata[16] = 0;
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 16U)  // 0
+      out << Internal::indent(depth) << stringFormat(format, address, 16)  // 0
           << "       magic : " << reinterpret_cast<char*>(magicdata) << '\n';
     }
 
@@ -101,7 +101,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->read(data1, 4);
     data1[4] = 0;
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U)  // 16
+      out << Internal::indent(depth) << stringFormat(format, address, 4)  // 16
           << "       data1 : " << std::string(reinterpret_cast<char*>(&data1)) << '\n';
     }
 
@@ -110,7 +110,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->read(data2, 8);
     data2[8] = 0;
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 8U)  // 20
+      out << Internal::indent(depth) << stringFormat(format, address, 8)  // 20
           << "       data2 : " << std::string(reinterpret_cast<char*>(&data2)) << '\n';
     }
 
@@ -119,7 +119,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->read(camdata, 32);
     camdata[32] = 0;
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 32U)  // 28
+      out << Internal::indent(depth) << stringFormat(format, address, 32)  // 28
           << "      camera : " << std::string(reinterpret_cast<char*>(&camdata)) << '\n';
     }
 
@@ -128,7 +128,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->read(dir_version, 4);
     dir_version[4] = 0;
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U)  // 60
+      out << Internal::indent(depth) << stringFormat(format, address, 4)  // 60
           << "     version : " << std::string(reinterpret_cast<char*>(&dir_version)) << '\n';
     }
 
@@ -136,7 +136,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     DataBuf unknown(20);
     io_->readOrThrow(unknown.data(), unknown.size());
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 20U)
+      out << Internal::indent(depth) << stringFormat(format, address, 20)
           << "     unknown : " << Internal::binaryToString(makeSlice(unknown, 0, unknown.size())) << '\n';
     }
 
@@ -154,10 +154,8 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       std::stringstream j_len;
       j_off << jpg_img_off;
       j_len << jpg_img_len;
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << " JPEG offset : " << j_off.str()
-          << '\n';
-      out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << " JPEG length : " << j_len.str()
-          << '\n';
+      out << Internal::indent(depth) << stringFormat(format, address, 4) << " JPEG offset : " << j_off.str() << '\n';
+      out << Internal::indent(depth) << stringFormat(format, address2, 4) << " JPEG length : " << j_len.str() << '\n';
     }
 
     // RAFs can carry the payload in one or two parts
@@ -176,10 +174,10 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
         std::stringstream c_len;
         c_off << meta_off[i];
         c_len << meta_len[i];
-        out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << "meta offset" << i + 1 << " : "
+        out << Internal::indent(depth) << stringFormat(format, address, 4) << "meta offset" << i + 1 << " : "
             << c_off.str() << '\n';
-        out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << "meta length" << i + 1
-            << " : " << c_len.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address2, 4) << "meta length" << i + 1 << " : "
+            << c_len.str() << '\n';
       }
 
       address = io_->tell();
@@ -208,16 +206,16 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
         c_comp << comp[i];
         c_size << cfa_size[i];
         c_data << cfa_data[i];
-        out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << " CFA offset" << i + 1 << " : "
+        out << Internal::indent(depth) << stringFormat(format, address, 4U) << " CFA offset" << i + 1 << " : "
             << c_off.str() << '\n';
-        out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << " CFA length" << i + 1
-            << " : " << c_len.str() << '\n';
-        out << Internal::indent(depth) << Internal::stringFormat(format, address3, 4U) << "compression" << i + 1
-            << " : " << c_comp.str() << '\n';
-        out << Internal::indent(depth) << Internal::stringFormat(format, address4, 4U) << "  CFA chunk" << i + 1
-            << " : " << c_size.str() << '\n';
-        out << Internal::indent(depth) << Internal::stringFormat(format, address5, 4U) << "    unknown" << i + 1
-            << " : " << c_data.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address2, 4U) << " CFA length" << i + 1 << " : "
+            << c_len.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address3, 4U) << "compression" << i + 1 << " : "
+            << c_comp.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address4, 4U) << "  CFA chunk" << i + 1 << " : "
+            << c_size.str() << '\n';
+        out << Internal::indent(depth) << stringFormat(format, address5, 4U) << "    unknown" << i + 1 << " : "
+            << c_data.str() << '\n';
       }
     }
 
@@ -226,7 +224,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     DataBuf payload(16);  // header is different from chunks
     io_->readOrThrow(payload.data(), payload.size());
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, jpg_img_len)
+      out << Internal::indent(depth) << stringFormat(format, address, jpg_img_len)
           << "   JPEG data : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
@@ -234,7 +232,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     address = io_->tell();
     io_->readOrThrow(payload.data(), payload.size());
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, meta_len[0])
+      out << Internal::indent(depth) << stringFormat(format, address, meta_len[0])
           << "  meta data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
@@ -243,7 +241,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       address = io_->tell();
       io_->readOrThrow(payload.data(), payload.size());
       {
-        out << Internal::indent(depth) << Internal::stringFormat(format, address, meta_len[1])
+        out << Internal::indent(depth) << stringFormat(format, address, meta_len[1])
             << "  meta data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
       }
     }
@@ -252,7 +250,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     address = io_->tell();
     io_->readOrThrow(payload.data(), payload.size());
     {
-      out << Internal::indent(depth) << Internal::stringFormat(format, address, cfa_len[0])
+      out << Internal::indent(depth) << stringFormat(format, address, cfa_len[0])
           << "   CFA data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
@@ -261,7 +259,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       address = io_->tell();
       io_->readOrThrow(payload.data(), payload.size());
       {
-        out << Internal::indent(depth) << Internal::stringFormat(format, address, cfa_len[1])  // cfa_off
+        out << Internal::indent(depth) << stringFormat(format, address, cfa_len[1])  // cfa_off
             << "   CFA data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
       }
     }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -433,8 +433,7 @@ void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, s
       io_->read(payload.data(), payload.size());
 
       if (bPrint) {
-        out << Internal::indent(depth)
-            << Internal::stringFormat("  %s | %8u | %8u | ", chunkId.c_str(), size, static_cast<uint32_t>(offset))
+        out << Internal::indent(depth) << stringFormat("  {} | {:8} | {:8} | ", chunkId.c_str(), size, offset)
             << Internal::binaryToString(makeSlice(payload, 0, payload.size() > 32 ? 32 : payload.size())) << '\n';
       }
 

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = fmt-11.1.1
+source_url = https://github.com/fmtlib/fmt/archive/11.1.1.tar.gz
+source_filename = fmt-11.1.1.tar.gz
+source_hash = 482eed9efbc98388dbaee5cb5f368be5eca4893456bb358c18b7ff71f835ae43
+patch_filename = fmt_11.1.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.1.1-2/get_patch
+patch_hash = eee2e90d5d43061a0a1f0b9f8eb188c5b8820ef3e1b15e4b8a4eb791ef82b325
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.1.1-2/fmt-11.1.1.tar.gz
+wrapdb_version = 11.1.1-2
+
+[provide]
+fmt = fmt_dep

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -44,6 +44,10 @@ target_compile_definitions(unit_tests PRIVATE exiv2lib_STATIC TESTDATA_PATH="${P
 
 target_link_libraries(unit_tests PRIVATE exiv2lib GTest::gmock_main std::filesystem)
 
+if(NOT HAVE_STD_FORMAT)
+  target_link_libraries(unit_tests PRIVATE fmt::fmt)
+endif()
+
 if(EXIV2_ENABLE_INIH)
   target_link_libraries(unit_tests PRIVATE inih::libinih inih::inireader)
 endif()


### PR DESCRIPTION
The latter helps to avoid wrong format errors and is simpler to use. Will be replaced by std::format once C++20 becomes mandatory.