### PR TITLE
placeholder basesuffix for rename format

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -1826,7 +1826,13 @@ int renameFile(std::string& newPath, const tm* tm) {
   std::string path = newPath;
   auto oldFsPath = fs::path(path);
   std::string format = Params::instance().format_;
+  std::string filename = p.stem().string();
+  std::string basesuffix = "";
+  int pos = filename.find('.');
+  if (pos > 0)
+   basesuffix = filename.substr(filename.find('.'));
   replace(format, ":basename:", p.stem().string());
+  replace(format, ":basesuffix:", basesuffix);
   replace(format, ":dirname:", p.parent_path().filename().string());
   replace(format, ":parentname:", p.parent_path().parent_path().filename().string());
 

--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -1830,7 +1830,7 @@ int renameFile(std::string& newPath, const tm* tm) {
   std::string basesuffix = "";
   int pos = filename.find('.');
   if (pos > 0)
-   basesuffix = filename.substr(filename.find('.'));
+    basesuffix = filename.substr(filename.find('.'));
   replace(format, ":basename:", p.stem().string());
   replace(format, ":basesuffix:", basesuffix);
   replace(format, ":dirname:", p.parent_path().filename().string());

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -334,6 +334,7 @@ void Params::help(std::ostream& os) const {
      << _("   -r fmt  Filename format for the 'rename' action. The format string\n")
      << _("           follows strftime(3). The following keywords are also supported:\n")
      << _("             :basename:   - original filename without extension\n")
+     << _("             :basesuffix: - suffix in original filename, starts with first dot and ends before extension\n")
      << _("             :dirname:    - name of the directory holding the original file\n")
      << _("             :parentname: - name of parent directory\n") << _("           Default 'fmt' is %Y%m%d_%H%M%S\n")
      << _("   -c txt  JPEG comment string to set in the image.\n")

--- a/exiv2.md
+++ b/exiv2.md
@@ -455,11 +455,12 @@ environment variable). The *fmt* string follows the definitions in
 date and time. In addition, the following special character sequences are 
 also provided:
 
-| Variable       | Description                                     |
-|:------         |:----                                            |
-| :basename:     | Original filename without extension             |
-| :dirname:      | Name of the directory holding the original file |
-| :parentname:   | Name of parent directory                        |
+| Variable       | Description                                                                                                                   |
+|:------         |:----                                                                                                                          |
+| :basename:     | Original filename without extension                                                                                           |
+| :basesuffix:   | Suffix in original filename, starts with first dot and ends before extension, e.g. PANO, MP, NIGHT added by Google Camera app |
+| :dirname:      | Name of the directory holding the original file                                                                               |
+| :parentname:   | Name of parent directory                                                                                                      |
 
 The default *fmt* is %Y%m%d_%H%M%S
 
@@ -490,6 +491,12 @@ File 1/1: Stonehenge.jpg
 exiv2.exe: File `./Stonehenge_16_Jul_2015.jpg' exists. [O]verwrite, [r]ename or [s]kip? r
 Renaming file to ./Stonehenge_16_Jul_2015_1.jpg
 ```
+
+If the filename contains a suffix, which shall be included in new filename:
+```
+$ exiv2 --verbose --rename '%d_%b_%Y:basesuffix:' Stonehenge.PANO.jpg
+File 1/1: Stonehenge.PANO.jpg
+Renaming file to '16_Jul_2015.PANO'.jpg```
 
 <div id="adjust_time">
 

--- a/test/data/test_reference_files/exiv2-test.out
+++ b/test/data/test_reference_files/exiv2-test.out
@@ -140,6 +140,7 @@ Options:
    -r fmt  Filename format for the 'rename' action. The format string
            follows strftime(3). The following keywords are also supported:
              :basename:   - original filename without extension
+             :basesuffix: - suffix in original filename, starts with first dot and ends before extension
              :dirname:    - name of the directory holding the original file
              :parentname: - name of parent directory
            Default 'fmt' is %Y%m%d_%H%M%S


### PR DESCRIPTION
refers to second issue in #1770:
A placeholder "basesuffix" is added for rename formats, which holds the text from first to last dot of original filename. The format "%d_%b_%Y:basesuffix" would then keep suffixes e.g. added from Google Camera app.