### PR TITLE
meson: update brotli and libobsd subprojects

### DIFF
--- a/subprojects/google-brotli.wrap
+++ b/subprojects/google-brotli.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = brotli-1.0.9
-source_url = https://github.com/google/brotli/archive/v1.0.9.tar.gz
-source_filename = v1.0.9.tar.gz
-source_hash = f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46
-patch_filename = google-brotli_1.0.9-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/google-brotli_1.0.9-2/get_patch
-patch_hash = 790d795f0929df9ee64eb96689b5e5bb197fb5b6683fc58627df0c4e3aaff2f3
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-brotli_1.0.9-2/v1.0.9.tar.gz
-wrapdb_version = 1.0.9-2
+directory = brotli-1.1.0
+source_url = https://github.com/google/brotli/archive/v1.1.0.tar.gz
+source_filename = v1.1.0.tar.gz
+source_hash = e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff
+patch_filename = google-brotli_1.1.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-brotli_1.1.0-1/get_patch
+patch_hash = 6826873a148c670d90a80715a7083284da7e19d59cda6a135fae6774411914dc
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-brotli_1.1.0-1/v1.1.0.tar.gz
+wrapdb_version = 1.1.0-1
 
 [provide]
 libbrotlicommon = brotli_common_dep

--- a/subprojects/libobsd.wrap
+++ b/subprojects/libobsd.wrap
@@ -1,10 +1,11 @@
 [wrap-file]
-directory = libobsd-1.1.0
-source_url = https://github.com/guijan/libobsd/releases/download/v1.1.0/libobsd-1.1.0.tar.xz
-source_filename = libobsd-1.1.0.tar.xz
-source_hash = 64343ccdd3b7c479954d9806a4531091195d410cc54d0172018d959a61693c2c
+directory = libobsd-1.1.1
+source_url = https://github.com/guijan/libobsd/releases/download/v1.1.1/libobsd-1.1.1.tar.xz
+source_filename = libobsd-1.1.1.tar.xz
+source_hash = 332b72ba5f9a76c40f8a526771b78dae3ac3388f689f818c0ac4ab77ef52809d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libobsd_1.1.1-1/libobsd-1.1.1.tar.xz
+wrapdb_version = 1.1.1-1
 
 [provide]
 libbsd-overlay = libobsd_dep
 libobsd = libobsd_dep
-


### PR DESCRIPTION
Probably should get rid of libobsd...