### PR TITLE
three Nikon keys added to easyaccess

### DIFF
--- a/src/easyaccess.cpp
+++ b/src/easyaccess.cpp
@@ -25,6 +25,29 @@ ExifData::const_iterator findMetadatum(const ExifData& ed, const char* const key
   return ed.end();
 }  // findMetadatum
 
+/*!
+  @brief Search \em ed for a Metadatum specified by the \em keys.
+         The \em keys are searched in the order of their appearance, the
+         first available Metadatum is returned, except it is in NikonLd4
+         and its value 0.
+         Example: Exif.NikonLd4.LensID and Exif.NikonLd4.LensIDNumber are
+         usually together included, one of them has value 0 (which means
+         undefined), so skip tag with value 0.
+
+  @param ed The %Exif metadata container to search
+  @param keys Array of keys to look for
+  @param count Number of elements in the array
+ */
+ExifData::const_iterator findMetadatumSkip0inNikonLd4(const ExifData& ed, const char* const keys[], size_t count) {
+  for (size_t i = 0; i < count; ++i) {
+    auto pos = ed.findKey(ExifKey(keys[i]));
+    if (pos != ed.end()) {
+      if (strncmp(keys[i], "Exif.NikonLd4", 13) != 0 || pos->getValue()->toInt64(0) > 0)
+        return pos;
+    }
+  }
+  return ed.end();
+}  // findMetadatumSkip0inNikonLd4
 }  // anonymous namespace
 
 // *****************************************************************************
@@ -263,26 +286,18 @@ ExifData::const_iterator lensName(const ExifData& ed) {
       "Exif.Nikon3.Lens",
   };
 
-  for (const auto& key : keys) {
-    auto pos = ed.findKey(ExifKey(key));
-    if (pos != ed.end()) {
-      // Exif.NikonLd4.LensID and Exif.NikonLd4.LensIDNumber are usually together included,
-      // one of them has value 0 (which means undefined), so skip tag with value 0
-      if (strncmp(key, "Exif.NikonLd4", 13) != 0 || pos->getValue()->toInt64(0) > 0)
-        return pos;
-    }
-  }
-  return ed.end();
+  return findMetadatumSkip0inNikonLd4(ed, keys, std::size(keys));
 }
 
 ExifData::const_iterator saturation(const ExifData& ed) {
   static constexpr const char* keys[] = {
       "Exif.Photo.Saturation",        "Exif.CanonCs.Saturation",     "Exif.MinoltaCsNew.Saturation",
       "Exif.MinoltaCsOld.Saturation", "Exif.MinoltaCs7D.Saturation", "Exif.MinoltaCs5D.Saturation",
-      "Exif.Fujifilm.Color",          "Exif.Nikon3.Saturation",      "Exif.NikonPc.Saturation",
-      "Exif.Panasonic.Saturation",    "Exif.Pentax.Saturation",      "Exif.PentaxDng.Saturation",
-      "Exif.Sigma.Saturation",        "Exif.Sony1.Saturation",       "Exif.Sony2.Saturation",
-      "Exif.Casio.Saturation",        "Exif.Casio2.Saturation",      "Exif.Casio2.Saturation2",
+      "Exif.Fujifilm.Color",          "Exif.Nikon3.Saturation",      "Exif.Nikon3.Saturation2",
+      "Exif.NikonPc.Saturation",      "Exif.Panasonic.Saturation",   "Exif.Pentax.Saturation",
+      "Exif.PentaxDng.Saturation",    "Exif.Sigma.Saturation",       "Exif.Sony1.Saturation",
+      "Exif.Sony2.Saturation",        "Exif.Casio.Saturation",       "Exif.Casio2.Saturation",
+      "Exif.Casio2.Saturation2",
   };
   return findMetadatum(ed, keys, std::size(keys));
 }
@@ -418,10 +433,11 @@ ExifData::const_iterator subjectDistance(const ExifData& ed) {
       "Exif.Photo.SubjectDistance",      "Exif.Image.SubjectDistance",      "Exif.CanonSi.SubjectDistance",
       "Exif.CanonFi.FocusDistanceUpper", "Exif.CanonFi.FocusDistanceLower", "Exif.MinoltaCsNew.FocusDistance",
       "Exif.Nikon1.FocusDistance",       "Exif.Nikon3.FocusDistance",       "Exif.NikonLd2.FocusDistance",
-      "Exif.NikonLd3.FocusDistance",     "Exif.NikonLd4.FocusDistance",     "Exif.Olympus.FocusDistance",
-      "Exif.OlympusFi.FocusDistance",    "Exif.Casio.ObjectDistance",       "Exif.Casio2.ObjectDistance",
+      "Exif.NikonLd3.FocusDistance",     "Exif.NikonLd4.FocusDistance",     "Exif.NikonLd4.FocusDistance2",
+      "Exif.Olympus.FocusDistance",      "Exif.OlympusFi.FocusDistance",    "Exif.Casio.ObjectDistance",
+      "Exif.Casio2.ObjectDistance",
   };
-  return findMetadatum(ed, keys, std::size(keys));
+  return findMetadatumSkip0inNikonLd4(ed, keys, std::size(keys));
 }
 
 ExifData::const_iterator lightSource(const ExifData& ed) {
@@ -453,11 +469,12 @@ ExifData::const_iterator serialNumber(const ExifData& ed) {
 
 ExifData::const_iterator focalLength(const ExifData& ed) {
   static constexpr const char* keys[] = {
-      "Exif.Photo.FocalLength",    "Exif.Image.FocalLength",     "Exif.Canon.FocalLength",
-      "Exif.NikonLd2.FocalLength", "Exif.NikonLd3.FocalLength",  "Exif.MinoltaCsNew.FocalLength",
-      "Exif.Pentax.FocalLength",   "Exif.PentaxDng.FocalLength", "Exif.Casio2.FocalLength",
+      "Exif.Photo.FocalLength",        "Exif.Image.FocalLength",    "Exif.Canon.FocalLength",
+      "Exif.NikonLd2.FocalLength",     "Exif.NikonLd3.FocalLength", "Exif.NikonLd4.FocalLength2",
+      "Exif.MinoltaCsNew.FocalLength", "Exif.Pentax.FocalLength",   "Exif.PentaxDng.FocalLength",
+      "Exif.Casio2.FocalLength",
   };
-  return findMetadatum(ed, keys, std::size(keys));
+  return findMetadatumSkip0inNikonLd4(ed, keys, std::size(keys));
 }
 
 ExifData::const_iterator subjectArea(const ExifData& ed) {

--- a/tests/bash_tests/test_easyaccess.py
+++ b/tests/bash_tests/test_easyaccess.py
@@ -520,6 +520,59 @@ Del Exif.Photo.BodySerialNumber
     retval = [0] * len(commands)
 
 ###########################################################
+# NIKON Z 6: NikonLd4.FocalLength2
+###########################################################
+@CopyTmpFiles("$data_path/NikonZ6.exv")
+class NikonLd4FocalLength2(metaclass=CaseMeta):
+
+    filename = path("$tmp_path/NikonZ6.exv")
+
+    commands = [
+        "$easyaccess_test $filename FocalLength",
+		"""$exiv2 -u -v -M"del Exif.Photo.FocalLength" $filename""",
+        "$easyaccess_test $filename FocalLength",
+        "$easyaccess_test $filename SubjectDistance",
+    ]
+    stdout = [
+	"""Focal length          (Exif.Photo.FocalLength             ) : 35.0 mm
+""",
+    """File 1/1: $filename
+Del Exif.Photo.FocalLength
+""",
+	"""Focal length          (Exif.NikonLd4.FocalLength2         ) : 35 mm
+""",
+	"""Subject distance      (Exif.NikonLd4.FocusDistance2       ) : 9.92 m
+"""
+    ]
+    stderr = [""] * len(commands)
+    retval = [0] * len(commands)
+
+###########################################################
+# Nikon D70; Nikon3.Saturation2
+###########################################################
+@CopyTmpFiles("$data_path/exiv2-nikon-d70.jpg")
+class Nikon3Saturation2(metaclass=CaseMeta):
+
+    filename = path("$tmp_path/exiv2-nikon-d70.jpg")
+
+    commands = [
+        "$easyaccess_test $filename Saturation",
+		"""$exiv2 -u -v -M"del Exif.Photo.Saturation" $filename""",
+        "$easyaccess_test $filename Saturation"
+    ]
+    stdout = [
+	"""Saturation            (Exif.Photo.Saturation              ) : Normal
+""",
+    """File 1/1: $filename
+Del Exif.Photo.Saturation
+""",
+	"""Saturation            (Exif.Nikon3.Saturation2            ) : NORMAL         
+"""
+    ]
+    stderr = [""] * len(commands)
+    retval = [0] * len(commands)
+
+###########################################################
 # Pentax K100D
 ###########################################################
 @CopyTmpFiles("$data_path/RAW_PENTAX_K100.exv")


### PR DESCRIPTION
Following tags are added to easyaccess:
Exif.NikonLd4.FocusDistance2
Exif.NikonLd4.FocalLength2
Exif.Nikon3.Saturation2

As there are now 3 groups with NikonLd4, where keys with value 0 (which means undefined) shall be skipped, the code formerly included in lensName is now included in the new function findMetadatumSkip0inNikonLd4.
