### PR TITLE
easy access: Tag sequence changed for serialNumber and lensName

### DIFF
--- a/src/easyaccess.cpp
+++ b/src/easyaccess.cpp
@@ -272,15 +272,17 @@ ExifData::const_iterator whiteBalance(const ExifData& ed) {
 ExifData::const_iterator lensName(const ExifData& ed) {
   static constexpr const char* keys[] = {
       // Try Exif.CanonCs.LensType first.
-      "Exif.CanonCs.LensType",      "Exif.Photo.LensModel",
-      "Exif.Canon.LensModel",       "Exif.NikonLd1.LensIDNumber",
-      "Exif.NikonLd2.LensIDNumber", "Exif.NikonLd3.LensIDNumber",
-      "Exif.NikonLd4.LensID",       "Exif.NikonLd4.LensIDNumber",
+      // Exif.OlympusEq.LensType and Exif.Pentax.LensType in most cases give better information than
+      // Exif.Photo.LensModel
+      "Exif.CanonCs.LensType",      "Exif.OlympusEq.LensType",
       "Exif.Pentax.LensType",       "Exif.PentaxDng.LensType",
-      "Exif.Minolta.LensID",        "Exif.SonyMinolta.LensID",
-      "Exif.Sony1.LensID",          "Exif.Sony2.LensID",
-      "Exif.Sony1.LensSpec",        "Exif.Sony2.LensSpec",
-      "Exif.OlympusEq.LensType",    "Exif.Panasonic.LensType",
+      "Exif.Photo.LensModel",       "Exif.Canon.LensModel",
+      "Exif.NikonLd1.LensIDNumber", "Exif.NikonLd2.LensIDNumber",
+      "Exif.NikonLd3.LensIDNumber", "Exif.NikonLd4.LensID",
+      "Exif.NikonLd4.LensIDNumber", "Exif.Minolta.LensID",
+      "Exif.SonyMinolta.LensID",    "Exif.Sony1.LensID",
+      "Exif.Sony2.LensID",          "Exif.Sony1.LensSpec",
+      "Exif.Sony2.LensSpec",        "Exif.Panasonic.LensType",
       "Exif.Samsung2.LensType",     "Exif.Photo.LensSpecification",
       "Exif.Nikon3.Lens",
   };
@@ -457,10 +459,12 @@ ExifData::const_iterator flash(const ExifData& ed) {
 
 ExifData::const_iterator serialNumber(const ExifData& ed) {
   static constexpr const char* keys[] = {
-      "Exif.Image.CameraSerialNumber", "Exif.Photo.BodySerialNumber", "Exif.Canon.SerialNumber",
-      "Exif.Nikon3.SerialNumber",      "Exif.Nikon3.SerialNO",        "Exif.Fujifilm.SerialNumber",
-      "Exif.Olympus.SerialNumber2",    "Exif.OlympusEq.SerialNumber", "Exif.Pentax.SerialNumber",
-      "Exif.PentaxDng.SerialNumber",   "Exif.Sigma.SerialNumber",     "Exif.Sony1.SerialNumber",
+      // first check Exif.Canon.SerialNumber, because some Canon images contain a wrong value in
+      // Exif.Photo.BodySerialNumber
+      "Exif.Canon.SerialNumber",     "Exif.Image.CameraSerialNumber", "Exif.Photo.BodySerialNumber",
+      "Exif.Nikon3.SerialNumber",    "Exif.Nikon3.SerialNO",          "Exif.Fujifilm.SerialNumber",
+      "Exif.Olympus.SerialNumber2",  "Exif.OlympusEq.SerialNumber",   "Exif.Pentax.SerialNumber",
+      "Exif.PentaxDng.SerialNumber", "Exif.Sigma.SerialNumber",       "Exif.Sony1.SerialNumber",
       "Exif.Sony2.SerialNumber",
   };
   return findMetadatum(ed, keys, std::size(keys));


### PR DESCRIPTION
In general the sequence of tags should not matter: if a camera writes two tags for the same information, the value should be the same. But ...

SerialNumber (reference: #2792): A few images were found, where both Exif.Canon.SerialNumber and Exif.Photo.BodySerialNumber are filled, but with different values. Comparing the value with the output of Canon Digital Photo Professional, the value in Exif.Canon.SerialNumber is regarded to be correct. With Fuji it is different. FujiFilm X RAW Studio shows the value from Exif.Photo.BodySerialNumber, not the one from Exif.Fujifilm.SerialNumber. Nikon, Olympus, Sigma, Pentax write maker tags for serial number as well as Exif.Photo.BodySerialNumber, but here the values are the same. So the only change in sequence is to check Exif.Canon.SerialNumber before Exif.Photo.BodySerialNumber.

LensName: Exif.OlympusEq.LensType and Exif.Pentax.LensType in some cases are more specific than Exif.Photo.LensModel:

- "Olympus Zuiko Digital ED 50mm F2.0 Macro" instead of "OLYMPUS 50mm Lens"

- "02 Standard Zoom 5-15mm F2.8-4.5" instead of "02 STANDARD ZOOM"

So Exif.OlympusEq.LensType, Exif.Pentax.LensType and Exif.PentaxDng.LensType are now read before Exif.Photo.LensModel. In the other cases, where two tags are written, the one read first in easy access in most cases is the better one.
