### PR TITLE
Fix test failure on Mac

### DIFF
--- a/tests/bugfixes/github/test_issue_2427.py
+++ b/tests/bugfixes/github/test_issue_2427.py
@@ -7,7 +7,5 @@ class issue_2427_BmffImage_brotliUncompress_memleak(metaclass=CaseMeta):
     filename = "$data_path/issue_2427_poc.jpg"
     commands = ["$exiv2 $filename"]
     retval   = [1]
-    stderr   = ["""$exiv2_exception_message $filename:
-CL_SPACE
-"""]
     stdout   = [""]
+    compare_stderr = check_no_ASAN_UBSAN_errors


### PR DESCRIPTION
Fix this error, which is happening on Mac:

```
======================================================================
FAIL: test_run (github.test_issue_2427.issue_2427_BmffImage_brotliUncompress_memleak.test_run)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/exiv2/exiv2/tests/system_tests.py", line 652, in test_run
    self.compare_stderr(i, command, processed_stderr, stderr)
  File "/Users/runner/work/exiv2/exiv2/tests/system_tests.py", line 773, in compare_stderr
    self._compare_output(
  File "/Users/runner/work/exiv2/exiv2/tests/system_tests.py", line 745, in _compare_output
    self.assertMultiLineEqual(
AssertionError: 'Exiv[61 chars]/exiv2/test/data/issue_2427_poc.jpg:\n_ERROR_FORMAT_CL_SPACE\n' != 'Exiv[61 chars]/exiv2/test/data/issue_2427_poc.jpg:\nCL_SPACE\n'
  Exiv2 exception in print action for file /Users/runner/work/exiv2/exiv2/test/data/issue_2427_poc.jpg:
- _ERROR_FORMAT_CL_SPACE
+ CL_SPACE
 : Standard error does not match
```

`git grep` shows that the string `CL_SPACE` isn't coming from our own codebase, so it's probably coming from brotli. On Mac it's `_ERROR_FORMAT_CL_SPACE` instead.