### PR TITLE
install exiv2 cmake module in LIBDIR (backport #2819)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,7 +284,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ../cmake/exiv2Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake
-  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 
 install(FILES
@@ -294,7 +294,7 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
 install(EXPORT exiv2Export
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
     NAMESPACE Exiv2::
 )
 
@@ -302,5 +302,5 @@ install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/exiv2ConfigVersion.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/exiv2")
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2")
 


### PR DESCRIPTION
installed cmake module contains arch dependent library description. It should be installed not in DATADIR but in LIBDIR.

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>
(cherry picked from commit 3e977c5cf014750fa850fcbfb2715115c75e4610)