### PR TITLE
tests: fix parsing w/ path containing "-pa" or "-pS"

### DIFF
--- a/tests/tiff_test/test_tag_compare.py
+++ b/tests/tiff_test/test_tag_compare.py
@@ -98,9 +98,9 @@ class OutputTagExtract(metaclass=system_tests.CaseMeta):
     def compare_stdout(self, i, command, got_stdout, expected_stdout):
         super().compare_stdout(i, command, got_stdout, expected_stdout)
 
-        if '-pa' in command:
+        if ' -pa ' in command:
             self.pa_data = self.parse_pa(got_stdout.splitlines())
-        if '-pS' in command:
+        if ' -pS ' in command:
             self.pS_data = self.parse_pS(got_stdout.splitlines())
 
         if i == 1:


### PR DESCRIPTION
The `OutputTagExtract` test case for `tiff_test` runs exiv2 two times, with `-pa` and `-pS`, and parses their outputs. To know which output to parse, it checks for `-pa` and `-pS` in the string of the command being run; considering that the command string contains the full path to the test data, which is a subdirectory of the sources, this means that a wrong parser will be used in case the full source path contains any of `-pa` or `-pS` (e.g. `/build/some-path/exiv2/...`).

Cheap fix for this: since `-pa`/`-pS` are options in the command string, check for them using spaces around.