### PR TITLE
translation for Exif.NikonAf2.AFAreaMode

### DIFF
--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -744,6 +744,28 @@ constexpr TagDetails nikonAfAreaMode[] = {
     {3, N_("Group Dynamic")}, {4, N_("Single Area (wide)")}, {5, N_("Dynamic Area (wide)")},
 };
 
+//! AF2 Area Mode
+constexpr TagDetails nikonAf2AreaMode[] = {
+    {0, N_("Single-point AF")},
+    {1, N_("Dynamic-area AF")},
+    {2, N_("Closest Subject")},
+    {3, N_("Group Dynamic AF")},
+    {4, N_("Dynamic-area AF (9 points)")},
+    {5, N_("Dynamic-area AF (21 points)")},
+    {6, N_("Dynamic-area AF (51 points)")},
+    {7, N_("Dynamic-area AF (51 points), 3D-tracking")},
+    {8, N_("Auto-area AF")},
+    {9, N_("3D-tracking")},
+    {10, N_("Single Area AF, Wide")},
+    {11, N_("Dynamic-area AF, Wide")},
+    {12, N_("3D-tracking/Wide")},
+    {13, N_("Group-area AF")},
+    {14, N_("Dynamic-area AF (25 points)")},
+    {15, N_("Dynamic-area AF (72 points)")},
+    {16, N_("Group-area AF (HL)")},
+    {17, N_("Group-area AF (VL)")},
+};
+
 //! AfPoint
 constexpr TagDetails nikonAfPoint[] = {
     {0, N_("Center")},      {1, N_("Top")},        {2, N_("Bottom")},      {3, N_("Mid-left")},
@@ -788,7 +810,7 @@ constexpr TagInfo Nikon3MakerNote::tagInfoAf21_[] = {
     {4, "ContrastDetectAF", N_("Contrast Detect AF"), N_("Contrast detect AF"), IfdId::nikonAf21Id,
      SectionId::makerTags, unsignedByte, 1, EXV_PRINT_TAG(nikonOffOn)},
     {5, "AFAreaMode", N_("AF Area Mode"), N_("AF area mode"), IfdId::nikonAf21Id, SectionId::makerTags, unsignedByte, 1,
-     printValue},
+     EXV_PRINT_TAG(nikonAf2AreaMode)},
     {6, "PhaseDetectAF", N_("Phase Detect AF"), N_("Phase detect AF"), IfdId::nikonAf21Id, SectionId::makerTags,
      unsignedByte, 1, EXV_PRINT_TAG(nikonPhaseDetectAF)},
     {7, "PrimaryAFPoint", N_("Primary AF Point"), N_("Primary AF point"), IfdId::nikonAf21Id, SectionId::makerTags,

--- a/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_20mm_F1.4_DG_HSM_A.exv.out
@@ -137,7 +137,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
+++ b/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A.exv.out
@@ -137,7 +137,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
+++ b/test/data/test_reference_files/Sigma_APO_MACRO_180_F3.5_EX_DG_HSM.exv.out
@@ -148,7 +148,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  0  Off
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/Stonehenge.exv.out
+++ b/test/data/test_reference_files/Stonehenge.exv.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
+++ b/test/data/test_reference_files/Tamron_SP70-300_F4-5.6_Di_VC_USD_A030.exv.out
@@ -130,7 +130,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  0  Off
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
+++ b/test/data/test_reference_files/Tamron_SP_24-70mm_F2.8_Di_VC_USD_G2_0E.exv.out
@@ -130,7 +130,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  6  High
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  5  5
+Exif.NikonAf2.AFAreaMode                     Byte        1  5  Dynamic-area AF (21 points)
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  1 0 0 0 0 0 0  1 0 0 0 0 0 0

--- a/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
+++ b/test/data/test_reference_files/Tokina_AT-X_14-20_F2_PRO_DX.exv.out
@@ -149,7 +149,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  0  Off
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  1  On
-Exif.NikonAf2.AFAreaMode                     Byte        1  2  2
+Exif.NikonAf2.AFAreaMode                     Byte        1  2  Closest Subject
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
+++ b/test/data/test_reference_files/Tokina_ATX-i_11-20mm_F2.8_CF.exv.out
@@ -141,7 +141,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  2  On (11-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  15 0 0 0 0 0 0  15 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1014.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014.exv.out
@@ -141,7 +141,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  28  28
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 8 0 0 0  0 0 0 8 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1014_2.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1014_2.exv.out
@@ -147,7 +147,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  7  7
 Exif.NikonAf2.AFPointsUsed                   Byte        7  64 0 0 0 0 0 0  64 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1026.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1026.jpg.out
@@ -124,7 +124,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1062.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1062.jpg.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1108.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1108.exv.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/exiv2-bug1108.xmp.out
+++ b/test/data/test_reference_files/exiv2-bug1108.xmp.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/exiv2-bug1114.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug1114.jpg.out
@@ -133,7 +133,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug1199.webp.out
+++ b/test/data/test_reference_files/exiv2-bug1199.webp.out
@@ -89,7 +89,7 @@ Exif.Nikon3.WhiteBalance                     Ascii      13  AUTO          AUTO
 Exif.Nikon3.WhiteBalanceBias                 SShort      2  0 0  0 0
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/exiv2-bug1348.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1348.exv.out
@@ -80,7 +80,7 @@ Exif.NikonMe.MultiExposureShots              Long        1  0  0
 Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  1  1
+Exif.NikonAf2.AFAreaMode                     Byte        1  1  Dynamic-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  1 0 0 0 0 0 0  1 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-bug922a.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug922a.jpg.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  0  Off
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-issue1941-4.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-4.exv.out
@@ -152,7 +152,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-issue1941-5.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-5.exv.out
@@ -144,7 +144,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-issue1941-6_coverage.exv.out
+++ b/test/data/test_reference_files/exiv2-issue1941-6_coverage.exv.out
@@ -144,7 +144,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  1  1
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/exiv2-pr1105.exv.out
+++ b/test/data/test_reference_files/exiv2-pr1105.exv.out
@@ -148,7 +148,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  9  9
+Exif.NikonAf2.AFAreaMode                     Byte        1  9  3D-tracking
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  2  2
 Exif.NikonAf2.AFPointsUsed                   Byte        7  2 0 0 0 0 0 0  2 0 0 0 0 0 0

--- a/test/data/test_reference_files/issue_1934_poc1.exv.out
+++ b/test/data/test_reference_files/issue_1934_poc1.exv.out
@@ -127,7 +127,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/issue_743.exv.out
+++ b/test/data/test_reference_files/issue_743.exv.out
@@ -142,7 +142,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  0  0
+Exif.NikonAf2.AFAreaMode                     Byte        1  0  Single-point AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  0  0
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 0 0 0  0 0 0 0 0 0 0

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.exv.out
@@ -90,7 +90,7 @@ Exif.Nikon3.WhiteBalance                     Ascii      13  AUTO          AUTO
 Exif.Nikon3.WhiteBalanceBias                 SShort      2  0 0  0 0
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
+++ b/test/data/test_reference_files/issue_ghsa_5p8g_9xf3_gfrr_poc.webp.out
@@ -90,7 +90,7 @@ Exif.Nikon3.WhiteBalance                     Ascii      13  AUTO          AUTO
 Exif.Nikon3.WhiteBalanceBias                 SShort      2  0 0  0 0
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  105 5 128 0 16 0 0  105 5 128 0 16 0 0

--- a/test/data/test_reference_files/pr_1994_poc1.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc1.jpg.out
@@ -133,7 +133,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  8  8
+Exif.NikonAf2.AFAreaMode                     Byte        1  8  Auto-area AF
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  3  On (39-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  6  6
 Exif.NikonAf2.AFPointsUsed                   Byte        7  49 100 0 64 27 0 0  49 100 0 64 27 0 0

--- a/test/data/test_reference_files/pr_1994_poc2.jpg.out
+++ b/test/data/test_reference_files/pr_1994_poc2.jpg.out
@@ -133,7 +133,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  9  9
+Exif.NikonAf2.AFAreaMode                     Byte        1  9  3D-tracking
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  34  34
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 0 0 0 2 0 0  0 0 0 0 2 0 0

--- a/test/data/test_reference_files/test_issue_990.exv.out
+++ b/test/data/test_reference_files/test_issue_990.exv.out
@@ -148,7 +148,7 @@ Exif.NikonMe.MultiExposureAutoGain           Long        1  0  Off
 Exif.Nikon3.HighISONoiseReduction            Short       1  4  Normal
 Exif.NikonAf2.Version                        Undefined   4  48 49 48 48  1.00
 Exif.NikonAf2.ContrastDetectAF               Byte        1  0  Off
-Exif.NikonAf2.AFAreaMode                     Byte        1  9  9
+Exif.NikonAf2.AFAreaMode                     Byte        1  9  3D-tracking
 Exif.NikonAf2.PhaseDetectAF                  Byte        1  1  On (51-point)
 Exif.NikonAf2.PrimaryAFPoint                 Byte        1  11  11
 Exif.NikonAf2.AFPointsUsed                   Byte        7  0 4 0 0 0 0 0  0 4 0 0 0 0 0


### PR DESCRIPTION
Texts are taken from Nikon NX Studio.
NX Studio shows sligthly different texts for Exif.NikonAf.AFAreaMode, which is already translated in exiv2, e.g. "Single-point AF" instead of "Single Area (wide) (4)". This could be changed, but as the texts are not misleading I prefer to avoid, that users are irritated by a change.