### PR TITLE
Fix build for uwp (gai_strerror WCHAR*)

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -211,7 +211,7 @@ int Exiv2::http(Exiv2::Dictionary& request, Exiv2::Dictionary& response, std::st
     int res = getaddrinfo(servername_p, port_p, &hints, &result);
     if (res != 0) {
       closesocket(sockfd);
-      return error(errors, "no such host: %s", gai_strerror(res));
+      return error(errors, "no such host: %s", reinterpret_cast<const char*>(gai_strerror(res)));
     }
 
     serv_addr = *reinterpret_cast<sockaddr_in*>(result->ai_addr);


### PR DESCRIPTION
When building for Universal Windows Platform (UWP) `gai_strerror` from `ws2tcpip.h` returns `WCHAR *` instead of `char *` see https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-gai_strerrorw.
Hence this requires a `reinterpret_cast` to the expected `error()` argument type.

PoC: https://github.com/xbmc/xbmc/pull/24109