### PR TITLE
Set conditional HTTP depending on EXIV2_ENABLE_WEBREADY

### DIFF
--- a/include/exiv2/exiv2.hpp
+++ b/include/exiv2/exiv2.hpp
@@ -19,7 +19,9 @@
 #include "exiv2/exif.hpp"
 #include "exiv2/futils.hpp"
 #include "exiv2/gifimage.hpp"
+#ifdef EXV_ENABLE_WEBREADY
 #include "exiv2/http.hpp"
+#endif
 #include "exiv2/image.hpp"
 #include "exiv2/iptc.hpp"
 #include "exiv2/jp2image.hpp"

--- a/include/meson.build
+++ b/include/meson.build
@@ -14,7 +14,6 @@ headers = files(
   'exiv2/exiv2.hpp',
   'exiv2/futils.hpp',
   'exiv2/gifimage.hpp',
-  'exiv2/http.hpp',
   'exiv2/image.hpp',
   'exiv2/image_types.hpp',
   'exiv2/iptc.hpp',
@@ -45,6 +44,10 @@ headers = files(
 
 if get_option('video')
   headers += files('exiv2/asfvideo.hpp', 'exiv2/matroskavideo.hpp', 'exiv2/quicktimevideo.hpp', 'exiv2/riffvideo.hpp')
+endif
+
+if get_option('webready')
+  headers += files('exiv2/http.hpp')
 endif
 
 if zlib_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,12 @@ if brotli_dep.found()
   deps += brotli_dep
 endif
 
-curl_dep = dependency('libcurl', disabler: true, required: get_option('curl'))
+if get_option('webready')
+  curl_dep = dependency('libcurl', disabler: true, required: get_option('curl'))
+else
+  curl_dep = dependency('', disabler: true, required: false)
+endif
+
 if curl_dep.found()
   deps += curl_dep
 endif
@@ -113,9 +118,9 @@ cdata.set('EXV_HAVE_XMP_TOOLKIT', expat_dep.found())
 cdata.set('EXV_HAVE_BROTLI', brotli_dep.found())
 cdata.set('EXV_HAVE_ICONV', iconv_dep.found())
 cdata.set('EXV_HAVE_LIBZ', zlib_dep.found())
+cdata.set('EXV_ENABLE_WEBREADY', get_option('webready'))
 cdata.set('EXV_USE_CURL', curl_dep.found())
 cdata.set('EXV_ENABLE_NLS', intl_dep.found())
-cdata.set('EXV_ENABLE_WEBREADY', curl_dep.found())
 
 cfile = configure_file(
   input: 'cmake/config.h.cmake',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,3 +44,8 @@ option('xmp', type : 'feature',
 option('unitTests', type : 'feature',
   description : 'Build and run unit tests',
 )
+
+option('webready', type : 'boolean',
+  value: true,
+  description : 'Build with support for webready',
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,6 @@ set(PUBLIC_HEADERS
     ../include/exiv2/exiv2.hpp
     ../include/exiv2/futils.hpp
     ../include/exiv2/gifimage.hpp
-    ../include/exiv2/http.hpp
     ../include/exiv2/image.hpp
     ../include/exiv2/image_types.hpp
     ../include/exiv2/iptc.hpp
@@ -117,7 +116,6 @@ add_library(
   futils.cpp
   fff.h
   gifimage.cpp
-  http.cpp
   image.cpp
   iptc.cpp
   jp2image.cpp
@@ -158,6 +156,10 @@ generate_export_header(
 
 # Conditional addition of sources to library targets
 # ---------------------------------------------------------
+if(EXIV2_ENABLE_WEBREADY)
+  set(PUBLIC_HEADERS ${PUBLIC_HEADERS} ../include/exiv2/http.hpp)
+  target_sources(exiv2lib PRIVATE http.cpp ../include/exiv2/http.hpp)
+endif()
 
 if(EXIV2_ENABLE_PNG)
   set(PUBLIC_HEADERS ${PUBLIC_HEADERS} ../include/exiv2/pngimage.hpp)

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1364,6 +1364,7 @@ void RemoteIo::populateFakeData() {
   }
 }
 
+#ifdef EXV_ENABLE_WEBREADY
 //! Internal Pimpl structure of class HttpIo.
 class HttpIo::HttpImpl : public Impl {
  public:
@@ -1503,6 +1504,7 @@ void HttpIo::HttpImpl::writeRemote(const byte* data, size_t size, size_t from, s
 HttpIo::HttpIo(const std::string& url, size_t blockSize) {
   p_ = std::make_unique<HttpImpl>(url, blockSize);
 }
+#endif
 
 #ifdef EXV_USE_CURL
 //! Internal Pimpl structure of class RemoteIo.

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -813,8 +813,10 @@ BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, [[maybe_unuse
   }
 #endif
 
+#ifdef EXV_ENABLE_WEBREADY
   if (fProt == pHttp)
     return std::make_unique<HttpIo>(path);  // may throw
+#endif
   if (fProt == pFileUri)
     return std::make_unique<FileIo>(pathOfFileUrl(path));
   if (fProt == pStdin || fProt == pDataUri)


### PR DESCRIPTION
HTTP support is being enabled regardless of the fact `EXIV2_ENABLE_WEBREADY` is configured or not.
This PR makes sure http is not included/built if `EXIV2_ENABLE_WEBREADY` specifically disabled.

This is an alternative to https://github.com/Exiv2/exiv2/pull/2843
PoC: https://github.com/xbmc/xbmc/pull/24109
