### PR TITLE
add release workflow badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 
 
-| **CI Status:**    |      |      |
-|:--                |:--   |:--   |
-| [![Basic jobs for all platforms](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![Nightly jobs for Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) | [![On PUSH - Linux Special Builds for main branch](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml) |
+| **CI Status:**    |      |      |     |
+|:--                |:--   |:--   |:--  |
+| [![Release](https://github.com/Exiv2/exiv2/actions/workflows/release.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/release.yml) | [![Basic jobs for all platforms](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![Nightly jobs for Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) | [![On PUSH - Linux Special Builds for main branch](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml) | 
 
 <div id="Welcome">
 


### PR DESCRIPTION
The release workflow which also runs every night to create a pre-release is currently failing: https://github.com/Exiv2/exiv2/actions/workflows/release.yml

I'm adding a badge to the readme to make this more visible. 
Per [GitHub docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs) I'm the only one who receives a notification about this as I'm the one who created the workflow. 
I'm no longer actively contributing to this project, though. To change the notifications, I'll disable the workflow in the hope that one of the active maintainers will re-enable the workflow which will make them the person that will receive notifications about future failures.