### PR TITLE
Decode Exif.CanonLe.LensSerialNumber

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -1081,8 +1081,7 @@ constexpr TagInfo CanonMakerNote::tagInfoLe_[] = {
     {0x0000, "LensSerialNumber", N_("Lens Serial Number"),
     N_("Lens Serial Number. Convert each byte to hexadecimal to get two "
        "digits of the lens serial number."),
-     IfdId::canonLeId, SectionId::makerTags, unsignedByte, -1,
-     printLe0x0000},
+     IfdId::canonLeId, SectionId::makerTags, unsignedByte, -1, printLe0x0000},
     {0xffff, "(UnkownCanonLensInfoTag)", "(UnkownCanonLensInfoTag)", N_("UnkownCanonLensInfoTag"), IfdId::canonLeId,
      SectionId::makerTags, undefined, 1, printValue}  // important to add end of tag
 };

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -1079,8 +1079,8 @@ const TagInfo* CanonMakerNote::tagListLiOp() {
 // Canon LensInfo Tag
 constexpr TagInfo CanonMakerNote::tagInfoLe_[] = {
     {0x0000, "LensSerialNumber", N_("Lens Serial Number"),
-    N_("Lens Serial Number. Convert each byte to hexadecimal to get two "
-       "digits of the lens serial number."),
+     N_("Lens Serial Number. Convert each byte to hexadecimal to get two "
+        "digits of the lens serial number."),
      IfdId::canonLeId, SectionId::makerTags, unsignedByte, -1, printLe0x0000},
     {0xffff, "(UnkownCanonLensInfoTag)", "(UnkownCanonLensInfoTag)", N_("UnkownCanonLensInfoTag"), IfdId::canonLeId,
      SectionId::makerTags, undefined, 1, printValue}  // important to add end of tag

--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -1078,8 +1078,11 @@ const TagInfo* CanonMakerNote::tagListLiOp() {
 
 // Canon LensInfo Tag
 constexpr TagInfo CanonMakerNote::tagInfoLe_[] = {
-    {0x0000, "LensSerialNumber", N_("Lens Seria lNumber"), N_("Lens Serial Number"), IfdId::canonLeId,
-     SectionId::makerTags, asciiString, -1, printValue},
+    {0x0000, "LensSerialNumber", N_("Lens Serial Number"),
+    N_("Lens Serial Number. Convert each byte to hexadecimal to get two "
+       "digits of the lens serial number."),
+     IfdId::canonLeId, SectionId::makerTags, unsignedByte, -1,
+     printLe0x0000},
     {0xffff, "(UnkownCanonLensInfoTag)", "(UnkownCanonLensInfoTag)", N_("UnkownCanonLensInfoTag"), IfdId::canonLeId,
      SectionId::makerTags, undefined, 1, printValue}  // important to add end of tag
 };
@@ -2953,6 +2956,20 @@ std::ostream& CanonMakerNote::printCsLens(std::ostream& os, const Value& value, 
     os << len1 << " mm";
   } else {
     os << len2 << " - " << len1 << " mm";
+  }
+  os.copyfmt(oss);
+  os.flags(f);
+  return os;
+}
+
+std::ostream& CanonMakerNote::printLe0x0000(std::ostream& os, const Value& value, const ExifData*) {
+  if (value.typeId() != unsignedByte || value.size() != 5)
+    return os << "(" << value << ")";
+  std::ios::fmtflags f(os.flags());
+  std::ostringstream oss;
+  oss.copyfmt(os);
+  for (size_t i = 0; i < value.size(); ++i) {
+    os << std::setw(2) << std::setfill('0') << std::hex << value.toInt64(i);
   }
   os.copyfmt(oss);
   os.flags(f);

--- a/src/canonmn_int.hpp
+++ b/src/canonmn_int.hpp
@@ -111,6 +111,8 @@ class CanonMakerNote {
   static std::ostream& printCsLensType(std::ostream& os, const Value& value, const ExifData* metadata);
   //! Camera lens information
   static std::ostream& printCsLens(std::ostream& os, const Value& value, const ExifData*);
+  //! CanonLe lens serial number
+  static std::ostream& printLe0x0000(std::ostream& os, const Value& value, const ExifData*);
   //! AutoISO speed used
   static std::ostream& printSi0x0001(std::ostream& os, const Value& value, const ExifData*);
   //! ISO speed used

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -165,12 +165,17 @@ constexpr ArrayCfg canonLiOpCfg = {
 constexpr ArrayCfg canonLeCfg = {
     IfdId::canonLeId,  // Group for the elements
     invalidByteOrder,  // Use byte order from parent
-    ttSignedLong,      // Type for array entry and size element
+    ttUndefined,       // Type for array entry and size element
     notEncrypted,      // Not encrypted
     true,              // Has a size element
     false,             // No fillers
     false,             // Don't concatenate gaps
-    {0, ttSignedLong, 1},
+    {0, ttUnsignedByte, 1},
+};
+//! Canon LensInfo binary array - definition
+constexpr ArrayDef canonLeDef[] = {
+    {0, ttUnsignedByte, 5},  // Serial number
+    {5, ttUndefined, 25},    // The array contains 30 bytes
 };
 
 //! Canon Ambience Selection Info binary array - configuration
@@ -1684,7 +1689,7 @@ const TiffGroupTable TiffCreator::tiffGroupTable_ = {
     //  {{    0x4015, IfdId::canonId,          EXV_SIMPLE_BINARY_ARRAY(canonVigCorCfg)   },
     {{0x4016, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonVigCor2Cfg)},
     {{0x4018, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonLiOpCfg)},
-    {{0x4019, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonLeCfg)},
+    {{0x4019, IfdId::canonId}, EXV_BINARY_ARRAY(canonLeCfg, canonLeDef)},
     {{0x4020, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonAmCfg)},
     {{0x4021, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonMeCfg)},
     {{0x4024, IfdId::canonId}, EXV_SIMPLE_BINARY_ARRAY(canonFilCfg)},

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -167,7 +167,7 @@ constexpr ArrayCfg canonLeCfg = {
     invalidByteOrder,  // Use byte order from parent
     ttUndefined,       // Type for array entry and size element
     notEncrypted,      // Not encrypted
-    true,              // Has a size element
+    false,             // No size element
     false,             // No fillers
     false,             // Don't concatenate gaps
     {0, ttUnsignedByte, 1},

--- a/test/data/test_reference_files/20220610_MG_7237.exv.out
+++ b/test/data/test_reference_files/20220610_MG_7237.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  28  28
+Exif.CanonLe.LensSerialNumber                Byte        5  28 0 0 0 0  1c00000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/20220610_MG_7238.exv.out
+++ b/test/data/test_reference_files/20220610_MG_7238.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  28  28
+Exif.CanonLe.LensSerialNumber                Byte        5  28 0 0 0 0  1c00000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/20220610_MG_7239.exv.out
+++ b/test/data/test_reference_files/20220610_MG_7239.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  28  28
+Exif.CanonLe.LensSerialNumber                Byte        5  28 0 0 0 0  1c00000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/20220610_MG_7240.exv.out
+++ b/test/data/test_reference_files/20220610_MG_7240.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  28  28
+Exif.CanonLe.LensSerialNumber                Byte        5  28 0 0 0 0  1c00000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/20220610_MG_7241.exv.out
+++ b/test/data/test_reference_files/20220610_MG_7241.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  28  28
+Exif.CanonLe.LensSerialNumber                Byte        5  28 0 0 0 0  1c00000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/Canon_Sigma_18_35_F18_DC_HSM_firmware_1xx.exv.out
+++ b/test/data/test_reference_files/Canon_Sigma_18_35_F18_DC_HSM_firmware_1xx.exv.out
@@ -171,7 +171,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  2  On
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  2  Strong
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/Canon_Sigma_18_35_F18_DC_HSM_firmware_2xx.exv.out
+++ b/test/data/test_reference_files/Canon_Sigma_18_35_F18_DC_HSM_firmware_2xx.exv.out
@@ -171,7 +171,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  2  On
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  2  Strong
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/Sigma_14-24mm_F2.8_DG_HSM_A_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_14-24mm_F2.8_DG_HSM_A_for_EOS.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/Sigma_28mm_F1.4_DG_HSM_A_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_28mm_F1.4_DG_HSM_A_for_EOS.exv.out
@@ -174,7 +174,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/Sigma_35mm_F1.4_DG_HSM_A_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_35mm_F1.4_DG_HSM_A_for_EOS.exv.out
@@ -174,7 +174,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  1  On
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/Sigma_40mm_F1.4_DG_HSM_A_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_40mm_F1.4_DG_HSM_A_for_EOS.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_50mm_F1.4_DG_HSM_A_for_EOS.exv.out
@@ -174,7 +174,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  1  On
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  3  off
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/Sigma_60-600mm_F4.5-6.3_DG_OS_HSM_S_for_EOS.exv.out
+++ b/test/data/test_reference_files/Sigma_60-600mm_F4.5-6.3_DG_OS_HSM_S_for_EOS.exv.out
@@ -173,7 +173,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/TamronSP15-30mmF2.8DiVCUSDA012.exv.out
+++ b/test/data/test_reference_files/TamronSP15-30mmF2.8DiVCUSDA012.exv.out
@@ -169,7 +169,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/TamronSP90mmF2.8DiVCUSDMacroF017.exv.out
+++ b/test/data/test_reference_files/TamronSP90mmF2.8DiVCUSDMacroF017.exv.out
@@ -164,7 +164,7 @@ Exif.Canon.VignettingCorr                    Undefined 116  0 16 116 0 0 0 0 0 0
 Exif.CanonVigCor2.PeripheralLightingSetting  SLong       1  0  Off
 Exif.CanonLiOp.PeripheralIlluminationCorr    SLong       1  0  Off
 Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  1  Low
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.Photo.UserComment                       Undefined 264    
 Exif.Photo.SubSecTime                        Ascii       3  40  40

--- a/test/data/test_reference_files/canon_ef_100_400mm_f4.5_5.6_2x_.exv.out
+++ b/test/data/test_reference_files/canon_ef_100_400mm_f4.5_5.6_2x_.exv.out
@@ -178,7 +178,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  -1879011276  -1879011276
+Exif.CanonLe.LensSerialNumber                Byte        5  52 144 0 144 117  3490009075
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/exiv2-bug1024.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1024.exv.out
@@ -169,7 +169,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-bug1122.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1122.exv.out
@@ -169,7 +169,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-bug1166.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1166.exv.out
@@ -172,7 +172,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  2  On
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  2  Strong
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-bug1167.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1167.exv.out
@@ -172,7 +172,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  2  On
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  2  Strong
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-bug1170.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1170.exv.out
@@ -170,7 +170,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-bug1252a.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1252a.exv.out
@@ -169,7 +169,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/exiv2-bug1252b.exv.out
+++ b/test/data/test_reference_files/exiv2-bug1252b.exv.out
@@ -169,7 +169,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/exiv2-bug876.jpg.out
+++ b/test/data/test_reference_files/exiv2-bug876.jpg.out
@@ -167,7 +167,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  318767104  318767104
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 19 232  00000013e8
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/exiv2-g20.exv.out
+++ b/test/data/test_reference_files/exiv2-g20.exv.out
@@ -164,7 +164,7 @@ Exif.Canon.VignettingCorr                    Undefined 116  0 16 116 0 0 0 0 0 0
 Exif.CanonVigCor2.PeripheralLightingSetting  SLong       1  0  Off
 Exif.CanonLiOp.PeripheralIlluminationCorr    SLong       1  0  Off
 Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  1  Low
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.Photo.UserComment                       Undefined 264    
 Exif.Photo.SubSecTime                        Ascii       3  40  40

--- a/test/data/test_reference_files/exiv2-g45.exv.out
+++ b/test/data/test_reference_files/exiv2-g45.exv.out
@@ -179,7 +179,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/issue_1782_canon_lens_sigma_30mm_f1.4_DC_DN_C.exv.out
+++ b/test/data/test_reference_files/issue_1782_canon_lens_sigma_30mm_f1.4_DC_DN_C.exv.out
@@ -176,7 +176,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  0  Off
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonHdr.HDR                            SLong       1  0  Off
 Exif.CanonHdr.HDREffect                      SLong       1  0  Natural

--- a/test/data/test_reference_files/pr_2216.exv.out
+++ b/test/data/test_reference_files/pr_2216.exv.out
@@ -188,7 +188,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  0  Standard
-Exif.CanonLe.LensSerialNumber                SLong       1  -1509818368  -1509818368
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 2 166 32  000002a620
 Exif.CanonAm.AmbienceSelection               SLong       1  0  Standard
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive

--- a/test/data/test_reference_files/test_issue_981b.exv.out
+++ b/test/data/test_reference_files/test_issue_981b.exv.out
@@ -174,7 +174,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  3  Off
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  2  On
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  1  Low
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/test_issue_981c.exv.out
+++ b/test/data/test_reference_files/test_issue_981c.exv.out
@@ -178,7 +178,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  1  Low
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/test/data/test_reference_files/test_issue_981d.exv.out
+++ b/test/data/test_reference_files/test_issue_981d.exv.out
@@ -178,7 +178,7 @@ Exif.CanonLiOp.AutoLightingOptimizer         SLong       1  0  Standard
 Exif.CanonLiOp.HighlightTonePriority         SLong       1  0  Off
 Exif.CanonLiOp.LongExposureNoiseReduction    SLong       1  1  Auto
 Exif.CanonLiOp.HighISONoiseReduction         SLong       1  1  Low
-Exif.CanonLe.LensSerialNumber                SLong       1  0  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0 0 0 0 0  0000000000
 Exif.CanonMe.MultiExposure                   SLong       1  0  Off
 Exif.CanonMe.MultiExposureControl            SLong       1  0  Additive
 Exif.CanonMe.MultiExposureShots              SLong       1  0  Off

--- a/tests/bugfixes/github/test_issue_20.py
+++ b/tests/bugfixes/github/test_issue_20.py
@@ -26,7 +26,7 @@ class TamronSupport(metaclass=system_tests.CaseMeta):
         """Exif.CanonCs.LensType                        Short       1  Tamron SP 90mm f/2.8 Di VC USD Macro 1:1
 Exif.CanonCs.Lens                            Short       3  90.0 mm
 Exif.Canon.LensModel                         Ascii      70  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F017
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.Photo.LensSpecification                 Rational    4  90mm
 Exif.Photo.LensModel                         Ascii      70  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F017
 Exif.Photo.LensSerialNumber                  Ascii      12  0000000000

--- a/tests/bugfixes/github/test_issue_45.py
+++ b/tests/bugfixes/github/test_issue_45.py
@@ -13,7 +13,7 @@ class Sigma24_105mmRecognition(metaclass=system_tests.CaseMeta):
 Exif.CanonCs.Lens                            Short       3  24.0 - 105.0 mm
 Exif.CanonCf.LensAFStopButton                Short       1  0
 Exif.Canon.LensModel                         Ascii      74  24-105mm F4 DG OS HSM | Art 013
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 """]
     stderr = [""]
     retval = [0]

--- a/tests/bugfixes/redmine/test_issue_1122.py
+++ b/tests/bugfixes/redmine/test_issue_1122.py
@@ -14,7 +14,7 @@ class CheckLensDetectionTeleconverter(metaclass=system_tests.CaseMeta):
     stdout = [ """0x0016 CanonCs      LensType                    Short       1  173
 0x0017 CanonCs      Lens                        Short       3  1000 300 1
 0x0095 Canon        LensModel                   Ascii      74  300-1000mm
-0x0000 CanonLe      LensSerialNumber            SLong       1  0
+0x0000 CanonLe      LensSerialNumber            Byte        5  0000000000
 0xa432 Photo        LensSpecification           Rational    4  300/1 1000/1 0/1 0/1
 0xa434 Photo        LensModel                   Ascii      11  300-1000mm
 0xa435 Photo        LensSerialNumber            Ascii      11  0000000000
@@ -22,7 +22,7 @@ class CheckLensDetectionTeleconverter(metaclass=system_tests.CaseMeta):
     """Exif.CanonCs.LensType                        Short       1  Sigma 150-500mm f/5-6.3 APO DG OS HSM + 2x
 Exif.CanonCs.Lens                            Short       3  300.0 - 1000.0 mm
 Exif.Canon.LensModel                         Ascii      74  300-1000mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.Photo.LensSpecification                 Rational    4  300-1000mm
 Exif.Photo.LensModel                         Ascii      11  300-1000mm
 Exif.Photo.LensSerialNumber                  Ascii      11  0000000000

--- a/tests/bugfixes/redmine/test_issue_1122.py
+++ b/tests/bugfixes/redmine/test_issue_1122.py
@@ -14,7 +14,7 @@ class CheckLensDetectionTeleconverter(metaclass=system_tests.CaseMeta):
     stdout = [ """0x0016 CanonCs      LensType                    Short       1  173
 0x0017 CanonCs      Lens                        Short       3  1000 300 1
 0x0095 Canon        LensModel                   Ascii      74  300-1000mm
-0x0000 CanonLe      LensSerialNumber            Byte        5  0000000000
+0x0000 CanonLe      LensSerialNumber            Byte        5  0 0 0 0 0
 0xa432 Photo        LensSpecification           Rational    4  300/1 1000/1 0/1 0/1
 0xa434 Photo        LensModel                   Ascii      11  300-1000mm
 0xa435 Photo        LensSerialNumber            Ascii      11  0000000000

--- a/tests/bugfixes/redmine/test_issue_1166.py
+++ b/tests/bugfixes/redmine/test_issue_1166.py
@@ -13,7 +13,7 @@ class CheckTokina11_20mm(metaclass=system_tests.CaseMeta):
     stdout = [ """Exif.CanonCs.LensType                        Short       1  Tokina AT-X 11-20 f/2.8 PRO DX Aspherical 11-20mm f/2.8
 Exif.CanonCs.Lens                            Short       3  11.0 - 20.0 mm
 Exif.Canon.LensModel                         Ascii      74  11-20mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.Photo.LensSpecification                 Rational    4  11-20mm
 Exif.Photo.LensModel                         Ascii       8  11-20mm
 Exif.Photo.LensSerialNumber                  Ascii      11  0000000000

--- a/tests/bugfixes/redmine/test_issue_1167.py
+++ b/tests/bugfixes/redmine/test_issue_1167.py
@@ -13,7 +13,7 @@ class CheckSigma17_70Lens(metaclass=system_tests.CaseMeta):
     stdout = [ """Exif.CanonCs.LensType                        Short       1  Sigma 17-70mm f/2.8-4 DC Macro OS HSM
 Exif.CanonCs.Lens                            Short       3  17.0 - 70.0 mm
 Exif.Canon.LensModel                         Ascii      74  17-70mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.Photo.LensSpecification                 Rational    4  17-70mm
 Exif.Photo.LensModel                         Ascii       8  17-70mm
 Exif.Photo.LensSerialNumber                  Ascii      11  0000000000

--- a/tests/bugfixes/redmine/test_issue_1170.py
+++ b/tests/bugfixes/redmine/test_issue_1170.py
@@ -13,7 +13,7 @@ class CheckSigma35mm(metaclass=system_tests.CaseMeta):
     stdout = [ """Exif.CanonCs.LensType                        Short       1  Sigma 35mm f/1.4 DG HSM *OR* Sigma 35mm f/1.5 FF High-Speed Prime | 017
 Exif.CanonCs.Lens                            Short       3  35.0 mm
 Exif.Canon.LensModel                         Ascii      74  35mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.Photo.LensSpecification                 Rational    4  35mm
 Exif.Photo.LensModel                         Ascii       5  35mm
 Exif.Photo.LensSerialNumber                  Ascii      11  0000000000

--- a/tests/bugfixes/redmine/test_issue_1252.py
+++ b/tests/bugfixes/redmine/test_issue_1252.py
@@ -19,7 +19,7 @@ class CanonLenses(metaclass=system_tests.CaseMeta):
     stdout = ["""Exif.CanonCs.LensType                        Short       1  Sigma APO 120-300mm f/2.8 EX DG OS HSM *OR* Sigma 120-300mm f/2.8 DG OS HSM S013
 Exif.CanonCs.Lens                            Short       3  120.0 - 300.0 mm
 Exif.Canon.LensModel                         Ascii      74  120-300mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.CanonAfC.USMLensElectronicMF            SLong       1  Enable After AF
 Exif.CanonAfC.LensDriveWhenAFImpossible      SLong       1  Continue Focus Search
 Exif.Photo.LensSpecification                 Rational    4  120-300mm
@@ -29,7 +29,7 @@ Exif.Photo.LensSerialNumber                  Ascii      11  0000000000
               """Exif.CanonCs.LensType                        Short       1  Sigma 150-500mm f/5-6.3 APO DG OS HSM
 Exif.CanonCs.Lens                            Short       3  150.0 - 500.0 mm
 Exif.Canon.LensModel                         Ascii      74  150-500mm
-Exif.CanonLe.LensSerialNumber                SLong       1  0
+Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
 Exif.CanonAfC.USMLensElectronicMF            SLong       1  Enable After AF
 Exif.CanonAfC.LensDriveWhenAFImpossible      SLong       1  Continue Focus Search
 Exif.Photo.LensSpecification                 Rational    4  150-500mm


### PR DESCRIPTION
The first 5 bytes of the CanonLe block give the serial number when converted to hexadecimal. This PR also fixes bug #2138 as it stops the 30 byte length of the block being truncated to a multiple of 4 bytes.