### PR TITLE
Do not require dependencies for static linking when exiv2 was built as shared

### DIFF
--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -1,28 +1,30 @@
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 include(CMakeFindDependencyMacro)
 
-if(@EXIV2_ENABLE_PNG@) # if(EXIV2_ENABLE_PNG)
-  find_dependency(ZLIB REQUIRED)
-endif()
-
-if(@EXIV2_ENABLE_WEBREADY@) # if(EXIV2_ENABLE_WEBREADY)
-  if(@EXIV2_ENABLE_CURL@) # if(EXIV2_ENABLE_CURL)
-    find_dependency(CURL REQUIRED)
+if(NOT @BUILD_SHARED_LIBS@) # if(NOT BUILD_SHARED_LIBS)
+  if(@EXIV2_ENABLE_PNG@) # if(EXIV2_ENABLE_PNG)
+    find_dependency(ZLIB REQUIRED)
   endif()
-endif()
 
-if(@EXIV2_ENABLE_XMP@) # if(EXIV2_ENABLE_XMP)
-  find_dependency(EXPAT REQUIRED)
-endif()
+  if(@EXIV2_ENABLE_WEBREADY@) # if(EXIV2_ENABLE_WEBREADY)
+    if(@EXIV2_ENABLE_CURL@) # if(EXIV2_ENABLE_CURL)
+      find_dependency(CURL REQUIRED)
+    endif()
+  endif()
 
-if(@EXIV2_ENABLE_NLS@) # if(EXIV2_ENABLE_NLS)
+  if(@EXIV2_ENABLE_XMP@) # if(EXIV2_ENABLE_XMP)
+    find_dependency(EXPAT REQUIRED)
+  endif()
+
+  if(@EXIV2_ENABLE_NLS@) # if(EXIV2_ENABLE_NLS)
     find_dependency(Intl REQUIRED)
-endif()
+  endif()
 
-if(@EXV_HAVE_LIBICONV@) # if(EXV_HAVE_LIBICONV)
+  if(@EXV_HAVE_LIBICONV@) # if(EXV_HAVE_LIBICONV)
     find_dependency(Iconv REQUIRED)
+  endif()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/exiv2Export.cmake")


### PR DESCRIPTION
exiv2 can be built either as shared library, or static, never both at the same time. Hence, requiring the dependencies needed for static linking to exiv2 when exiv2 was built shared does not make much sense, and it only adds unneeded bits to the exiv2 users.

Hence, fix both the pkg-config file, and the cmake config file, to require the dependencies needed for static linking only in case exiv2 was built as static library. This avoids e.g. having the expat and zlib development bits when using exiv2 in cmake with `find_package(exiv2)`.

See the specific commit messages for longer descriptions.