### PR TITLE
jpeg: add encodingProcess and numColorComponents SOF members

### DIFF
--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: install dependencies
         run: |
+          sudo apt-get install -y libxml2-dev libxslt-dev python3-dev
           python3 -m pip install conan==1.59.0 gcovr ninja
 
       - name: Conan common config

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -86,6 +86,9 @@ class EXIV2API JpegBase : public Image {
   virtual int writeHeader(BasicIo& oIo) const = 0;
   //@}
 
+  int num_color_components_{-1};      //!< image number of color components
+  std::string sof_encoding_process_;  //!< image encoding process
+
  private:
   //! @name Manipulators
   //@{
@@ -153,6 +156,18 @@ class EXIV2API JpegImage : public JpegBase {
   //! @name Accessors
   //@{
   [[nodiscard]] std::string mimeType() const override;
+  /*!
+    @brief Get the number of color components of the JPEG Image
+  */
+  [[nodiscard]] int numColorComponents() const {
+    return num_color_components_;
+  }
+  /*!
+    @brief Get the encoding process of the JPEG Image derived from the Start of Frame (SOF) markers
+  */
+  [[nodiscard]] std::string encodingProcess() const {
+    return sof_encoding_process_;
+  }
   //@}
 
  protected:

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SAMPLES
     iptceasy.cpp
     iptcprint.cpp
     iptctest.cpp
+    jpegparsetest.cpp
     key-test.cpp
     largeiptc-test.cpp
     mmap-test.cpp

--- a/samples/jpegparsetest.cpp
+++ b/samples/jpegparsetest.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Sample program to parse jpeg files and obtain its specific metadata
+
+#include <exiv2/exiv2.hpp>
+#include <exiv2/image_types.hpp>
+#include <iostream>
+
+int main(int argc, char* const argv[]) {
+  try {
+    if (argc != 2) {
+      std::cout << "Usage: " << argv[0] << " file\n";
+      return EXIT_FAILURE;
+    }
+
+    auto image = Exiv2::ImageFactory::open(argv[1]);
+    if (image->imageType() == Exiv2::ImageType::jpeg) {
+      auto jpegImage = dynamic_cast<Exiv2::JpegImage*>(image.get());
+      jpegImage->readMetadata();
+      std::cout << "Number of color components: " << jpegImage->numColorComponents() << "\n";
+      std::cout << "Encoding process: " << jpegImage->encodingProcess() << "\n";
+    }
+
+    return EXIT_SUCCESS;
+  } catch (Exiv2::Error& e) {
+    std::cout << "Caught Exiv2 exception '" << e << "'\n";
+    return EXIT_FAILURE;
+  }
+}

--- a/tests/bash_tests/test_jpegparse.py
+++ b/tests/bash_tests/test_jpegparse.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+class TestJpegParse(metaclass=system_tests.CaseMeta):
+    url = "https://github.com/Exiv2/exiv2/pull/2874"
+    
+    # Test extraction of jpeg specific metadata
+    filename = "$data_path/exiv2-fujifilm-finepix-s2pro.jpg"
+    commands = ["$jpegparsetest $filename"]
+    stderr = [""] * len(commands)
+    stdout = ["""Number of color components: 3\nEncoding process: Baseline DCT, Huffman coding\n"""]
+    retval = [0] * len(commands)

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -35,6 +35,7 @@ tiff_test: ${ENV:exiv2_path}/tiff-test
 largeiptc_test: ${ENV:exiv2_path}/largeiptc-test
 easyaccess_test: ${ENV:exiv2_path}/easyaccess-test
 taglist: ${ENV:exiv2_path}/taglist
+jpegparsetest: ${ENV:exiv2_path}/jpegparsetest
 
 [variables]
 kerOffsetOutOfRange: Offset out of range


### PR DESCRIPTION
This adds support for extracting and storing some of the metadata that can be obtained from start of frame (SOF) tags in Jpeg files, namely:
- The encoding process
- The number of color components

Afaik only exiftool supports such "tags" see (SOF tags in https://exiftool.org/TagNames/JPEG.html#SOF). As they don't really belong to a metadata class like exif or iptc and are only specific of a specific format (jpeg) I added them as members of `Exiv2:: JpegImage`. Added a small sample and test to validate the implementation.

**Motivation:**
Kodi currently implements its own jpeg parser and can thus obtain these two properties (https://github.com/xbmc/xbmc/blob/4532c7441510a9c9ebfa2023dd129ce13544890b/xbmc/pictures/PictureInfoTag.cpp#L416-L441 https://github.com/xbmc/xbmc/blob/master/xbmc/pictures/JpegParse.cpp#L73-L87). With my aim to rewrite the implementation based on exiv2 (https://github.com/xbmc/xbmc/pull/24109) they'll be removed if no alternative exists. So I decided to have a go at it and leave it to your consideration to collect feedback (and check if it's possible to have it upstream).