### PR TITLE
replace reinterpret_cast with memcpy

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -47,9 +47,9 @@ bool AsfVideo::GUIDTag::operator==(const AsfVideo::GUIDTag& other) const {
 }
 
 AsfVideo::GUIDTag::GUIDTag(const uint8_t* bytes) {
-  std::copy_n(bytes, DWORD, reinterpret_cast<uint8_t*>(&data1_));
-  std::copy_n(bytes + DWORD, WORD, reinterpret_cast<uint8_t*>(&data2_));
-  std::copy_n(bytes + DWORD + WORD, WORD, reinterpret_cast<uint8_t*>(&data3_));
+  std::memcpy(&data1_, bytes, DWORD);
+  std::memcpy(&data2_, bytes + DWORD, WORD);
+  std::memcpy(&data3_, bytes + DWORD + WORD, WORD);
   std::copy(bytes + QWORD, bytes + 2 * QWORD, data4_.begin());
   if (isBigEndianPlatform()) {
     data1_ = byteSwap(data1_, true);

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -210,7 +210,7 @@ int Exiv2::http(Exiv2::Dictionary& request, Exiv2::Dictionary& response, std::st
       return error(errors, "no such host: %s", gai_strerror(res));
     }
 
-    serv_addr = *reinterpret_cast<sockaddr_in*>(result->ai_addr);
+    std::memcpy(&serv_addr, result->ai_addr, serv_len);
 
     freeaddrinfo(result);
   }

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -601,7 +601,7 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
   while (count < length && !bWroteColor) {
     Internal::enforce(boxHSize <= length - count, ErrorCode::kerCorruptedMetadata);
     Internal::Jp2BoxHeader subBox;
-    std::copy_n(boxBuf.c_data(count), boxHSize, reinterpret_cast<byte*>(&subBox));
+    std::memcpy(&subBox, boxBuf.c_data(count), boxHSize);
     Internal::Jp2BoxHeader newBox = subBox;
 
     if (count < length) {

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -582,12 +582,6 @@ void Jp2Image::writeMetadata() {
 
 }  // Jp2Image::writeMetadata
 
-#ifdef __clang__
-// ignore cast align errors.  dataBuf.pData_ is allocated by malloc() and 4 (or 8 byte aligned).
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
-#endif
-
 void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
   DataBuf output(boxBuf.size() + iccProfile_.size() + 100);  // allocate sufficient space
   size_t outlen = boxHSize;                                  // now many bytes have we written to output?
@@ -658,10 +652,6 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
   ul2Data(outBuf.data(0), static_cast<uint32_t>(outlen), bigEndian);
   ul2Data(outBuf.data(4), kJp2BoxTypeHeader, bigEndian);
 }
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 void Jp2Image::doWriteMetadata(BasicIo& outIo) {
   if (!io_->isopen())

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -601,7 +601,7 @@ uint32_t TiffEncoder::updateDirEntry(byte* buf, ByteOrder byteOrder, TiffCompone
 #endif
     memset(buf + 8, 0x0, 4);
     if (pTiffEntry->size() > 0) {
-      memmove(buf + 8, pTiffEntry->pData(), pTiffEntry->size());
+      std::copy_n(pTiffEntry->pData(), pTiffEntry->size(), buf + 8);
       memset(const_cast<byte*>(pTiffEntry->pData()), 0x0, pTiffEntry->size());
     }
   }


### PR DESCRIPTION
Fixes cast-align warning on 32-bit.