### PR TITLE
Restore localisation of error messages/exceptions

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -163,7 +163,7 @@ const char* Error::what() const noexcept {
 }
 
 void Error::setMsg(int count) {
-  std::string msg{errList.at(static_cast<size_t>(code_))};
+  std::string msg{_(errList.at(static_cast<size_t>(code_)))};
   auto pos = msg.find("%0");
   if (pos != std::string::npos) {
     msg.replace(pos, 2, std::to_string(static_cast<int>(code_)));


### PR DESCRIPTION
Since v0.28.0 libexiv2's error messages have not been localised. This small change adds the `_()` gettext function to localise the error message before doing the `%n` substitutions.