### PR TITLE
CMake: Fix building samples without webready

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -92,10 +92,9 @@ endif()
 
 # ******************************************************************************
 # connection test application
-add_executable(conntest conntest.cpp)
-list(APPEND APPLICATIONS conntest)
-
 if(EXIV2_ENABLE_WEBREADY)
+  add_executable(conntest conntest.cpp)
+  list(APPEND APPLICATIONS conntest)
   if(EXIV2_ENABLE_CURL)
     target_include_directories(conntest SYSTEM PRIVATE ${CURL_INCLUDE_DIR})
     target_link_libraries(conntest PRIVATE ${CURL_LIBRARIES})


### PR DESCRIPTION
If `EXIV2_ENABLE_WEBREADY` is false, the `conntest` sample can't be built, as its code depends on `Exiv2::http` which doesn't exist  in a non-webready build.

Fixes #2961 
