### PR TITLE
Meson: Fix building conntest sample without curl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,13 +68,12 @@ if brotli_dep.found()
 endif
 
 if get_option('webready')
-  curl_dep = dependency('libcurl', disabler: true, required: get_option('curl'))
+  curl_dep = dependency('libcurl', required: get_option('curl'))
+  web_dep = declare_dependency(dependencies: [curl_dep])
+  deps += web_dep
 else
-  curl_dep = dependency('', disabler: true, required: false)
-endif
-
-if curl_dep.found()
-  deps += curl_dep
+  web_dep = dependency('', disabler: true, required: false)
+  curl_dep = web_dep
 endif
 
 expat_dep = dependency('expat', disabler: true, required: get_option('xmp'))
@@ -118,7 +117,7 @@ cdata.set('EXV_HAVE_XMP_TOOLKIT', expat_dep.found())
 cdata.set('EXV_HAVE_BROTLI', brotli_dep.found())
 cdata.set('EXV_HAVE_ICONV', iconv_dep.found())
 cdata.set('EXV_HAVE_LIBZ', zlib_dep.found())
-cdata.set('EXV_ENABLE_WEBREADY', get_option('webready'))
+cdata.set('EXV_ENABLE_WEBREADY', web_dep.found())
 cdata.set('EXV_USE_CURL', curl_dep.found())
 cdata.set('EXV_ENABLE_NLS', intl_dep.found())
 cdata.set('EXV_ENABLE_FILESYSTEM', true)
@@ -157,7 +156,7 @@ executable(
 
 samples = {
   'addmoddel': [],
-  'conntest': curl_dep,
+  'conntest': web_dep,
   'convert-test': [],
   'easyaccess-test': [],
   'exifcomment': [],


### PR DESCRIPTION
Somewhat related to #2963 and #2961

When building with _Meson_ the dependency logic made it impossible to build the `conntest` sample without curl, even though webready can be enabled in a limited, `http://`-only mode that doesn't require curl.

This PR separates the `curl_dep` dependency for libcurl from the `web_dep` dependency that indicates whether the `webready` option is enabled, in the meson configuration. The latter is now used both to determine whether `EXV_ENABLE_WEBREADY` should be defined, and whether `conntest` should be built at all.

When `web_dep` represents a `webready`-enabled configuration, `curl_dep` is set as a dependency. Anything depending on `web_dep` (currently only `conntest`) will be linked with libcurl iff it's available.