### PR TITLE
In src/futils.cpp Added #include <cstdint>

### DIFF
--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -11,6 +11,7 @@
 // + standard includes
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Added the standard include file <cstdint> containing the declarations of fied width integer type, uint8_t etc.  