### PR TITLE
Added compiler option -fPIC.  Required for clang+static linking with libexiv2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ option(EXIV2_TEAM_OSS_FUZZ "Build config for OSS-Fuzz" OFF)
 
 option(EXIV2_TEAM_PACKAGING "Additional stuff for generating packages" OFF)
 set(EXTRA_COMPILE_FLAGS " ")
+add_compile_options( "-fPIC" )
 
 mark_as_advanced(EXIV2_TEAM_EXTRA_WARNINGS EXIV2_TEAM_WARNINGS_AS_ERRORS EXIV2_ENABLE_EXTERNAL_XMP EXTRA_COMPILE_FLAGS EXIV2_TEAM_USE_SANITIZERS)
 

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -11,6 +11,7 @@
 // + standard includes
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
When using clang++ (18.0.0, 19.0.0)  I cannot not link my application against the static exiv2 library libexiv2.a.  The linker complaines about missing a -fPIC (or -fPIE) flag.
Adding this flag solves the issue.

This linking error does not occur when g++ is used.  It also does not occur when the .so library is used. Not for g++ and not for clang++.  However, still adding the -fPIC flag doesn't hurt in those cases.

So strictly speaking, the fix is required for at least clang++ and static exiv2. The fix provided does not take this into account, and simply applies the flag regardless.    