### PR TITLE
Remove the need to enable BMFF via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,13 +730,9 @@ int main(int argc, const char* argv[])
 {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF(true);
-#endif
     ...
 }
 ```
-The use of the _**thread unsafe function**_ Exiv2::enableBMFF(true) is discussed in [Support for BMFF files (e.g., CR3, HEIF, HEIC, AVIF, and JPEG XL)](#BMFF)
 
 [TOC](#TOC)
 <div id="InitAndCleanup">
@@ -752,9 +748,6 @@ The exiv2 command-line program and sample applications call the following at the
 ```cpp
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF(true);
-#endif
 ```
 
 [TOC](#TOC)
@@ -898,15 +891,7 @@ This is discussed: [https://github.com/Exiv2/exiv2/issues/1230](https://github.c
 
 **Attention is drawn to the possibility that BMFF support may be the subject of patent rights. _Exiv2 shall not be held responsible for identifying any or all such patent rights.  Exiv2 shall not be held responsible for the legal consequences of the use of this code_.**
 
-Access to the BMFF code is guarded in two ways.  Firstly, you have to build the library with the CMake option: `-DEXIV2_ENABLE_BMFF=ON`.  Secondly, the application must enable BMFF support at run-time by calling the following function.
-
-```cpp
-EXIV2API bool enableBMFF(bool enable);
-```
-
-The return value from `enableBMFF()` is true if the library has been build with BMFF support (CMake option -DEXIV2_ENABLE_BMFF=ON).
-
-Applications may wish to provide a preference setting to enable BMFF support and thereby place the responsibility for the use of this code with the user of the application.
+Access to the BMFF code is guarded by the CMake option: `-DEXIV2_ENABLE_BMFF=ON` (enabled by default).
 
 [TOC](#TOC)
 <div id="LicenseSupport">

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -118,9 +118,6 @@ int main(int argc, char* const argv[]) {
 
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
 #ifdef EXV_ENABLE_NLS
   setlocale(LC_ALL, "");

--- a/fuzz/fuzz-read-print-write.cpp
+++ b/fuzz/fuzz-read-print-write.cpp
@@ -10,9 +10,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     Exiv2::DataBuf data_copy(data, size);

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -10,9 +10,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -75,9 +75,6 @@ void curlcon(const std::string& url, bool useHttp1_0 = false) {
 int main(int argc, const char** argv) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc < 2) {
     std::cout << "Usage: " << argv[0] << " url {-http1_0}" << std::endl;

--- a/samples/convert-test.cpp
+++ b/samples/convert-test.cpp
@@ -9,9 +9,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/easyaccess-test.cpp
+++ b/samples/easyaccess-test.cpp
@@ -64,9 +64,6 @@ int main(int argc, char** argv) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc < 2) {
       int count = 0;

--- a/samples/exifcomment.cpp
+++ b/samples/exifcomment.cpp
@@ -10,9 +10,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -12,9 +12,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -150,9 +150,6 @@ std::string formatXML(Exiv2::ExifData& exifData) {
 int main(int argc, const char* argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   format_t formats;
   formats["wolf"] = wolf;

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -16,9 +16,6 @@ int main(int argc, char* const argv[]) {
     setlocale(LC_CTYPE, ".utf8");
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     const char* prog = argv[0];
     if (argc == 1) {

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -8,9 +8,6 @@
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " file key\n";

--- a/samples/geotag.cpp
+++ b/samples/geotag.cpp
@@ -690,9 +690,6 @@ bool mySort(const std::string& a, const std::string& b) {
 int main(int argc, const char* argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   int result = 0;
   const char* program = argv[0];

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -73,9 +73,6 @@ class Params : public Util::Getopt {
 int main(int argc, char** const argv) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   int n;
 

--- a/samples/ini-test.cpp
+++ b/samples/ini-test.cpp
@@ -16,9 +16,6 @@ Config loaded from : 'initest.ini' version=6, name=Bob Smith, email=bob@smith.co
 int main() {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   const char* ini = "ini-test.ini";
   INIReader reader(ini);

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -18,9 +18,6 @@ int WriteReadSeek(BasicIo& io);
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc < 4 || argc > 6) {

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -8,9 +8,6 @@
 int main(int argc, char* const argv[]) try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -8,9 +8,6 @@
 int main(int argc, char* const argv[]) try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/iptctest.cpp
+++ b/samples/iptctest.cpp
@@ -16,9 +16,6 @@ void processModify(const std::string& line, int num, IptcData& iptcData);
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 2) {

--- a/samples/key-test.cpp
+++ b/samples/key-test.cpp
@@ -9,9 +9,6 @@ using namespace Exiv2;
 int main() {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   int tc = 0;
   int rc = 0;

--- a/samples/largeiptc-test.cpp
+++ b/samples/largeiptc-test.cpp
@@ -10,9 +10,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 3) {
       std::cout << "Usage: " << argv[0] << " image datafile\n";

--- a/samples/metacopy.cpp
+++ b/samples/metacopy.cpp
@@ -11,9 +11,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     // Handle command line arguments
     Params params;

--- a/samples/mmap-test.cpp
+++ b/samples/mmap-test.cpp
@@ -11,9 +11,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/mrwthumb.cpp
+++ b/samples/mrwthumb.cpp
@@ -7,9 +7,6 @@
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 2) {

--- a/samples/path-test.cpp
+++ b/samples/path-test.cpp
@@ -16,9 +16,6 @@ namespace fs = std::experimental::filesystem;
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -8,9 +8,6 @@
 int main(int argc, char* const argv[]) try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -11,9 +11,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc < 2) {
       std::cout << "Usage: " << argv[0] << " file {--nocurl | --curl}\n\n";

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -39,9 +39,6 @@ static constexpr const char* testcases[] = {
 int main() {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   std::cout << std::setfill(' ');
 

--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -9,9 +9,6 @@ using namespace Exiv2;
 int main(int argc, char* argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   int rc = EXIT_SUCCESS;
   std::ostringstream out;

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -19,9 +19,6 @@ int main(int argc, char* const argv[]) {
   try {
     Exiv2::XmpParser::initialize();
     ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-    Exiv2::enableBMFF();
-#endif
 
     if (argc != 2) {
       std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -18,9 +18,6 @@ void exifPrint(const ExifData& exifData);
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 3) {

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -11,9 +11,6 @@ void print(const std::string& file);
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 2) {

--- a/samples/xmpdump.cpp
+++ b/samples/xmpdump.cpp
@@ -7,9 +7,6 @@
 int main(int argc, char* const argv[]) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 2) {

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -7,9 +7,6 @@
 int main(int argc, char* const argv[]) try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -7,9 +7,6 @@
 int main(int argc, char* const argv[]) try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   if (argc != 2) {
     std::cout << "Usage: " << argv[0] << " file\n";

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -9,9 +9,6 @@
 int main(int argc, char** argv) {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   try {
     if (argc != 2) {

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -15,9 +15,6 @@ bool isEqual(float a, float b) {
 int main() try {
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-#ifdef EXV_ENABLE_BMFF
-  Exiv2::enableBMFF();
-#endif
 
   // The XMP property container
   Exiv2::XmpData xmpData;

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -68,17 +68,12 @@ enum {
 
 // *****************************************************************************
 // class member definitions
-#ifndef EXV_ENABLE_BMFF
 namespace Exiv2 {
 bool enableBMFF(bool) {
+#ifndef EXV_ENABLE_BMFF
   return false;
 }
-}  // namespace Exiv2
 #else
-namespace Exiv2 {
-static bool enabled = false;
-bool enableBMFF(bool enable) {
-  enabled = enable;
   return true;
 }
 
@@ -791,9 +786,6 @@ Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, bool create) {
 }
 
 bool isBmffType(BasicIo& iIo, bool advance) {
-  if (!enabled) {
-    return false;
-  }
   const int32_t len = 12;
   byte buf[len];
   iIo.read(buf, len);
@@ -812,5 +804,5 @@ bool isBmffType(BasicIo& iIo, bool advance) {
   }
   return matched;
 }
+#endif  // EXV_ENABLE_BMFF
 }  // namespace Exiv2
-#endif


### PR DESCRIPTION
BMFF support is either explicitly removed at build time, or is assumed to be on/available w/o a need for the second gating mechanism.

The `Exiv2::enableBMFF(bool)` dummy is kept in the API for legacy apps for the time being. (Hopefully no one ever called `enableBMFF(false)`!?)

This is to remove the somewhat artificial constraint on thread safety.

I'd be bold and backport this to 0.28.x if there are no objections as a step towards leaving the whole BMFF IPR confusion behind... (and remove completely from API on main next?)