### PR TITLE
Disable psapi in UWP (unsupported)

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -33,8 +33,11 @@
 // platform specific support for getLoadedLibraries
 #if defined(_WIN32) || defined(__CYGWIN__)
 // clang-format off
+#include <winapifamily.h>
 #include <windows.h>
-#include <psapi.h>
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_APP)
+  #include <psapi.h>
+#endif
 // clang-format on
 #if __LP64__
 #ifdef _WIN64
@@ -121,7 +124,8 @@ static std::vector<std::string> getLoadedLibraries() {
   std::string path;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-  // enumerate loaded libraries and determine path to executable
+// enumerate loaded libraries and determine path to executable (unsupported on UWP)
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_APP)
   HMODULE handles[200];
   DWORD cbNeeded;
   if (EnumProcessModules(GetCurrentProcess(), handles, static_cast<DWORD>(std::size(handles)), &cbNeeded)) {
@@ -131,6 +135,7 @@ static std::vector<std::string> getLoadedLibraries() {
       pushPath(szFilename, libs, paths);
     }
   }
+#endif
 #elif defined(__APPLE__)
   // man 3 dyld
   uint32_t count = _dyld_image_count();


### PR DESCRIPTION
The EnumProcessModules function from the PSAPI (Process Status API) library, which is used to enumerate the loaded modules for a specified process, is not supported in Universal Windows Platform (UWP) applications. This limitation is due to the security and sandboxing model of UWP, which restricts certain system-level interactions to ensure app isolation and user privacy.