### PR TITLE
[backport] ci: add noFilesystemAccess special build

### DIFF
--- a/.github/workflows/on_PR_linux_special_builds.yml
+++ b/.github/workflows/on_PR_linux_special_builds.yml
@@ -128,6 +128,28 @@ jobs:
           cd build
           ctest --output-on-failure
 
+  special_noFilesystemAccess:
+    name: 'Ubuntu 22.04 - GCC - No filesystem access build'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt install -y ninja-build
+          python3 -m pip install conan==1.*
+
+      - name: Conan common config
+        run: |
+          conan profile new --detect default
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+
+      - name: Build
+        run: |
+          cmake --preset linux-release -S . -B build -DEXIV2_ENABLE_FILESYSTEM_ACCESS=OFF -DEXIV2_BUILD_SAMPLES=OFF -DEXIV2_BUILD_UNIT_TESTS=OFF -DEXIV2_BUILD_EXIV2_COMMAND=OFF
+          cmake --build build --parallel
+
   special_allEnabled:
     name: 'Ubuntu 22.04 - GCC - All Options Enabled + Documentation'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Backport of [96f9e9ae99144e51446d706c73d38db149f43c54](https://github.com/Exiv2/exiv2/pull/2837/commits/96f9e9ae99144e51446d706c73d38db149f43c54) which was part of https://github.com/Exiv2/exiv2/pull/2837 and serves as a companion PR to the backport in https://github.com/Exiv2/exiv2/pull/2994