### PR TITLE
[Build][Windows] Add windows debug postfix definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,6 +236,7 @@ if(WIN32)
   target_compile_definitions(exiv2lib PRIVATE PSAPI_VERSION=1) # to be compatible with <= WinVista (#905)
   # Since windows.h is included in some headers, we need to propagate this definition
   target_compile_definitions(exiv2lib PUBLIC WIN32_LEAN_AND_MEAN)
+  set_target_properties(exiv2lib PROPERTIES DEBUG_POSTFIX d)
 endif()
 
 if(NOT MSVC)


### PR DESCRIPTION
Allows to distinguish between release and debug builds.
In Kodi we are already using exiv2 on master (future release) and we are including this patch (added in https://github.com/xbmc/xbmc/commit/501ec1fae0fb86760548018f02702a9caf8ba997) so we though about submitting upstream.
cc @fuzzard