### PR TITLE
[WIP] xmp thread safety

### DIFF
--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -4,6 +4,7 @@
 #define XMP_HPP_
 
 // *****************************************************************************
+#include <atomic>
 #include "exiv2lib_export.h"
 
 // included header files
@@ -355,7 +356,9 @@ class EXIV2API XmpParser {
 
     @return True if the initialization was successful, else false.
    */
-  static bool initialize(XmpParser::XmpLockFct xmpLockFct = nullptr, void* pLockData = nullptr);
+  [[deprecated("xmpLockFct is no longer required")]] static bool initialize(XmpParser::XmpLockFct xmpLockFct, void* pLockData);
+
+  static bool initialize();
   /*!
     @brief Terminate the XMP Toolkit and unregister custom namespaces.
 
@@ -365,6 +368,9 @@ class EXIV2API XmpParser {
   static void terminate();
 
  private:
+
+  static bool initialize_unsafe();
+
   /*!
     @brief Register a namespace with the XMP Toolkit.
    */
@@ -382,9 +388,8 @@ class EXIV2API XmpParser {
   static void registeredNamespaces(Exiv2::Dictionary&);
 
   // DATA
-  static bool initialized_;  //! Indicates if the XMP Toolkit has been initialized
-  static XmpLockFct xmpLockFct_;
-  static void* pLockData_;
+  static std::atomic_bool initialized_;  //! Indicates if the XMP Toolkit has been initialized
+  static std::mutex global_mutex_; // meant to synchronize all xmp actions across all threads
 
   friend class XmpProperties;  // permit XmpProperties -> registerNs() and registeredNamespaces()
 


### PR DESCRIPTION
The `XMP` subsystem used in `Exiv2` employs a global state and is not thread-safe. While `Exiv2` has some locking mechanisms, they seem inadequate. Currently, if you try to read or write `XMP ` metadata from multiple files in separate threads, you will quickly encounter threading issues, and at best, your app will segfault.

This happens because, in several places, Exiv2 writes under locks but performs reads without locking.

The worst offenders are the `XmpParser::decode` and `XmpParser::encode` functions. Both of these functions attempt to register `XMP` namespaces if they do not exist, which is not a thread-safe operation.

I would also like to mention that `XmpParser::decode` is not a `const` operation, it will try to add namespaces if they do not exist, so even reading multiple images from different threads results in undefined behaviors. 

This pull request **does not** fix all of these issues.

It adds global locking to the encode, decode, and initialize functions; however, I am sure there are more threading issues in `XMP`.

As is, this is a quick and dirty solution for my particular use case.

It very much is a **work in progress** for general case.