### PR TITLE
Throw if open file with EXV_ENABLE_FILESYSTEM off

### DIFF
--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -224,6 +224,7 @@ enum class ErrorCode {
   kerArithmeticOverflow,
   kerMallocFailed,
   kerInvalidIconvEncoding,
+  kerFileAccessDisabled,
 
   kerErrorCount,
 };

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -90,6 +90,7 @@ constexpr std::array errList{
     N_("Arithmetic operation overflow"),                         // kerArithmeticOverflow
     N_("Memory allocation failed"),                              // kerMallocFailed
     N_("Cannot convert text encoding from '%1' to '%2'"),        // kerInvalidIconvEncoding
+    N_("%1: File access disabled in exiv2 build options"),       // kerFileOpenFailed %1=path
 };
 static_assert(errList.size() == static_cast<size_t>(Exiv2::ErrorCode::kerErrorCount),
               "errList needs to contain a error msg for every ErrorCode defined in error.hpp");

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -797,7 +797,7 @@ BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, [[maybe_unuse
 
   return std::make_unique<FileIo>(path);
 #else
-  throw Error(ErrorCode::kerFileOpenFailed, path, "", "file access disabled");
+  throw Error(ErrorCode::kerFileAccessDisabled, path);
 #endif
 }  // ImageFactory::createIo
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -797,7 +797,7 @@ BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, [[maybe_unuse
 
   return std::make_unique<FileIo>(path);
 #else
-  return nullptr;
+  throw Error(ErrorCode::kerFileOpenFailed, path, "", "file access disabled");
 #endif
 }  // ImageFactory::createIo
 


### PR DESCRIPTION
If ImageFactory::createIo() is called with a file path and has been built with EXV_ENABLE_FILESYSTEM off it returns a NULL pointer. ImageFactory::open() then calls io->open() on this pointer, causing a segfault. The documentation of ImageFactory::createIo does not say it can return a NULL pointer. This commit makes it throw an exception instead of returning a NULL pointer.