### PR TITLE
backport the security patch of CVE-2024-39695

### DIFF
--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -235,7 +235,7 @@ void AsfVideo::readMetadata() {
 
 AsfVideo::HeaderReader::HeaderReader(const BasicIo::UniquePtr& io) : IdBuf_(GUID) {
   if (io->size() >= io->tell() + GUID + QWORD) {
-    IdBuf_ = io->read(GUID);
+    io->readOrThrow(IdBuf_.data(), IdBuf_.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
 
     size_ = readQWORDTag(io);
     if (size_ >= GUID + QWORD)
@@ -291,7 +291,7 @@ void AsfVideo::decodeBlock() {
 
 void AsfVideo::decodeHeader() {
   DataBuf nbHeadersBuf(DWORD + 1);
-  io_->read(nbHeadersBuf.data(), DWORD);
+  io_->readOrThrow(nbHeadersBuf.data(), DWORD, Exiv2::ErrorCode::kerCorruptedMetadata);
 
   uint32_t nb_headers = Exiv2::getULong(nbHeadersBuf.data(), littleEndian);
   Internal::enforce(nb_headers < std::numeric_limits<uint32_t>::max(), Exiv2::ErrorCode::kerCorruptedMetadata);
@@ -353,7 +353,8 @@ void AsfVideo::DegradableJPEGMedia() {
 }
 
 void AsfVideo::streamProperties() {
-  DataBuf streamTypedBuf = io_->read(GUID);
+  DataBuf streamTypedBuf(GUID);
+  io_->readOrThrow(streamTypedBuf.data(), streamTypedBuf.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
 
   enum class streamTypeInfo { Audio = 1, Video = 2 };
   auto stream = static_cast<streamTypeInfo>(0);
@@ -471,7 +472,8 @@ void AsfVideo::contentDescription() {
 }  // AsfVideo::extendedContentDescription
 
 void AsfVideo::fileProperties() {
-  DataBuf FileIddBuf = io_->read(GUID);
+  DataBuf FileIddBuf(GUID);
+  io_->readOrThrow(FileIddBuf.data(), FileIddBuf.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
   xmpData()["Xmp.video.FileID"] = GUIDTag(FileIddBuf.data()).to_string();
   xmpData()["Xmp.video.FileLength"] = readQWORDTag(io_);
   xmpData()["Xmp.video.CreationDate"] = readQWORDTag(io_);


### PR DESCRIPTION
Here is a vulnerability which is fixed in the main branch which is https://github.com/Exiv2/exiv2/commit/3a28346db5ae1735a8728fe3491b0aecc1dbf387, but is not fixed in the branch of kmilos/win_utf8, maybe it should be backported?