### PR TITLE
clang-tidy: replace endl with '\n'

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -189,7 +189,7 @@ static int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const st
         size_t length = code.size();
         for (size_t start = 0; start < length; start += chunk) {
           size_t count = (start + chunk) < length ? chunk : length - start;
-          std::cout << code.substr(start, count) << std::endl;
+          std::cout << code.substr(start, count) << '\n';
         }
       }
     }
@@ -245,19 +245,19 @@ int Print::printSummary() {
 
   // Filename
   printLabel(_("File name"));
-  std::cout << path_ << std::endl;
+  std::cout << path_ << '\n';
 
   // Filesize
   printLabel(_("File size"));
-  std::cout << fs::file_size(path_) << " " << _("Bytes") << std::endl;
+  std::cout << fs::file_size(path_) << " " << _("Bytes") << '\n';
 
   // MIME type
   printLabel(_("MIME type"));
-  std::cout << image->mimeType() << std::endl;
+  std::cout << image->mimeType() << '\n';
 
   // Image size
   printLabel(_("Image size"));
-  std::cout << image->pixelWidth() << " x " << image->pixelHeight() << std::endl;
+  std::cout << image->pixelWidth() << " x " << image->pixelHeight() << '\n';
 
   if (exifData.empty()) {
     std::cerr << path_ << ": " << _("No Exif data found in the file") << "\n";
@@ -278,7 +278,7 @@ int Print::printSummary() {
       std::cout << exifThumb.mimeType() << ", " << dataBuf.size() << " " << _("Bytes");
     }
   }
-  std::cout << std::endl;
+  std::cout << '\n';
 
   printTag(exifData, Exiv2::make, _("Camera make"));
   printTag(exifData, Exiv2::model, _("Camera model"));
@@ -300,7 +300,7 @@ int Print::printSummary() {
   printTag(exifData, "Exif.Image.Copyright", _("Copyright"));
   printTag(exifData, "Exif.Photo.UserComment", _("Exif comment"));
 
-  std::cout << std::endl;
+  std::cout << '\n';
 
   return 0;
 }  // Print::printSummary
@@ -325,7 +325,7 @@ int Print::printTag(const Exiv2::ExifData& exifData, const std::string& key, con
     rc = 1;
   }
   if (!label.empty())
-    std::cout << std::endl;
+    std::cout << '\n';
   return rc;
 }  // Print::printTag
 
@@ -347,7 +347,7 @@ int Print::printTag(const Exiv2::ExifData& exifData, EasyAccessFct easyAccessFct
     }
   }
   if (!label.empty())
-    std::cout << std::endl;
+    std::cout << '\n';
   return rc;
 }  // Print::printTag
 
@@ -552,14 +552,14 @@ bool Print::printMetadatum(const Exiv2::Metadatum& md, const Exiv2::Image* pImag
   }
   if (Params::instance().printItems_ & Params::prHex) {
     if (!first)
-      std::cout << std::endl;
+      std::cout << '\n';
     if (md.size() > 0) {
       Exiv2::DataBuf buf(md.size());
       md.copy(buf.data(), pImage->byteOrder());
       Exiv2::hexdump(std::cout, buf.c_data(), buf.size());
     }
   }
-  std::cout << std::endl;
+  std::cout << '\n';
   return true;
 }  // Print::printMetadatum
 
@@ -574,7 +574,7 @@ int Print::printComment() {
   if (Params::instance().verbose_) {
     std::cout << _("JPEG comment") << ": ";
   }
-  std::cout << image->comment() << std::endl;
+  std::cout << image->comment() << '\n';
   return 0;
 }  // Print::printComment
 
@@ -649,7 +649,7 @@ int Rename::run(const std::string& path) {
     std::string newPath = path;
     if (Params::instance().timestampOnly_) {
       if (Params::instance().verbose_) {
-        std::cout << _("Updating timestamp to") << " " << v << std::endl;
+        std::cout << _("Updating timestamp to") << " " << v << '\n';
       }
     } else {
       rc = renameFile(newPath, &tm);
@@ -730,14 +730,14 @@ int Erase::eraseThumbnail(Exiv2::Image* image) {
   }
   exifThumb.erase();
   if (Params::instance().verbose_) {
-    std::cout << _("Erasing thumbnail data") << std::endl;
+    std::cout << _("Erasing thumbnail data") << '\n';
   }
   return 0;
 }
 
 int Erase::eraseExifData(Exiv2::Image* image) {
   if (Params::instance().verbose_ && !image->exifData().empty()) {
-    std::cout << _("Erasing Exif data from the file") << std::endl;
+    std::cout << _("Erasing Exif data from the file") << '\n';
   }
   image->clearExifData();
   return 0;
@@ -745,7 +745,7 @@ int Erase::eraseExifData(Exiv2::Image* image) {
 
 int Erase::eraseIptcData(Exiv2::Image* image) {
   if (Params::instance().verbose_ && !image->iptcData().empty()) {
-    std::cout << _("Erasing IPTC data from the file") << std::endl;
+    std::cout << _("Erasing IPTC data from the file") << '\n';
   }
   image->clearIptcData();
   return 0;
@@ -753,7 +753,7 @@ int Erase::eraseIptcData(Exiv2::Image* image) {
 
 int Erase::eraseComment(Exiv2::Image* image) {
   if (Params::instance().verbose_ && !image->comment().empty()) {
-    std::cout << _("Erasing JPEG comment from the file") << std::endl;
+    std::cout << _("Erasing JPEG comment from the file") << '\n';
   }
   image->clearComment();
   return 0;
@@ -761,7 +761,7 @@ int Erase::eraseComment(Exiv2::Image* image) {
 
 int Erase::eraseXmpData(Exiv2::Image* image) {
   if (Params::instance().verbose_ && !image->xmpData().empty()) {
-    std::cout << _("Erasing XMP data from the file") << std::endl;
+    std::cout << _("Erasing XMP data from the file") << '\n';
   }
   image->clearXmpData();  // Quick fix for bug #612
   image->clearXmpPacket();
@@ -769,7 +769,7 @@ int Erase::eraseXmpData(Exiv2::Image* image) {
 }
 int Erase::eraseIccProfile(Exiv2::Image* image) {
   if (Params::instance().verbose_ && image->iccProfileDefined()) {
-    std::cout << _("Erasing ICC Profile data from the file") << std::endl;
+    std::cout << _("Erasing ICC Profile data from the file") << '\n';
   }
   image->clearIccProfile();
   return 0;
@@ -852,7 +852,7 @@ int Extract::writeThumbnail() const {
       Exiv2::DataBuf buf = exifThumb.copy();
       if (!buf.empty()) {
         std::cout << _("Writing thumbnail") << " (" << exifThumb.mimeType() << ", " << buf.size() << " " << _("Bytes")
-                  << ") " << _("to file") << " " << thumbPath << std::endl;
+                  << ") " << _("to file") << " " << thumbPath << '\n';
       }
     }
     rc = static_cast<int>(exifThumb.writeFile(thumb));
@@ -908,14 +908,14 @@ int Extract::writeIccProfile(const std::string& target) const {
     auto image = Exiv2::ImageFactory::open(path_);
     image->readMetadata();
     if (!image->iccProfileDefined()) {
-      std::cerr << _("No embedded iccProfile: ") << path_ << std::endl;
+      std::cerr << _("No embedded iccProfile: ") << path_ << '\n';
       rc = -2;
     } else {
       if (bStdout) {  // -eC-
         std::cout.write(image->iccProfile().c_str(), image->iccProfile().size());
       } else {
         if (Params::instance().verbose_) {
-          std::cout << _("Writing iccProfile: ") << target << std::endl;
+          std::cout << _("Writing iccProfile: ") << target << '\n';
         }
         Exiv2::FileIo iccFile(target);
         iccFile.open("wb");
@@ -937,7 +937,7 @@ void Extract::writePreviewFile(const Exiv2::PreviewImage& pvImg, size_t num) con
     if (pvImg.width() != 0 && pvImg.height() != 0) {
       std::cout << pvImg.width() << "x" << pvImg.height() << " " << _("pixels") << ", ";
     }
-    std::cout << pvImg.size() << " " << _("bytes") << ") " << _("to file") << " " << pvPath << std::endl;
+    std::cout << pvImg.size() << " " << _("bytes") << ") " << _("to file") << " " << pvPath << '\n';
   }
   auto rc = pvImg.writeFile(pvFile);
   if (rc == 0) {
@@ -1136,7 +1136,7 @@ int Modify::applyCommands(Exiv2::Image* pImage) {
     // If modify is used when extracting to stdout then ignore verbose
     if (Params::instance().verbose_ &&
         !(Params::instance().action_ & Action::extract && Params::instance().target_ & Params::ctStdInOut)) {
-      std::cout << _("Setting JPEG comment") << " '" << Params::instance().jpegComment_ << "'" << std::endl;
+      std::cout << _("Setting JPEG comment") << " '" << Params::instance().jpegComment_ << "'" << '\n';
     }
     pImage->setComment(Params::instance().jpegComment_);
   }
@@ -1175,7 +1175,7 @@ int Modify::addMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd) {
   if (Params::instance().verbose_ &&
       !(Params::instance().action_ & Action::extract && Params::instance().target_ & Params::ctStdInOut)) {
     std::cout << _("Add") << " " << modifyCmd.key_ << " \"" << modifyCmd.value_ << "\" ("
-              << Exiv2::TypeInfo::typeName(modifyCmd.typeId_) << ")" << std::endl;
+              << Exiv2::TypeInfo::typeName(modifyCmd.typeId_) << ")" << '\n';
   }
   Exiv2::ExifData& exifData = pImage->exifData();
   Exiv2::IptcData& iptcData = pImage->iptcData();
@@ -1206,7 +1206,7 @@ int Modify::setMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd) {
   if (Params::instance().verbose_ &&
       !(Params::instance().action_ & Action::extract && Params::instance().target_ & Params::ctStdInOut)) {
     std::cout << _("Set") << " " << modifyCmd.key_ << " \"" << modifyCmd.value_ << "\" ("
-              << Exiv2::TypeInfo::typeName(modifyCmd.typeId_) << ")" << std::endl;
+              << Exiv2::TypeInfo::typeName(modifyCmd.typeId_) << ")" << '\n';
   }
   Exiv2::ExifData& exifData = pImage->exifData();
   Exiv2::IptcData& iptcData = pImage->iptcData();
@@ -1266,7 +1266,7 @@ void Modify::delMetadatum(Exiv2::Image* pImage, const ModifyCmd& modifyCmd) {
   // If modify is used when extracting to stdout then ignore verbose
   if (Params::instance().verbose_ &&
       !(Params::instance().action_ & Action::extract && Params::instance().target_ & Params::ctStdInOut)) {
-    std::cout << _("Del") << " " << modifyCmd.key_ << std::endl;
+    std::cout << _("Del") << " " << modifyCmd.key_ << '\n';
   }
 
   Exiv2::ExifData& exifData = pImage->exifData();
@@ -1299,7 +1299,7 @@ void Modify::regNamespace(const ModifyCmd& modifyCmd) {
   // If modify is used when extracting to stdout then ignore verbose
   if (Params::instance().verbose_ &&
       !(Params::instance().action_ & Action::extract && Params::instance().target_ & Params::ctStdInOut)) {
-    std::cout << _("Reg ") << modifyCmd.key_ << "=\"" << modifyCmd.value_ << "\"" << std::endl;
+    std::cout << _("Reg ") << modifyCmd.key_ << "=\"" << modifyCmd.value_ << "\"" << '\n';
   }
   Exiv2::XmpProperties::registerNs(modifyCmd.value_, modifyCmd.key_);
 }
@@ -1404,7 +1404,7 @@ int Adjust::adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, co
   tm tm;
   if (str2Tm(timeStr, &tm) != 0) {
     if (Params::instance().verbose_)
-      std::cout << std::endl;
+      std::cout << '\n';
     std::cerr << path << ": " << _("Failed to parse timestamp") << " `" << timeStr << "'\n";
     return 1;
   }
@@ -1444,7 +1444,7 @@ int Adjust::adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, co
   // Let's not create files with non-4-digit years, we can't read them.
   if (tm.tm_year > 9999 - 1900 || tm.tm_year < 1000 - 1900) {
     if (Params::instance().verbose_)
-      std::cout << std::endl;
+      std::cout << '\n';
     std::cerr << path << ": " << _("Can't adjust timestamp by") << " " << yearAdjustment + monOverflow << " "
               << _("years") << "\n";
     return 1;
@@ -1453,7 +1453,7 @@ int Adjust::adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, co
   time = Safe::add(time, Safe::add(adjustment, dayAdjustment * secondsInDay));
   timeStr = time2Str(time);
   if (Params::instance().verbose_) {
-    std::cout << " " << _("to") << " " << timeStr << std::endl;
+    std::cout << " " << _("to") << " " << timeStr << '\n';
   }
   md->setValue(timeStr);
   return 0;
@@ -1689,7 +1689,7 @@ std::string temporaryPath() {
 int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType targetType, bool preserve) {
 #ifdef EXIV2_DEBUG_MESSAGES
   std::cerr << "actions.cpp::metacopy"
-            << " source = " << source << " target = " << tgt << std::endl;
+            << " source = " << source << " target = " << tgt << '\n';
 #endif
 
   // read the source metadata
@@ -1731,7 +1731,7 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
   // Copy each type of metadata
   if (Params::instance().target_ & Params::ctExif && !sourceImage->exifData().empty()) {
     if (Params::instance().verbose_ && !bStdout) {
-      std::cout << _("Writing Exif data from") << " " << source << " " << _("to") << " " << target << std::endl;
+      std::cout << _("Writing Exif data from") << " " << source << " " << _("to") << " " << target << '\n';
     }
     if (preserve) {
       for (const auto& exif : sourceImage->exifData()) {
@@ -1743,7 +1743,7 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
   }
   if (Params::instance().target_ & Params::ctIptc && !sourceImage->iptcData().empty()) {
     if (Params::instance().verbose_ && !bStdout) {
-      std::cout << _("Writing IPTC data from") << " " << source << " " << _("to") << " " << target << std::endl;
+      std::cout << _("Writing IPTC data from") << " " << source << " " << _("to") << " " << target << '\n';
     }
     if (preserve) {
       for (const auto& iptc : sourceImage->iptcData()) {
@@ -1755,13 +1755,13 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
   }
   if (Params::instance().target_ & (Params::ctXmp | Params::ctXmpRaw) && !sourceImage->xmpData().empty()) {
     if (Params::instance().verbose_ && !bStdout) {
-      std::cout << _("Writing XMP data from") << " " << source << " " << _("to") << " " << target << std::endl;
+      std::cout << _("Writing XMP data from") << " " << source << " " << _("to") << " " << target << '\n';
     }
 
     // #1148 use Raw XMP packet if there are no XMP modification commands
     Params::CommonTarget tRawSidecar = Params::ctXmpSidecar | Params::ctXmpRaw;  // option -eXX
     if (Params::instance().modifyCmds_.empty() && (Params::instance().target_ & tRawSidecar) == tRawSidecar) {
-      // std::cout << "short cut" << std::endl;
+      // std::cout << "short cut" << '\n';
       // http://www.cplusplus.com/doc/tutorial/files/
       std::ofstream os;
       os.open(target.c_str());
@@ -1773,13 +1773,13 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
         targetImage->xmpData()[xmp.key()] = xmp.value();
       }
     } else {
-      // std::cout << "long cut" << std::endl;
+      // std::cout << "long cut" << '\n';
       targetImage->setXmpData(sourceImage->xmpData());
     }
   }
   if (Params::instance().target_ & Params::ctComment && !sourceImage->comment().empty()) {
     if (Params::instance().verbose_ && !bStdout) {
-      std::cout << _("Writing JPEG comment from") << " " << source << " " << _("to") << " " << tgt << std::endl;
+      std::cout << _("Writing JPEG comment from") << " " << source << " " << _("to") << " " << tgt << '\n';
     }
     targetImage->setComment(sourceImage->comment());
   }
@@ -1848,7 +1848,7 @@ int renameFile(std::string& newPath, const tm* tm) {
 
   if (p.parent_path() == oldFsPath.parent_path() && p.filename() == oldFsPath.filename()) {
     if (Params::instance().verbose_) {
-      std::cout << _("This file already has the correct name") << std::endl;
+      std::cout << _("This file already has the correct name") << '\n';
     }
     return -1;
   }
@@ -1897,7 +1897,7 @@ int renameFile(std::string& newPath, const tm* tm) {
     if (Params::instance().timestamp_) {
       std::cout << ", " << _("updating timestamp");
     }
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 
   fs::rename(path, newPath);

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -155,7 +155,7 @@ int main(int argc, char* const argv[]) {
     // Process all files
     auto filesCount = params.files_.size();
     if (params.action_ & Action::extract && params.target_ & Params::ctStdInOut && filesCount > 1) {
-      std::cerr << params.progname() << ": " << _("Only one file is allowed when extracting to stdout") << std::endl;
+      std::cerr << params.progname() << ": " << _("Only one file is allowed when extracting to stdout") << '\n';
       returnCode = EXIT_FAILURE;
     } else {
       int w = [=]() {
@@ -171,7 +171,7 @@ int main(int argc, char* const argv[]) {
         // If extracting to stdout then ignore verbose
         if (params.verbose_ && !(params.action_ & Action::extract && params.target_ & Params::ctStdInOut)) {
           std::cout << _("File") << " " << std::setw(w) << std::right << n++ << "/" << filesCount << ": " << file
-                    << std::endl;
+                    << '\n';
         }
         task->setBinary(params.binary_);
         int ret = task->run(file);
@@ -183,7 +183,7 @@ int main(int argc, char* const argv[]) {
       Exiv2::XmpParser::terminate();
     }
   } catch (const std::exception& exc) {
-    std::cerr << "Uncaught exception: " << exc.what() << std::endl;
+    std::cerr << "Uncaught exception: " << exc.what() << '\n';
     returnCode = EXIT_FAILURE;
   }
 
@@ -207,7 +207,7 @@ Params& Params::instance() {
 }
 
 void Params::version(bool verbose, std::ostream& os) {
-  os << EXV_PACKAGE_STRING << std::endl;
+  os << EXV_PACKAGE_STRING << '\n';
   if (Params::instance().greps_.empty() && !verbose) {
     os << "\n"
        << _("This program is free software; you can redistribute it and/or\n"
@@ -971,7 +971,7 @@ void Params::getStdin(Exiv2::DataBuf& buf) {
     if (select(1, &readfds, nullptr, nullptr, &timeout)) {
 #endif
 #ifdef DEBUG
-      std::cerr << "stdin has data" << std::endl;
+      std::cerr << "stdin has data" << '\n';
 #endif
       readFileToBuf(stdin, stdinBuf);
     }
@@ -985,12 +985,12 @@ void Params::getStdin(Exiv2::DataBuf& buf) {
       if (f) {
         readFileToBuf(f, stdinBuf);
         fclose(f);
-        std::cerr << "read stdin from " << path << std::endl;
+        std::cerr << "read stdin from " << path << '\n';
       }
     }
 #endif
 #ifdef DEBUG
-    std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << std::endl;
+    std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << '\n';
 #endif
   }
 
@@ -1000,7 +1000,7 @@ void Params::getStdin(Exiv2::DataBuf& buf) {
     std::copy(stdinBuf.begin(), stdinBuf.end(), buf.begin());
   }
 #ifdef DEBUG
-  std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << std::endl;
+  std::cerr << "getStdin stdinBuf.size_ = " << stdinBuf.size() << '\n';
 #endif
 
 }  // Params::getStdin()
@@ -1223,7 +1223,7 @@ int parsePreviewNumbers(Params::PreviewNumbers& previewNumbers, const std::strin
   for (auto&& number : previewNumbers) {
     std::cout << number << ", ";
   }
-  std::cout << std::endl;
+  std::cout << '\n';
 #endif
   return static_cast<int>(k - j);
 }  // parsePreviewNumbers

--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -410,7 +410,7 @@ struct PtrSliceStorage {
  * // 3
  * // 4
  * for (const auto & elem : three_four) {
- *     std::cout << elem << std::endl;
+ *     std::cout << elem << '\n';
  * }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~
  *

--- a/samples/conntest.cpp
+++ b/samples/conntest.cpp
@@ -77,7 +77,7 @@ int main(int argc, const char** argv) {
   ::atexit(Exiv2::XmpParser::terminate);
 
   if (argc < 2) {
-    std::cout << "Usage: " << argv[0] << " url {-http1_0}" << std::endl;
+    std::cout << "Usage: " << argv[0] << " url {-http1_0}" << '\n';
     return EXIT_FAILURE;
   }
   std::string url(argv[1]);
@@ -103,14 +103,14 @@ int main(int argc, const char** argv) {
       isOk = true;
     }
   } catch (const Exiv2::Error& e) {
-    std::cout << "Error: '" << e << "'" << std::endl;
+    std::cout << "Error: '" << e << "'" << '\n';
     return EXIT_FAILURE;
   }
 
   if (!isOk)
-    std::cout << "The protocol is unsupported." << std::endl;
+    std::cout << "The protocol is unsupported." << '\n';
   else
-    std::cout << "OK." << std::endl;
+    std::cout << "OK." << '\n';
   return EXIT_SUCCESS;
 }
 

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -98,13 +98,11 @@ void print(const std::string& file) {
   auto image = Exiv2::ImageFactory::open(file);
   image->readMetadata();
 
-  Exiv2::ExifData& ed = image->exifData();
-  auto end = ed.end();
-  for (auto i = ed.begin(); i != end; ++i) {
-    std::cout << std::setw(45) << std::setfill(' ') << std::left << i->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " " << std::setw(12)
-              << std::setfill(' ') << std::left << i->ifdName() << " " << std::setw(9) << std::setfill(' ') << std::left
-              << i->typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right << i->count()
-              << " " << std::dec << i->toString() << "\n";
+  for (const auto& i : image->exifData()) {
+    std::cout << std::setw(45) << std::setfill(' ') << std::left << i.key() << " "
+              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " " << std::setw(12)
+              << std::setfill(' ') << std::left << i.ifdName() << " " << std::setw(9) << std::setfill(' ') << std::left
+              << i.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right << i.count() << " "
+              << std::dec << i.toString() << "\n";
   }
 }

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -7,7 +7,6 @@
 #include <string>
 
 using format_t = std::map<std::string, int>;
-using format_i = format_t::const_iterator;
 enum format_e { wolf, csv, json, xml };
 
 void syntax(const char* argv[], format_t& formats) {

--- a/samples/exifdata.cpp
+++ b/samples/exifdata.cpp
@@ -11,13 +11,13 @@ using format_i = format_t::const_iterator;
 enum format_e { wolf, csv, json, xml };
 
 void syntax(const char* argv[], format_t& formats) {
-  std::cout << "Usage: " << argv[0] << " file format" << std::endl;
+  std::cout << "Usage: " << argv[0] << " file format" << '\n';
   int count = 0;
   std::cout << "formats: ";
   for (auto&& format : formats) {
     std::cout << (count++ ? " | " : "") << format.first;
   }
-  std::cout << std::endl;
+  std::cout << '\n';
 }
 
 size_t formatInit(Exiv2::ExifData& exifData) {
@@ -52,7 +52,7 @@ std::string formatCSV(Exiv2::ExifData& exifData) {
   for (auto i = exifData.begin(); count++ < length; ++i) {
     result << escapeCSV(i, false) << (count != length ? ", " : "");
   }
-  result << std::endl;
+  result << '\n';
 
   count = 0;
   for (auto i = exifData.begin(); count++ < length; ++i) {
@@ -67,9 +67,9 @@ std::string formatWolf(Exiv2::ExifData& exifData) {
   size_t length = formatInit(exifData);
   std::ostringstream result;
 
-  result << "{ " << std::endl;
+  result << "{ " << '\n';
   for (auto i = exifData.begin(); count++ < length; ++i) {
-    result << "  " << i->key() << " -> " << i->value() << (count != length ? "," : "") << std::endl;
+    result << "  " << i->key() << " -> " << i->value() << (count != length ? "," : "") << '\n';
   }
   result << "}";
   return result.str();
@@ -101,9 +101,9 @@ std::string formatJSON(Exiv2::ExifData& exifData) {
   size_t length = formatInit(exifData);
   std::ostringstream result;
 
-  result << "{" << std::endl;
+  result << "{" << '\n';
   for (auto i = exifData.begin(); count++ < length; ++i) {
-    result << "  " << escapeJSON(i, false) << ":" << escapeJSON(i, true) << (count != length ? "," : "") << std::endl;
+    result << "  " << escapeJSON(i, false) << ":" << escapeJSON(i, true) << (count != length ? "," : "") << '\n';
   }
   result << "}";
   return result.str();
@@ -136,13 +136,13 @@ std::string formatXML(Exiv2::ExifData& exifData) {
   size_t length = formatInit(exifData);
   std::ostringstream result;
 
-  result << "<exif>" << std::endl;
+  result << "<exif>" << '\n';
   for (auto i = exifData.begin(); count++ < length; ++i) {
     std::string key = escapeXML(i, false);
     std::string value = escapeXML(i, true);
-    result << "  <" << key << ">" << value << "<" << key << "/>" << std::endl;
+    result << "  <" << key << ">" << value << "<" << key << "/>" << '\n';
   }
-  result << "</exif>" << std::endl;
+  result << "</exif>" << '\n';
   return result.str();
 }
 
@@ -167,7 +167,7 @@ int main(int argc, const char* argv[]) {
   const char* format = argv[2];
 
   if (!result && formats.find(format) == formats.end()) {
-    std::cout << "Unrecognised format " << format << std::endl;
+    std::cout << "Unrecognised format " << format << '\n';
     syntax(argv, formats);
     result = 2;
   }
@@ -180,28 +180,28 @@ int main(int argc, const char* argv[]) {
 
       switch (formats.find(format)->second) {
         case wolf:
-          std::cout << formatWolf(exifData) << std::endl;
+          std::cout << formatWolf(exifData) << '\n';
           break;
         case csv:
-          std::cout << formatCSV(exifData) << std::endl;
+          std::cout << formatCSV(exifData) << '\n';
           break;
         case json:
-          std::cout << formatJSON(exifData) << std::endl;
+          std::cout << formatJSON(exifData) << '\n';
           break;
         case xml:
-          std::cout << formatXML(exifData) << std::endl;
+          std::cout << formatXML(exifData) << '\n';
           break;
 
         default:
-          std::cout << "*** error: format not implemented yet: " << format << " ***" << std::endl;
+          std::cout << "*** error: format not implemented yet: " << format << " ***" << '\n';
           result = 3;
           break;
       }
     } catch (Exiv2::Error& e) {
-      std::cerr << "*** error exiv2 exception '" << e << "' ***" << std::endl;
+      std::cerr << "*** error exiv2 exception '" << e << "' ***" << '\n';
       result = 4;
     } catch (...) {
-      std::cerr << "*** error exception" << std::endl;
+      std::cerr << "*** error exception" << '\n';
       result = 5;
     }
 

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -19,7 +19,7 @@ int main(int argc, char* const argv[]) {
 
     const char* prog = argv[0];
     if (argc == 1) {
-      std::cout << "Usage: " << prog << " [ [--lint] path | --version | --version-test ]" << std::endl;
+      std::cout << "Usage: " << prog << " [ [--lint] path | --version | --version-test ]" << '\n';
       return EXIT_FAILURE;
     }
 
@@ -37,12 +37,12 @@ int main(int argc, char* const argv[]) {
     if (strcmp(file, "--version-test") == 0) {
       // verifies/test macro EXIV2_TEST_VERSION
       // described in include/exiv2/version.hpp
-      std::cout << "EXV_PACKAGE_VERSION             " << EXV_PACKAGE_VERSION << std::endl
-                << "Exiv2::version()                " << Exiv2::version() << std::endl
-                << "strlen(Exiv2::version())        " << ::strlen(Exiv2::version()) << std::endl
-                << "Exiv2::versionNumber()          " << Exiv2::versionNumber() << std::endl
-                << "Exiv2::versionString()          " << Exiv2::versionString() << std::endl
-                << "Exiv2::versionNumberHexString() " << Exiv2::versionNumberHexString() << std::endl;
+      std::cout << "EXV_PACKAGE_VERSION             " << EXV_PACKAGE_VERSION << '\n'
+                << "Exiv2::version()                " << Exiv2::version() << '\n'
+                << "strlen(Exiv2::version())        " << ::strlen(Exiv2::version()) << '\n'
+                << "Exiv2::versionNumber()          " << Exiv2::versionNumber() << '\n'
+                << "Exiv2::versionString()          " << Exiv2::versionString() << '\n'
+                << "Exiv2::versionNumberHexString() " << Exiv2::versionNumberHexString() << '\n';
 
 // Test the Exiv2 version available at runtime but compile the if-clause only if
 // the compile-time version is at least 0.15. Earlier versions didn't have a
@@ -97,7 +97,7 @@ int main(int argc, char* const argv[]) {
           ) {
             std::cerr << i->key() << " type " << i->typeName() << " (" << type << ")"
                       << " expected " << Exiv2::TypeInfo::typeName(tagInfo->typeId_) << " (" << tagInfo->typeId_ << ")"
-                      << std::endl;
+                      << '\n';
             rc = 2;
           }
         }

--- a/samples/exifprint.cpp
+++ b/samples/exifprint.cpp
@@ -77,25 +77,24 @@ int main(int argc, char* const argv[]) {
     shortLong.insert("Exif.Photo.StripOffsets");
     shortLong.insert("Exif.Photo.StripByteCounts");
 
-    auto end = exifData.end();
-    for (auto i = exifData.begin(); i != end; ++i) {
+    for (const auto& i : exifData) {
       if (!bLint) {
-        const char* tn = i->typeName();
-        std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
-                  << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " "
+        const char* tn = i.typeName();
+        std::cout << std::setw(44) << std::setfill(' ') << std::left << i.key() << " "
+                  << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " "
                   << std::setw(9) << std::setfill(' ') << std::left << (tn ? tn : "Unknown") << " " << std::dec
-                  << std::setw(3) << std::setfill(' ') << std::right << i->count() << "  " << std::dec << i->toString()
+                  << std::setw(3) << std::setfill(' ') << std::right << i.count() << "  " << std::dec << i.toString()
                   << "\n";
       } else {
-        const Exiv2::TagInfo* tagInfo = findTag(Exiv2::ExifTags::tagList(i->groupName()), i->tag());
+        const Exiv2::TagInfo* tagInfo = findTag(Exiv2::ExifTags::tagList(i.groupName()), i.tag());
         if (tagInfo) {
-          Exiv2::TypeId type = i->typeId();
+          Exiv2::TypeId type = i.typeId();
           if (type != tagInfo->typeId_ &&
               (tagInfo->typeId_ != Exiv2::comment || type != Exiv2::undefined)  // comment is stored as undefined
-              && (shortLong.find(i->key()) == shortLong.end() ||
+              && (shortLong.find(i.key()) == shortLong.end() ||
                   (type != Exiv2::unsignedShort && type != Exiv2::unsignedLong))  // can be short or long!
           ) {
-            std::cerr << i->key() << " type " << i->typeName() << " (" << type << ")"
+            std::cerr << i.key() << " type " << i.typeName() << " (" << type << ")"
                       << " expected " << Exiv2::TypeInfo::typeName(tagInfo->typeId_) << " (" << tagInfo->typeId_ << ")"
                       << '\n';
             rc = 2;

--- a/samples/exifvalue.cpp
+++ b/samples/exifvalue.cpp
@@ -22,17 +22,17 @@ int main(int argc, char* const argv[]) {
   Exiv2::ExifData& exifData = image->exifData();
 
   if (exifData.empty()) {
-    std::cerr << "no metadata found in file " << file << std::endl;
+    std::cerr << "no metadata found in file " << file << '\n';
     return EXIT_FAILURE;
   }
 
   try {
-    std::cout << exifData[key] << std::endl;
+    std::cout << exifData[key] << '\n';
   } catch (Exiv2::Error& e) {
-    std::cerr << "Caught Exiv2 exception '" << e << "'" << std::endl;
+    std::cerr << "Caught Exiv2 exception '" << e << "'" << '\n';
     return EXIT_FAILURE;
   } catch (...) {
-    std::cerr << "Caught a cold!" << std::endl;
+    std::cerr << "Caught a cold!" << '\n';
     return EXIT_FAILURE;
   }
 

--- a/samples/getopt-test.cpp
+++ b/samples/getopt-test.cpp
@@ -51,21 +51,21 @@ class Params : public Util::Getopt {
   int getopt(int argc, char** const argv) {
     int rc = Util::Getopt::getopt(argc, argv, ::optstring);
     std::cout << "Params::getopt()"
-              << " rc = " << rc << std::endl;
+              << " rc = " << rc << '\n';
     return rc;
   }
 
   //! Handle options and their arguments.
   int option(int opt, const std::string& optarg, int optopt) override {
     std::cout << "Params::option()"
-              << " opt = " << opt << " optarg = " << optarg << " optopt = " << optopt << std::endl;
+              << " opt = " << opt << " optarg = " << optarg << " optopt = " << optopt << '\n';
     return 0;
   }
 
   //! Handle non-option parameters.
   int nonoption(const std::string& argv) override {
     std::cout << "Params::nonoption()"
-              << " " << argv << std::endl;
+              << " " << argv << '\n';
     return 0;
   }
 };  // class Params
@@ -77,7 +77,7 @@ int main(int argc, char** const argv) {
   int n;
 
 #if __has_include(<unistd.h>)
-  std::cout << "standard getopt()" << std::endl;
+  std::cout << "standard getopt()" << '\n';
   do {
     n = ::getopt(argc, argv, ::optstring);
     if (n >= 0) {
@@ -87,12 +87,12 @@ int main(int argc, char** const argv) {
       std::cout << n;
     }
     std::cout << " optind = " << ::optind << " opterr = " << ::opterr << " optopt = " << ::optopt
-              << " optarg = " << Safe(::optarg) << std::endl;
+              << " optarg = " << Safe(::optarg) << '\n';
   } while (n >= 0);
-  std::cout << std::endl;
+  std::cout << '\n';
 #endif
 
-  std::cout << "homemade getopt()" << std::endl;
+  std::cout << "homemade getopt()" << '\n';
   do {
     n = Util::getopt(argc, argv, ::optstring);
     if (n >= 0) {
@@ -102,10 +102,10 @@ int main(int argc, char** const argv) {
       std::cout << n;
     }
     std::cout << " optind = " << Util::optind << " opterr = " << Util::opterr << " optopt = " << Util::optopt
-              << " optarg = " << Safe(Util::optarg) << std::endl;
+              << " optarg = " << Safe(Util::optarg) << '\n';
 
   } while (n >= 0);
-  std::cout << std::endl;
+  std::cout << '\n';
 
   // Handle command line arguments
   Params params;

--- a/samples/ini-test.cpp
+++ b/samples/ini-test.cpp
@@ -21,17 +21,17 @@ int main() {
   INIReader reader(ini);
 
   if (reader.ParseError() < 0) {
-    std::cerr << "Can't load '" << ini << "'" << std::endl;
+    std::cerr << "Can't load '" << ini << "'" << '\n';
     return EXIT_FAILURE;
   }
   std::cout << "Config loaded from : '" << ini << "' "
             << "version=" << reader.GetInteger("protocol", "version", -1)
             << ", name=" << reader.Get("user", "name", "UNKNOWN")
             << ", email=" << reader.Get("user", "email", "UNKNOWN") << ", pi=" << reader.GetReal("user", "pi", -1)
-            << ", active=" << reader.GetBoolean("user", "active", true) << std::endl;
+            << ", active=" << reader.GetBoolean("user", "active", true) << '\n';
 
   std::cout << "169=" << reader.Get("canon", "169", "UNDEFINED") << ", 170=" << reader.Get("canon", "170", "UNDEFINED")
-            << std::endl;
+            << '\n';
 
   return EXIT_SUCCESS;
 }

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -24,12 +24,11 @@ int main(int argc, char* const argv[]) try {
     throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, error);
   }
 
-  auto end = iptcData.end();
-  for (auto md = iptcData.begin(); md != end; ++md) {
-    std::cout << std::setw(44) << std::setfill(' ') << std::left << md->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << md->tag() << " " << std::setw(9)
-              << std::setfill(' ') << std::left << md->typeName() << " " << std::dec << std::setw(3)
-              << std::setfill(' ') << std::right << md->count() << "  " << std::dec << md->value() << '\n';
+  for (const auto& md : iptcData) {
+    std::cout << std::setw(44) << std::setfill(' ') << std::left << md.key() << " "
+              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << md.tag() << " " << std::setw(9)
+              << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ')
+              << std::right << md.count() << "  " << std::dec << md.value() << '\n';
   }
 
   return EXIT_SUCCESS;

--- a/samples/iptcprint.cpp
+++ b/samples/iptcprint.cpp
@@ -29,7 +29,7 @@ int main(int argc, char* const argv[]) try {
     std::cout << std::setw(44) << std::setfill(' ') << std::left << md->key() << " "
               << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << md->tag() << " " << std::setw(9)
               << std::setfill(' ') << std::left << md->typeName() << " " << std::dec << std::setw(3)
-              << std::setfill(' ') << std::right << md->count() << "  " << std::dec << md->value() << std::endl;
+              << std::setfill(' ') << std::right << md->count() << "  " << std::dec << md->value() << '\n';
   }
 
   return EXIT_SUCCESS;

--- a/samples/key-test.cpp
+++ b/samples/key-test.cpp
@@ -21,43 +21,43 @@ int main() {
   std::ostringstream os;
   os << ek;
   if (os.str() != key) {
-    std::cout << "Testcase failed (operator<<)" << std::endl;
+    std::cout << "Testcase failed (operator<<)" << '\n';
     rc += 1;
   }
   // familyName
   tc += 1;
   if (std::string(ek.familyName()) != "Exif") {
-    std::cout << "Testcase failed (familyName)" << std::endl;
+    std::cout << "Testcase failed (familyName)" << '\n';
     rc += 1;
   }
   // groupName
   tc += 1;
   if (ek.groupName() != "Iop") {
-    std::cout << "Testcase failed (groupName)" << std::endl;
+    std::cout << "Testcase failed (groupName)" << '\n';
     rc += 1;
   }
   // tagName
   tc += 1;
   if (ek.tagName() != "InteroperabilityVersion") {
-    std::cout << "Testcase failed (tagName)" << std::endl;
+    std::cout << "Testcase failed (tagName)" << '\n';
     rc += 1;
   }
   // tagName
   tc += 1;
   if (ek.tag() != 0x0002) {
-    std::cout << "Testcase failed (tag)" << std::endl;
+    std::cout << "Testcase failed (tag)" << '\n';
     rc += 1;
   }
   // ifdName
   tc += 1;
   if (std::string(ExifTags::ifdName(ek.groupName())) != "Iop") {
-    std::cout << "Testcase failed (ifdName: " << std::endl;
+    std::cout << "Testcase failed (ifdName: " << '\n';
     rc += 1;
   }
   // sectionName
   tc += 1;
   if (strcmp(ExifTags::sectionName(ek), "Interoperability") != 0) {
-    std::cout << "Testcase failed (sectionName)" << std::endl;
+    std::cout << "Testcase failed (sectionName)" << '\n';
     rc += 1;
   }
 
@@ -71,43 +71,43 @@ int main() {
   std::ostringstream os2;
   os2 << ek2;
   if (os2.str() != key) {
-    std::cout << "Testcase failed (operator<<)" << std::endl;
+    std::cout << "Testcase failed (operator<<)" << '\n';
     rc += 1;
   }
   // familyName
   tc += 1;
   if (std::string(ek2.familyName()) != "Exif") {
-    std::cout << "Testcase failed (familyName)" << std::endl;
+    std::cout << "Testcase failed (familyName)" << '\n';
     rc += 1;
   }
   // groupName
   tc += 1;
   if (ek2.groupName() != "Iop") {
-    std::cout << "Testcase failed (groupName)" << std::endl;
+    std::cout << "Testcase failed (groupName)" << '\n';
     rc += 1;
   }
   // tagName
   tc += 1;
   if (ek2.tagName() != "InteroperabilityVersion") {
-    std::cout << "Testcase failed (tagName)" << std::endl;
+    std::cout << "Testcase failed (tagName)" << '\n';
     rc += 1;
   }
   // tagName
   tc += 1;
   if (ek2.tag() != 0x0002) {
-    std::cout << "Testcase failed (tag)" << std::endl;
+    std::cout << "Testcase failed (tag)" << '\n';
     rc += 1;
   }
   // ifdName
   tc += 1;
   if (std::string(ExifTags::ifdName(ek2.groupName())) != "Iop") {
-    std::cout << "Testcase failed (ifdName: " << std::endl;
+    std::cout << "Testcase failed (ifdName: " << '\n';
     rc += 1;
   }
   // sectionName
   tc += 1;
   if (strcmp(ExifTags::sectionName(ek2), "Interoperability") != 0) {
-    std::cout << "Testcase failed (sectionName)" << std::endl;
+    std::cout << "Testcase failed (sectionName)" << '\n';
     rc += 1;
   }
 
@@ -116,12 +116,12 @@ int main() {
   ExifKey ek4("Exif.Image.0x0110");
   tc += 1;
   if (ek4.key() != "Exif.Image.Model") {
-    std::cout << "Testcase failed (converted key)" << std::endl;
+    std::cout << "Testcase failed (converted key)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ek4.tagName() != "Model") {
-    std::cout << "Testcase failed (converted tagName)" << std::endl;
+    std::cout << "Testcase failed (converted tagName)" << '\n';
     rc += 1;
   }
 
@@ -130,12 +130,12 @@ int main() {
   ExifKey ek5("Exif.Nikon3.0x0007");
   tc += 1;
   if (ek5.key() != "Exif.Nikon3.Focus") {
-    std::cout << "Testcase failed (converted key)" << std::endl;
+    std::cout << "Testcase failed (converted key)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ek5.tagName() != "Focus") {
-    std::cout << "Testcase failed (converted tagName)" << std::endl;
+    std::cout << "Testcase failed (converted tagName)" << '\n';
     rc += 1;
   }
 
@@ -144,17 +144,17 @@ int main() {
   IptcKey ik1("Iptc.Envelope.0x0005");
   tc += 1;
   if (ik1.key() != "Iptc.Envelope.Destination") {
-    std::cout << "Testcase failed (converted Iptc key)" << std::endl;
+    std::cout << "Testcase failed (converted Iptc key)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ik1.tagName() != "Destination") {
-    std::cout << "Testcase failed (converted tagName)" << std::endl;
+    std::cout << "Testcase failed (converted tagName)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ik1.recordName() != "Envelope") {
-    std::cout << "Testcase failed (converted recordName)" << std::endl;
+    std::cout << "Testcase failed (converted recordName)" << '\n';
     rc += 1;
   }
 
@@ -163,25 +163,25 @@ int main() {
   IptcKey ik2(0xabcd, 0x1234);
   tc += 1;
   if (ik2.key() != "Iptc.0x1234.0xabcd") {
-    std::cout << "Testcase failed (unknown Iptc key)" << std::endl;
+    std::cout << "Testcase failed (unknown Iptc key)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ik2.tagName() != "0xabcd") {
-    std::cout << "Testcase failed (converted tagName)" << std::endl;
+    std::cout << "Testcase failed (converted tagName)" << '\n';
     rc += 1;
   }
   tc += 1;
   if (ik2.recordName() != "0x1234") {
-    std::cout << "Testcase failed (converted recordName)" << std::endl;
+    std::cout << "Testcase failed (converted recordName)" << '\n';
     rc += 1;
   }
 
   // -----
 
   if (rc == 0) {
-    std::cout << "All " << tc << " testcases passed." << std::endl;
+    std::cout << "All " << tc << " testcases passed." << '\n';
   } else {
-    std::cout << rc << " of " << tc << " testcases failed." << std::endl;
+    std::cout << rc << " of " << tc << " testcases failed." << '\n';
   }
 }

--- a/samples/prevtest.cpp
+++ b/samples/prevtest.cpp
@@ -19,8 +19,7 @@ int main(int argc, char* const argv[]) try {
   image->readMetadata();
 
   Exiv2::PreviewManager loader(*image);
-  Exiv2::PreviewPropertiesList list = loader.getPreviewProperties();
-  for (auto&& pos : list) {
+  for (const auto& pos : loader.getPreviewProperties()) {
     std::cout << pos.mimeType_ << " preview, type " << pos.id_ << ", " << pos.size_ << " bytes, " << pos.width_ << 'x'
               << pos.height_ << " pixels"
               << "\n";

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -56,14 +56,12 @@ int main(int argc, char* const argv[]) {
       error += ": No Exif data found in the file";
       throw Exiv2::Error(Exiv2::ErrorCode::kerErrorMessage, error);
     }
-    auto end = exifReadData.end();
-    for (auto i = exifReadData.begin(); i != end; ++i) {
-      const char* tn = i->typeName();
-      std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
-                << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " "
-                << std::setw(9) << std::setfill(' ') << std::left << (tn ? tn : "Unknown") << " " << std::dec
-                << std::setw(3) << std::setfill(' ') << std::right << i->count() << "  " << std::dec << i->value()
-                << "\n";
+    for (const auto& i : exifReadData) {
+      const char* tn = i.typeName();
+      std::cout << std::setw(44) << std::setfill(' ') << std::left << i.key() << " "
+                << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " " << std::setw(9)
+                << std::setfill(' ') << std::left << (tn ? tn : "Unknown") << " " << std::dec << std::setw(3)
+                << std::setfill(' ') << std::right << i.count() << "  " << std::dec << i.value() << "\n";
     }
 
     // del, reset the metadata

--- a/samples/stringto-test.cpp
+++ b/samples/stringto-test.cpp
@@ -47,7 +47,7 @@ int main() {
   std::cout << std::setw(12) << std::left << "float";
   std::cout << std::setw(12) << std::left << "Rational";
 
-  std::cout << std::endl;
+  std::cout << '\n';
 
   for (auto&& testcase : testcases) {
     try {
@@ -75,7 +75,7 @@ int main() {
       else
         std::cout << "nok";
 
-      std::cout << std::endl;
+      std::cout << '\n';
     } catch (Exiv2::Error& e) {
       std::cout << "Caught Exiv2 exception '" << e << "'\n";
       return EXIT_FAILURE;

--- a/samples/taglist.cpp
+++ b/samples/taglist.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
           const GroupInfo* groupList = ExifTags::groupList();
           if (groupList) {
             while (groupList->tagList_) {
-              std::cout << groupList->groupName_ << std::endl;
+              std::cout << groupList->groupName_ << '\n';
               groupList++;
             }
           }
@@ -45,7 +45,7 @@ int main(int argc, char* argv[]) {
               std::istringstream input(tags.str());
               while (std::getline(input, line)) {
                 std::cout << groupList->groupName_ << "." << (item == "all" ? line.substr(0, line.find(',')) : line)
-                          << std::endl;
+                          << '\n';
               }
               groupList++;
             }
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
         } catch (const Error&) {
           rc = 2;
         }
-        std::cerr << "Unexpected argument " << argv[1] << std::endl;
+        std::cerr << "Unexpected argument " << argv[1] << '\n';
 
         break;
       }
@@ -92,14 +92,14 @@ int main(int argc, char* argv[]) {
             ExifTags::taglist(std::cout, name);
             rc = EXIT_SUCCESS;  // result is good
           } else {
-            std::cerr << "warning:" << name << " is not a valid Exif group name " << std::endl;
+            std::cerr << "warning:" << name << " is not a valid Exif group name " << '\n';
             const GroupInfo* groupList = ExifTags::groupList();
             if (groupList) {
               while (rc && groupList->tagList_) {
                 if (name == groupList->groupName_) {
                   const Exiv2::TagInfo* tagInfo = groupList->tagList_();
                   while (tagInfo->tag_ != 0xFFFF) {
-                    std::cout << tagInfo->name_ << std::endl;
+                    std::cout << tagInfo->name_ << '\n';
                     tagInfo++;
                   }
                   rc = EXIT_SUCCESS;  // result is good
@@ -117,16 +117,16 @@ int main(int argc, char* argv[]) {
     }
 
     if (rc || bHelp) {
-      std::cout << "Usage: taglist [--help]" << std::endl
-                << "           [--group name|" << std::endl
+      std::cout << "Usage: taglist [--help]" << '\n'
+                << "           [--group name|" << '\n'
                 << "            "
                    "Groups|Exif|Canon|CanonCs|CanonSi|CanonCf|CanonHdr|Fujifilm|Minolta|Nikon1|Nikon2|Nikon3|Olympus|"
-                << std::endl
-                << "            Panasonic|Pentax|Sigma|Sony|Iptc|" << std::endl
+                << '\n'
+                << "            Panasonic|Pentax|Sigma|Sony|Iptc|" << '\n'
                 << "            dc|xmp|xmpRights|xmpMM|xmpBJ|xmpTPg|xmpDM|pdf|photoshop|crs|tiff|exif|aux|iptc|all|ALL"
-                << std::endl
-                << "           ]" << std::endl
-                << "Print Exif tags, MakerNote tags, or Iptc datasets" << std::endl;
+                << '\n'
+                << "           ]" << '\n'
+                << "Print Exif tags, MakerNote tags, or Iptc datasets" << '\n';
     }
   } catch (Error& e) {
     std::cout << "Caught Exiv2 exception '" << e << "'\n";

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -87,11 +87,10 @@ void print(const ExifData& exifData) {
     std::string error("No Exif data found in the file");
     throw Exiv2::Error(ErrorCode::kerErrorMessage, error);
   }
-  auto end = exifData.end();
-  for (auto i = exifData.begin(); i != end; ++i) {
-    std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " " << std::setw(9)
-              << std::setfill(' ') << std::left << i->typeName() << " " << std::dec << std::setw(3) << std::setfill(' ')
-              << std::right << i->count() << "  " << std::dec << i->value() << "\n";
+  for (const auto& i : exifData) {
+    std::cout << std::setw(44) << std::setfill(' ') << std::left << i.key() << " "
+              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " " << std::setw(9)
+              << std::setfill(' ') << std::left << i.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ')
+              << std::right << i.count() << "  " << std::dec << i.value() << "\n";
   }
 }

--- a/samples/write-test.cpp
+++ b/samples/write-test.cpp
@@ -153,11 +153,10 @@ void testCase(const std::string& file1, const std::string& file2, const std::str
 // *****************************************************************************
 
 void exifPrint(const ExifData& exifData) {
-  auto i = exifData.begin();
-  for (; i != exifData.end(); ++i) {
-    std::cout << std::setw(44) << std::setfill(' ') << std::left << i->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " " << std::setw(9)
-              << std::setfill(' ') << std::left << i->typeName() << " " << std::dec << std::setw(3) << std::setfill(' ')
-              << std::right << i->count() << "  " << std::dec << i->value() << "\n";
+  for (const auto& i : exifData) {
+    std::cout << std::setw(44) << std::setfill(' ') << std::left << i.key() << " "
+              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " " << std::setw(9)
+              << std::setfill(' ') << std::left << i.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ')
+              << std::right << i.count() << "  " << std::dec << i.value() << "\n";
   }
 }

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -201,13 +201,11 @@ void print(const std::string& file) {
   auto image = Exiv2::ImageFactory::open(file);
   image->readMetadata();
 
-  Exiv2::ExifData& ed = image->exifData();
-  auto end = ed.end();
-  for (auto i = ed.begin(); i != end; ++i) {
-    std::cout << std::setw(45) << std::setfill(' ') << std::left << i->key() << " "
-              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i->tag() << " " << std::setw(12)
-              << std::setfill(' ') << std::left << i->ifdName() << " " << std::setw(9) << std::setfill(' ') << std::left
-              << i->typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right << i->count()
-              << " " << std::dec << i->value() << "\n";
+  for (const auto& i : image->exifData()) {
+    std::cout << std::setw(45) << std::setfill(' ') << std::left << i.key() << " "
+              << "0x" << std::setw(4) << std::setfill('0') << std::right << std::hex << i.tag() << " " << std::setw(12)
+              << std::setfill(' ') << std::left << i.ifdName() << " " << std::setw(9) << std::setfill(' ') << std::left
+              << i.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right << i.count() << " "
+              << std::dec << i.value() << "\n";
   }
 }

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* const argv[]) try {
   for (auto&& md : xmpData) {
     std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9) << std::setfill(' ')
               << std::left << md.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right
-              << md.count() << "  " << std::dec << md.toString() << std::endl;
+              << md.count() << "  " << std::dec << md.toString() << '\n';
   }
   Exiv2::XmpParser::terminate();
   return EXIT_SUCCESS;

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* const argv[]) try {
   for (auto&& md : xmpData) {
     std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9) << std::setfill(' ')
               << std::left << md.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right
-              << md.count() << "  " << std::dec << md.toString() << std::endl;
+              << md.count() << "  " << std::dec << md.toString() << '\n';
   }
   filename += "-new";
   std::cerr << "-----> Encoding XMP data to write to " << filename << " <-----\n";

--- a/samples/xmpprint.cpp
+++ b/samples/xmpprint.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
     for (auto&& md : xmpData) {
       std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9)
                 << std::setfill(' ') << std::left << md.typeName() << " " << std::dec << std::setw(3)
-                << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.toString() << std::endl;
+                << std::setfill(' ') << std::right << md.count() << "  " << std::dec << md.toString() << '\n';
     }
 
     Exiv2::XmpParser::terminate();

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -185,7 +185,7 @@ int main() try {
   for (auto&& md : xmpData) {
     std::cout << std::setfill(' ') << std::left << std::setw(44) << md.key() << " " << std::setw(9) << std::setfill(' ')
               << std::left << md.typeName() << " " << std::dec << std::setw(3) << std::setfill(' ') << std::right
-              << md.count() << "  " << std::dec << md.value() << std::endl;
+              << md.count() << "  " << std::dec << md.value() << '\n';
   }
 
   // -------------------------------------------------------------------------

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -248,7 +248,7 @@ void AsfVideo::decodeBlock() {
   HeaderReader objectHeader(io_);
 #ifdef EXIV2_DEBUG_MESSAGES
   EXV_INFO << "decodeBlock = " << GUIDTag(objectHeader.getId().data()).to_string()
-           << "\tsize= " << objectHeader.getSize() << "\t " << io_->tell() << "/" << io_->size() << std::endl;
+           << "\tsize= " << objectHeader.getSize() << "\t " << io_->tell() << "/" << io_->size() << '\n';
 #endif
   Internal::enforce(objectHeader.getSize() <= io_->size() - io_->tell(), Exiv2::ErrorCode::kerCorruptedMetadata);
   auto tag = GUIDReferenceTags.find(GUIDTag(objectHeader.getId().data()));

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1129,7 +1129,7 @@ int RemoteIo::close() {
     p_->idx_ = 0;
   }
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cerr << "RemoteIo::close totalRead_ = " << p_->totalRead_ << std::endl;
+  std::cerr << "RemoteIo::close totalRead_ = " << p_->totalRead_ << '\n';
 #endif
   if (bigBlock_) {
     delete[] bigBlock_;
@@ -1322,7 +1322,7 @@ byte* RemoteIo::mmap(bool /*isWriteable*/) {
       }
     }
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cerr << "RemoteIo::mmap nRealData = " << nRealData << std::endl;
+    std::cerr << "RemoteIo::mmap nRealData = " << nRealData << '\n';
 #endif
   }
 

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -295,7 +295,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
   const auto buffer_size = box_length - hdrsize;
   if (skipBox(box_type)) {
     if (bTrace) {
-      out << std::endl;
+      out << '\n';
     }
     // The enforce() above checks that restore + buffer_size won't
     // exceed pbox_end, and by implication, won't exceed LONG_MAX
@@ -332,7 +332,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     // 8.11.6.1
     case TAG_iinf: {
       if (bTrace) {
-        out << std::endl;
+        out << '\n';
         bLF = false;
       }
 
@@ -376,7 +376,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     case TAG_ipco:
     case TAG_meta: {
       if (bTrace) {
-        out << std::endl;
+        out << '\n';
         bLF = false;
       }
       io_->seek(skip, BasicIo::cur);
@@ -388,14 +388,14 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
         if (ilocs_.find(exifID_) != ilocs_.end()) {
           const Iloc& iloc = ilocs_.find(exifID_)->second;
           if (bTrace) {
-            out << Internal::indent(depth) << "Exiv2::BMFF Exif: " << iloc.toString() << std::endl;
+            out << Internal::indent(depth) << "Exiv2::BMFF Exif: " << iloc.toString() << '\n';
           }
           parseTiff(Internal::Tag::root, iloc.length_, iloc.start_);
         }
         if (ilocs_.find(xmpID_) != ilocs_.end()) {
           const Iloc& iloc = ilocs_.find(xmpID_)->second;
           if (bTrace) {
-            out << Internal::indent(depth) << "Exiv2::BMFF XMP: " << iloc.toString() << std::endl;
+            out << Internal::indent(depth) << "Exiv2::BMFF XMP: " << iloc.toString() << '\n';
           }
           parseXmp(iloc.length_, iloc.start_);
         }
@@ -424,7 +424,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       if (itemCount && itemCount < box_length / 14 && offsetSize == 4 && lengthSize == 4 &&
           ((box_length - 16) % itemCount) == 0) {
         if (bTrace) {
-          out << std::endl;
+          out << '\n';
           bLF = false;
         }
         auto step = (static_cast<size_t>(box_length) - 16) / itemCount;  // length of data per item.
@@ -446,7 +446,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
           if (bTrace) {
             out << Internal::indent(depth)
                 << Internal::stringFormat("%8zd | %8zd |   ID | %4u | %6u,%6u", address + skip, step, ID, offset, ldata)
-                << std::endl;
+                << '\n';
           }
           // save data for post-processing in meta box
           if (offset && ldata && ID != unknownID_) {
@@ -500,7 +500,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       io_->read(uuid.data(), uuid.size());
       std::string name = uuidName(uuid);
       if (bTrace) {
-        out << " uuidName " << name << std::endl;
+        out << " uuidName " << name << '\n';
         bLF = false;
       }
       if (name == "cano" || name == "canp") {
@@ -585,7 +585,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       break; /* do nothing */
   }
   if (bLF && bTrace)
-    out << std::endl;
+    out << '\n';
 
   // return address of next box
   return box_end;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -353,7 +353,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
 
     if (bFirst && bPrint) {
       out << Internal::indent(depth) << Internal::stringFormat("STRUCTURE OF TIFF FILE (%c%c): ", c, c) << io.path()
-          << std::endl;
+          << '\n';
     }
 
     // Read the dictionary
@@ -377,7 +377,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
 
       // Break for unknown tag types else we may segfault.
       if (!typeValid(type)) {
-        EXV_ERROR << "invalid type in tiff structure" << type << std::endl;
+        EXV_ERROR << "invalid type in tiff structure" << type << '\n';
         throw Error(ErrorCode::kerInvalidTypeValue);
       }
 
@@ -465,7 +465,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
         }
 
         sp = kount == count ? "" : " ...";
-        out << sp << std::endl;
+        out << sp << '\n';
 
         if (option == kpsRecursive && (tag == 0x8769 /* ExifTag */ || tag == 0x014a /*SubIFDs*/ || type == tiffIfd)) {
           for (size_t k = 0; k < count; k++) {
@@ -533,7 +533,7 @@ void Image::printIFDStructure(BasicIo& io, std::ostream& out, Exiv2::PrintStruct
   } while (start);
 
   if (bPrint) {
-    out << Internal::indent(depth) << "END " << io.path() << std::endl;
+    out << Internal::indent(depth) << "END " << io.path() << '\n';
   }
   out.flush();
 }

--- a/src/iptc.cpp
+++ b/src/iptc.cpp
@@ -282,7 +282,7 @@ void IptcData::printStructure(std::ostream& out, const Slice<byte*>& bytes, size
   size_t i = 0;
   while (i < bytes.size() - 3 && bytes.at(i) != 0x1c)
     i++;
-  out << Internal::indent(++depth) << "Record | DataSet | Name                     | Length | Data" << std::endl;
+  out << Internal::indent(++depth) << "Record | DataSet | Name                     | Length | Data" << '\n';
   while (i < bytes.size() - 3) {
     if (bytes.at(i) != 0x1c) {
       break;
@@ -297,7 +297,7 @@ void IptcData::printStructure(std::ostream& out, const Slice<byte*>& bytes, size
 
     Internal::enforce(bytes.size() - i >= 5 + static_cast<size_t>(len), ErrorCode::kerCorruptedMetadata);
     out << buff << Internal::binaryToString(makeSlice(bytes, i + 5, i + 5 + (len > 40 ? 40 : len)))
-        << (len > 40 ? "..." : "") << std::endl;
+        << (len > 40 ? "..." : "") << '\n';
     i += 5 + len;
   }
 }

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -66,7 +66,7 @@ const size_t boxHSize = sizeof(Internal::Jp2BoxHeader);
 
 void lf(std::ostream& out, bool& bLF) {
   if (bLF) {
-    out << std::endl;
+    out << '\n';
     out.flush();
     bLF = false;
   }
@@ -75,7 +75,7 @@ void lf(std::ostream& out, bool& bLF) {
 void boxes_check(size_t b, size_t m) {
   if (b > m) {
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cout << "Exiv2::Jp2Image::readMetadata box maximum exceeded" << std::endl;
+    std::cout << "Exiv2::Jp2Image::readMetadata box maximum exceeded" << '\n';
 #endif
     throw Error(ErrorCode::kerCorruptedMetadata);
   }
@@ -86,12 +86,12 @@ void boxes_check(size_t b, size_t m) {
 Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create) : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, std::move(io)) {
   if (create && io_->open() == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cerr << "Exiv2::Jp2Image:: Creating JPEG2000 image to memory" << std::endl;
+    std::cerr << "Exiv2::Jp2Image:: Creating JPEG2000 image to memory" << '\n';
 #endif
     IoCloser closer(*io_);
     if (io_->write(Jp2Blank.data(), Jp2Blank.size()) != Jp2Blank.size()) {
 #ifdef EXIV2_DEBUG_MESSAGES
-      std::cerr << "Exiv2::Jp2Image:: Failed to create JPEG2000 image on memory" << std::endl;
+      std::cerr << "Exiv2::Jp2Image:: Failed to create JPEG2000 image on memory" << '\n';
 #endif
     }
   }
@@ -119,7 +119,7 @@ void Jp2Image::setComment(const std::string&) {
 
 void Jp2Image::readMetadata() {
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cerr << "Exiv2::Jp2Image::readMetadata: Reading JPEG-2000 file " << io_->path() << std::endl;
+  std::cerr << "Exiv2::Jp2Image::readMetadata: Reading JPEG-2000 file " << io_->path() << '\n';
 #endif
   if (io_->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
@@ -145,9 +145,8 @@ void Jp2Image::readMetadata() {
     box.length = getULong(reinterpret_cast<byte*>(&box.length), bigEndian);
     box.type = getULong(reinterpret_cast<byte*>(&box.type), bigEndian);
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cout << "Exiv2::Jp2Image::readMetadata: "
-              << "Position: " << position << " box type: " << toAscii(box.type) << " length: " << box.length
-              << std::endl;
+    std::cout << "Exiv2::Jp2Image::readMetadata: Position: " << position << " box type: " << toAscii(box.type)
+              << " length: " << box.length << '\n';
 #endif
     Internal::enforce(box.length <= boxHSize + io_->size() - io_->tell(), ErrorCode::kerCorruptedMetadata);
 
@@ -180,7 +179,7 @@ void Jp2Image::readMetadata() {
       }
       case kJp2BoxTypeHeader: {
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Exiv2::Jp2Image::readMetadata: JP2Header box found" << std::endl;
+        std::cout << "Exiv2::Jp2Image::readMetadata: JP2Header box found\n";
 #endif
         size_t restore = io_->tell();
 
@@ -193,12 +192,12 @@ void Jp2Image::readMetadata() {
           }
 #ifdef EXIV2_DEBUG_MESSAGES
           std::cout << "Exiv2::Jp2Image::readMetadata: "
-                    << "subBox = " << toAscii(subBox.type) << " length = " << subBox.length << std::endl;
+                    << "subBox = " << toAscii(subBox.type) << " length = " << subBox.length << '\n';
 #endif
           if (subBox.type == kJp2BoxTypeColorSpec && subBox.length != 15) {
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "Exiv2::Jp2Image::readMetadata: "
-                      << "Color data found" << std::endl;
+                      << "Color data found" << '\n';
 #endif
 
             const size_t pad = 3;  // 3 padding bytes 2 0 0
@@ -225,7 +224,7 @@ void Jp2Image::readMetadata() {
               fclose(f);
             }
             std::cout << "Exiv2::Jp2Image::readMetadata: wrote iccProfile " << icc.size() << " bytes to " << iccPath
-                      << std::endl;
+                      << '\n';
 #endif
             setIccProfile(std::move(icc));
           }
@@ -233,7 +232,7 @@ void Jp2Image::readMetadata() {
           if (subBox.type == kJp2BoxTypeImageHeader) {
             io_->read(reinterpret_cast<byte*>(&ihdr), sizeof(ihdr));
 #ifdef EXIV2_DEBUG_MESSAGES
-            std::cout << "Exiv2::Jp2Image::readMetadata: Ihdr data found" << std::endl;
+            std::cout << "Exiv2::Jp2Image::readMetadata: Ihdr data found" << '\n';
 #endif
             ihdr.imageHeight = getULong(reinterpret_cast<byte*>(&ihdr.imageHeight), bigEndian);
             ihdr.imageWidth = getULong(reinterpret_cast<byte*>(&ihdr.imageWidth), bigEndian);
@@ -255,7 +254,7 @@ void Jp2Image::readMetadata() {
 
       case kJp2BoxTypeUuid: {
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Exiv2::Jp2Image::readMetadata: UUID box found" << std::endl;
+        std::cout << "Exiv2::Jp2Image::readMetadata: UUID box found" << '\n';
 #endif
 
         if (io_->read(reinterpret_cast<byte*>(&uuid), sizeof(uuid)) == sizeof(uuid)) {
@@ -267,7 +266,7 @@ void Jp2Image::readMetadata() {
 
           if (bIsExif) {
 #ifdef EXIV2_DEBUG_MESSAGES
-            std::cout << "Exiv2::Jp2Image::readMetadata: Exif data found" << std::endl;
+            std::cout << "Exiv2::Jp2Image::readMetadata: Exif data found" << '\n';
 #endif
             Internal::enforce(box.length >= boxHSize + sizeof(uuid), ErrorCode::kerCorruptedMetadata);
             rawData.alloc(box.length - (boxHSize + sizeof(uuid)));
@@ -291,7 +290,7 @@ void Jp2Image::readMetadata() {
                 if (rawData.cmpBytes(i, exifHeader.data(), exifHeader.size()) == 0) {
                   pos = i + sizeof(exifHeader);
 #ifndef SUPPRESS_WARNINGS
-                  EXV_WARNING << "Reading non-standard UUID-EXIF_bad box in " << io_->path() << std::endl;
+                  EXV_WARNING << "Reading non-standard UUID-EXIF_bad box in " << io_->path() << '\n';
 #endif
                 }
               }
@@ -299,7 +298,7 @@ void Jp2Image::readMetadata() {
               // If found it, store only these data at from this place.
               if (pos != notfound) {
 #ifdef EXIV2_DEBUG_MESSAGES
-                std::cout << "Exiv2::Jp2Image::readMetadata: Exif header found at position " << pos << std::endl;
+                std::cout << "Exiv2::Jp2Image::readMetadata: Exif header found at position " << pos << '\n';
 #endif
                 ByteOrder bo =
                     TiffParser::decode(exifData(), iptcData(), xmpData(), rawData.c_data(pos), rawData.size() - pos);
@@ -307,7 +306,7 @@ void Jp2Image::readMetadata() {
               }
             } else {
 #ifndef SUPPRESS_WARNINGS
-              EXV_WARNING << "Failed to decode Exif metadata." << std::endl;
+              EXV_WARNING << "Failed to decode Exif metadata." << '\n';
 #endif
               exifData_.clear();
             }
@@ -315,7 +314,7 @@ void Jp2Image::readMetadata() {
 
           if (bIsIPTC) {
 #ifdef EXIV2_DEBUG_MESSAGES
-            std::cout << "Exiv2::Jp2Image::readMetadata: Iptc data found" << std::endl;
+            std::cout << "Exiv2::Jp2Image::readMetadata: Iptc data found" << '\n';
 #endif
             Internal::enforce(box.length >= boxHSize + sizeof(uuid), ErrorCode::kerCorruptedMetadata);
             rawData.alloc(box.length - (boxHSize + sizeof(uuid)));
@@ -327,7 +326,7 @@ void Jp2Image::readMetadata() {
 
             if (IptcParser::decode(iptcData_, rawData.c_data(), rawData.size())) {
 #ifndef SUPPRESS_WARNINGS
-              EXV_WARNING << "Failed to decode IPTC metadata." << std::endl;
+              EXV_WARNING << "Failed to decode IPTC metadata." << '\n';
 #endif
               iptcData_.clear();
             }
@@ -335,7 +334,7 @@ void Jp2Image::readMetadata() {
 
           if (bIsXMP) {
 #ifdef EXIV2_DEBUG_MESSAGES
-            std::cout << "Exiv2::Jp2Image::readMetadata: Xmp data found" << std::endl;
+            std::cout << "Exiv2::Jp2Image::readMetadata: Xmp data found" << '\n';
 #endif
             Internal::enforce(box.length >= boxHSize + sizeof(uuid), ErrorCode::kerCorruptedMetadata);
             rawData.alloc(box.length - (boxHSize + sizeof(uuid)));
@@ -349,14 +348,14 @@ void Jp2Image::readMetadata() {
             if (auto idx = xmpPacket_.find_first_of('<'); idx != std::string::npos && idx > 0) {
 #ifndef SUPPRESS_WARNINGS
               EXV_WARNING << "Removing " << static_cast<uint32_t>(idx)
-                          << " characters from the beginning of the XMP packet" << std::endl;
+                          << " characters from the beginning of the XMP packet" << '\n';
 #endif
               xmpPacket_ = xmpPacket_.substr(idx);
             }
 
             if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
-              EXV_WARNING << "Failed to decode XMP metadata." << std::endl;
+              EXV_WARNING << "Failed to decode XMP metadata." << '\n';
 #endif
             }
           }
@@ -396,8 +395,8 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
   bool boxSignatureFound = false;
 
   if (bPrint) {
-    out << "STRUCTURE OF JPEG2000 FILE: " << io_->path() << std::endl;
-    out << " address |   length | box       | data" << std::endl;
+    out << "STRUCTURE OF JPEG2000 FILE: " << io_->path() << '\n';
+    out << " address |   length | box       | data" << '\n';
   }
 
   if (bPrint || bXMP || bICC || bIPTCErase) {
@@ -603,7 +602,7 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
       subBox.type = getULong(boxBuf.c_data(count + 4), bigEndian);
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Jp2Image::encodeJp2Header subbox: " << toAscii(subBox.type) << " length = " << subBox.length
-                << std::endl;
+                << '\n';
 #endif
       Internal::enforce(subBox.length > 0, ErrorCode::kerCorruptedMetadata);
       Internal::enforce(subBox.length <= length - count, ErrorCode::kerCorruptedMetadata);
@@ -660,8 +659,8 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
     throw Error(ErrorCode::kerImageWriteFailed);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Exiv2::Jp2Image::doWriteMetadata: Writing JPEG-2000 file " << io_->path() << std::endl;
-  std::cout << "Exiv2::Jp2Image::doWriteMetadata: tmp file created " << outIo.path() << std::endl;
+  std::cout << "Exiv2::Jp2Image::doWriteMetadata: Writing JPEG-2000 file " << io_->path() << '\n';
+  std::cout << "Exiv2::Jp2Image::doWriteMetadata: tmp file created " << outIo.path() << '\n';
 #endif
 
   // Ensure that this is the correct image type
@@ -674,7 +673,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
     throw Error(ErrorCode::kerImageWriteFailed);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Jp2Image::doWriteMetadata: JPEG 2000 Signature box written" << std::endl;
+  std::cout << "Jp2Image::doWriteMetadata: JPEG 2000 Signature box written" << '\n';
 #endif
 
   Internal::Jp2BoxHeader box = {0, 0};
@@ -685,7 +684,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
   while (io_->tell() < io_->size()) {
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cout << "Exiv2::Jp2Image::doWriteMetadata: Position: " << io_->tell() << " / " << io_->size() << std::endl;
+    std::cout << "Exiv2::Jp2Image::doWriteMetadata: Position: " << io_->tell() << " / " << io_->size() << '\n';
 #endif
 
     // Read chunk header.
@@ -697,14 +696,14 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
     std::cout << "Exiv2::Jp2Image::doWriteMetadata: box type: " << toAscii(box.type) << " length: " << box.length
-              << std::endl;
+              << '\n';
 #endif
 
     if (box.length == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::Jp2Image::doWriteMetadata: Null Box size has been found. "
                    "This is the last box of file."
-                << std::endl;
+                << '\n';
 #endif
       box.length = static_cast<uint32_t>(io_->size() - io_->tell() + 8);
     }
@@ -727,8 +726,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
         DataBuf newBuf;
         encodeJp2Header(boxBuf, newBuf);
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write JP2Header box (length: " << box.length << ")"
-                  << std::endl;
+        std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write JP2Header box (length: " << box.length << ")\n";
 #endif
         if (outIo.write(newBuf.data(), newBuf.size()) != newBuf.size())
           throw Error(ErrorCode::kerImageWriteFailed);
@@ -754,7 +752,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with Exif metadata (length: " << boxData.size()
-                      << std::endl;
+                      << '\n';
 #endif
             if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size())
               throw Error(ErrorCode::kerImageWriteFailed);
@@ -776,7 +774,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with Iptc metadata (length: " << boxData.size()
-                      << std::endl;
+                      << '\n';
 #endif
             if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size())
               throw Error(ErrorCode::kerImageWriteFailed);
@@ -785,7 +783,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
         if (!writeXmpFromPacket() && XmpParser::encode(xmpPacket_, xmpData_) > 1) {
 #ifndef SUPPRESS_WARNINGS
-          EXV_ERROR << "Failed to encode XMP metadata." << std::endl;
+          EXV_ERROR << "Failed to encode XMP metadata." << '\n';
 #endif
         }
         if (!xmpPacket_.empty()) {
@@ -802,7 +800,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
           std::cout << "Exiv2::Jp2Image::doWriteMetadata: Write box with XMP metadata (length: " << boxData.size()
-                    << ")" << std::endl;
+                    << ")" << '\n';
 #endif
           if (outIo.write(boxData.c_data(), boxData.size()) != boxData.size())
             throw Error(ErrorCode::kerImageWriteFailed);
@@ -815,19 +813,19 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
         Internal::enforce(boxBuf.size() >= 24, ErrorCode::kerCorruptedMetadata);
         if (boxBuf.cmpBytes(8, kJp2UuidExif, 16) == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
-          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Exif Uuid box" << std::endl;
+          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Exif Uuid box" << '\n';
 #endif
         } else if (boxBuf.cmpBytes(8, kJp2UuidIptc, 16) == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
-          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Iptc Uuid box" << std::endl;
+          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Iptc Uuid box" << '\n';
 #endif
         } else if (boxBuf.cmpBytes(8, kJp2UuidXmp, 16) == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
-          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Xmp Uuid box" << std::endl;
+          std::cout << "Exiv2::Jp2Image::doWriteMetadata: strip Xmp Uuid box" << '\n';
 #endif
         } else {
 #ifdef EXIV2_DEBUG_MESSAGES
-          std::cout << "Exiv2::Jp2Image::doWriteMetadata: write Uuid box (length: " << box.length << ")" << std::endl;
+          std::cout << "Exiv2::Jp2Image::doWriteMetadata: write Uuid box (length: " << box.length << ")" << '\n';
 #endif
           if (outIo.write(boxBuf.c_data(), boxBuf.size()) != boxBuf.size())
             throw Error(ErrorCode::kerImageWriteFailed);
@@ -837,7 +835,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
       default: {
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Exiv2::Jp2Image::doWriteMetadata: write box (length: " << box.length << ")" << std::endl;
+        std::cout << "Exiv2::Jp2Image::doWriteMetadata: write box (length: " << box.length << ")" << '\n';
 #endif
         if (outIo.write(boxBuf.c_data(), boxBuf.size()) != boxBuf.size())
           throw Error(ErrorCode::kerImageWriteFailed);
@@ -848,7 +846,7 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
   }
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Exiv2::Jp2Image::doWriteMetadata: EOF" << std::endl;
+  std::cout << "Exiv2::Jp2Image::doWriteMetadata: EOF" << '\n';
 #endif
 
 }  // Jp2Image::doWriteMetadata

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -259,7 +259,7 @@ void JpegBase::readMetadata() {
       uint32_t s = buf.read_uint32(2 + 14, bigEndian);
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cerr << "Found ICC Profile chunk " << chunk << " of " << chunks << (chunk == 1 ? " size: " : "")
-                << (chunk == 1 ? s : 0) << std::endl;
+                << (chunk == 1 ? s : 0) << '\n';
 #endif
       // #1286 profile can be padded
       size_t icc_size = size - 2 - 14;
@@ -378,8 +378,8 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
     while (!done) {
       // print marker bytes
       if (first && bPrint) {
-        out << "STRUCTURE OF JPEG FILE: " << io_->path() << std::endl;
-        out << " address | marker       |  length | data" << std::endl;
+        out << "STRUCTURE OF JPEG FILE: " << io_->path() << '\n';
+        out << " address | marker       |  length | data" << '\n';
         REPORT_MARKER;
       }
       first = false;
@@ -445,7 +445,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
           if (size >= 16) {
             out.write(buf.c_str(16), size - 16);
 #ifdef EXIV2_DEBUG_MESSAGES
-            std::cout << "iccProfile size = " << size - 16 << std::endl;
+            std::cout << "iccProfile size = " << size - 16 << '\n';
 #endif
           }
         } else if (option == kpsIptcErase && signature == "Photoshop 3.0") {
@@ -482,7 +482,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
         bool bPS = option == kpsRecursive && signature == "Photoshop 3.0";
         if (bFlir || bExif || bMPF || bPS) {
           // extract Exif data block which is tiff formatted
-          out << std::endl;
+          out << '\n';
 
           //                        const byte* exif = buf.c_data();
           uint32_t start = signature == "Exif" ? 8 : 6;
@@ -514,8 +514,8 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
             }
 #ifdef EXIV2_DEBUG_MESSAGES
             if (start < max)
-              std::cout << "  FFF start = " << start << std::endl;
-              // << " index = " << pFFF->dwIndexOff << std::endl;
+              std::cout << "  FFF start = " << start << '\n';
+              // << " index = " << pFFF->dwIndexOff << '\n';
 #endif
           }
 
@@ -544,7 +544,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
       }
 
       if (bLF)
-        out << std::endl;
+        out << '\n';
 
       if (marker != sos_) {
         // Read the beginning of the next segment
@@ -553,7 +553,7 @@ void JpegBase::printStructure(std::ostream& out, PrintStructureOption option, si
       }
       done |= marker == eoi_ || marker == sos_;
       if (done && bPrint)
-        out << std::endl;
+        out << '\n';
     }
   }
   if (option == kpsIptcErase && !iptcDataSegs.empty()) {

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -52,7 +52,7 @@ void OrfImage::setComment(const std::string&) {
 }
 
 void OrfImage::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
-  out << "ORF IMAGE" << std::endl;
+  out << "ORF IMAGE" << '\n';
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   // Ensure that this is the correct image type

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -1089,7 +1089,7 @@ static std::ostream& resolveLens0x32c(std::ostream& os, const Value& value, cons
     long focalLength = getKeyLong("Exif.Photo.FocalLength", metadata);
     bool bFL10_20 = 10 <= focalLength && focalLength <= 20;
 
-    // std::cout << "model,focalLength = " << model << "," << focalLength << std::endl;
+    // std::cout << "model,focalLength = " << model << "," << focalLength << '\n';
     if (bFL10_20) {
       index = 1;
     }
@@ -1260,7 +1260,7 @@ static std::ostream& printLensType(std::ostream& os, const Value& value, const E
 
   const auto index = value.toUint32(0) * 256 + value.toUint32(1);
 
-  // std::cout << std::endl << "printLensType value =" << value.toLong() << " index = " << index << std::endl;
+  // std::cout << '\n' << "printLensType value =" << value.toLong() << " index = " << index << '\n';
   auto lif = Exiv2::find(lensIdFct, index);
   if (!lif)
     return EXV_PRINT_COMBITAG_MULTI(pentaxLensType, 2, 1, 2)(os, value, metadata);

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -54,7 +54,7 @@ void PngChunk::decodeTXTChunk(Image* pImage, const DataBuf& data, TxtChunkType t
   DataBuf arr = parseTXTChunk(data, key.size(), type);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk data: " << std::string(arr.c_str(), arr.size()) << std::endl;
+  std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk data: " << std::string(arr.c_str(), arr.size()) << '\n';
 #endif
   if (!key.empty())
     parseChunkContent(pImage, key.c_data(), key.size(), arr);
@@ -64,7 +64,7 @@ DataBuf PngChunk::decodeTXTChunk(const DataBuf& data, TxtChunkType type) {
   DataBuf key = keyTXTChunk(data);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk key: " << std::string(key.c_str(), key.size()) << std::endl;
+  std::cout << "Exiv2::PngChunk::decodeTXTChunk: TXT chunk key: " << std::string(key.c_str(), key.size()) << '\n';
 #endif
   return parseTXTChunk(data, key.size(), type);
 }

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -200,8 +200,8 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
 
     bool bPrint = option == kpsBasic || option == kpsRecursive;
     if (bPrint) {
-      out << "STRUCTURE OF PNG FILE: " << io_->path() << std::endl;
-      out << " address | chunk |  length | data                           | checksum" << std::endl;
+      out << "STRUCTURE OF PNG FILE: " << io_->path() << '\n';
+      out << " address | chunk |  length | data                           | checksum" << '\n';
     }
 
     const size_t imgSize = io_->size();
@@ -259,7 +259,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
         out << Internal::stringFormat("%8d | %-5s |%8d | ", static_cast<uint32_t>(address), chType, dataOffset)
             << dataString
             << Internal::stringFormat(" | 0x%02x%02x%02x%02x", checksum[0], checksum[1], checksum[2], checksum[3])
-            << std::endl;
+            << '\n';
       }
 
       // chunk type
@@ -323,7 +323,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
 #ifdef EXIV2_DEBUG_MESSAGES
             std::cerr << Exiv2::Internal::binaryToString(
                              makeSlice(parsedBuf.c_data(), parsedBuf.size() > 50 ? 50 : parsedBuf.size(), 0))
-                      << std::endl;
+                      << '\n';
 #endif
             if (!parsedBuf.empty()) {
               if (bExif) {
@@ -364,7 +364,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
           }
 
           if (bLF)
-            out << std::endl;
+            out << '\n';
         }
       }
       io_->seek(dataOffset + 4, BasicIo::cur);  // jump past checksum
@@ -376,7 +376,7 @@ void PngImage::printStructure(std::ostream& out, PrintStructureOption option, si
 
 static void readChunk(DataBuf& buffer, BasicIo& io) {
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Exiv2::PngImage::readMetadata: Position: " << io.tell() << std::endl;
+  std::cout << "Exiv2::PngImage::readMetadata: Position: " << io.tell() << '\n';
 #endif
   const size_t bufRead = io.read(buffer.data(), buffer.size());
   if (io.error()) {
@@ -389,7 +389,7 @@ static void readChunk(DataBuf& buffer, BasicIo& io) {
 
 void PngImage::readMetadata() {
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cerr << "Exiv2::PngImage::readMetadata: Reading PNG file " << io_->path() << std::endl;
+  std::cerr << "Exiv2::PngImage::readMetadata: Reading PNG file " << io_->path() << '\n';
 #endif
   if (io_->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
@@ -414,7 +414,7 @@ void PngImage::readMetadata() {
 
     std::string chunkType(cheaderBuf.c_str(4), 4);
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cout << "Exiv2::PngImage::readMetadata: chunk type: " << chunkType << " length: " << chunkLength << std::endl;
+    std::cout << "Exiv2::PngImage::readMetadata: chunk type: " << chunkType << " length: " << chunkLength << '\n';
 #endif
 
     /// \todo analyse remaining chunks of the standard
@@ -453,9 +453,8 @@ void PngImage::readMetadata() {
 
         zlibToDataBuf(chunkData.c_data(iccOffset), static_cast<uLongf>(chunkLength - iccOffset), iccProfile_);
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Exiv2::PngImage::readMetadata: profile name: " << profileName_ << std::endl;
-        std::cout << "Exiv2::PngImage::readMetadata: iccProfile.size_ (uncompressed) : " << iccProfile_.size()
-                  << std::endl;
+        std::cout << "Exiv2::PngImage::readMetadata: profile name: " << profileName_ << '\n';
+        std::cout << "Exiv2::PngImage::readMetadata: iccProfile.size_ (uncompressed) : " << iccProfile_.size() << '\n';
 #endif
       }
 
@@ -466,7 +465,7 @@ void PngImage::readMetadata() {
 
     // Move to the next chunk: chunk data size + 4 CRC bytes.
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cout << "Exiv2::PngImage::readMetadata: Seek to offset: " << chunkLength + 4 << std::endl;
+    std::cout << "Exiv2::PngImage::readMetadata: Seek to offset: " << chunkLength + 4 << '\n';
 #endif
     io_->seek(chunkLength + 4, BasicIo::cur);
     if (io_->error() || io_->eof()) {
@@ -551,7 +550,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
       // together with the ICC profile as fresh eXIf and iCCP chunks
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::PngImage::doWriteMetadata: strip " << szChunk << " chunk (length: " << dataOffset << ")"
-                << std::endl;
+                << '\n';
 #endif
     } else if (!strcmp(szChunk, "IHDR")) {
 #ifdef EXIV2_DEBUG_MESSAGES
@@ -590,7 +589,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
           }
 #ifdef EXIV2_DEBUG_MESSAGES
           std::cout << "Exiv2::PngImage::doWriteMetadata: build eXIf"
-                    << " chunk (length: " << blob.size() << ")" << std::endl;
+                    << " chunk (length: " << blob.size() << ")" << '\n';
 #endif
         }
       }
@@ -633,7 +632,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
           }
 #ifdef EXIV2_DEBUG_MESSAGES
           std::cout << "Exiv2::PngImage::doWriteMetadata: build iCCP"
-                    << " chunk (length: " << chunkLength << ")" << std::endl;
+                    << " chunk (length: " << chunkLength << ")" << '\n';
 #endif
         }
       }
@@ -657,12 +656,12 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
                            compare("XML:com.adobe.xmp", key) || compare("Description", key))) {
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngImage::doWriteMetadata: strip " << szChunk << " chunk (length: " << dataOffset << ")"
-                  << std::endl;
+                  << '\n';
 #endif
       } else {
 #ifdef EXIV2_DEBUG_MESSAGES
         std::cout << "Exiv2::PngImage::doWriteMetadata: write " << szChunk << " chunk (length: " << dataOffset << ")"
-                  << std::endl;
+                  << '\n';
 #endif
         if (outIo.write(chunkBuf.c_data(), chunkBuf.size()) != chunkBuf.size())
           throw Error(ErrorCode::kerImageWriteFailed);
@@ -671,7 +670,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
       // Write all others chunk as well.
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::PngImage::doWriteMetadata:  copy " << szChunk << " chunk (length: " << dataOffset << ")"
-                << std::endl;
+                << '\n';
 #endif
       if (outIo.write(chunkBuf.c_data(), chunkBuf.size()) != chunkBuf.size())
         throw Error(ErrorCode::kerImageWriteFailed);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -5247,7 +5247,7 @@ std::ostream& operator<<(std::ostream& os, const XmpPropertyInfo& property) {
       os << Q;
     os << c;
   }
-  os << Q << std::endl;
+  os << Q << '\n';
   return os;
 }
 //! @endcond

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -613,7 +613,7 @@ void QuickTimeVideo::decodeBlock(size_t recursion_depth, std::string const& ente
   enforce(size - hdrsize <= io_->size() - io_->tell(), Exiv2::ErrorCode::kerCorruptedMetadata);
   enforce(size - hdrsize <= std::numeric_limits<size_t>::max(), Exiv2::ErrorCode::kerCorruptedMetadata);
 
-  // std::cerr<<"Tag=>"<<buf.data()<<"     size=>"<<size-hdrsize << std::endl;
+  // std::cerr<<"Tag=>"<<buf.data()<<"     size=>"<<size-hdrsize << '\n';
   const auto newsize = static_cast<size_t>(size - hdrsize);
   if (newsize > buf.size()) {
     buf.resize(newsize);

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -84,8 +84,8 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     constexpr auto format = " %9zu | %9" PRIu32 " | ";
 
     {
-      out << Internal::indent(depth) << "STRUCTURE OF RAF FILE: " << io().path() << std::endl;
-      out << Internal::indent(depth) << "   Address |    Length | Payload" << std::endl;
+      out << Internal::indent(depth) << "STRUCTURE OF RAF FILE: " << io().path() << '\n';
+      out << Internal::indent(depth) << "   Address |    Length | Payload" << '\n';
     }
 
     byte magicdata[17];
@@ -93,7 +93,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     magicdata[16] = 0;
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 16U)  // 0
-          << "       magic : " << reinterpret_cast<char*>(magicdata) << std::endl;
+          << "       magic : " << reinterpret_cast<char*>(magicdata) << '\n';
     }
 
     address = io_->tell();
@@ -102,7 +102,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     data1[4] = 0;
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U)  // 16
-          << "       data1 : " << std::string(reinterpret_cast<char*>(&data1)) << std::endl;
+          << "       data1 : " << std::string(reinterpret_cast<char*>(&data1)) << '\n';
     }
 
     address = io_->tell();
@@ -111,7 +111,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     data2[8] = 0;
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 8U)  // 20
-          << "       data2 : " << std::string(reinterpret_cast<char*>(&data2)) << std::endl;
+          << "       data2 : " << std::string(reinterpret_cast<char*>(&data2)) << '\n';
     }
 
     address = io_->tell();
@@ -120,7 +120,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     camdata[32] = 0;
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 32U)  // 28
-          << "      camera : " << std::string(reinterpret_cast<char*>(&camdata)) << std::endl;
+          << "      camera : " << std::string(reinterpret_cast<char*>(&camdata)) << '\n';
     }
 
     address = io_->tell();
@@ -129,7 +129,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     dir_version[4] = 0;
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U)  // 60
-          << "     version : " << std::string(reinterpret_cast<char*>(&dir_version)) << std::endl;
+          << "     version : " << std::string(reinterpret_cast<char*>(&dir_version)) << '\n';
     }
 
     address = io_->tell();
@@ -137,7 +137,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->readOrThrow(unknown.data(), unknown.size());
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 20U)
-          << "     unknown : " << Internal::binaryToString(makeSlice(unknown, 0, unknown.size())) << std::endl;
+          << "     unknown : " << Internal::binaryToString(makeSlice(unknown, 0, unknown.size())) << '\n';
     }
 
     address = io_->tell();
@@ -155,9 +155,9 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       j_off << jpg_img_off;
       j_len << jpg_img_len;
       out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << " JPEG offset : " << j_off.str()
-          << std::endl;
+          << '\n';
       out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << " JPEG length : " << j_len.str()
-          << std::endl;
+          << '\n';
     }
 
     // RAFs can carry the payload in one or two parts
@@ -177,9 +177,9 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
         c_off << meta_off[i];
         c_len << meta_len[i];
         out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << "meta offset" << i + 1 << " : "
-            << c_off.str() << std::endl;
+            << c_off.str() << '\n';
         out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << "meta length" << i + 1
-            << " : " << c_len.str() << std::endl;
+            << " : " << c_len.str() << '\n';
       }
 
       address = io_->tell();
@@ -209,15 +209,15 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
         c_size << cfa_size[i];
         c_data << cfa_data[i];
         out << Internal::indent(depth) << Internal::stringFormat(format, address, 4U) << " CFA offset" << i + 1 << " : "
-            << c_off.str() << std::endl;
+            << c_off.str() << '\n';
         out << Internal::indent(depth) << Internal::stringFormat(format, address2, 4U) << " CFA length" << i + 1
-            << " : " << c_len.str() << std::endl;
+            << " : " << c_len.str() << '\n';
         out << Internal::indent(depth) << Internal::stringFormat(format, address3, 4U) << "compression" << i + 1
-            << " : " << c_comp.str() << std::endl;
+            << " : " << c_comp.str() << '\n';
         out << Internal::indent(depth) << Internal::stringFormat(format, address4, 4U) << "  CFA chunk" << i + 1
-            << " : " << c_size.str() << std::endl;
+            << " : " << c_size.str() << '\n';
         out << Internal::indent(depth) << Internal::stringFormat(format, address5, 4U) << "    unknown" << i + 1
-            << " : " << c_data.str() << std::endl;
+            << " : " << c_data.str() << '\n';
       }
     }
 
@@ -227,7 +227,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->readOrThrow(payload.data(), payload.size());
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, jpg_img_len)
-          << "   JPEG data : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << std::endl;
+          << "   JPEG data : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
     io_->seek(meta_off[0], BasicIo::beg);  // rewind
@@ -235,7 +235,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->readOrThrow(payload.data(), payload.size());
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, meta_len[0])
-          << "  meta data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << std::endl;
+          << "  meta data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
     if (meta_off[1] && meta_len[1]) {
@@ -244,7 +244,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       io_->readOrThrow(payload.data(), payload.size());
       {
         out << Internal::indent(depth) << Internal::stringFormat(format, address, meta_len[1])
-            << "  meta data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << std::endl;
+            << "  meta data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
       }
     }
 
@@ -253,7 +253,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
     io_->readOrThrow(payload.data(), payload.size());
     {
       out << Internal::indent(depth) << Internal::stringFormat(format, address, cfa_len[0])
-          << "   CFA data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << std::endl;
+          << "   CFA data1 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
     }
 
     if (cfa_off[1] && cfa_len[1]) {
@@ -262,7 +262,7 @@ void RafImage::printStructure(std::ostream& out, PrintStructureOption option, si
       io_->readOrThrow(payload.data(), payload.size());
       {
         out << Internal::indent(depth) << Internal::stringFormat(format, address, cfa_len[1])  // cfa_off
-            << "   CFA data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << std::endl;
+            << "   CFA data2 : " << Internal::binaryToString(makeSlice(payload, 0, payload.size())) << '\n';
       }
     }
   }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -410,7 +410,7 @@ void RiffVideo::readList(const HeaderReader& header_) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
   EXV_INFO << "-> Reading list : id= " << header_.getId() << "  type= " << chunk_type << " size= " << header_.getSize()
-           << "(" << io_->tell() << "/" << io_->size() << ")" << std::endl;
+           << "(" << io_->tell() << "/" << io_->size() << ")" << '\n';
 #endif
 
   if (equal(chunk_type, CHUNK_ID_INFO))
@@ -424,7 +424,7 @@ void RiffVideo::readChunk(const HeaderReader& header_) {
 #ifdef EXIV2_DEBUG_MESSAGES
   if (header_.getSize())
     EXV_INFO << "--> Reading Chunk : [" << header_.getId() << "] size= " << header_.getSize() << "(" << io_->tell()
-             << "/" << io_->size() << ")" << std::endl;
+             << "/" << io_->size() << ")" << '\n';
 #endif
 
   if (equal(header_.getId(), CHUNK_ID_AVIH))
@@ -452,7 +452,7 @@ void RiffVideo::readChunk(const HeaderReader& header_) {
 #ifdef EXIV2_DEBUG_MESSAGES
     if (header_.getSize())
       EXV_WARNING << "--> Ignoring Chunk : " << header_.getId() << "] size= " << header_.getSize() << "(" << io_->tell()
-                  << "/" << io_->size() << ")" << std::endl;
+                  << "/" << io_->size() << ")" << '\n';
 #endif
     io_->seekOrThrow(io_->tell() + header_.getSize(), BasicIo::beg, ErrorCode::kerFailedToReadImageData);
   }
@@ -470,20 +470,20 @@ void RiffVideo::decodeBlocks() {
 
 void RiffVideo::readAviHeader() {
 #ifdef EXIV2_DEBUG_MESSAGES
-  EXV_INFO << "--> dwMicroSecPerFrame    = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwMaxBytesPerSec      = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwPaddingGranularity  = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwFlags               = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwTotalFrames         = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwInitialFrames       = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwStreams             = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwSuggestedBufferSize = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwWidth               = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwHeight              = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwReserved1           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwReserved2           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwReserved3           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwReserved4           = " << readDWORDTag(io_) << std::endl;
+  EXV_INFO << "--> dwMicroSecPerFrame    = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwMaxBytesPerSec      = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwPaddingGranularity  = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwFlags               = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwTotalFrames         = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwInitialFrames       = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwStreams             = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwSuggestedBufferSize = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwWidth               = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwHeight              = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwReserved1           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwReserved2           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwReserved3           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwReserved4           = " << readDWORDTag(io_) << '\n';
   if (LogMsg::info >= LogMsg::level() && LogMsg::handler())
     io_->seekOrThrow(io_->tell() - DWORD * 14, BasicIo::beg, ErrorCode::kerFailedToReadImageData);
 #endif
@@ -526,23 +526,23 @@ void RiffVideo::readStreamHeader() {
   streamType_ = (equal(stream, "VIDS")) ? Video : Audio;
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  EXV_INFO << "--> fccType                = " << stream << std::endl;
-  EXV_INFO << "--> fccHandler             = " << readStringTag(io_) << std::endl;
-  EXV_INFO << "--> dwFlags                = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> wPriority              = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> wLanguage              = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwInitialFrames        = " << readDWORDTag(io_) << std::endl;  // 20
-  EXV_INFO << "--> dwScale                = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwRate                 = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwStart                = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwLength               = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> dwSuggestedBufferSize  = " << readDWORDTag(io_) << std::endl;  // 40
-  EXV_INFO << "--> dwSampleSize           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> Left                   = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> top                    = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> right                  = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> bottom                 = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> XXXXXX                 = " << readDWORDTag(io_) << std::endl;  // 56
+  EXV_INFO << "--> fccType                = " << stream << '\n';
+  EXV_INFO << "--> fccHandler             = " << readStringTag(io_) << '\n';
+  EXV_INFO << "--> dwFlags                = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> wPriority              = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> wLanguage              = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwInitialFrames        = " << readDWORDTag(io_) << '\n';  // 20
+  EXV_INFO << "--> dwScale                = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwRate                 = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwStart                = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwLength               = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> dwSuggestedBufferSize  = " << readDWORDTag(io_) << '\n';  // 40
+  EXV_INFO << "--> dwSampleSize           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> Left                   = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> top                    = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> right                  = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> bottom                 = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> XXXXXX                 = " << readDWORDTag(io_) << '\n';  // 56
   if (LogMsg::info >= LogMsg::level() && LogMsg::handler())
     io_->seekOrThrow(io_->tell() - DWORD * 13, BasicIo::beg, ErrorCode::kerFailedToReadImageData);
 #endif
@@ -579,26 +579,26 @@ void RiffVideo::readStreamFormat(uint64_t size_) {
 
 #ifdef EXIV2_DEBUG_MESSAGES
   if (streamType_ == Audio) {
-    EXV_INFO << "--> wFormatTag      = " << readWORDTag(io_) << std::endl;
-    EXV_INFO << "--> nChannels       = " << readWORDTag(io_) << std::endl;
-    EXV_INFO << "--> nSamplesPerSec  = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> nAvgBytesPerSec = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> nBlockAlign     = " << readWORDTag(io_) << std::endl;
-    EXV_INFO << "--> wBitsPerSample  = " << readWORDTag(io_) << std::endl;
+    EXV_INFO << "--> wFormatTag      = " << readWORDTag(io_) << '\n';
+    EXV_INFO << "--> nChannels       = " << readWORDTag(io_) << '\n';
+    EXV_INFO << "--> nSamplesPerSec  = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> nAvgBytesPerSec = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> nBlockAlign     = " << readWORDTag(io_) << '\n';
+    EXV_INFO << "--> wBitsPerSample  = " << readWORDTag(io_) << '\n';
     if (LogMsg::info >= LogMsg::level() && LogMsg::handler())
       io_->seekOrThrow(io_->tell() - DWORD * 4, BasicIo::beg, ErrorCode::kerFailedToReadImageData);
   } else if (streamType_ == Video) {
-    EXV_INFO << "--> biSize            = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biWidth           = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biHeight          = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biPlanes          = " << readWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biBitCount        = " << readWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biCompression     = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biSizeImage       = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biXPelsPerMeter   = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biYPelsPerMeter   = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biClrUsed         = " << readDWORDTag(io_) << std::endl;
-    EXV_INFO << "--> biClrImportant    = " << readDWORDTag(io_) << std::endl;
+    EXV_INFO << "--> biSize            = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biWidth           = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biHeight          = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biPlanes          = " << readWORDTag(io_) << '\n';
+    EXV_INFO << "--> biBitCount        = " << readWORDTag(io_) << '\n';
+    EXV_INFO << "--> biCompression     = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biSizeImage       = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biXPelsPerMeter   = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biYPelsPerMeter   = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biClrUsed         = " << readDWORDTag(io_) << '\n';
+    EXV_INFO << "--> biClrImportant    = " << readDWORDTag(io_) << '\n';
     if (LogMsg::info >= LogMsg::level() && LogMsg::handler())
       io_->seekOrThrow(io_->tell() - DWORD * 10, BasicIo::beg, ErrorCode::kerFailedToReadImageData);
   }
@@ -667,24 +667,24 @@ void RiffVideo::readMoviList(uint64_t size_) const {
 
 void RiffVideo::readVPRPChunk(uint64_t size_) const {
 #ifdef EXIV2_DEBUG_MESSAGES
-  EXV_INFO << "--> VideoFormatToken         = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> VideoStandard            = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> VerticalRefreshRate      = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> HTotalInT                = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> VTotalInLines            = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> FrameAspectRatio Height  = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> FrameAspectRatio Width   = " << readWORDTag(io_) << std::endl;
-  EXV_INFO << "--> FrameWidthInPixels       = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> FrameHeightInLines       = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> CompressedBMHeight       = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> FieldPerFrame            = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> CompressedBMWidth        = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> ValidBMHeight            = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> ValidBMWidth             = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> ValidBMXOffset           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> ValidBMYOffset           = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> VideoXOffsetInT          = " << readDWORDTag(io_) << std::endl;
-  EXV_INFO << "--> VideoYValidStartLine     = " << readDWORDTag(io_) << std::endl;
+  EXV_INFO << "--> VideoFormatToken         = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> VideoStandard            = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> VerticalRefreshRate      = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> HTotalInT                = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> VTotalInLines            = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> FrameAspectRatio Height  = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> FrameAspectRatio Width   = " << readWORDTag(io_) << '\n';
+  EXV_INFO << "--> FrameWidthInPixels       = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> FrameHeightInLines       = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> CompressedBMHeight       = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> FieldPerFrame            = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> CompressedBMWidth        = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> ValidBMHeight            = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> ValidBMWidth             = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> ValidBMXOffset           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> ValidBMYOffset           = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> VideoXOffsetInT          = " << readDWORDTag(io_) << '\n';
+  EXV_INFO << "--> VideoYValidStartLine     = " << readDWORDTag(io_) << '\n';
   if (LogMsg::info >= LogMsg::level() && LogMsg::handler())
     io_->seekOrThrow(io_->tell() - DWORD * 17, BasicIo::beg, ErrorCode::kerFailedToReadImageData);
 #endif
@@ -696,13 +696,13 @@ void RiffVideo::readIndexChunk(uint64_t size_) const {
   uint64_t current_size = 0;
   while (current_size < size_) {
     EXV_DEBUG << "--> Identifier               = " << readStringTag(io_) << "\t(" << current_size << "/" << size_ << ")"
-              << std::endl;
+              << '\n';
     EXV_DEBUG << "--> Flags                    = " << readDWORDTag(io_) << "\t(" << current_size << "/" << size_ << ")"
-              << std::endl;
+              << '\n';
     EXV_DEBUG << "--> Offset                   = " << readDWORDTag(io_) << "\t(" << current_size << "/" << size_ << ")"
-              << std::endl;
+              << '\n';
     EXV_DEBUG << "--> Length                   = " << readDWORDTag(io_) << "\t(" << current_size << "/" << size_ << ")"
-              << std::endl;
+              << '\n';
     current_size += DWORD * 4;
   }
   if (LogMsg::debug >= LogMsg::level() && LogMsg::handler())
@@ -713,10 +713,10 @@ void RiffVideo::readIndexChunk(uint64_t size_) const {
 
 void RiffVideo::readDataChunk(uint64_t size_) const {
 #ifdef EXIV2_DEBUG_MESSAGES
-  EXV_INFO << "--> Data               = " << readStringTag(io_, static_cast<size_t>(size_)) << std::endl;
+  EXV_INFO << "--> Data               = " << readStringTag(io_, static_cast<size_t>(size_)) << '\n';
   uint64_t readed_size = size_;
   if (size_ % 2 != 0) {
-    EXV_INFO << "--> pad byte          = " << readStringTag(io_, 1) << std::endl;
+    EXV_INFO << "--> pad byte          = " << readStringTag(io_, 1) << '\n';
     readed_size += 1;
   }
   if (LogMsg::info >= LogMsg::level() && LogMsg::handler())

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -60,7 +60,7 @@ void Rw2Image::setComment(const std::string&) {
 }
 
 void Rw2Image::printStructure(std::ostream& out, PrintStructureOption option, size_t depth) {
-  out << "RW2 IMAGE" << std::endl;
+  out << "RW2 IMAGE" << '\n';
   if (io_->open() != 0)
     throw Error(ErrorCode::kerDataSourceOpenFailed, io_->path(), strError());
   // Ensure that this is the correct image type

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -100,7 +100,7 @@ static bool shouldOutput(const std::vector<std::regex>& greps, const char* key, 
 
 static void output(std::ostream& os, const std::vector<std::regex>& greps, const char* name, const std::string& value) {
   if (shouldOutput(greps, name, value))
-    os << name << "=" << value << std::endl;
+    os << name << "=" << value << '\n';
 }
 
 static void output(std::ostream& os, const std::vector<std::regex>& greps, const char* name, int value) {

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -56,11 +56,11 @@ namespace {
         }
         hexOutput << static_cast<char>(c);
       }
-      hexOutput << std::endl;
+      hexOutput << '\n';
     }
   }
 
-  hexOutput << std::endl << std::endl << std::endl;
+  hexOutput << '\n' << '\n' << '\n';
 
   return hexOutput.str();
 }
@@ -109,7 +109,7 @@ void WebPImage::doWriteMetadata(BasicIo& outIo) {
     throw Error(ErrorCode::kerImageWriteFailed);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Writing metadata" << std::endl;
+  std::cout << "Writing metadata" << '\n';
 #endif
 
   byte data[WEBP_TAG_SIZE * 3];
@@ -418,8 +418,8 @@ void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, s
     chunkId.write_uint8(4, '\0');
 
     if (bPrint) {
-      out << Internal::indent(depth) << "STRUCTURE OF WEBP FILE: " << io().path() << std::endl;
-      out << Internal::indent(depth) << " Chunk |   Length |   Offset | Payload" << std::endl;
+      out << Internal::indent(depth) << "STRUCTURE OF WEBP FILE: " << io().path() << '\n';
+      out << Internal::indent(depth) << " Chunk |   Length |   Offset | Payload" << '\n';
     }
 
     io_->seek(0, BasicIo::beg);  // rewind
@@ -435,7 +435,7 @@ void WebPImage::printStructure(std::ostream& out, PrintStructureOption option, s
       if (bPrint) {
         out << Internal::indent(depth)
             << Internal::stringFormat("  %s | %8u | %8u | ", chunkId.c_str(), size, static_cast<uint32_t>(offset))
-            << Internal::binaryToString(makeSlice(payload, 0, payload.size() > 32 ? 32 : payload.size())) << std::endl;
+            << Internal::binaryToString(makeSlice(payload, 0, payload.size() > 32 ? 32 : payload.size())) << '\n';
       }
 
       if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option == kpsRecursive) {
@@ -489,7 +489,7 @@ void WebPImage::decodeChunks(uint32_t filesize) {
   bool has_canvas_data = false;
 
 #ifdef EXIV2_DEBUG_MESSAGES
-  std::cout << "Reading metadata" << std::endl;
+  std::cout << "Reading metadata" << '\n';
 #endif
 
   chunkId.write_uint8(4, '\0');
@@ -639,7 +639,7 @@ void WebPImage::decodeChunks(uint32_t filesize) {
       std::copy(payload.begin(), payload.end(), rawExifData.begin() + offset);
 
 #ifdef EXIV2_DEBUG_MESSAGES
-      std::cout << "Display Hex Dump [size:" << sizePayload << "]" << std::endl;
+      std::cout << "Display Hex Dump [size:" << sizePayload << "]" << '\n';
       std::cout << binaryToHex(rawExifData.c_data(), sizePayload);
 #endif
 
@@ -649,7 +649,7 @@ void WebPImage::decodeChunks(uint32_t filesize) {
         setByteOrder(bo);
       } else {
 #ifndef SUPPRESS_WARNINGS
-        EXV_WARNING << "Failed to decode Exif metadata." << std::endl;
+        EXV_WARNING << "Failed to decode Exif metadata." << '\n';
 #endif
         exifData_.clear();
       }
@@ -658,11 +658,11 @@ void WebPImage::decodeChunks(uint32_t filesize) {
       xmpPacket_.assign(payload.c_str(), payload.size());
       if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_)) {
 #ifndef SUPPRESS_WARNINGS
-        EXV_WARNING << "Failed to decode XMP metadata." << std::endl;
+        EXV_WARNING << "Failed to decode XMP metadata." << '\n';
 #endif
       } else {
 #ifdef EXIV2_DEBUG_MESSAGES
-        std::cout << "Display Hex Dump [size:" << payload.size() << "]" << std::endl;
+        std::cout << "Display Hex Dump [size:" << payload.size() << "]" << '\n';
         std::cout << binaryToHex(payload.c_data(), payload.size());
 #endif
       }

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -1048,7 +1048,7 @@ void printNode(const std::string& schemaNs, const std::string& propPath, const s
   } else {
     std::cout << propPath << " = " << propValue;
   }
-  std::cout << std::endl;
+  std::cout << '\n';
 }
 #else
 void printNode(const std::string&, const std::string&, const std::string&, const XMP_OptionBits&) {

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -109,7 +109,7 @@ void XmpSidecar::writeMetadata() {
       Exiv2::XmpKey key(sKey);
       if (xmpData_.findKey(key) != xmpData_.end()) {
         std::string value_now(xmpData_[sKey].value().toString());
-        // std::cout << key << " -> " << value_now << " => " << value_orig << std::endl;
+        // std::cout << key << " -> " << value_now << " => " << value_orig << '\n';
         if (Internal::contains(value_orig, value_now.substr(0, 10))) {
           xmpData_[sKey] = value_orig;
         }


### PR DESCRIPTION
Found wth performance-avoid-endl