### PR TITLE
Do not interpret OlympusEq.LensType  0 0 0 0 0 0

### DIFF
--- a/src/olympusmn_int.cpp
+++ b/src/olympusmn_int.cpp
@@ -1364,7 +1364,6 @@ std::ostream& OlympusMakerNote::print0x0201(std::ostream& os, const Value& value
     byte val[3];
     const char* label;
   } lensTypes[] = {
-      {{0, 0, 0}, N_("None")},
       {{0, 1, 0}, "Olympus Zuiko Digital ED 50mm F2.0 Macro"},
       {{0, 1, 1}, "Olympus Zuiko Digital 40-150mm F3.5-4.5"},
       {{0, 1, 16}, "Olympus M.Zuiko Digital ED 14-42mm F3.5-5.6"},


### PR DESCRIPTION
Olympus/OMDS cameras use '0 0 0 0 0 0' LensType, when mechanical lense is used. Currently Exiv2 interprets this into localised string ‘None’. However Olympus cameras traditionally allow to enter a custom string for lens name and then add that to Exif LensModel of images taken. Image processing software can take None from the LensType and ignore LensModel. Having LensType of '0 0 0 0 0 0' would allow for an easy `if` statement and then use LensModel instead.
