### PR TITLE
CI: bump min macOS version to 13

### DIFF
--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -86,8 +86,8 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-12, arch: X64   }
-          - { os: macos-14, arch: ARM64 }
+          - { os: macos-13,     arch: X64   }
+          - { os: macos-latest, arch: ARM64 }
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
macOS 12 runners are being phased out, 13 is the only one still running on and able to test X64