### PR TITLE
CMake: Resolve Missing ZLIB Warning When PNG is Disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,7 +200,6 @@ endif()
 set_target_properties(exiv2lib_int PROPERTIES POSITION_INDEPENDENT_CODE ON COMPILE_DEFINITIONS exiv2lib_EXPORTS)
 
 # NOTE: Cannot use target_link_libraries on OBJECT libraries with old versions of CMake
-target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
 target_include_directories(exiv2lib SYSTEM PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/xmpsdk/include>)
 
 if(EXIV2_ENABLE_XMP OR EXIV2_ENABLE_EXTERNAL_XMP)
@@ -254,6 +253,7 @@ endif()
 
 if(EXIV2_ENABLE_PNG)
   target_link_libraries(exiv2lib PRIVATE ZLIB::ZLIB)
+  target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
   list(APPEND requires_private_list "zlib")
 endif()
 


### PR DESCRIPTION
closes #3053