### PR TITLE
CI: use system meson on Ubuntu 24.04

### DIFF
--- a/.github/workflows/on_PR_meson.yaml
+++ b/.github/workflows/on_PR_meson.yaml
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install packages
         run: |
-          python3 -m pip install meson ninja
+          sudo apt install -y meson
       - name: Emscripten
         uses: mymindstorm/setup-emsdk@v14
       - name: Compile


### PR DESCRIPTION
`ubuntu-latest` label got switched over to `ubuntu-24.04` runners recently...

This fixes
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/Exiv2/exiv2/actions/runs/11253057491/job/31287533802#step:3:7)68 for the detailed specification.
```