### PR TITLE
base64decode should return immediately if the input is empty

### DIFF
--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -90,7 +90,7 @@ static char to_hex(char code) {
 
 /// @brief Convert a hex character to its integer value.
 static char from_hex(char ch) {
-  return isdigit(ch) ? ch - '0' : static_cast<char>(tolower(ch)) - 'a' + 10;
+  return 0xF & (isdigit(ch) ? ch - '0' : static_cast<char>(tolower(ch)) - 'a' + 10);
 }
 
 std::string urlencode(const std::string& str) {
@@ -168,7 +168,7 @@ int base64encode(const void* data_buf, size_t dataLength, char* result, size_t r
 size_t base64decode(const char* in, char* out, size_t out_size) {
   size_t result = 0;
   size_t input_length = in ? ::strlen(in) : 0;
-  if (!in || input_length % 4 != 0)
+  if (!in || input_length % 4 != 0 || input_length == 0)
     return result;
 
   auto encoding_table = reinterpret_cast<const unsigned char*>(base64_encode);
@@ -324,21 +324,26 @@ Uri Uri::Parse(const std::string& uri) {
   auto hostEnd = std::find(authEnd, (pathStart != uriEnd) ? pathStart : queryStart,
                            ':');  // check for port
 
-  result.Host = std::string(hostStart, hostEnd);
+  if (hostStart < hostEnd) {
+    result.Host = std::string(hostStart, hostEnd);
+  }
 
   // port
   if ((hostEnd != uriEnd) && (*hostEnd == ':'))  // we have a port
   {
     ++hostEnd;
     auto portEnd = (pathStart != uriEnd) ? pathStart : queryStart;
-    result.Port = std::string(hostEnd, portEnd);
+    if (hostEnd < portEnd) {
+      result.Port = std::string(hostEnd, portEnd);
+    }
   }
   if (result.Port.empty() && result.Protocol == "http")
     result.Port = "80";
 
   // path
-  if (pathStart != uriEnd)
+  if (pathStart < queryStart) {
     result.Path = std::string(pathStart, queryStart);
+  }
 
   // query
   if (queryStart != uriEnd)


### PR DESCRIPTION
This fixes some minor issues found by https://github.com/google/oss-fuzz-gen. They're using an AI system to generate new fuzz targets that test internal functions. In this case, they're fuzzing `base64decode` and `Uri::Parse`. I'll fix these issues, but I'm worried that this is going to turn into a massive spam problem, because it's easy to find crashes if you call internal functions with invalid arguments.