### PR TITLE
Fix 3080

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -873,7 +873,11 @@ float DateValue::toFloat(size_t n) const {
 }
 
 Rational DateValue::toRational(size_t n) const {
-  return {static_cast<int32_t>(toInt64(n)), 1};
+  const int64_t t = toInt64(n);
+  if (t < std::numeric_limits<int32_t>::min() || t > std::numeric_limits<int32_t>::max()) {
+    return {0, 1};
+  }
+  return {static_cast<int32_t>(t), 1};
 }
 
 TimeValue::TimeValue() : Value(time) {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -863,6 +863,7 @@ int64_t DateValue::toInt64(size_t /*n*/) const {
 uint32_t DateValue::toUint32(size_t /*n*/) const {
   const int64_t t = toInt64();
   if (t < 0 || t > std::numeric_limits<uint32_t>::max()) {
+    ok_ = false;
     return 0;
   }
   return static_cast<uint32_t>(t);
@@ -875,6 +876,7 @@ float DateValue::toFloat(size_t n) const {
 Rational DateValue::toRational(size_t n) const {
   const int64_t t = toInt64(n);
   if (t < std::numeric_limits<int32_t>::min() || t > std::numeric_limits<int32_t>::max()) {
+    ok_ = false;
     return {0, 1};
   }
   return {static_cast<int32_t>(t), 1};


### PR DESCRIPTION
Add overflow checking to DateValue toRational method. Sets ok_ to false if the result is invalid.