### PR TITLE
Update link to GPano documentation

### DIFF
--- a/doc/templates/tags-xmp-GPano.html.in
+++ b/doc/templates/tags-xmp-GPano.html.in
@@ -26,7 +26,7 @@ __index2__
 
  </ul>
 
-Reference: <a href=" https://developers.google.com/photo-sphere/metadata/" title="Photo Sphere XMP Metadata">Photo Sphere XMP Metadata</a></p>
+Reference: <a href="https://developers.google.com/streetview/spherical-metadata" title="Photo Sphere XMP Metadata">Photo Sphere XMP Metadata</a></p>
 
 <p>Click on a column header to sort the table.</p>
 


### PR DESCRIPTION
Fixes the link to Google's official doc page for the GPano scheme. The old link redirects to a landing page now.