### PR TITLE
CI: attempt to install gcc13 for Cygwin

### DIFF
--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           platform: ${{matrix.platform}}
           packages: >-
-            gcc-13.3.1+20241129-0.1
+            gcc-g++-13.3.1+20241129-0.1
             cmake
             ninja
             pkg-config

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           platform: ${{matrix.platform}}
           packages: >-
-            gcc-g++-13.3.1+20241129-0.1
+            gcc-g++=13.3.1+20241129-0.1
             cmake
             ninja
             pkg-config

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -168,7 +168,7 @@ jobs:
             zlib-devel
 
       - name: Install GCC 13 from test
-        run: C:\setup.exe -qnOt -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ | Out-Default
+        run: C:\setup.exe -qnOt -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1,libgcc1=13.3.1+20241129-0.1,libstdc++6=13.3.1+20241129-0.1,libgomp1=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ | Out-Default
         shell: pwsh
 
       - name: Build

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -156,7 +156,6 @@ jobs:
         with:
           platform: ${{matrix.platform}}
           packages: >-
-            gcc-g++=13.3.1+20241129-0.1
             cmake
             ninja
             pkg-config
@@ -167,6 +166,10 @@ jobs:
             libiconv-devel
             libinih-devel
             zlib-devel
+
+      - name: Install GCC 13
+        run: C:\setup.exe -qnO -P gcc-g++=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/
+        shell: pwsh
 
       - name: Build
         run: |

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -167,8 +167,8 @@ jobs:
             libinih-devel
             zlib-devel
 
-      - name: Install GCC 13
-        run: C:\setup.exe -qnO -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/
+      - name: Install GCC 13 from test
+        run: & C:\setup.exe -qnOt -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ | Out-Default
         shell: pwsh
 
       - name: Build

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -168,7 +168,7 @@ jobs:
             zlib-devel
 
       - name: Install GCC 13 from test
-        run: & C:\setup.exe -qnOt -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ | Out-Default
+        run: C:\setup.exe -qnOt -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ | Out-Default
         shell: pwsh
 
       - name: Build

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           platform: ${{matrix.platform}}
           packages: >-
-            gcc-g++
+            gcc-13.3.1+20241129-0.1
             cmake
             ninja
             pkg-config

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -168,7 +168,7 @@ jobs:
             zlib-devel
 
       - name: Install GCC 13
-        run: C:\setup.exe -qnO -P gcc-g++=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/
+        run: C:\setup.exe -qnO -P gcc-g++=13.3.1+20241129-0.1,libatomic1=13.3.1+20241129-0.1,libquadmath0=13.3.1+20241129-0.1 -l C:\cygwin-packages -R C:\cygwin -s http://mirrors.kernel.org/sourceware/cygwin/
         shell: pwsh
 
       - name: Build


### PR DESCRIPTION
The small inconvenience is having to update the version string manually when it changes, until such a time this workaround can be dropped, i.e. 13.4 is published and becomes Cygwin "stable", probably around mid-2025...