### PR TITLE
fix: ditch not recommended -Wp prefixes preventing default gcc flag overwrite

### DIFF
--- a/cmake/compilerFlags.cmake
+++ b/cmake/compilerFlags.cmake
@@ -48,10 +48,10 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
             endif()
         endif()
 
-        add_compile_options(-Wp,-D_GLIBCXX_ASSERTIONS)
+        add_compile_options(-D_GLIBCXX_ASSERTIONS)
 
         if (CMAKE_BUILD_TYPE STREQUAL Release AND NOT (APPLE OR MINGW OR MSYS))
-            add_compile_options(-Wp,-D_FORTIFY_SOURCE=2) # Requires to compile with -O2
+            add_compile_options(-D_FORTIFY_SOURCE=2) # Requires to compile with -O2
         endif()
 
         if(BUILD_WITH_COVERAGE)


### PR DESCRIPTION
While building for Ubuntu >=24.04, noticed loads of the following:
```
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
```

Which can also be seen on GitHub action runs, for example here:
https://github.com/Exiv2/exiv2/actions/runs/12740529422/job/35505851531#step:5:122

Apparently, Ubuntu switched to adding `_FORTIFY_SOURCE=3` by default, and extra `-Wp` prefix on Exiv2 code-base was preventing those defaults being overwritten.

Running on Ubuntu 24.04:
```
$ gcc -dM -E -O3 - < /dev/null | grep FORTIFY
#define _FORTIFY_SOURCE 3
```

Also, according to GCC docs, `-Wp` prefix is **not** recommended:
```
-Wp,option

You can use -Wp,option to bypass the compiler driver and pass option directly through to the preprocessor.
If option contains commas, it is split into multiple options at the commas. However, many options are
modified, translated or interpreted by the compiler driver before being passed to the preprocessor,
and -Wp forcibly bypasses this phase. The preprocessor’s direct interface is undocumented and
subject to change, so whenever possible you should avoid using -Wp and let the driver handle
the options instead.
```

https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-Wp


**TL;DR**: removing directive which supposed to be avoided for easier integration and cleaner build on Ubuntu >=24.04 machines (or whatever going to be crazy enough to add defaults of `_FORTIFY_SOURCE=3` on distro level.