### PR TITLE
avoid testing __cpp_lib_format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,7 @@ endif()
 
 include_directories(${CMAKE_BINARY_DIR}) # Make the exv_conf.h file visible for the full project
 
-check_cxx_symbol_exists(__cpp_lib_format "format" HAVE_STD_FORMAT)
-if(NOT HAVE_STD_FORMAT)
+if(NOT EXV_HAVE_STD_FORMAT)
   find_package(fmt REQUIRED)
 endif()
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -24,6 +24,9 @@
 // Define if you want to use the inih library.
 #cmakedefine EXV_ENABLE_INIH
 
+// Define if you have the std::format function.
+#cmakedefine EXV_HAVE_STD_FORMAT
+
 // Define if you have the strerror_r function.
 #cmakedefine EXV_HAVE_STRERROR_R
 

--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -26,7 +26,7 @@ if(NOT @BUILD_SHARED_LIBS@) # if(NOT BUILD_SHARED_LIBS)
     find_dependency(Iconv REQUIRED)
   endif()
 
-  if(NOT "@HAVE_STD_FORMAT@") # if(NOT HAVE_STD_FORMAT)
+  if(NOT "@EXV_HAVE_STD_FORMAT@") # if(NOT EXV_HAVE_STD_FORMAT)
     find_dependency(fmt REQUIRED)
   endif()
 endif()

--- a/cmake/generateConfigFile.cmake
+++ b/cmake/generateConfigFile.cmake
@@ -24,6 +24,7 @@ set(EXV_HAVE_ICONV       ${ICONV_FOUND})
 set(EXV_HAVE_LIBZ        ${ZLIB_FOUND})
 set(EXV_HAVE_BROTLI      ${BROTLI_FOUND})
 
+check_cxx_source_compiles("#include <format>\nint main(){std::format(\"t\");}" EXV_HAVE_STD_FORMAT)
 check_cxx_symbol_exists(strerror_r  string.h       EXV_HAVE_STRERROR_R )
 
 check_cxx_source_compiles( "

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ cdata.set('EXV_PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), cdata.get
 
 cdata.set('EXV_HAVE_STRERROR_R', cpp.has_function('strerror_r'))
 cdata.set('EXV_STRERROR_R_CHAR_P', not cpp.compiles('#define _GNU_SOURCE\n#include <string.h>\nint strerror_r(int,char*,size_t);int main(){}'))
+cdata.set('EXV_HAVE_STD_FORMAT', cpp.has_header_symbol('format', 'std::format'))
 
 cdata.set('EXV_ENABLE_BMFF', get_option('bmff'))
 cdata.set('EXV_HAVE_LENSDATA', get_option('lensdata'))
@@ -54,7 +55,7 @@ deps = []
 deps += cpp.find_library('ws2_32', required: host_machine.system() == 'windows')
 deps += cpp.find_library('procstat', required: host_machine.system() == 'freebsd')
 
-if not cpp.has_header_symbol('format', '__cpp_lib_format')
+if not cpp.has_header_symbol('format', 'std::format')
   deps += dependency('fmt')
 endif
 
@@ -150,7 +151,7 @@ exiv2_sources = files(
 
 if host_machine.system() == 'windows'
   windows = import('windows')
-  exiv2_sources += windows.compile_resources('app/utf8.rc', depend_files: 'app/utf8.manifest') 
+  exiv2_sources += windows.compile_resources('app/utf8.rc', depend_files: 'app/utf8.manifest')
 endif
 
 exiv2inc = include_directories('src', 'include/exiv2')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,7 +251,7 @@ else()
   target_link_libraries(exiv2lib PRIVATE psapi ws2_32 shell32)
 endif()
 
-if(NOT HAVE_STD_FORMAT)
+if(NOT EXV_HAVE_STD_FORMAT)
   target_link_libraries(exiv2lib PRIVATE fmt::fmt)
   target_link_libraries(exiv2lib_int PRIVATE fmt::fmt)
   list(APPEND requires_private_list "fmt")

--- a/src/image_int.cpp
+++ b/src/image_int.cpp
@@ -1,12 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "image_int.hpp"
+#include "config.h"
 
-#include <cstdarg>
-#include <cstddef>
-#include <cstdio>
-#include <cstring>
-#include <vector>
+#include "image_int.hpp"
 
 namespace Exiv2::Internal {
 [[nodiscard]] std::string indent(size_t i) {

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -15,7 +15,7 @@
 #if __has_include(<format>)
 #include <format>
 #endif
-#ifndef __cpp_lib_format
+#ifndef EXV_HAVE_STD_FORMAT
 #include <fmt/core.h>
 #define stringFormat fmt::format
 #else

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -44,7 +44,7 @@ target_compile_definitions(unit_tests PRIVATE exiv2lib_STATIC TESTDATA_PATH="${P
 
 target_link_libraries(unit_tests PRIVATE exiv2lib GTest::gmock_main std::filesystem)
 
-if(NOT HAVE_STD_FORMAT)
+if(NOT EXV_HAVE_STD_FORMAT)
   target_link_libraries(unit_tests PRIVATE fmt::fmt)
 endif()
 


### PR DESCRIPTION
It was introduced late into LLVM's libc++. Test for the function directly.