### PR TITLE
WIP: use fs::path for app

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -286,8 +286,14 @@ class EXIV2API FileIo : public BasicIo {
     @param path The full path of a file
    */
   explicit FileIo(const std::string& path);
+
 #ifdef _WIN32
-  explicit FileIo(const std::wstring& path);
+  /*!
+    @brief Like FileIo(const std::string& path) but accepts a
+        unicode path in an std::wstring.
+    @note This constructor is only available on Windows.
+   */
+  explicit FileIo(const std::wstring& wpath);
 #endif
 
   //! Destructor. Flushes and closes an open file.
@@ -686,6 +692,15 @@ class EXIV2API XPathIo : public FileIo {
   //! Default constructor that reads data from stdin/data uri path and writes them to the temp file.
   explicit XPathIo(const std::string& orgPath);
 
+#ifdef _WIN32
+  /*!
+    @brief Like XPathIo(const std::string& path) but accepts a
+        unicode url in an std::wstring.
+    @note This constructor is only available on Windows.
+   */
+  explicit XPathIo(const std::wstring& wpath);
+#endif
+
   //! Destructor. Releases all managed memory and removes the temp file.
   ~XPathIo() override;
   //@}
@@ -712,6 +727,14 @@ class EXIV2API XPathIo : public FileIo {
       @throw Error if it fails.
    */
   static std::string writeDataToFile(const std::string& orgPath);
+#ifdef _WIN32
+  /*!
+    @brief Like writeDataToFile(const std::string& orgPath) but accepts a
+        unicode url in an std::wstring.
+    @note This constructor is only available on Windows.
+   */
+  static std::string writeDataToFile(const std::wstring& wOrgPath);
+#endif
   //@}
 
  private:
@@ -905,6 +928,15 @@ class EXIV2API HttpIo : public RemoteIo {
    */
   explicit HttpIo(const std::string& url, size_t blockSize = 1024);
 
+#ifdef _WIN32
+  /*!
+    @brief Like HttpIo(const std::string& url, size_t blockSize = 1024) but accepts a
+        unicode url in an std::wstring.
+    @note This constructor is only available on Windows.
+   */
+  explicit HttpIo(const std::wstring& wurl, size_t blockSize = 1024);
+#endif
+
  private:
   // Pimpl idiom
   class HttpImpl;
@@ -929,6 +961,14 @@ class EXIV2API CurlIo : public RemoteIo {
     @throw Error if it is unable to init curl pointer.
    */
   explicit CurlIo(const std::string& url, size_t blockSize = 0);
+#ifdef _WIN32
+  /*!
+    @brief Like CurlIo(const std::string&  url,  size_t blockSize = 0) but accepts a
+        unicode url in an std::wstring.
+    @note This constructor is only available on Windows.
+   */
+  explicit CurlIo(const std::wstring& wurl, size_t blockSize = 0);
+#endif
 
   /*!
     @brief Write access is only available for some protocols. This method

--- a/include/exiv2/futils.hpp
+++ b/include/exiv2/futils.hpp
@@ -70,6 +70,14 @@ EXIV2API size_t base64decode(const char* in, char* out, size_t out_size);
  */
 EXIV2API Protocol fileProtocol(const std::string& path);
 
+#ifdef _WIN32
+/*!
+  @brief Like fileProtocol() but accepts a unicode path in an std::wstring.
+  @note This function is only available on Windows.
+*/
+EXIV2API Protocol fileProtocol(const std::wstring& path);
+#endif
+
 /*!
   @brief Test if a file exists.
 
@@ -82,6 +90,15 @@ EXIV2API Protocol fileProtocol(const std::string& path);
   in case of an error.
  */
 EXIV2API bool fileExists(const std::string& path);
+
+#ifdef _WIN32
+/*!
+  @brief Like fileExists(const std::string& path) but
+        accepts a unicode path in an std::wstring.
+  @note This function is only available on Windows.
+*/
+EXIV2API bool fileExists(const std::wstring& path);
+#endif
 
 /*!
   @brief Return a system error message and the error code (errno).

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -522,9 +522,15 @@ class EXIV2API ImageFactory {
           read the remote file.
    */
   static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
+
 #ifdef _WIN32
-  static BasicIo::UniquePtr createIo(const std::wstring& path);
+  /*!
+    @brief Like createIo() but accepts a unicode path in an std::wstring.
+    @note This function is only available on Windows.
+   */
+  static BasicIo::UniquePtr createIo(const std::wstring& wpath, bool useCurl = true);
 #endif
+
   /*!
     @brief Create an Image subclass of the appropriate type by reading
         the specified file. %Image type is derived from the file
@@ -539,9 +545,15 @@ class EXIV2API ImageFactory {
         unknown image type.
    */
   static Image::UniquePtr open(const std::string& path, bool useCurl = true);
+
 #ifdef _WIN32
-  static Image::UniquePtr open(const std::wstring& path);
+  /*!
+    @brief Like open() but accepts a unicode path in an std::wstring.
+    @note This function is only available on Windows.
+   */
+  static Image::UniquePtr open(const std::wstring& wpath, bool useCurl = true);
 #endif
+
   /*!
     @brief Create an Image subclass of the appropriate type by reading
         the provided memory. %Image type is derived from the memory
@@ -582,6 +594,13 @@ class EXIV2API ImageFactory {
     @throw Error If the image type is not supported.
    */
   static Image::UniquePtr create(ImageType type, const std::string& path);
+#ifdef _WIN32
+  /*!
+    @brief Like create() but accepts a unicode path in an std::wstring.
+    @note This function is only available on Windows.
+   */
+  static Image::UniquePtr create(ImageType type, const std::wstring& wpath);
+#endif
   /*!
     @brief Create an Image subclass of the requested type by creating a
         new image in memory.


### PR DESCRIPTION
This fails on both Linux and Windows. The latter is a compilation issue. I'm not sure how to fix.

Linux fails tests because sstreams add quotes around a path.

I assume the simplest way to fix that would be to use std::format and output that.