### PR TITLE
CI: bump to macOS 13 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-12, arch: x64   }
+          - { os: macos-13, arch: x64   }
           - { os: macos-14, arch: arm64 }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The macOS 12 one is deprecated.