### PR TITLE
CI: drop fmt dependency on macOS and MSYS2

### DIFF
--- a/.github/workflows/on_PR_mac_matrix.yml
+++ b/.github/workflows/on_PR_mac_matrix.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja fmt inih googletest
+          brew install ninja inih googletest
 
       - name: Build
         run: |

--- a/.github/workflows/on_PR_mac_special_builds.yml
+++ b/.github/workflows/on_PR_mac_special_builds.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja fmt inih googletest
+          brew install ninja inih googletest
 
       - name: Build
         run: |

--- a/.github/workflows/on_PR_meson.yaml
+++ b/.github/workflows/on_PR_meson.yaml
@@ -115,7 +115,6 @@ jobs:
             cc:p
             cmake:p
             curl:p
-            fmt:p
             gtest:p
             libinih:p
             meson:p

--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -115,7 +115,6 @@ jobs:
             libiconv:p
             libinih:p
             zlib:p
-            fmt:p
 
       - name: Build
         run: |
@@ -180,7 +179,6 @@ jobs:
           cmake --preset base_windows \
             -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
             -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}} \
-            -DCMAKE_CXX_STANDARD=20 \
             -DCONAN_AUTO_INSTALL=OFF \
             -DEXIV2_BUILD_SAMPLES=OFF \
             -DEXIV2_BUILD_UNIT_TESTS=OFF \

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -94,7 +94,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install ninja fmt inih googletest
+          brew install ninja inih googletest
+
+      - name: Install fmt on macOS 13
+        if: ${{ matrix.runner.os == 'macos-13' }}
+        run: |
+          brew install fmt
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
           brew install doxygen
           brew install graphviz
 
+      - name: Install fmt on macOS 13
+        if: ${{ matrix.runner.os == 'macos-13' }}
+        run: |
+          brew install fmt
+
       - name: Build packaged release
         run: |
           mkdir build


### PR DESCRIPTION
No longer needed as C++20 is now used and these platforms ship toolchains w/ `std::format`.