### PR TITLE
Remove unnecessary field

### DIFF
--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -557,20 +557,20 @@ CiffComponent* CiffDirectory::doAdd(CrwDirs& crwDirs, uint16_t crwTagId) {
       add(std::move(m_));
     }
     // Recursive call to next lower level directory
-    cc = cc->add(crwDirs, crwTagId);
-  } else {
-    // Find the tag
-    for (const auto& c : components_)
-      if (c->tagId() == crwTagId) {
-        cc = c;
-        break;
-      }
-    if (!cc) {
-      // Tag doesn't exist yet, add it
-      m_ = std::make_unique<CiffEntry>(crwTagId, tag());
-      cc = m_.get();
-      add(std::move(m_));
+    return cc->add(crwDirs, crwTagId);
+  }
+
+  // Find the tag
+  for (const auto& c : components_)
+    if (c->tagId() == crwTagId) {
+      cc = c;
+      break;
     }
+  if (!cc) {
+    // Tag doesn't exist yet, add it
+    m_ = std::make_unique<CiffEntry>(crwTagId, tag());
+    cc = m_.get();
+    add(std::move(m_));
   }
   return cc;
 }  // CiffDirectory::doAdd

--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -540,38 +540,39 @@ CiffComponent* CiffDirectory::doAdd(CrwDirs& crwDirs, uint16_t crwTagId) {
         if not found, create it
         set value
   */
+  CiffComponent* cc = nullptr;
   if (!crwDirs.empty()) {
     auto dir = crwDirs.top();
     crwDirs.pop();
     // Find the directory
     for (const auto& c : components_)
       if (c->tag() == dir.dir) {
-        cc_ = c;
+        cc = c;
         break;
       }
-    if (!cc_) {
+    if (!cc) {
       // Directory doesn't exist yet, add it
       m_ = std::make_unique<CiffDirectory>(dir.dir, dir.parent);
-      cc_ = m_.get();
+      cc = m_.get();
       add(std::move(m_));
     }
     // Recursive call to next lower level directory
-    cc_ = cc_->add(crwDirs, crwTagId);
+    cc = cc->add(crwDirs, crwTagId);
   } else {
     // Find the tag
     for (const auto& c : components_)
       if (c->tagId() == crwTagId) {
-        cc_ = c;
+        cc = c;
         break;
       }
-    if (!cc_) {
+    if (!cc) {
       // Tag doesn't exist yet, add it
       m_ = std::make_unique<CiffEntry>(crwTagId, tag());
-      cc_ = m_.get();
+      cc = m_.get();
       add(std::move(m_));
     }
   }
-  return cc_;
+  return cc;
 }  // CiffDirectory::doAdd
 
 void CiffHeader::remove(uint16_t crwTagId, uint16_t crwDir) const {

--- a/src/crwimage_int.hpp
+++ b/src/crwimage_int.hpp
@@ -371,7 +371,6 @@ class CiffDirectory : public CiffComponent {
   // DATA
   Components components_;  //!< List of components in this dir
   UniquePtr m_;            // used by recursive doAdd
-  CiffComponent* cc_ = nullptr;
 
 };  // class CiffDirectory
 

--- a/test/data/test_reference_files/crw-test.out
+++ b/test/data/test_reference_files/crw-test.out
@@ -95,7 +95,7 @@ Exif.Image.Make                              Ascii       6  Canon
 Exif.Image.Model                             Ascii      20  Canon PowerShot S40
 Exif.Canon.SerialNumber                      Long        2  1 0
 Exif.Canon.FirmwareVersion                   Ascii      17  Whatever version
-Exif.Canon.FocalLength                       Short       4  2 227 286 215
+Exif.Canon.FocalLength                       Short       4  7.1 mm
 Exif.CanonSi.AutoISO                         Short       1  100
 Exif.CanonSi.ISOSpeed                        Short       1  100
 Exif.CanonSi.MeasuredEV                      Short       1  6.97
@@ -121,6 +121,38 @@ Exif.CanonSi.BulbDuration                    Short       1  0
 Exif.CanonSi.CameraType                      Short       1  Compact
 Exif.Photo.FNumber                           Rational    1  F2.9
 Exif.Photo.ExposureTime                      Rational    1  1/15 s
+Exif.CanonCs.Macro                           Short       1  Off
+Exif.CanonCs.Selftimer                       Short       1  Off
+Exif.CanonCs.Quality                         Short       1  RAW
+Exif.CanonCs.FlashMode                       Short       1  Off
+Exif.CanonCs.DriveMode                       Short       1  Single / timer
+Exif.CanonCs.FocusMode                       Short       1  AI servo AF
+Exif.CanonCs.RecordMode                      Short       1  CRW+THM
+Exif.CanonCs.ImageSize                       Short       1  Large
+Exif.CanonCs.EasyMode                        Short       1  Manual
+Exif.CanonCs.DigitalZoom                     Short       1  None
+Exif.CanonCs.Contrast                        Short       1  Normal
+Exif.CanonCs.Saturation                      Short       1  Normal
+Exif.CanonCs.Sharpness                       Short       1  Normal
+Exif.CanonCs.ISOSpeed                        Short       1  100
+Exif.CanonCs.MeteringMode                    Short       1  Evaluative
+Exif.CanonCs.FocusType                       Short       1  Auto
+Exif.CanonCs.AFPoint                         Short       1  Center
+Exif.CanonCs.ExposureProgram                 Short       1  Program (P)
+Exif.CanonCs.LensType                        Short       1  n/a
+Exif.CanonCs.Lens                            Short       3  7.1 - 21.3 mm
+Exif.CanonCs.MaxAperture                     Short       1  F2.9
+Exif.CanonCs.MinAperture                     Short       1  F8
+Exif.CanonCs.FlashActivity                   Short       1  Did not fire
+Exif.CanonCs.FlashDetails                    Short       1  
+Exif.CanonCs.FocusContinuous                 Short       1  Single
+Exif.CanonCs.AESetting                       Short       1  Normal AE
+Exif.CanonCs.ImageStabilization              Short       1  (65535)
+Exif.CanonCs.DisplayAperture                 Short       1  0
+Exif.CanonCs.ZoomSourceWidth                 Short       1  2272
+Exif.CanonCs.ZoomTargetWidth                 Short       1  2272
+Exif.CanonCs.SpotMeteringMode                Short       1  Center
+Exif.Photo.ColorSpace                        Short       1  Uncalibrated
 File 1/1: exiv2-canon-powershot-s40.crw
 Exif.Thumbnail.Compression                   Short       1  JPEG (old-style)
 Exif.Thumbnail.JPEGInterchangeFormat         Long        1  0


### PR DESCRIPTION
Remove `CiffDirectory::cc_`. It's a raw pointer, so it's ownership is unclear. There also doesn't seem to be any reason to store it in the object.