### PR TITLE
Add Linux and MacOS ARM64 support to CI (backport to 0.28.x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: exiv2-linux64
+          name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
           path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
@@ -57,7 +57,6 @@ jobs:
     name: 'Build macOS Release'
     runs-on: ${{ matrix.runner.os }}
     strategy:
-      fail-fast: false
       matrix:
         runner:
           - { os: macos-12, arch: x64   }
@@ -92,7 +91,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: exiv2-${{ matrix.runner.os }}-${{ matrix.runner.arch }}
+          name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
           path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
@@ -141,7 +140,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: exiv2-win
+          name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
           path: ./build/exiv2-*.zip
           if-no-files-found: error
           retention-days: 1
@@ -228,6 +227,5 @@ jobs:
           prerelease: ${{ env.TAG_NAME == 'nightly' }}
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            ./exiv2-linux64/exiv2-*
-            ./exiv2-macos-*/exiv2-*
-            ./exiv2-win/exiv2-*
+            ./exiv2-*/exiv2-*
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-12, arch: x64   }
+          - { os: macos-13, arch: x64   }
           - { os: macos-14, arch: arm64 }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,11 @@ on:
 jobs:
   Linux:
     name: 'Build Linux Release'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner.os }}
+    strategy:
+      matrix:
+        runner:
+          - { os: ubuntu-22.04, arch: x64   }
     steps:
       - uses: actions/checkout@v4
 
@@ -98,7 +102,11 @@ jobs:
 
   Windows:
     name: 'Build Windows Release'
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner.os }}
+    strategy:
+      matrix:
+        runner:
+          - { os: windows-2022, arch: x64   }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         runner:
           - { os: ubuntu-22.04, arch: x64   }
+          - { os: ubuntu-22.04-arm, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - { os: macos-12, arch: X64   }
-          - { os: macos-14, arch: ARM64 }
+          - { os: macos-12, arch: x64   }
+          - { os: macos-14, arch: arm64 }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: exiv2-${{ matrix.runner.os }}
+          name: exiv2-${{ matrix.runner.os }}-${{ matrix.runner.arch }}
           path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
@@ -229,5 +229,5 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           files: |
             ./exiv2-linux64/exiv2-*
-            ./exiv2-macos/exiv2-*
+            ./exiv2-macos-*/exiv2-*
             ./exiv2-win/exiv2-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,13 @@ jobs:
 
   macOS:
     name: 'Build macOS Release'
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - { os: macos-12, arch: X64   }
+          - { os: macos-14, arch: ARM64 }
     steps:
       - uses: actions/checkout@v4
 
@@ -86,7 +92,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: exiv2-macos
+          name: exiv2-${{ matrix.runner.os }}
           path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -12,16 +12,10 @@ else()
     set(CPACK_GENERATOR TGZ)  # MinGW/Cygwin/Linux/macOS etc use .tar.gz
 endif()
 
-set (BARCH "") # Target architecture
-if ( MSVC OR MSYS OR CYGWIN OR MINGW )
-  if ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-    set (BARCH 64bit)
-  else()
-    set (BARCH 32bit)
-  endif()
-else()
-  # Will be "arm64", "x86_64" / "amd64", etc.
-  set (BARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+set (BARCH ${CMAKE_HOST_SYSTEM_PROCESSOR}) # Target architecture
+if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
+  # 32-bit build, force architecture
+  set (BARCH "i686")
 endif()
 
 set (LT "") # Library Type

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -12,13 +12,16 @@ else()
     set(CPACK_GENERATOR TGZ)  # MinGW/Cygwin/Linux/macOS etc use .tar.gz
 endif()
 
-set (BS "") # Bit Size
-if ( NOT APPLE )
+set (BARCH "") # Target architecture
+if ( MSVC OR MSYS OR CYGWIN OR MINGW )
   if ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-    set (BS 64)
+    set (BARCH 64bit)
   else()
-    set (BS 32)
+    set (BARCH 32bit)
   endif()
+else()
+  # Will be "arm64", "x86_64" / "amd64", etc.
+  set (BARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
 endif()
 
 set (LT "") # Library Type
@@ -113,7 +116,7 @@ endif()
 # Set RV = Release Version
 set(RV "Exiv2 v${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
-set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${VS}${BUNDLE_NAME}${BS}${CC}${LT}${BT}${WR})
+set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${BARCH}-${VS}${BUNDLE_NAME}${CC}${LT}${BT}${WR})
 
 # https://stackoverflow.com/questions/17495906/copying-files-and-including-them-in-a-cpack-archive
 install(FILES     "${PROJECT_SOURCE_DIR}/samples/exifprint.cpp" DESTINATION "samples")

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -12,7 +12,7 @@ else()
     set(CPACK_GENERATOR TGZ)  # MinGW/Cygwin/Linux/macOS etc use .tar.gz
 endif()
 
-set (BARCH ${CMAKE_HOST_SYSTEM_PROCESSOR}) # Target architecture
+set (BARCH ${CMAKE_SYSTEM_PROCESSOR}) # Target architecture
 if ( CMAKE_SIZEOF_VOID_P EQUAL 4 )
   # 32-bit build, force architecture
   set (BARCH "i686")
@@ -20,12 +20,12 @@ endif()
 
 set (LT "") # Library Type
 if ( NOT BUILD_SHARED_LIBS )
-	set (LT Static)
+	set (LT -Static)
 endif()
 
 set (BT "") # Build Type
 if ( NOT ${CMAKE_BUILD_TYPE} STREQUAL Release )
-	set (BT ${CMAKE_BUILD_TYPE})
+	set (BT -${CMAKE_BUILD_TYPE})
 endif()
 
 if ( MINGW OR MSYS )
@@ -52,13 +52,13 @@ endif()
 set (CC "") # Compiler
 if ( NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" )
   if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    set (CC Clang)
+    set (CC -Clang)
   endif()
 endif()
 
 set (WR "") # WebReady
 if ( EXIV2_ENABLE_WEBREADY )
-    set (WR Webready)
+    set (WR -Webready)
 endif()
 
 set (VS "") # VisualStudio
@@ -110,7 +110,7 @@ endif()
 # Set RV = Release Version
 set(RV "Exiv2 v${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
-set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${BARCH}-${VS}${BUNDLE_NAME}${CC}${LT}${BT}${WR})
+set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${VS}${BUNDLE_NAME}-${BARCH}${CC}${LT}${BT}${WR})
 
 # https://stackoverflow.com/questions/17495906/copying-files-and-including-them-in-a-cpack-archive
 install(FILES     "${PROJECT_SOURCE_DIR}/samples/exifprint.cpp" DESTINATION "samples")


### PR DESCRIPTION
This PR is a backport of https://github.com/Exiv2/exiv2/pull/3142 to 0.28.x (with the hopes that it gets included before 0.28.4 @neheb release) with minimal changes to not break the version naming scheme of "linux64" even though the master branch has moved away from that scheme. This is to not break any other dependent projects CI that might hardcode or search for "linux64".

See https://github.com/gmesm/exiv2/releases/tag/v0.28.3 and https://github.com/gmesm/exiv2/releases/tag/v0.28.3 for successful release creation