### PR TITLE
CMake: rename exported targets file

### DIFF
--- a/cmake/exiv2Config.cmake.in
+++ b/cmake/exiv2Config.cmake.in
@@ -31,7 +31,7 @@ if(NOT @BUILD_SHARED_LIBS@) # if(NOT BUILD_SHARED_LIBS)
   endif()
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/exiv2Export.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/exiv2Targets.cmake")
 
 check_required_components(exiv2)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,7 +317,7 @@ set(requires_private_for_pc_file
 
 write_basic_package_version_file(exiv2ConfigVersion.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS exiv2lib EXPORT exiv2Export)
+install(TARGETS exiv2lib EXPORT exiv2Targets)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
@@ -327,7 +327,7 @@ configure_package_config_file(
 install(FILES ${PUBLIC_HEADERS} ${CMAKE_BINARY_DIR}/exv_conf.h ${CMAKE_BINARY_DIR}/exiv2lib_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
 install(
-  EXPORT exiv2Export
+  EXPORT exiv2Targets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
   NAMESPACE Exiv2::
 )


### PR DESCRIPTION
Uses the more conventional naming pattern:

https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#exporting-targets

This should be a transparent no-op as it is wrapped in exiv2Config.cmake that is being looked for anyway.