### PR TITLE
Revert "fix copy constructors"

### DIFF
--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -124,6 +124,25 @@ TiffEntryBase::TiffEntryBase(const TiffEntryBase& rhs) :
     storage_(rhs.storage_) {
 }
 
+TiffDirectory::TiffDirectory(const TiffDirectory& rhs) : TiffComponent(rhs), hasNext_(rhs.hasNext_) {
+}
+
+TiffSubIfd::TiffSubIfd(const TiffSubIfd& rhs) : TiffEntryBase(rhs), newGroup_(rhs.newGroup_) {
+}
+
+TiffBinaryArray::TiffBinaryArray(const TiffBinaryArray& rhs) :
+    TiffEntryBase(rhs),
+    cfgSelFct_(rhs.cfgSelFct_),
+    arraySet_(rhs.arraySet_),
+    arrayCfg_(rhs.arrayCfg_),
+    arrayDef_(rhs.arrayDef_),
+    defSize_(rhs.defSize_),
+    setSize_(rhs.setSize_),
+    origData_(rhs.origData_),
+    origSize_(rhs.origSize_),
+    pRoot_(rhs.pRoot_) {
+}
+
 TiffComponent::UniquePtr TiffComponent::clone() const {
   return UniquePtr(doClone());
 }

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -851,7 +851,7 @@ class TiffDirectory : public TiffComponent {
   //! @name Protected Creators
   //@{
   //! Copy constructor (used to implement clone()).
-  TiffDirectory(const TiffDirectory&) = default;
+  TiffDirectory(const TiffDirectory& rhs);
   //@}
 
   //! @name Protected Manipulators
@@ -944,7 +944,7 @@ class TiffSubIfd : public TiffEntryBase {
   //! @name Protected Creators
   //@{
   //! Copy constructor (used to implement clone()).
-  TiffSubIfd(const TiffSubIfd&) = default;
+  TiffSubIfd(const TiffSubIfd& rhs);
   TiffSubIfd& operator=(const TiffSubIfd&) = delete;
   //@}
 
@@ -1334,7 +1334,7 @@ class TiffBinaryArray : public TiffEntryBase {
   //! @name Protected Creators
   //@{
   //! Copy constructor (used to implement clone()).
-  TiffBinaryArray(const TiffBinaryArray&) = default;
+  TiffBinaryArray(const TiffBinaryArray& rhs);
   //@}
 
   //! @name Protected Manipulators


### PR DESCRIPTION
This reverts commit afb2d998fe62f7e829e93e62506bf9968117c9c5.

This commit is wrong and ends up resulting in use after frees because of C pointers. The proper solution is shared_ptr instead of C pointers but that's a lot more involved than reverting this.

Fixes: https://github.com/Exiv2/exiv2/issues/3168