### PR TITLE
Use std::unique_ptr rather than raw pointer

### DIFF
--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -75,6 +75,9 @@ TiffIfdMakernote::TiffIfdMakernote(uint16_t tag, IfdId group, IfdId mnGroup, std
     TiffComponent(tag, group), pHeader_(std::move(pHeader)), ifd_(tag, mnGroup, hasNext) {
 }
 
+TiffIfdMakernote::~TiffIfdMakernote() {
+}
+
 TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArrayCfg& arrayCfg, const ArrayDef* arrayDef,
                                  size_t defSize) :
     TiffEntryBase(tag, group, arrayCfg.elTiffType_), arrayCfg_(&arrayCfg), arrayDef_(arrayDef), defSize_(defSize) {

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -89,14 +89,6 @@ TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arra
   // We'll figure out the correct cfg later
 }
 
-TiffDirectory::~TiffDirectory() {}
-
-TiffSubIfd::~TiffSubIfd() {}
-
-TiffEntryBase::~TiffEntryBase() {}
-
-TiffBinaryArray::~TiffBinaryArray() {}
-
 TiffEntryBase::TiffEntryBase(const TiffEntryBase& rhs) :
     TiffComponent(rhs),
     tiffType_(rhs.tiffType_),
@@ -213,7 +205,7 @@ void TiffEntryBase::setValue(Value::UniquePtr value) {
     return;
   tiffType_ = toTiffType(value->typeId());
   count_ = value->count();
-  std::swap(pValue_, value);
+  pValue_ = std::move(value);
 }
 
 void TiffDataEntry::setStrips(const Value* pSize, const byte* pData, size_t sizeData, size_t baseOffset) {
@@ -560,9 +552,8 @@ TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/) {
 }  // TiffComponent::doAddChild
 
 TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent) {
-  TiffComponent* tc = tiffComponent.get();
   components_.push_back(std::move(tiffComponent));
-  return tc;
+  return components_.back().get();
 }  // TiffDirectory::doAddChild
 
 TiffComponent* TiffSubIfd::doAddChild(TiffComponent::UniquePtr tiffComponent) {
@@ -588,10 +579,9 @@ TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::UniquePtr tiffCompone
 }
 
 TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::UniquePtr tiffComponent) {
-  TiffComponent* tc = tiffComponent.get();
   elements_.push_back(std::move(tiffComponent));
   setDecoded(true);
-  return tc;
+  return elements_.back().get();
 }  // TiffBinaryArray::doAddChild
 
 TiffComponent* TiffComponent::addNext(TiffComponent::UniquePtr tiffComponent) {
@@ -604,7 +594,7 @@ TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/) {
 
 TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent) {
   if (hasNext_) {
-    std::swap(pNext_, tiffComponent);
+    pNext_ = std::move(tiffComponent);
     return pNext_.get();
   }
   return nullptr;
@@ -1192,7 +1182,7 @@ size_t TiffComponent::writeImage(IoWrapper& ioWrapper, ByteOrder byteOrder) cons
 size_t TiffDirectory::doWriteImage(IoWrapper& ioWrapper, ByteOrder byteOrder) const {
   size_t len = 0;
   TiffComponent* pSubIfd = nullptr;
-  for (auto& component : components_) {
+  for (const auto& component : components_) {
     if (component->tag() == 0x014a) {
       // Hack: delay writing of sub-IFD image data to get the order correct
 #ifndef SUPPRESS_WARNINGS

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -75,8 +75,7 @@ TiffIfdMakernote::TiffIfdMakernote(uint16_t tag, IfdId group, IfdId mnGroup, std
     TiffComponent(tag, group), pHeader_(std::move(pHeader)), ifd_(tag, mnGroup, hasNext) {
 }
 
-TiffIfdMakernote::~TiffIfdMakernote() {
-}
+TiffIfdMakernote::~TiffIfdMakernote() = default;
 
 TiffBinaryArray::TiffBinaryArray(uint16_t tag, IfdId group, const ArrayCfg& arrayCfg, const ArrayDef* arrayDef,
                                  size_t defSize) :

--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -562,7 +562,7 @@ TiffComponent* TiffSubIfd::doAddChild(TiffComponent::UniquePtr tiffComponent) {
     throw Error(ErrorCode::kerErrorMessage, "dynamic_cast to TiffDirectory failed");
   }
   tiffComponent.release();
-  ifds_.push_back(std::unique_ptr<TiffDirectory>(d));
+  ifds_.emplace_back(d);
   return d;
 }  // TiffSubIfd::doAddChild
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -1073,7 +1073,7 @@ class TiffIfdMakernote : public TiffComponent {
   //! Default constructor
   TiffIfdMakernote(uint16_t tag, IfdId group, IfdId mnGroup, std::unique_ptr<MnHeader> pHeader, bool hasNext = true);
   //! Virtual destructor
-  ~TiffIfdMakernote() override = default;
+  ~TiffIfdMakernote() override;
   //@}
 
   /*!

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -552,7 +552,7 @@ class TiffEntryBase : public TiffComponent {
   // storage_ DataBuf below.
   byte* pData_{};  //!< Pointer to the data area
 
-  int idx_{};        //!< Unique id of the entry in the image
+  int idx_{};                      //!< Unique id of the entry in the image
   std::unique_ptr<Value> pValue_;  //!< Converted data value
 
   // This DataBuf is only used when TiffEntryBase::setData is called.
@@ -917,9 +917,9 @@ class TiffDirectory : public TiffComponent {
   //@}
 
   // DATA
-  Components components_;   //!< List of components in this directory
-  bool hasNext_;            //!< True if the directory has a next pointer
-  UniquePtr pNext_;         //!< Pointer to the next IFD
+  Components components_;  //!< List of components in this directory
+  bool hasNext_;           //!< True if the directory has a next pointer
+  UniquePtr pNext_;        //!< Pointer to the next IFD
 };
 
 /*!

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -390,7 +390,7 @@ class TiffEntryBase : public TiffComponent {
   }
 
   //! Virtual destructor.
-  ~TiffEntryBase() override {};
+  ~TiffEntryBase() override = default;
   //@}
 
   //! @name NOT implemented
@@ -553,7 +553,7 @@ class TiffEntryBase : public TiffComponent {
   byte* pData_{};  //!< Pointer to the data area
 
   int idx_{};        //!< Unique id of the entry in the image
-  std::unique_ptr<Value> pValue_{};  //!< Converted data value
+  std::unique_ptr<Value> pValue_;  //!< Converted data value
 
   // This DataBuf is only used when TiffEntryBase::setData is called.
   // Otherwise, it remains empty. It is wrapped in a shared_ptr because
@@ -830,7 +830,7 @@ class TiffDirectory : public TiffComponent {
   //! Default constructor
   TiffDirectory(uint16_t tag, IfdId group, bool hasNext = true);
   //! Virtual destructor
-  ~TiffDirectory() override {};
+  ~TiffDirectory() override = default;
   //@}
 
   //! @name NOT implemented
@@ -938,7 +938,7 @@ class TiffSubIfd : public TiffEntryBase {
   //! Default constructor
   TiffSubIfd(uint16_t tag, IfdId group, IfdId newGroup);
   //! Virtual destructor
-  ~TiffSubIfd() override {};
+  ~TiffSubIfd() override = default;
   //@}
 
   //! @name Protected Creators
@@ -1269,7 +1269,7 @@ class TiffBinaryArray : public TiffEntryBase {
   //! Constructor for a complex binary array
   TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arraySet, size_t setSize, CfgSelFct cfgSelFct);
   //! Virtual destructor
-  ~TiffBinaryArray() override {};
+  ~TiffBinaryArray() override = default;
   TiffBinaryArray& operator=(const TiffBinaryArray&) = delete;
   //@}
 

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -154,7 +154,7 @@ class TiffComponent {
   //! TiffComponent auto_ptr type
   using UniquePtr = std::unique_ptr<TiffComponent>;
   //! Container type to hold all metadata
-  using Components = std::vector<std::unique_ptr<TiffComponent>>;
+  using Components = std::vector<UniquePtr>;
 
   //! @name Creators
   //@{
@@ -390,7 +390,7 @@ class TiffEntryBase : public TiffComponent {
   }
 
   //! Virtual destructor.
-  ~TiffEntryBase() override;
+  ~TiffEntryBase() override {};
   //@}
 
   //! @name NOT implemented
@@ -830,7 +830,7 @@ class TiffDirectory : public TiffComponent {
   //! Default constructor
   TiffDirectory(uint16_t tag, IfdId group, bool hasNext = true);
   //! Virtual destructor
-  ~TiffDirectory() override;
+  ~TiffDirectory() override {};
   //@}
 
   //! @name NOT implemented
@@ -919,7 +919,7 @@ class TiffDirectory : public TiffComponent {
   // DATA
   Components components_;   //!< List of components in this directory
   bool hasNext_;            //!< True if the directory has a next pointer
-  UniquePtr pNext_{};       //!< Pointer to the next IFD
+  UniquePtr pNext_;         //!< Pointer to the next IFD
 };
 
 /*!
@@ -938,7 +938,7 @@ class TiffSubIfd : public TiffEntryBase {
   //! Default constructor
   TiffSubIfd(uint16_t tag, IfdId group, IfdId newGroup);
   //! Virtual destructor
-  ~TiffSubIfd() override;
+  ~TiffSubIfd() override {};
   //@}
 
   //! @name Protected Creators
@@ -1269,7 +1269,7 @@ class TiffBinaryArray : public TiffEntryBase {
   //! Constructor for a complex binary array
   TiffBinaryArray(uint16_t tag, IfdId group, const ArraySet* arraySet, size_t setSize, CfgSelFct cfgSelFct);
   //! Virtual destructor
-  ~TiffBinaryArray() override;
+  ~TiffBinaryArray() override {};
   TiffBinaryArray& operator=(const TiffBinaryArray&) = delete;
   //@}
 
@@ -1470,7 +1470,7 @@ class TiffBinaryElement : public TiffEntryBase {
   @brief Compare two TIFF component pointers by tag. Return true if the tag
          of component lhs is less than that of rhs.
  */
-bool cmpTagLt(const std::unique_ptr<TiffComponent>& lhs, const std::unique_ptr<TiffComponent>& rhs);
+bool cmpTagLt(const TiffComponent::UniquePtr& lhs, const TiffComponent::UniquePtr& rhs);
 
 /*!
   @brief Compare two TIFF component pointers by group. Return true if the

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -154,7 +154,7 @@ class TiffComponent {
   //! TiffComponent auto_ptr type
   using UniquePtr = std::unique_ptr<TiffComponent>;
   //! Container type to hold all metadata
-  using Components = std::vector<TiffComponent*>;
+  using Components = std::vector<std::unique_ptr<TiffComponent>>;
 
   //! @name Creators
   //@{
@@ -475,7 +475,7 @@ class TiffEntryBase : public TiffComponent {
   }
   //! Return a const pointer to the converted value of this component
   [[nodiscard]] const Value* pValue() const {
-    return pValue_;
+    return pValue_.get();
   }
   //@}
 
@@ -553,7 +553,7 @@ class TiffEntryBase : public TiffComponent {
   byte* pData_{};  //!< Pointer to the data area
 
   int idx_{};        //!< Unique id of the entry in the image
-  Value* pValue_{};  //!< Converted data value
+  std::unique_ptr<Value> pValue_{};  //!< Converted data value
 
   // This DataBuf is only used when TiffEntryBase::setData is called.
   // Otherwise, it remains empty. It is wrapped in a shared_ptr because
@@ -919,7 +919,7 @@ class TiffDirectory : public TiffComponent {
   // DATA
   Components components_;   //!< List of components in this directory
   bool hasNext_;            //!< True if the directory has a next pointer
-  TiffComponent* pNext_{};  //!< Pointer to the next IFD
+  UniquePtr pNext_{};       //!< Pointer to the next IFD
 };
 
 /*!
@@ -989,7 +989,7 @@ class TiffSubIfd : public TiffEntryBase {
 
  private:
   //! A collection of TIFF directories (IFDs)
-  using Ifds = std::vector<TiffDirectory*>;
+  using Ifds = std::vector<std::unique_ptr<TiffDirectory>>;
 
   // DATA
   IfdId newGroup_;  //!< Start of the range of group numbers for the sub-IFDs
@@ -1470,13 +1470,13 @@ class TiffBinaryElement : public TiffEntryBase {
   @brief Compare two TIFF component pointers by tag. Return true if the tag
          of component lhs is less than that of rhs.
  */
-bool cmpTagLt(const TiffComponent* lhs, const TiffComponent* rhs);
+bool cmpTagLt(const std::unique_ptr<TiffComponent>& lhs, const std::unique_ptr<TiffComponent>& rhs);
 
 /*!
   @brief Compare two TIFF component pointers by group. Return true if the
          group of component lhs is less than that of rhs.
  */
-bool cmpGroupLt(const TiffComponent* lhs, const TiffComponent* rhs);
+bool cmpGroupLt(const std::unique_ptr<TiffDirectory>& lhs, const std::unique_ptr<TiffDirectory>& rhs);
 
 //! Function to create and initialize a new TIFF entry
 TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group);

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -580,8 +580,8 @@ void TiffEncoder::visitDirectory(TiffDirectory* /*object*/) {
 void TiffEncoder::visitDirectoryNext(TiffDirectory* object) {
   // Update type and count in IFD entries, in case they changed
   byte* p = object->start() + 2;
-  for (auto component : object->components_) {
-    p += updateDirEntry(p, byteOrder(), component);
+  for (auto& component : object->components_) {
+    p += updateDirEntry(p, byteOrder(), component.get());
   }
 }
 

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -580,7 +580,7 @@ void TiffEncoder::visitDirectory(TiffDirectory* /*object*/) {
 void TiffEncoder::visitDirectoryNext(TiffDirectory* object) {
   // Update type and count in IFD entries, in case they changed
   byte* p = object->start() + 2;
-  for (auto& component : object->components_) {
+  for (const auto& component : object->components_) {
     p += updateDirEntry(p, byteOrder(), component.get());
   }
 }

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -302,8 +302,7 @@ void TiffDecoder::decodeIptc(const TiffEntryBase* object) {
       return;
     }
 #ifndef SUPPRESS_WARNINGS
-    EXV_WARNING << "Failed to decode IPTC block found in "
-                << "Directory Image, entry 0x83bb\n";
+    EXV_WARNING << "Failed to decode IPTC block found in " << "Directory Image, entry 0x83bb\n";
 
 #endif
   }
@@ -324,8 +323,7 @@ void TiffDecoder::decodeIptc(const TiffEntryBase* object) {
       return;
     }
 #ifndef SUPPRESS_WARNINGS
-    EXV_WARNING << "Failed to decode IPTC block found in "
-                << "Directory Image, entry 0x8649\n";
+    EXV_WARNING << "Failed to decode IPTC block found in " << "Directory Image, entry 0x8649\n";
 
 #endif
   }
@@ -1229,8 +1227,7 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
     if (p + 12 > pLast_) {
 #ifndef SUPPRESS_WARNINGS
       EXV_ERROR << "Entry in directory " << groupName(object->group())
-                << "requests access to memory beyond the data buffer. "
-                << "Skipping entry.\n";
+                << "requests access to memory beyond the data buffer. " << "Skipping entry.\n";
 #endif
       return;
     }
@@ -1284,9 +1281,8 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
       } else {
 #ifndef SUPPRESS_WARNINGS
         EXV_ERROR << "Offset of directory " << groupName(object->group()) << ", entry 0x" << std::setw(4)
-                  << std::setfill('0') << std::hex << object->tag() << " is out of bounds: "
-                  << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset
-                  << "; truncating the entry\n";
+                  << std::setfill('0') << std::hex << object->tag() << " is out of bounds: " << "Offset = 0x"
+                  << std::setw(8) << std::setfill('0') << std::hex << offset << "; truncating the entry\n";
 #endif
       }
       size = 0;
@@ -1302,11 +1298,10 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
       // check for size being invalid
       if (size > static_cast<size_t>(pLast_ - pData)) {
 #ifndef SUPPRESS_WARNINGS
-        EXV_ERROR << "Upper boundary of data for "
-                  << "directory " << groupName(object->group()) << ", entry 0x" << std::setw(4) << std::setfill('0')
-                  << std::hex << object->tag() << " is out of bounds: "
-                  << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset << ", size = " << std::dec
-                  << size
+        EXV_ERROR << "Upper boundary of data for " << "directory " << groupName(object->group()) << ", entry 0x"
+                  << std::setw(4) << std::setfill('0') << std::hex << object->tag()
+                  << " is out of bounds: " << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset
+                  << ", size = " << std::dec << size
                   << ", exceeds buffer size by "
                   // cast to make MSVC happy
                   << size - static_cast<size_t>(pLast_ - pData) << " Bytes; truncating the entry\n";


### PR DESCRIPTION
This is a follow-up to #3174. Switching to `std::unique_ptr` means that we cannot accidentally introduce the same bug again. This PR doesn't change the behavior of the copy constructor, so when you clone a `TiffComponent`, these fields don't get copied. I'm not sure if that's actually the correct behavior, but it's the way it was before, so I think it's safer not to change it for the purposes of a security fix. If we decide to change the cloning behavior in the future then it might make sense to replace these unique_ptrs with shared_ptrs.