### PR TITLE
fix python syntax warnings

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1568,11 +1568,9 @@ CurlIo::CurlImpl::CurlImpl(const std::string& url, size_t blockSize) : Impl(url,
 
 int64_t CurlIo::CurlImpl::getFileLength() {
   curl_easy_reset(curl_);  // reset all options
-  std::string response;
   curl_easy_setopt(curl_, CURLOPT_URL, path_.c_str());
   curl_easy_setopt(curl_, CURLOPT_NOBODY, 1);  // HEAD
   curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, curlWriter);
-  curl_easy_setopt(curl_, CURLOPT_WRITEDATA, &response);
   curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 0L);
   curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYHOST, 0L);
   curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT, timeout_);

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -93,7 +93,7 @@ std::string BmffImage::toAscii(uint32_t n) {
   // show 0 as _
   std::replace(result.begin(), result.end(), '\0', '_');
   // show non 7-bit printable ascii as .
-  auto f = [](unsigned char c) { return !std::isprint(c); };
+  auto f = [](unsigned char c) { return c < 32 || c > 126; };
   std::replace_if(result.begin(), result.end(), f, '.');
   return result;
 }

--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -49,12 +49,12 @@ struct binaryToStringHelper;
 template <typename T>
 std::ostream& operator<<(std::ostream& stream, const binaryToStringHelper<T>& binToStr) {
   for (size_t i = 0; i < binToStr.buf_.size(); ++i) {
-    auto c = static_cast<int>(binToStr.buf_.at(i));
+    auto c = static_cast<unsigned char>(binToStr.buf_.at(i));
     if (c != 0 || i != binToStr.buf_.size() - 1) {
-      if (!std::isprint(static_cast<unsigned char>(c))) {
-        c = '.';
-      }
-      stream.put(static_cast<char>(c));
+      if (c < 32 || c > 126)
+        stream.put('.');
+      else
+        stream.put(static_cast<char>(c));
     }
   }
   return stream;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -453,6 +453,8 @@ void hexdump(std::ostream& os, const byte* buf, size_t len, size_t offset) {
   const std::string align(pos, ' ');
   std::ios::fmtflags f(os.flags());
 
+  auto space = [](unsigned char c) { return (c < 32 || c > 126) ? '.' : static_cast<char>(c); };
+
   size_t i = 0;
   while (i < len) {
     os << "  " << std::setw(4) << std::setfill('0') << std::hex << i + offset << "  ";
@@ -461,7 +463,7 @@ void hexdump(std::ostream& os, const byte* buf, size_t len, size_t offset) {
     for (size_t j = 0; j < hexbase && i < len; ++j, ++i) {
       auto c = static_cast<int>(buf[i]);
       os << std::setw(2) << std::setfill('0') << std::right << std::hex << c << " ";
-      ss += std::isprint(c) ? static_cast<char>(c) : '.';
+      ss += space(c);
     }
 
     std::string::size_type width = 9 + (((i - 1) % hexbase + 1) * 3);

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -576,7 +576,7 @@ static XMP_Status nsDumper(void* refCon, XMP_StringPtr buffer, XMP_StringLen buf
   std::string out(buffer, bufferSize);
 
   // remove blanks: http://stackoverflow.com/questions/83439/remove-spaces-from-stdstring-in-c
-  std::erase_if(out, [](unsigned char c) { return std::isspace(c); });
+  std::erase_if(out, [](unsigned char c) { return c < 32 || c > 126; });
 
   bool bURI = Internal::contains(out, "http://");
   bool bNS = Internal::contains(out, ':') && !bURI;

--- a/tests/bugfixes/redmine/test_issue_1108.py
+++ b/tests/bugfixes/redmine/test_issue_1108.py
@@ -159,7 +159,7 @@ class CheckDumpSubFiles(metaclass=system_tests.CaseMeta):
        2 |     120 | Caption                  |     12 | Classic View
    17987 | 0xffd9 EOI  
 """,
-    """STRUCTURE OF PNG FILE: """ + filenames[1] + """
+    """STRUCTURE OF PNG FILE: """ + filenames[1] + r"""
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ...@........                   | 0x7f775da4
       33 | iCCP  |    1404 | icc..x...i8........af\...w_3.. | 0x363e2409

--- a/tests/bugfixes/redmine/test_issue_662.py
+++ b/tests/bugfixes/redmine/test_issue_662.py
@@ -100,7 +100,7 @@ UserComment
 
 """,
         "",
-        """ExifTag                    
+        r"""ExifTag                    
   0000  1a 00 00 00                                      ....
 
 UserComment                

--- a/tests/bugfixes/redmine/test_issue_922.py
+++ b/tests/bugfixes/redmine/test_issue_922.py
@@ -127,7 +127,7 @@ class AddMinusPSOption(metaclass=CaseMeta):
                                                                                                     
                            
 <?xpacket end="w"?>""",
-        """STRUCTURE OF PNG FILE: $png_bug_file
+        r"""STRUCTURE OF PNG FILE: $png_bug_file
  address | chunk |  length | data                           | checksum
        8 | IHDR  |      13 | ...@........                   | 0x7f775da4
       33 | zTXt  |    8769 | Raw profile type exif..x...[r. | 0x4a89d860


### PR DESCRIPTION
Also remove std::isprint. This is impacted by locale. Unfortunately there's a lot more sections of code that seem to be impacted.