### PR TITLE
switch several formats to g

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -3111,7 +3111,7 @@ std::ostream& CanonMakerNote::printSi0x0015(std::ostream& os, const Value& value
   const auto val = static_cast<int16_t>(value.toInt64());
   if (val < 0)
     return os << value;
-  return os << stringFormat("F{:.2}", fnumber(canonEv(val)));
+  return os << stringFormat("F{:.2g}", fnumber(canonEv(val)));
 }
 
 std::ostream& CanonMakerNote::printSi0x0016(std::ostream& os, const Value& value, const ExifData*) {

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -923,11 +923,11 @@ std::ostream& PentaxMakerNote::printTime(std::ostream& os, const Value& value, c
 }
 
 std::ostream& PentaxMakerNote::printExposure(std::ostream& os, const Value& value, const ExifData*) {
-  return os << stringFormat("{} ms", static_cast<float>(value.toInt64()) / 100);
+  return os << stringFormat("{:g} ms", static_cast<float>(value.toInt64()) / 100);
 }
 
 std::ostream& PentaxMakerNote::printFValue(std::ostream& os, const Value& value, const ExifData*) {
-  return os << stringFormat("F{:.2}", static_cast<float>(value.toInt64()) / 10);
+  return os << stringFormat("F{:.2g}", static_cast<float>(value.toInt64()) / 10);
 }
 
 std::ostream& PentaxMakerNote::printFocalLength(std::ostream& os, const Value& value, const ExifData*) {
@@ -935,7 +935,7 @@ std::ostream& PentaxMakerNote::printFocalLength(std::ostream& os, const Value& v
 }
 
 std::ostream& PentaxMakerNote::printCompensation(std::ostream& os, const Value& value, const ExifData*) {
-  return os << stringFormat("{:.2} EV", (static_cast<float>(value.toInt64()) - 50) / 10);
+  return os << stringFormat("{:.2g} EV", (static_cast<float>(value.toInt64()) - 50) / 10);
 }
 
 std::ostream& PentaxMakerNote::printTemperature(std::ostream& os, const Value& value, const ExifData*) {
@@ -943,7 +943,7 @@ std::ostream& PentaxMakerNote::printTemperature(std::ostream& os, const Value& v
 }
 
 std::ostream& PentaxMakerNote::printFlashCompensation(std::ostream& os, const Value& value, const ExifData*) {
-  return os << stringFormat("{:.2} EV", static_cast<float>(value.toInt64()) / 256);
+  return os << stringFormat("{:.2g} EV", static_cast<float>(value.toInt64()) / 256);
 }
 
 std::ostream& PentaxMakerNote::printBracketing(std::ostream& os, const Value& value, const ExifData*) {


### PR DESCRIPTION
Adds compatibility with fmt < 8 which behaves differently than std::format.