### PR TITLE
Fix zlib.h not found in src/pngimage.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,6 +231,7 @@ endif()
 if( EXIV2_ENABLE_PNG )
     target_link_libraries( exiv2lib PRIVATE ZLIB::ZLIB)
     target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
+    target_include_directories(exiv2lib PRIVATE ${ZLIB_INCLUDE_DIR})
     list(APPEND requires_private_list "zlib")
 endif()
 


### PR DESCRIPTION
compiling exif2lib with EXV_HAVE_LIBZ fails at least on windows because the cmake does not set the include path for zlib