### PR TITLE
use actual array instead of C string

### DIFF
--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -25,45 +25,45 @@
 #include <iostream>
 #include <string>
 
-enum {
-  TAG_ftyp = 0x66747970U,  //!< "ftyp" File type box */
-  TAG_avci = 0x61766369U,  //!< "avci" AVC */
-  TAG_avcs = 0x61766373U,  //!< "avcs" AVC */
-  TAG_avif = 0x61766966U,  //!< "avif" AVIF */
-  TAG_avio = 0x6176696fU,  //!< "avio" AVIF */
-  TAG_avis = 0x61766973U,  //!< "avis" AVIF */
-  TAG_heic = 0x68656963U,  //!< "heic" HEIC */
-  TAG_heif = 0x68656966U,  //!< "heif" HEIF */
-  TAG_heim = 0x6865696dU,  //!< "heim" HEIC */
-  TAG_heis = 0x68656973U,  //!< "heis" HEIC */
-  TAG_heix = 0x68656978U,  //!< "heix" HEIC */
-  TAG_j2is = 0x6a326973U,  //!< "j2is" HEJ2K */
-  TAG_j2ki = 0x6a326b69U,  //!< "j2ki" HEJ2K */
-  TAG_mif1 = 0x6d696631U,  //!< "mif1" HEIF */
-  TAG_crx = 0x63727820U,   //!< "crx " Canon CR3 */
-  TAG_jxl = 0x6a786c20U,   //!< "jxl " JPEG XL file type */
-  TAG_moov = 0x6d6f6f76U,  //!< "moov" Movie */
-  TAG_meta = 0x6d657461U,  //!< "meta" Metadata */
-  TAG_mdat = 0x6d646174U,  //!< "mdat" Media data */
-  TAG_uuid = 0x75756964U,  //!< "uuid" UUID */
-  TAG_dinf = 0x64696e66U,  //!< "dinf" Data information */
-  TAG_iprp = 0x69707270U,  //!< "iprp" Item properties */
-  TAG_ipco = 0x6970636fU,  //!< "ipco" Item property container */
-  TAG_iinf = 0x69696e66U,  //!< "iinf" Item info */
-  TAG_iloc = 0x696c6f63U,  //!< "iloc" Item location */
-  TAG_ispe = 0x69737065U,  //!< "ispe" Image spatial extents */
-  TAG_infe = 0x696e6665U,  //!< "infe" Item Info Extension */
-  TAG_ipma = 0x69706d61U,  //!< "ipma" Item Property Association */
-  TAG_cmt1 = 0x434d5431U,  //!< "CMT1" ifd0Id */
-  TAG_cmt2 = 0x434D5432U,  //!< "CMD2" exifID */
-  TAG_cmt3 = 0x434D5433U,  //!< "CMT3" canonID */
-  TAG_cmt4 = 0x434D5434U,  //!< "CMT4" gpsID */
-  TAG_colr = 0x636f6c72U,  //!< "colr" Colour information */
-  TAG_exif = 0x45786966U,  //!< "Exif" Used by JXL */
-  TAG_xml = 0x786d6c20U,   //!< "xml " Used by JXL */
-  TAG_brob = 0x62726f62U,  //!< "brob" Used by JXL (brotli box) */
-  TAG_thmb = 0x54484d42U,  //!< "THMB" Canon thumbnail */
-  TAG_prvw = 0x50525657U,  //!< "PRVW" Canon preview image */
+enum TAG {
+  ftyp = 0x66747970U,  //!< "ftyp" File type box */
+  avci = 0x61766369U,  //!< "avci" AVC */
+  avcs = 0x61766373U,  //!< "avcs" AVC */
+  avif = 0x61766966U,  //!< "avif" AVIF */
+  avio = 0x6176696fU,  //!< "avio" AVIF */
+  avis = 0x61766973U,  //!< "avis" AVIF */
+  heic = 0x68656963U,  //!< "heic" HEIC */
+  heif = 0x68656966U,  //!< "heif" HEIF */
+  heim = 0x6865696dU,  //!< "heim" HEIC */
+  heis = 0x68656973U,  //!< "heis" HEIC */
+  heix = 0x68656978U,  //!< "heix" HEIC */
+  j2is = 0x6a326973U,  //!< "j2is" HEJ2K */
+  j2ki = 0x6a326b69U,  //!< "j2ki" HEJ2K */
+  mif1 = 0x6d696631U,  //!< "mif1" HEIF */
+  crx = 0x63727820U,   //!< "crx " Canon CR3 */
+  jxl = 0x6a786c20U,   //!< "jxl " JPEG XL file type */
+  moov = 0x6d6f6f76U,  //!< "moov" Movie */
+  meta = 0x6d657461U,  //!< "meta" Metadata */
+  mdat = 0x6d646174U,  //!< "mdat" Media data */
+  uuid = 0x75756964U,  //!< "uuid" UUID */
+  dinf = 0x64696e66U,  //!< "dinf" Data information */
+  iprp = 0x69707270U,  //!< "iprp" Item properties */
+  ipco = 0x6970636fU,  //!< "ipco" Item property container */
+  iinf = 0x69696e66U,  //!< "iinf" Item info */
+  iloc = 0x696c6f63U,  //!< "iloc" Item location */
+  ispe = 0x69737065U,  //!< "ispe" Image spatial extents */
+  infe = 0x696e6665U,  //!< "infe" Item Info Extension */
+  ipma = 0x69706d61U,  //!< "ipma" Item Property Association */
+  cmt1 = 0x434d5431U,  //!< "CMT1" ifd0Id */
+  cmt2 = 0x434D5432U,  //!< "CMD2" exifID */
+  cmt3 = 0x434D5433U,  //!< "CMT3" canonID */
+  cmt4 = 0x434D5434U,  //!< "CMT4" gpsID */
+  colr = 0x636f6c72U,  //!< "colr" Colour information */
+  exif = 0x45786966U,  //!< "Exif" Used by JXL */
+  xml = 0x786d6c20U,   //!< "xml " Used by JXL */
+  brob = 0x62726f62U,  //!< "brob" Used by JXL (brotli box) */
+  thmb = 0x54484d42U,  //!< "THMB" Canon thumbnail */
+  prvw = 0x50525657U,  //!< "PRVW" Canon preview image */
 };
 
 // *****************************************************************************
@@ -99,46 +99,46 @@ std::string BmffImage::toAscii(uint32_t n) {
 }
 
 bool BmffImage::superBox(uint32_t box) {
-  return box == TAG_moov || box == TAG_dinf || box == TAG_iprp || box == TAG_ipco || box == TAG_meta ||
-         box == TAG_iinf || box == TAG_iloc;
+  return box == TAG::moov || box == TAG::dinf || box == TAG::iprp || box == TAG::ipco || box == TAG::meta ||
+         box == TAG::iinf || box == TAG::iloc;
 }
 
 bool BmffImage::fullBox(uint32_t box) {
-  return box == TAG_meta || box == TAG_iinf || box == TAG_iloc || box == TAG_thmb || box == TAG_prvw;
+  return box == TAG::meta || box == TAG::iinf || box == TAG::iloc || box == TAG::thmb || box == TAG::prvw;
 }
 
 static bool skipBox(uint32_t box) {
   // Allows boxHandler() to optimise the reading of files by identifying
   // box types that we're not interested in. Box types listed here must
   // not appear in the cases in switch (box_type) in boxHandler().
-  return box == 0 || box == TAG_mdat;  // mdat is where the main image lives and can be huge
+  return box == 0 || box == TAG::mdat;  // mdat is where the main image lives and can be huge
 }
 
 std::string BmffImage::mimeType() const {
   switch (fileType_) {
-    case TAG_avci:
+    case TAG::avci:
       return "image/avci";
-    case TAG_avcs:
+    case TAG::avcs:
       return "image/avcs";
-    case TAG_avif:
-    case TAG_avio:
-    case TAG_avis:
+    case TAG::avif:
+    case TAG::avio:
+    case TAG::avis:
       return "image/avif";
-    case TAG_heic:
-    case TAG_heim:
-    case TAG_heis:
-    case TAG_heix:
+    case TAG::heic:
+    case TAG::heim:
+    case TAG::heis:
+    case TAG::heix:
       return "image/heic";
-    case TAG_heif:
-    case TAG_mif1:
+    case TAG::heif:
+    case TAG::mif1:
       return "image/heif";
-    case TAG_j2is:
+    case TAG::j2is:
       return "image/j2is";
-    case TAG_j2ki:
+    case TAG::j2ki:
       return "image/hej2k";
-    case TAG_crx:
+    case TAG::crx:
       return "image/x-canon-cr3";
-    case TAG_jxl:
+    case TAG::jxl:
       return "image/jxl";  // https://github.com/novomesk/qt-jpegxl-image-plugin/issues/1
     default:
       return "image/generic";
@@ -325,7 +325,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 
   switch (box_type) {
     //  See notes in skipBox()
-    case TAG_ftyp: {
+    case TAG::ftyp: {
       Internal::enforce(data.size() >= 4, Exiv2::ErrorCode::kerCorruptedMetadata);
       fileType_ = data.read_uint32(0, endian_);
       if (bTrace) {
@@ -334,7 +334,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     } break;
 
     // 8.11.6.1
-    case TAG_iinf: {
+    case TAG::iinf: {
       if (bTrace) {
         out << '\n';
         bLF = false;
@@ -351,7 +351,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     } break;
 
     // 8.11.6.2
-    case TAG_infe: {  // .__._.__hvc1_ 2 0 0 1 0 1 0 0 104 118 99 49 0
+    case TAG::infe: {  // .__._.__hvc1_ 2 0 0 1 0 1 0 0 104 118 99 49 0
       Internal::enforce(data.size() - skip >= 8, Exiv2::ErrorCode::kerCorruptedMetadata);
       /* getULong (data.pData_+skip,endian_) ; */ skip += 4;
       uint16_t ID = data.read_uint16(skip, endian_);
@@ -375,10 +375,10 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       }
     } break;
 
-    case TAG_moov:
-    case TAG_iprp:
-    case TAG_ipco:
-    case TAG_meta: {
+    case TAG::moov:
+    case TAG::iprp:
+    case TAG::ipco:
+    case TAG::meta: {
       if (bTrace) {
         out << '\n';
         bLF = false;
@@ -388,7 +388,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
         io_->seek(boxHandler(out, option, box_end, depth + 1), BasicIo::beg);
       }
       // post-process meta box to recover Exif and XMP
-      if (box_type == TAG_meta) {
+      if (box_type == TAG::meta) {
         auto ilo = ilocs_.find(exifID_);
         if (ilo != ilocs_.end()) {
           const Iloc& iloc = ilo->second;
@@ -410,7 +410,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     } break;
 
     // 8.11.3.1
-    case TAG_iloc: {
+    case TAG::iloc: {
       Internal::enforce(data.size() - skip >= 2, Exiv2::ErrorCode::kerCorruptedMetadata);
       uint8_t u = data.read_uint8(skip++);
       uint16_t offsetSize = u >> 4;
@@ -461,7 +461,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       }
     } break;
 
-    case TAG_ispe: {
+    case TAG::ispe: {
       Internal::enforce(data.size() - skip >= 12, Exiv2::ErrorCode::kerCorruptedMetadata);
       skip += 4;
       uint32_t width = data.read_uint32(skip, endian_);
@@ -480,7 +480,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
     } break;
 
     // 12.1.5.2
-    case TAG_colr: {
+    case TAG::colr: {
       if (data.size() >= (skip + 4 + 8)) {  // .____.HLino..__mntrR 2 0 0 0 0 12 72 76 105 110 111 2 16 ...
         // https://www.ics.uci.edu/~dan/class/267/papers/jpeg2000.pdf
         uint8_t meth = data.read_uint8(skip + 0);
@@ -500,7 +500,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       }
     } break;
 
-    case TAG_uuid: {
+    case TAG::uuid: {
       DataBuf uuid(16);
       io_->read(uuid.data(), uuid.size());
       std::string name = uuidName(uuid);
@@ -522,25 +522,25 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       }
     } break;
 
-    case TAG_cmt1:
+    case TAG::cmt1:
       parseTiff(Internal::Tag::root, box_length);
       break;
-    case TAG_cmt2:
+    case TAG::cmt2:
       parseTiff(Internal::Tag::cmt2, box_length);
       break;
-    case TAG_cmt3:
+    case TAG::cmt3:
       parseTiff(Internal::Tag::cmt3, box_length);
       break;
-    case TAG_cmt4:
+    case TAG::cmt4:
       parseTiff(Internal::Tag::cmt4, box_length);
       break;
-    case TAG_exif:
+    case TAG::exif:
       parseTiff(Internal::Tag::root, buffer_size, io_->tell());
       break;
-    case TAG_xml:
+    case TAG::xml:
       parseXmp(buffer_size, io_->tell());
       break;
-    case TAG_brob: {
+    case TAG::brob: {
       Internal::enforce(data.size() >= 4, Exiv2::ErrorCode::kerCorruptedMetadata);
       uint32_t realType = data.read_uint32(0, endian_);
       if (bTrace) {
@@ -549,12 +549,12 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 #ifdef EXV_HAVE_BROTLI
       DataBuf arr;
       brotliUncompress(data.c_data(4), data.size() - 4, arr);
-      if (realType == TAG_exif) {
+      if (realType == TAG::exif) {
         uint32_t offset = Safe::add(arr.read_uint32(0, endian_), 4u);
         Internal::enforce(Safe::add(offset, 4u) < arr.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
         Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(), arr.c_data(offset), arr.size() - offset,
                                            Internal::Tag::root, Internal::TiffMapping::findDecoder);
-      } else if (realType == TAG_xml) {
+      } else if (realType == TAG::xml) {
         try {
           Exiv2::XmpParser::decode(xmpData(), std::string(arr.c_str(), arr.size()));
         } catch (...) {
@@ -563,7 +563,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
       }
 #endif
     } break;
-    case TAG_thmb:
+    case TAG::thmb:
       switch (version) {
         case 0:  // JPEG
           parseCr3Preview(data, out, bTrace, version, skip, skip + 2, skip + 4, skip + 12);
@@ -575,7 +575,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
           break;
       }
       break;
-    case TAG_prvw:
+    case TAG::prvw:
       switch (version) {
         case 0:  // JPEG
         case 1:  // HDR

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -22,40 +22,42 @@
 
 namespace Exiv2 {
 
+enum markers : byte {
+  // JPEG Segment markers (The first byte is always 0xFF, the value of these constants correspond to the 2nd byte)
+  sos_ = 0xda,    //!< JPEG SOS marker
+  app0_ = 0xe0,   //!< JPEG APP0 marker
+  app1_ = 0xe1,   //!< JPEG APP1 marker
+  app2_ = 0xe2,   //!< JPEG APP2 marker
+  app13_ = 0xed,  //!< JPEG APP13 marker
+  com_ = 0xfe,    //!< JPEG Comment marker
+
+  // Markers without payload
+  soi_ = 0xd8,   //!< SOI marker
+  eoi_ = 0xd9,   //!< JPEG EOI marker
+  rst1_ = 0xd0,  //!< JPEG Restart 0 Marker (from 0xD0 to 0xD7 there might be 8 of these markers)
+
+  // Start of Frame markers, nondifferential Huffman-coding frames
+  sof0_ = 0xc0,  //!< JPEG Start-Of-Frame marker
+  sof1_ = 0xc1,  //!< JPEG Start-Of-Frame marker
+  sof2_ = 0xc2,  //!< JPEG Start-Of-Frame marker
+  sof3_ = 0xc3,  //!< JPEG Start-Of-Frame marker
+
+  // Start of Frame markers, differential Huffman-coding frames
+  sof5_ = 0xc5,  //!< JPEG Start-Of-Frame marker
+  sof6_ = 0xc6,  //!< JPEG Start-Of-Frame marker
+  sof7_ = 0xc6,  //!< JPEG Start-Of-Frame marker
+
+  // Start of Frame markers, differential arithmetic-coding frames
+  sof9_ = 0xc9,   //!< JPEG Start-Of-Frame marker
+  sof10_ = 0xca,  //!< JPEG Start-Of-Frame marker
+  sof11_ = 0xcb,  //!< JPEG Start-Of-Frame marker
+  sof13_ = 0xcd,  //!< JPEG Start-Of-Frame marker
+  sof14_ = 0xce,  //!< JPEG Start-Of-Frame marker
+  sof15_ = 0xcf,  //!< JPEG Start-Of-Frame marker
+};
+
 using Exiv2::Internal::enforce;
 namespace {
-// JPEG Segment markers (The first byte is always 0xFF, the value of these constants correspond to the 2nd byte)
-constexpr byte sos_ = 0xda;    //!< JPEG SOS marker
-constexpr byte app0_ = 0xe0;   //!< JPEG APP0 marker
-constexpr byte app1_ = 0xe1;   //!< JPEG APP1 marker
-constexpr byte app2_ = 0xe2;   //!< JPEG APP2 marker
-constexpr byte app13_ = 0xed;  //!< JPEG APP13 marker
-constexpr byte com_ = 0xfe;    //!< JPEG Comment marker
-
-// Markers without payload
-constexpr byte soi_ = 0xd8;   //!< SOI marker
-constexpr byte eoi_ = 0xd9;   //!< JPEG EOI marker
-constexpr byte rst1_ = 0xd0;  //!< JPEG Restart 0 Marker (from 0xD0 to 0xD7 there might be 8 of these markers)
-
-// Start of Frame markers, nondifferential Huffman-coding frames
-constexpr byte sof0_ = 0xc0;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof1_ = 0xc1;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof2_ = 0xc2;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof3_ = 0xc3;  //!< JPEG Start-Of-Frame marker
-
-// Start of Frame markers, differential Huffman-coding frames
-constexpr byte sof5_ = 0xc5;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof6_ = 0xc6;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof7_ = 0xc6;  //!< JPEG Start-Of-Frame marker
-
-// Start of Frame markers, differential arithmetic-coding frames
-constexpr byte sof9_ = 0xc9;   //!< JPEG Start-Of-Frame marker
-constexpr byte sof10_ = 0xca;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof11_ = 0xcb;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof13_ = 0xcd;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof14_ = 0xce;  //!< JPEG Start-Of-Frame marker
-constexpr byte sof15_ = 0xcf;  //!< JPEG Start-Of-Frame marker
-
 // JPEG process SOF markers
 constexpr Internal::TagDetails jpegProcessMarkerTags[] = {
     {sof0_, N_("Baseline DCT, Huffman coding")},

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -529,11 +529,9 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
     if (bufRead != dataOffset + 4)
       throw Error(ErrorCode::kerInputDataReadFailed);
 
-    char szChunk[5];
-    std::copy(cheaderBuf.begin() + 4, cheaderBuf.end(), szChunk);
-    szChunk[4] = 0;
+    const std::string szChunk(cheaderBuf.begin() + 4, cheaderBuf.end());
 
-    if (!strcmp(szChunk, "IEND")) {
+    if (szChunk == "IEND") {
       // Last chunk found: we write it and done.
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::PngImage::doWriteMetadata: Write IEND chunk (length: " << dataOffset << ")\n";
@@ -542,14 +540,14 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
         throw Error(ErrorCode::kerImageWriteFailed);
       return;
     }
-    if (!strcmp(szChunk, "eXIf") || !strcmp(szChunk, "iCCP")) {
+    if (szChunk == "eXIf" || szChunk == "iCCP") {
       // do nothing (strip): Exif metadata is written following IHDR
       // together with the ICC profile as fresh eXIf and iCCP chunks
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::PngImage::doWriteMetadata: strip " << szChunk << " chunk (length: " << dataOffset << ")"
                 << '\n';
 #endif
-    } else if (!strcmp(szChunk, "IHDR")) {
+    } else if (szChunk == "IHDR") {
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cout << "Exiv2::PngImage::doWriteMetadata: Write IHDR chunk (length: " << dataOffset << ")\n";
 #endif
@@ -646,7 +644,7 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
           throw Error(ErrorCode::kerImageWriteFailed);
         }
       }
-    } else if (!strcmp(szChunk, "tEXt") || !strcmp(szChunk, "zTXt") || !strcmp(szChunk, "iTXt")) {
+    } else if (szChunk == "tEXt" || szChunk == "zTXt" || szChunk == "iTXt") {
       DataBuf key = PngChunk::keyTXTChunk(chunkBuf, true);
       if (!key.empty() && (compare("Raw profile type exif", key) || compare("Raw profile type APP1", key) ||
                            compare("Raw profile type iptc", key) || compare("Raw profile type xmp", key) ||

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -943,10 +943,9 @@ DataBuf makePnm(size_t width, size_t height, const DataBuf& rgb) {
   }
 
   const std::string header = "P6\n" + std::to_string(width) + " " + std::to_string(height) + "\n255\n";
-  const auto headerBytes = reinterpret_cast<const byte*>(header.data());
 
   dest = DataBuf(header.size() + rgb.size());
-  std::copy_n(headerBytes, header.size(), dest.begin());
+  std::copy(header.begin(), header.end(), dest.begin());
   std::copy(rgb.cbegin(), rgb.cend(), dest.begin() + header.size());
   return dest;
 }

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -31,71 +31,67 @@ struct PhotoshopResourceBlock {
 
 // Photoshop resource IDs (Cf.
 // <http://search.cpan.org/~bettelli/Image-MetaData-JPEG-0.15/lib/Image/MetaData/JPEG/TagLists.pod>)
-enum {
-  kPhotoshopResourceID_Photoshop2Info =
-      0x03e8,  // [obsolete -- Photoshop 2.0 only] General information -- contains five 2-byte values: number of
-               // channels, rows, columns, depth and mode
-  kPhotoshopResourceID_MacintoshClassicPrintInfo = 0x03e9,  // [optional] Macintosh classic print record (120 bytes)
-  kPhotoshopResourceID_MacintoshCarbonPrintInfo =
-      0x03ea,  // [optional] Macintosh carbon print info (variable-length XML format)
-  kPhotoshopResourceID_Photoshop2ColorTable = 0x03eb,   // [obsolete -- Photoshop 2.0 only] Indexed color table
-  kPhotoshopResourceID_ResolutionInfo = 0x03ed,         // PhotoshopResolutionInfo structure (see below)
-  kPhotoshopResourceID_AlphaChannelsNames = 0x03ee,     // as a series of Pstrings
-  kPhotoshopResourceID_DisplayInfo = 0x03ef,            // see appendix A in Photoshop SDK
-  kPhotoshopResourceID_PStringCaption = 0x03f0,         // [optional] the caption, as a Pstring
-  kPhotoshopResourceID_BorderInformation = 0x03f1,      // border width and units
-  kPhotoshopResourceID_BackgroundColor = 0x03f2,        // see additional Adobe information
-  kPhotoshopResourceID_PrintFlags = 0x03f3,             // labels, crop marks, colour bars, ecc...
-  kPhotoshopResourceID_BWHalftoningInfo = 0x03f4,       // Gray-scale and multich. half-toning info
-  kPhotoshopResourceID_ColorHalftoningInfo = 0x03f5,    // Colour half-toning information
-  kPhotoshopResourceID_DuotoneHalftoningInfo = 0x03f6,  // Duo-tone half-toning information
-  kPhotoshopResourceID_BWTransferFunc = 0x03f7,         // Gray-scale and multich. transfer function
-  kPhotoshopResourceID_ColorTransferFuncs = 0x03f8,     // Colour transfer function
-  kPhotoshopResourceID_DuotoneTransferFuncs = 0x03f9,   // Duo-tone transfer function
-  kPhotoshopResourceID_DuotoneImageInfo = 0x03fa,       // Duo-tone image information
-  kPhotoshopResourceID_EffectiveBW = 0x03fb,            // two bytes for the effective black and white values
-  kPhotoshopResourceID_ObsoletePhotoshopTag1 = 0x03fc,  // [obsolete]
-  kPhotoshopResourceID_EPSOptions = 0x03fd,             // Encapsulated Postscript options
-  kPhotoshopResourceID_QuickMaskInfo = 0x03fe,  // Quick Mask information. 2 bytes containing Quick Mask channel ID,
-                                                // 1 byte boolean indicating whether the mask was initially empty.
-  kPhotoshopResourceID_ObsoletePhotoshopTag2 = 0x03ff,    // [obsolete]
-  kPhotoshopResourceID_LayerStateInfo = 0x0400,           // index of target layer (0 means bottom)
-  kPhotoshopResourceID_WorkingPathInfo = 0x0401,          // should not be saved to the file
-  kPhotoshopResourceID_LayersGroupInfo = 0x0402,          // for grouping layers together
-  kPhotoshopResourceID_ObsoletePhotoshopTag3 = 0x0403,    // [obsolete] ??
-  kPhotoshopResourceID_IPTC_NAA = 0x0404,                 // IPTC/NAA data
-  kPhotoshopResourceID_RawImageMode = 0x0405,             // image mode for raw format files
-  kPhotoshopResourceID_JPEGQuality = 0x0406,              // [private]
-  kPhotoshopResourceID_GridGuidesInfo = 0x0408,           // see additional Adobe information
-  kPhotoshopResourceID_ThumbnailResource = 0x0409,        // see additional Adobe information
-  kPhotoshopResourceID_CopyrightFlag = 0x040a,            // true if image is copyrighted
-  kPhotoshopResourceID_URL = 0x040b,                      // text string with a resource locator
-  kPhotoshopResourceID_ThumbnailResource2 = 0x040c,       // see additional Adobe information
-  kPhotoshopResourceID_GlobalAngle = 0x040d,              // global lighting angle for effects layer
-  kPhotoshopResourceID_ColorSamplersResource = 0x040e,    // see additional Adobe information
-  kPhotoshopResourceID_ICCProfile = 0x040f,               // see notes from Internat. Color Consortium
-  kPhotoshopResourceID_Watermark = 0x0410,                // one byte
-  kPhotoshopResourceID_ICCUntagged = 0x0411,              // 1 means intentionally untagged
-  kPhotoshopResourceID_EffectsVisible = 0x0412,           // 1 byte to show/hide all effects layers
-  kPhotoshopResourceID_SpotHalftone = 0x0413,             // version, length and data
-  kPhotoshopResourceID_IDsBaseValue = 0x0414,             // base value for new layers ID's
-  kPhotoshopResourceID_UnicodeAlphaNames = 0x0415,        // length plus Unicode string
-  kPhotoshopResourceID_IndexedColourTableCount = 0x0416,  // [Photoshop 6.0 and later] 2 bytes
-  kPhotoshopResourceID_TransparentIndex = 0x0417,         // [Photoshop 6.0 and later] 2 bytes
-  kPhotoshopResourceID_GlobalAltitude = 0x0419,           // [Photoshop 6.0 and later] 4 bytes
-  kPhotoshopResourceID_Slices = 0x041a,                   // [Photoshop 6.0 and later] see additional Adobe info
-  kPhotoshopResourceID_WorkflowURL = 0x041b,              // [Photoshop 6.0 and later] 4 bytes length + Unicode string
-  kPhotoshopResourceID_JumpToXPEP = 0x041c,               // [Photoshop 6.0 and later] see additional Adobe info
-  kPhotoshopResourceID_AlphaIdentifiers = 0x041d,         // [Photoshop 6.0 and later] 4*(n+1) bytes
-  kPhotoshopResourceID_URLList = 0x041e,                  // [Photoshop 6.0 and later] structured Unicode URL's
-  kPhotoshopResourceID_VersionInfo = 0x0421,              // [Photoshop 6.0 and later] see additional Adobe info
-  kPhotoshopResourceID_ExifInfo = 0x0422,                 // [Photoshop 7.0?] Exif metadata
-  kPhotoshopResourceID_XMPPacket =
-      0x0424,  // [Photoshop 7.0?] XMP packet -- see  http://www.adobe.com/devnet/xmp/pdfs/xmp_specification.pdf
-  kPhotoshopResourceID_ClippingPathName = 0x0bb7,  // [Photoshop 6.0 and later] name of clipping path
-  kPhotoshopResourceID_MorePrintFlags =
-      0x2710  // [Photoshop 6.0 and later] Print flags information. 2 bytes version (=1), 1 byte center crop  marks, 1
-              // byte (=0), 4 bytes bleed width value, 2 bytes bleed width  scale.
+enum kPhotoshopResourceID {
+  Photoshop2Info = 0x03e8,  // [obsolete -- Photoshop 2.0 only] General information -- contains five 2-byte values:
+                            // number of channels, rows, columns, depth and mode
+  MacintoshClassicPrintInfo = 0x03e9,  // [optional] Macintosh classic print record (120 bytes)
+  MacintoshCarbonPrintInfo = 0x03ea,   // [optional] Macintosh carbon print info (variable-length XML format)
+  Photoshop2ColorTable = 0x03eb,       // [obsolete -- Photoshop 2.0 only] Indexed color table
+  ResolutionInfo = 0x03ed,             // PhotoshopResolutionInfo structure (see below)
+  AlphaChannelsNames = 0x03ee,         // as a series of Pstrings
+  DisplayInfo = 0x03ef,                // see appendix A in Photoshop SDK
+  PStringCaption = 0x03f0,             // [optional] the caption, as a Pstring
+  BorderInformation = 0x03f1,          // border width and units
+  BackgroundColor = 0x03f2,            // see additional Adobe information
+  PrintFlags = 0x03f3,                 // labels, crop marks, colour bars, ecc...
+  BWHalftoningInfo = 0x03f4,           // Gray-scale and multich. half-toning info
+  ColorHalftoningInfo = 0x03f5,        // Colour half-toning information
+  DuotoneHalftoningInfo = 0x03f6,      // Duo-tone half-toning information
+  BWTransferFunc = 0x03f7,             // Gray-scale and multich. transfer function
+  ColorTransferFuncs = 0x03f8,         // Colour transfer function
+  DuotoneTransferFuncs = 0x03f9,       // Duo-tone transfer function
+  DuotoneImageInfo = 0x03fa,           // Duo-tone image information
+  EffectiveBW = 0x03fb,                // two bytes for the effective black and white values
+  ObsoletePhotoshopTag1 = 0x03fc,      // [obsolete]
+  EPSOptions = 0x03fd,                 // Encapsulated Postscript options
+  QuickMaskInfo = 0x03fe,              // Quick Mask information. 2 bytes containing Quick Mask channel ID,
+                                       // 1 byte boolean indicating whether the mask was initially empty.
+  ObsoletePhotoshopTag2 = 0x03ff,      // [obsolete]
+  LayerStateInfo = 0x0400,             // index of target layer (0 means bottom)
+  WorkingPathInfo = 0x0401,            // should not be saved to the file
+  LayersGroupInfo = 0x0402,            // for grouping layers together
+  ObsoletePhotoshopTag3 = 0x0403,      // [obsolete] ??
+  IPTC_NAA = 0x0404,                   // IPTC/NAA data
+  RawImageMode = 0x0405,               // image mode for raw format files
+  JPEGQuality = 0x0406,                // [private]
+  GridGuidesInfo = 0x0408,             // see additional Adobe information
+  ThumbnailResource = 0x0409,          // see additional Adobe information
+  CopyrightFlag = 0x040a,              // true if image is copyrighted
+  URL = 0x040b,                        // text string with a resource locator
+  ThumbnailResource2 = 0x040c,         // see additional Adobe information
+  GlobalAngle = 0x040d,                // global lighting angle for effects layer
+  ColorSamplersResource = 0x040e,      // see additional Adobe information
+  ICCProfile = 0x040f,                 // see notes from Internat. Color Consortium
+  Watermark = 0x0410,                  // one byte
+  ICCUntagged = 0x0411,                // 1 means intentionally untagged
+  EffectsVisible = 0x0412,             // 1 byte to show/hide all effects layers
+  SpotHalftone = 0x0413,               // version, length and data
+  IDsBaseValue = 0x0414,               // base value for new layers ID's
+  UnicodeAlphaNames = 0x0415,          // length plus Unicode string
+  IndexedColourTableCount = 0x0416,    // [Photoshop 6.0 and later] 2 bytes
+  TransparentIndex = 0x0417,           // [Photoshop 6.0 and later] 2 bytes
+  GlobalAltitude = 0x0419,             // [Photoshop 6.0 and later] 4 bytes
+  Slices = 0x041a,                     // [Photoshop 6.0 and later] see additional Adobe info
+  WorkflowURL = 0x041b,                // [Photoshop 6.0 and later] 4 bytes length + Unicode string
+  JumpToXPEP = 0x041c,                 // [Photoshop 6.0 and later] see additional Adobe info
+  AlphaIdentifiers = 0x041d,           // [Photoshop 6.0 and later] 4*(n+1) bytes
+  URLList = 0x041e,                    // [Photoshop 6.0 and later] structured Unicode URL's
+  VersionInfo = 0x0421,                // [Photoshop 6.0 and later] see additional Adobe info
+  ExifInfo = 0x0422,                   // [Photoshop 7.0?] Exif metadata
+  XMPPacket = 0x0424,  // [Photoshop 7.0?] XMP packet -- see  http://www.adobe.com/devnet/xmp/pdfs/xmp_specification.pdf
+  ClippingPathName = 0x0bb7,  // [Photoshop 6.0 and later] name of clipping path
+  MorePrintFlags = 0x2710,    // [Photoshop 6.0 and later] Print flags information. 2 bytes version (=1), 1 byte center
+                              // crop  marks, 1 byte (=0), 4 bytes bleed width value, 2 bytes bleed width  scale.
 };
 
 // *****************************************************************************
@@ -213,7 +209,7 @@ void PsdImage::readMetadata() {
 
 void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
   switch (resourceId) {
-    case kPhotoshopResourceID_IPTC_NAA: {
+    case kPhotoshopResourceID::IPTC_NAA: {
       DataBuf rawIPTC(resourceSize);
       io_->read(rawIPTC.data(), rawIPTC.size());
       if (io_->error() || io_->eof())
@@ -227,7 +223,7 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       break;
     }
 
-    case kPhotoshopResourceID_ExifInfo: {
+    case kPhotoshopResourceID::ExifInfo: {
       DataBuf rawExif(resourceSize);
       io_->read(rawExif.data(), rawExif.size());
       if (io_->error() || io_->eof())
@@ -243,7 +239,7 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       break;
     }
 
-    case kPhotoshopResourceID_XMPPacket: {
+    case kPhotoshopResourceID::XMPPacket: {
       DataBuf xmpPacket(resourceSize);
       io_->read(xmpPacket.data(), xmpPacket.size());
       if (io_->error() || io_->eof())
@@ -259,8 +255,8 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
 
     // - PS 4.0 preview data is fetched from ThumbnailResource
     // - PS >= 5.0 preview data is fetched from ThumbnailResource2
-    case kPhotoshopResourceID_ThumbnailResource:
-    case kPhotoshopResourceID_ThumbnailResource2: {
+    case kPhotoshopResourceID::ThumbnailResource:
+    case kPhotoshopResourceID::ThumbnailResource2: {
       /*
         Photoshop thumbnail resource header
 
@@ -433,27 +429,26 @@ void PsdImage::doWriteMetadata(BasicIo& outIo) {
     const size_t curOffset = io_->tell();
 
     // Write IPTC_NAA resource block
-    if ((resourceId == kPhotoshopResourceID_IPTC_NAA || resourceId > kPhotoshopResourceID_IPTC_NAA) && !iptcDone) {
+    if (resourceId >= kPhotoshopResourceID::IPTC_NAA && !iptcDone) {
       newResLength += writeIptcData(iptcData_, outIo);
       iptcDone = true;
     }
 
     // Write ExifInfo resource block
-    else if ((resourceId == kPhotoshopResourceID_ExifInfo || resourceId > kPhotoshopResourceID_ExifInfo) && !exifDone) {
+    else if (resourceId >= kPhotoshopResourceID::ExifInfo && !exifDone) {
       newResLength += writeExifData(exifData_, outIo);
       exifDone = true;
     }
 
     // Write XMPpacket resource block
-    else if ((resourceId == kPhotoshopResourceID_XMPPacket || resourceId > kPhotoshopResourceID_XMPPacket) &&
-             !xmpDone) {
+    else if (resourceId >= kPhotoshopResourceID::XMPPacket && !xmpDone) {
       newResLength += writeXmpData(xmpData_, outIo);
       xmpDone = true;
     }
 
     // Copy all other resource blocks
-    if (resourceId != kPhotoshopResourceID_IPTC_NAA && resourceId != kPhotoshopResourceID_ExifInfo &&
-        resourceId != kPhotoshopResourceID_XMPPacket) {
+    if (resourceId != kPhotoshopResourceID::IPTC_NAA && resourceId != kPhotoshopResourceID::ExifInfo &&
+        resourceId != kPhotoshopResourceID::XMPPacket) {
 #ifdef EXIV2_DEBUG_MESSAGES
       std::cerr << std::hex << "copy : resourceType: " << resourceType << "\n";
       std::cerr << std::hex << "copy : resourceId: " << resourceId << "\n";
@@ -548,12 +543,12 @@ uint32_t PsdImage::writeIptcData(const IptcData& iptcData, BasicIo& out) {
     DataBuf rawIptc = IptcParser::encode(iptcData);
     if (!rawIptc.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
-      std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_IPTC_NAA << "\n";
+      std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::IPTC_NAA << "\n";
       std::cerr << std::dec << "Writing IPTC_NAA: size: " << rawIptc.size() << "\n";
 #endif
       if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
-      us2Data(buf, kPhotoshopResourceID_IPTC_NAA, bigEndian);
+      us2Data(buf, kPhotoshopResourceID::IPTC_NAA, bigEndian);
       if (out.write(buf, 2) != 2)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, 0, bigEndian);  // NULL resource name
@@ -593,12 +588,12 @@ uint32_t PsdImage::writeExifData(ExifData& exifData, BasicIo& out) {
 
     if (!blob.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
-      std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_ExifInfo << "\n";
+      std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::ExifInfo << "\n";
       std::cerr << std::dec << "Writing ExifInfo: size: " << blob.size() << "\n";
 #endif
       if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
-      us2Data(buf, kPhotoshopResourceID_ExifInfo, bigEndian);
+      us2Data(buf, kPhotoshopResourceID::ExifInfo, bigEndian);
       if (out.write(buf, 2) != 2)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, 0, bigEndian);  // NULL resource name
@@ -640,12 +635,12 @@ uint32_t PsdImage::writeXmpData(const XmpData& xmpData, BasicIo& out) const {
 
   if (!xmpPacket.empty()) {
 #ifdef EXIV2_DEBUG_MESSAGES
-    std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID_XMPPacket << "\n";
+    std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::XMPPacket << "\n";
     std::cerr << std::dec << "Writing XMPPacket: size: " << xmpPacket.size() << "\n";
 #endif
     if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
       throw Error(ErrorCode::kerImageWriteFailed);
-    us2Data(buf, kPhotoshopResourceID_XMPPacket, bigEndian);
+    us2Data(buf, kPhotoshopResourceID::XMPPacket, bigEndian);
     if (out.write(buf, 2) != 2)
       throw Error(ErrorCode::kerImageWriteFailed);
     us2Data(buf, 0, bigEndian);  // NULL resource name


### PR DESCRIPTION
C strings in C++ have an extra member for NULL termination. replacing copy_n with copy like this will allow eventual conversion to std::ranges.

Missed changes from last PR.