### PR TITLE
fix wrong if constexpr usage

### DIFF
--- a/src/safe_op.hpp
+++ b/src/safe_op.hpp
@@ -170,8 +170,9 @@ T abs(T num) noexcept {
     if (num == std::numeric_limits<T>::min())
       return std::numeric_limits<T>::max();
     return num < 0 ? -num : num;
+  } else {
+    return num;
   }
-  return num;
 }
 
 }  // namespace Safe


### PR DESCRIPTION
Not having the else after return is fine for normal if statements, but not if constexpr. Fixes an MSVC warning about an unreachable path.