### PR TITLE
rewrite loops to get rid of i++ as array index

### DIFF
--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -643,8 +643,11 @@ void CrwMap::decode0x080a(const CiffComponent& ciffComponent, const CrwMapping* 
   ExifKey key1("Exif.Image.Make");
   auto value1 = Value::create(ciffComponent.typeId());
   uint32_t i = 0;
-  while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
-    // empty
+  while (i < ciffComponent.size()) {
+    ++i;
+    if (ciffComponent.pData()[i - 1] == '\0') {
+      break;
+    }
   }
   value1->read(ciffComponent.pData(), i, byteOrder);
   image.exifData().add(key1, value1.get());
@@ -653,8 +656,11 @@ void CrwMap::decode0x080a(const CiffComponent& ciffComponent, const CrwMapping* 
   ExifKey key2("Exif.Image.Model");
   auto value2 = Value::create(ciffComponent.typeId());
   uint32_t j = i;
-  while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
-    // empty
+  while (i < ciffComponent.size()) {
+    ++i;
+    if (ciffComponent.pData()[i - 1] == '\0') {
+      break;
+    }
   }
   value2->read(ciffComponent.pData() + j, i - j, byteOrder);
   image.exifData().add(key2, value2.get());
@@ -790,8 +796,11 @@ void CrwMap::decodeBasic(const CiffComponent& ciffComponent, const CrwMapping* p
     } else if (ciffComponent.typeId() == asciiString) {
       // determine size from the data, by looking for the first 0
       uint32_t i = 0;
-      while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
-        // empty
+      while (i < ciffComponent.size()) {
+        ++i;
+        if (ciffComponent.pData()[i - 1] == '\0') {
+          break;
+        }
       }
       size = i;
     } else {


### PR DESCRIPTION
clang-tidy complains about it.