### PR TITLE
clang-tidy: use to_string

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -1245,7 +1245,7 @@ std::string Converter::computeExifDigest(bool tiff) {
 
       if (!res.empty())
         res += ',';
-      res += key.tag();
+      res += std::to_string(key.tag());
       auto pos = exifData_->findKey(key);
       if (pos == exifData_->end())
         continue;


### PR DESCRIPTION
Found with bugprone-string-integer-assignment