### PR TITLE
remove some static_casts

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -1577,7 +1577,7 @@ int Timestamp::read(const std::string& path) {
 int Timestamp::read(tm* tm) {
   int rc = 1;
   time_t t = mktime(tm);  // interpret tm according to current timezone settings
-  if (t != static_cast<time_t>(-1)) {
+  if (t != time_t{-1}) {
     rc = 0;
     actime_ = t;
     modtime_ = t;
@@ -1635,7 +1635,7 @@ int str2Tm(const std::string& timeStr, tm* tm) {
   tm->tm_sec = static_cast<decltype(tm->tm_sec)>(tmp);
 
   // Conversions to set remaining fields of the tm structure
-  if (mktime(tm) == static_cast<time_t>(-1))
+  if (mktime(tm) == time_t{-1})
     return 11;
 
   return 0;

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -760,7 +760,7 @@ int Params::evalDelete(const std::string& optArg) {
   switch (action_) {
     case Action::none:
       action_ = Action::erase;
-      target_ = static_cast<CommonTarget>(0);
+      target_ = CommonTarget{0};
       [[fallthrough]];
     case Action::erase: {
       const auto rc = parseCommonTargets(optArg, "erase");
@@ -781,7 +781,7 @@ int Params::evalExtract(const std::string& optArg) {
     case Action::none:
     case Action::modify:
       action_ = Action::extract;
-      target_ = static_cast<CommonTarget>(0);
+      target_ = CommonTarget{0};
       [[fallthrough]];
     case Action::extract: {
       const auto rc = parseCommonTargets(optArg, "extract");
@@ -802,7 +802,7 @@ int Params::evalInsert(const std::string& optArg) {
     case Action::none:
     case Action::modify:
       action_ = Action::insert;
-      target_ = static_cast<CommonTarget>(0);
+      target_ = CommonTarget{0};
       [[fallthrough]];
     case Action::insert: {
       const auto rc = parseCommonTargets(optArg, "insert");
@@ -1134,7 +1134,7 @@ void printUnrecognizedArgument(const char argc, const std::string& action) {
 
 int64_t parseCommonTargets(const std::string& optArg, const std::string& action) {
   int64_t rc = 0;
-  auto target = static_cast<Params::CommonTarget>(0);
+  auto target = Params::CommonTarget{0};
   Params::CommonTarget all = Params::ctExif | Params::ctIptc | Params::ctComment | Params::ctXmp;
   Params::CommonTarget extra = Params::ctXmpSidecar | Params::ctExif | Params::ctIptc | Params::ctXmp;
   for (size_t i = 0; rc == 0 && i < optArg.size(); ++i) {

--- a/samples/addmoddel.cpp
+++ b/samples/addmoddel.cpp
@@ -28,10 +28,10 @@ int main(int argc, char* const argv[]) {
     // This is the quickest way to add (simple) Exif data. If a metadatum for
     // a given key already exists, its value is overwritten. Otherwise a new
     // tag is added.
-    exifData["Exif.Image.Model"] = "Test 1";                              // AsciiValue
-    exifData["Exif.Image.SamplesPerPixel"] = static_cast<uint16_t>(162);  // UShortValue
-    exifData["Exif.Image.XResolution"] = -2;                              // LongValue
-    exifData["Exif.Image.YResolution"] = Exiv2::Rational(-2, 3);          // RationalValue
+    exifData["Exif.Image.Model"] = "Test 1";                      // AsciiValue
+    exifData["Exif.Image.SamplesPerPixel"] = std::uint16_t{162};  // UShortValue
+    exifData["Exif.Image.XResolution"] = -2;                      // LongValue
+    exifData["Exif.Image.YResolution"] = Exiv2::Rational(-2, 3);  // RationalValue
     std::cout << "Added a few tags the quick way.\n";
 
     // Create a ASCII string value (note the use of create)

--- a/samples/exifdata-test.cpp
+++ b/samples/exifdata-test.cpp
@@ -31,9 +31,9 @@ int main(int argc, char* const argv[]) {
     std::cout << "Copy construction, non-intrusive changes\n";
     Exiv2::ExifData ed1(ed);
     ed1["Exif.Image.DateTime"] = "Sunday, 11am";
-    ed1["Exif.Image.Orientation"] = static_cast<uint16_t>(2);
+    ed1["Exif.Image.Orientation"] = std::uint16_t{2};
     ed1["Exif.Photo.DateTimeOriginal"] = "Sunday, 11am";
-    ed1["Exif.Photo.MeteringMode"] = static_cast<uint16_t>(1);
+    ed1["Exif.Photo.MeteringMode"] = std::uint16_t{1};
     ed1["Exif.Iop.InteroperabilityIndex"] = "123";
     //    ed1["Exif.Thumbnail.Orientation"] = uint16_t(2);
     write(file, ed1);
@@ -58,11 +58,11 @@ int main(int argc, char* const argv[]) {
     ed3["Exif.Thumbnail.Artist"] = "Test 6 Ifd1 tag";
     ed3 = ed;
     ed3["Exif.Image.DateTime"] = "Sunday, 11am";
-    ed3["Exif.Image.Orientation"] = static_cast<uint16_t>(2);
+    ed3["Exif.Image.Orientation"] = std::uint16_t{2};
     ed3["Exif.Photo.DateTimeOriginal"] = "Sunday, 11am";
-    ed3["Exif.Photo.MeteringMode"] = static_cast<uint16_t>(1);
+    ed3["Exif.Photo.MeteringMode"] = std::uint16_t{1};
     ed3["Exif.Iop.InteroperabilityIndex"] = "123";
-    ed3["Exif.Thumbnail.Orientation"] = static_cast<uint16_t>(2);
+    ed3["Exif.Thumbnail.Orientation"] = std::uint16_t{2};
     write(file, ed3);
     print(file);
     std::cout << "----------------------------------------------\n";
@@ -75,9 +75,9 @@ int main(int argc, char* const argv[]) {
     ed4["Exif.Image.DateTime"] = "Sunday, 11am and ten minutes";
     ed4["Exif.Image.Orientation"] = "2 3 4 5";
     ed4["Exif.Photo.DateTimeOriginal"] = "Sunday, 11am and ten minutes";
-    ed4["Exif.Photo.MeteringMode"] = static_cast<uint16_t>(1);
+    ed4["Exif.Photo.MeteringMode"] = std::uint16_t{1};
     ed4["Exif.Iop.InteroperabilityIndex"] = "123";
-    ed4["Exif.Thumbnail.Orientation"] = static_cast<uint16_t>(2);
+    ed4["Exif.Thumbnail.Orientation"] = std::uint16_t{2};
     write(file, ed4);
     print(file);
 

--- a/samples/iptceasy.cpp
+++ b/samples/iptceasy.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* const argv[]) try {
   iptcData["Iptc.Application2.Headline"] = "The headline I am";
   iptcData["Iptc.Application2.Keywords"] = "Yet another keyword";
   iptcData["Iptc.Application2.DateCreated"] = "2004-8-3";
-  iptcData["Iptc.Application2.Urgency"] = static_cast<uint16_t>(1);
+  iptcData["Iptc.Application2.Urgency"] = uint16_t{1};
   iptcData["Iptc.Envelope.ModelVersion"] = 42;
   iptcData["Iptc.Envelope.TimeSent"] = "14:41:0-05:00";
   iptcData["Iptc.Application2.RasterizedCaption"] = "230 42 34 2 90 84 23 146";

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -31,12 +31,12 @@ int main(int argc, char* const argv[]) {
     // set/add metadata
     std::cout << "Modify the metadata ...\n";
     Exiv2::ExifData exifData;
-    exifData["Exif.Photo.UserComment"] = "Hello World";                // AsciiValue
-    exifData["Exif.Image.Software"] = "Exiv2";                         // AsciiValue
-    exifData["Exif.Image.Copyright"] = "Exiv2";                        // AsciiValue
-    exifData["Exif.Image.Make"] = "Canon";                             // AsciiValue
-    exifData["Exif.Canon.OwnerName"] = "Tuan";                         // UShortValue
-    exifData["Exif.CanonCs.LensType"] = static_cast<uint16_t>(65535);  // LongValue
+    exifData["Exif.Photo.UserComment"] = "Hello World";        // AsciiValue
+    exifData["Exif.Image.Software"] = "Exiv2";                 // AsciiValue
+    exifData["Exif.Image.Copyright"] = "Exiv2";                // AsciiValue
+    exifData["Exif.Image.Make"] = "Canon";                     // AsciiValue
+    exifData["Exif.Canon.OwnerName"] = "Tuan";                 // UShortValue
+    exifData["Exif.CanonCs.LensType"] = std::uint16_t{65535};  // LongValue
     Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
     v->read("2013:06:09 14:30:30");
     Exiv2::ExifKey key("Exif.Image.DateTime");

--- a/samples/write2-test.cpp
+++ b/samples/write2-test.cpp
@@ -53,11 +53,11 @@ int main(int argc, char* const argv[]) {
     edMn1["Exif.Image.Make"] = "Canon";
     edMn1["Exif.Image.Model"] = "Canon PowerShot S40";
     edMn1["Exif.Canon.0xabcd"] = "A Canon makernote tag";
-    edMn1["Exif.CanonCs.0x0002"] = static_cast<uint16_t>(41);
-    edMn1["Exif.CanonSi.0x0005"] = static_cast<uint16_t>(42);
-    edMn1["Exif.CanonCf.0x0001"] = static_cast<uint16_t>(43);
-    edMn1["Exif.CanonPi.0x0001"] = static_cast<uint16_t>(44);
-    edMn1["Exif.CanonPa.0x0001"] = static_cast<uint16_t>(45);
+    edMn1["Exif.CanonCs.0x0002"] = std::uint16_t{41};
+    edMn1["Exif.CanonSi.0x0005"] = std::uint16_t{42};
+    edMn1["Exif.CanonCf.0x0001"] = std::uint16_t{43};
+    edMn1["Exif.CanonPi.0x0001"] = std::uint16_t{44};
+    edMn1["Exif.CanonPa.0x0001"] = std::uint16_t{45};
     write(file, edMn1);
     print(file);
 
@@ -66,8 +66,8 @@ int main(int argc, char* const argv[]) {
     image->readMetadata();
 
     Exiv2::ExifData& rEd = image->exifData();
-    rEd["Exif.CanonCs.0x0001"] = static_cast<uint16_t>(88);
-    rEd["Exif.CanonSi.0x0004"] = static_cast<uint16_t>(99);
+    rEd["Exif.CanonCs.0x0001"] = std::uint16_t{88};
+    rEd["Exif.CanonSi.0x0004"] = std::uint16_t{99};
     image->writeMetadata();
     print(file);
 
@@ -115,7 +115,7 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifData edMn7;
     edMn7["Exif.Image.Make"] = "OLYMPUS CORPORATION";
     edMn7["Exif.Image.Model"] = "C8080WZ";
-    edMn7["Exif.Olympus.0x0201"] = static_cast<uint16_t>(1);
+    edMn7["Exif.Olympus.0x0201"] = std::uint16_t{1};
     write(file, edMn7);
     print(file);
 
@@ -123,7 +123,7 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifData edMn8;
     edMn8["Exif.Image.Make"] = "Panasonic";
     edMn8["Exif.Image.Model"] = "DMC-FZ5";
-    edMn8["Exif.Panasonic.0x0001"] = static_cast<uint16_t>(1);
+    edMn8["Exif.Panasonic.0x0001"] = std::uint16_t{1};
     write(file, edMn8);
     print(file);
 
@@ -131,7 +131,7 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifData edMn9;
     edMn9["Exif.Image.Make"] = "SONY";
     edMn9["Exif.Image.Model"] = "DSC-W7";
-    edMn9["Exif.Sony1.Quality"] = static_cast<uint32_t>(2);
+    edMn9["Exif.Sony1.Quality"] = std::uint32_t{2};
     write(file, edMn9);
     print(file);
 
@@ -139,13 +139,13 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifData edMn10;
     edMn10["Exif.Image.Make"] = "Minolta";
     edMn10["Exif.Image.Model"] = "A fancy Minolta camera";
-    edMn10["Exif.Minolta.ColorMode"] = static_cast<uint32_t>(1);
-    edMn10["Exif.MinoltaCsNew.WhiteBalance"] = static_cast<uint32_t>(2);
-    edMn10["Exif.MinoltaCs5D.WhiteBalance"] = static_cast<uint16_t>(3);
-    edMn10["Exif.MinoltaCs5D.ColorTemperature"] = static_cast<int16_t>(-1);
-    edMn10["Exif.MinoltaCs7D.WhiteBalance"] = static_cast<uint16_t>(4);
-    edMn10["Exif.MinoltaCs7D.ExposureCompensation"] = static_cast<int16_t>(-2);
-    edMn10["Exif.MinoltaCs7D.ColorTemperature"] = static_cast<int16_t>(-3);
+    edMn10["Exif.Minolta.ColorMode"] = std::uint32_t{1};
+    edMn10["Exif.MinoltaCsNew.WhiteBalance"] = std::uint32_t{2};
+    edMn10["Exif.MinoltaCs5D.WhiteBalance"] = std::uint16_t{3};
+    edMn10["Exif.MinoltaCs5D.ColorTemperature"] = std::int16_t{-1};
+    edMn10["Exif.MinoltaCs7D.WhiteBalance"] = std::uint16_t{4};
+    edMn10["Exif.MinoltaCs7D.ExposureCompensation"] = std::int16_t{-2};
+    edMn10["Exif.MinoltaCs7D.ColorTemperature"] = std::int16_t{-3};
     write(file, edMn10);
     print(file);
 

--- a/samples/xmpsample.cpp
+++ b/samples/xmpsample.cpp
@@ -39,7 +39,7 @@ int main() try {
   xmpData["Xmp.dc.one"] = -1;
   xmpData["Xmp.dc.two"] = 3.1415;
   xmpData["Xmp.dc.three"] = Exiv2::Rational(5, 7);
-  xmpData["Xmp.dc.four"] = static_cast<uint16_t>(255);
+  xmpData["Xmp.dc.four"] = std::uint16_t{255};
   xmpData["Xmp.dc.five"] = 256;
   xmpData["Xmp.dc.six"] = false;
 

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -344,7 +344,7 @@ void AsfVideo::streamProperties() {
   io_->readOrThrow(streamTypedBuf.data(), streamTypedBuf.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
 
   enum class streamTypeInfo { Audio = 1, Video = 2 };
-  auto stream = static_cast<streamTypeInfo>(0);
+  auto stream = streamTypeInfo{0};
 
   auto tag_stream_type = GUIDReferenceTags.find(GUIDTag(streamTypedBuf.data()));
   if (tag_stream_type != GUIDReferenceTags.end()) {

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -428,9 +428,9 @@ void ExifThumb::setJpegThumbnail(const std::string& path) {
 #endif
 
 void ExifThumb::setJpegThumbnail(const byte* buf, size_t size) {
-  exifData_["Exif.Thumbnail.Compression"] = static_cast<uint16_t>(6);
+  exifData_["Exif.Thumbnail.Compression"] = std::uint16_t{6};
   Exifdatum& format = exifData_["Exif.Thumbnail.JPEGInterchangeFormat"];
-  format = static_cast<uint32_t>(0);
+  format = 0U;
   format.setDataArea(buf, size);
   exifData_["Exif.Thumbnail.JPEGInterchangeFormatLength"] = static_cast<uint32_t>(size);
 }

--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -287,9 +287,9 @@ constexpr TagDetails fujiDriveSettingByte1[] = {
 //! DriveSetting, tag 0x1103
 static std::ostream& printFujiDriveSetting(std::ostream& os, const Value& value, const ExifData*) {
   auto valint = value.toUint32();
-  auto byte1 = valint & 0xff;
-  auto byte2 = (valint >> 8) & 0xff;
-  auto byte3 = (valint >> 16) & 0xff;
+  auto byte1 = static_cast<byte>(valint);
+  auto byte2 = static_cast<byte>(valint >> 8);
+  auto byte3 = static_cast<byte>(valint >> 16);
   auto fps = valint >> 24;
 
   if (auto setting = Exiv2::find(fujiDriveSettingByte1, byte1)) {

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -1092,7 +1092,7 @@ void ncrypt(Exiv2::byte* pData, uint32_t size, uint32_t count, uint32_t serial) 
   };
   Exiv2::byte key = 0;
   for (int i = 0; i < 4; ++i) {
-    key ^= (count >> (i * 8)) & 0xff;
+    key ^= static_cast<Exiv2::byte>(count >> (i * 8));
   }
   Exiv2::byte ci = xlat[0][serial & 0xff];
   Exiv2::byte cj = xlat[1][key];

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -876,7 +876,7 @@ void MatroskaVideo::decodeFloatTags(const MatroskaTag* tag, const byte* buf) {
       if (auto internalMt = Exiv2::find(streamRate, key)) {
         switch (stream_) {
           case 1:  // video
-            frame_rate = static_cast<double>(1000000000) / static_cast<double>(key);
+            frame_rate = 1000000000.0 / static_cast<double>(key);
             break;
           case 2:  // audio
             frame_rate = static_cast<double>(key) / 1000;

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1085,12 +1085,12 @@ static void printFlashCompensationValue(std::ostream& os, const unsigned char va
     ...
     255 = "+0.2"
      */
-    float output = 0.0;
+    auto output = 0.0f;
     if (value < 128) {
       if (value != 0)
-        output = static_cast<float>(value) * static_cast<float>(-1.0);
+        output = static_cast<float>(value) * -1.0f;
     } else {
-      output = static_cast<float>(256.0) - static_cast<float>(value);
+      output = 256.0f - static_cast<float>(value);
     }
     os.precision(1);
     if (value != 0)

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -959,7 +959,7 @@ std::ostream& PentaxMakerNote::printBracketing(std::ostream& os, const Value& va
       os << _("No extended bracketing");
     } else {
       auto type = l1 >> 8;
-      auto range = l1 & 0xff;
+      auto range = static_cast<byte>(l1);
       switch (type) {
         case 1:
           os << _("WB-BA");

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -107,7 +107,7 @@ DataBuf PngChunk::parseTXTChunk(const DataBuf& data, size_t keysize, TxtChunkTyp
       zlibUncompress(compressedText, static_cast<uint32_t>(compressedTextSize), arr);
     }
   } else if (type == tEXt_Chunk) {
-    enforce(data.size() >= Safe::add(keysize, static_cast<size_t>(1)), ErrorCode::kerCorruptedMetadata);
+    enforce(data.size() >= Safe::add(keysize, std::size_t{1}), ErrorCode::kerCorruptedMetadata);
     // Extract a non-compressed Latin-1 text chunk
 
     // the text comes after the key, but isn't null terminated
@@ -118,7 +118,7 @@ DataBuf PngChunk::parseTXTChunk(const DataBuf& data, size_t keysize, TxtChunkTyp
       arr = DataBuf(text, textsize);
     }
   } else if (type == iTXt_Chunk) {
-    enforce(data.size() > Safe::add(keysize, static_cast<size_t>(3)), ErrorCode::kerCorruptedMetadata);
+    enforce(data.size() > Safe::add(keysize, std::size_t{3}), ErrorCode::kerCorruptedMetadata);
     const size_t nullCount = std::count(data.c_data(keysize + 3), data.c_data(data.size() - 1), '\0');
     enforce(nullCount >= nullSeparators, ErrorCode::kerCorruptedMetadata);
 
@@ -138,15 +138,14 @@ DataBuf PngChunk::parseTXTChunk(const DataBuf& data, size_t keysize, TxtChunkTyp
     std::string languageText = string_from_unterminated(data.c_str(keysize + 3), languageTextMaxSize);
     const size_t languageTextSize = languageText.size();
 
-    enforce(data.size() >= Safe::add(Safe::add(keysize, static_cast<size_t>(4)), languageTextSize),
+    enforce(data.size() >= Safe::add(Safe::add(keysize, std::size_t{4}), languageTextSize),
             ErrorCode::kerCorruptedMetadata);
     // translated keyword string after the language description
     std::string translatedKeyText = string_from_unterminated(data.c_str(keysize + 3 + languageTextSize + 1),
                                                              data.size() - (keysize + 3 + languageTextSize + 1));
     const size_t translatedKeyTextSize = translatedKeyText.size();
 
-    enforce(Safe::add(keysize + 3 + languageTextSize + 1, Safe::add(translatedKeyTextSize, static_cast<size_t>(1))) <=
-                data.size(),
+    enforce(Safe::add(keysize + 3 + languageTextSize + 1, Safe::add(translatedKeyTextSize, size_t{1})) <= data.size(),
             ErrorCode::kerCorruptedMetadata);
 
     const auto textsize =

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -346,7 +346,7 @@ PreviewProperties Loader::getProperties() const {
 }
 
 PreviewId Loader::getNumLoaders() {
-  return static_cast<PreviewId>(std::size(loaderList_));
+  return PreviewId{std::size(loaderList_)};
 }
 
 LoaderNative::LoaderNative(PreviewId id, const Image& image, int parIdx) : Loader(id, image) {
@@ -750,7 +750,7 @@ DataBuf LoaderTiff::getData() const {
 
   // Fix compression value in the CR2 IFD2 image
   if (0 == strcmp(group_, "Image2") && image_.mimeType() == "image/x-canon-cr2") {
-    preview["Exif.Image.Compression"] = static_cast<uint16_t>(1);
+    preview["Exif.Image.Compression"] = std::uint16_t{1};
   }
 
   // write new image
@@ -884,7 +884,7 @@ DataBuf decodeBase64(const std::string& src) {
       bufferPos--;
     }
     for (int bufferPos = 2; bufferPos >= 0 && destPos < destSize; bufferPos--, destPos++) {
-      dest.write_uint8(destPos, static_cast<byte>((buffer >> (bufferPos * 8)) & 0xFF));
+      dest.write_uint8(destPos, static_cast<byte>((buffer >> (bufferPos * 8))));
     }
   }
   return dest;

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -565,7 +565,7 @@ void QuickTimeVideo::readMetadata() {
   continueTraversing_ = true;
   height_ = width_ = 1;
 
-  xmpData_["Xmp.video.FileSize"] = static_cast<double>(io_->size()) / static_cast<double>(1048576);
+  xmpData_["Xmp.video.FileSize"] = static_cast<double>(io_->size()) / 1048576.0;
   xmpData_["Xmp.video.MimeType"] = mimeType();
 
   while (continueTraversing_)
@@ -756,11 +756,11 @@ void QuickTimeVideo::trackApertureTagDecoder(size_t size) {
   byte n = 3;
 
   while (n--) {
-    io_->seek(static_cast<long>(4), BasicIo::cur);
+    io_->seek(4L, BasicIo::cur);
     io_->readOrThrow(buf.data(), 4);
 
     if (equalsQTimeTag(buf, "clef")) {
-      io_->seek(static_cast<long>(4), BasicIo::cur);
+      io_->seek(4L, BasicIo::cur);
       io_->readOrThrow(buf.data(), 2);
       io_->readOrThrow(buf2.data(), 2);
       xmpData_["Xmp.video.CleanApertureWidth"] =
@@ -772,7 +772,7 @@ void QuickTimeVideo::trackApertureTagDecoder(size_t size) {
     }
 
     else if (equalsQTimeTag(buf, "prof")) {
-      io_->seek(static_cast<long>(4), BasicIo::cur);
+      io_->seek(4L, BasicIo::cur);
       io_->readOrThrow(buf.data(), 2);
       io_->readOrThrow(buf2.data(), 2);
       xmpData_["Xmp.video.ProductionApertureWidth"] =
@@ -784,7 +784,7 @@ void QuickTimeVideo::trackApertureTagDecoder(size_t size) {
     }
 
     else if (equalsQTimeTag(buf, "enof")) {
-      io_->seek(static_cast<long>(4), BasicIo::cur);
+      io_->seek(4L, BasicIo::cur);
       io_->readOrThrow(buf.data(), 2);
       io_->readOrThrow(buf2.data(), 2);
       xmpData_["Xmp.video.EncodedPixelsWidth"] =
@@ -795,7 +795,7 @@ void QuickTimeVideo::trackApertureTagDecoder(size_t size) {
           Exiv2::toString(buf.read_uint16(0, bigEndian)) + "." + Exiv2::toString(buf2.read_uint16(0, bigEndian));
     }
   }
-  io_->seek(static_cast<long>(cur_pos + size), BasicIo::beg);
+  io_->seek(cur_pos + size, BasicIo::beg);
 }  // QuickTimeVideo::trackApertureTagDecoder
 
 void QuickTimeVideo::CameraTagsDecoder(size_t size_external) {
@@ -813,8 +813,7 @@ void QuickTimeVideo::CameraTagsDecoder(size_t size_external) {
     io_->readOrThrow(buf.data(), 14);
     xmpData_["Xmp.video.Model"] = Exiv2::toString(buf.data());
     io_->readOrThrow(buf.data(), 4);
-    xmpData_["Xmp.video.ExposureTime"] =
-        "1/" + Exiv2::toString(ceil(buf.read_uint32(0, littleEndian) / static_cast<double>(10)));
+    xmpData_["Xmp.video.ExposureTime"] = "1/" + Exiv2::toString(ceil(buf.read_uint32(0, littleEndian) / 10.0));
     io_->readOrThrow(buf.data(), 4);
     io_->readOrThrow(buf2.data(), 4);
     xmpData_["Xmp.video.FNumber"] =
@@ -832,7 +831,7 @@ void QuickTimeVideo::CameraTagsDecoder(size_t size_external) {
     io_->readOrThrow(buf2.data(), 4);
     xmpData_["Xmp.video.FocalLength"] =
         buf.read_uint32(0, littleEndian) / static_cast<double>(buf2.read_uint32(0, littleEndian));
-    io_->seek(static_cast<long>(95), BasicIo::cur);
+    io_->seek(95L, BasicIo::cur);
     io_->readOrThrow(buf.data(), 48);
     buf.write_uint8(48, 0);
     xmpData_["Xmp.video.Software"] = Exiv2::toString(buf.data());
@@ -1631,7 +1630,7 @@ bool isQTimeType(BasicIo& iIo, bool advance) {
   }
 
   if (!advance || !matched) {
-    iIo.seek(static_cast<long>(0), BasicIo::beg);
+    iIo.seek(0L, BasicIo::beg);
   }
 
   return matched;

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -2546,7 +2546,7 @@ const TagInfo* tagInfo(const std::string& tagName, IfdId ifdId) {
 
 IfdId groupId(const std::string& groupName) {
   if (auto ii = Exiv2::find(groupInfo, groupName))
-    return static_cast<IfdId>(ii->ifdId_);
+    return IfdId{ii->ifdId_};
   return IfdId::ifdIdNotSet;
 }
 
@@ -3014,7 +3014,7 @@ std::ostream& print0x9202(std::ostream& os, const Value& value, const ExifData*)
 std::ostream& print0x9204(std::ostream& os, const Value& value, const ExifData*) {
   Rational bias = value.toRational();
 
-  if (bias.first == 0 || bias.first == static_cast<int32_t>(0x80000000)) {
+  if (bias.first == 0 || bias.first == std::numeric_limits<std::int32_t>::min()) {
     os << "0 EV";
   } else if (bias.second <= 0) {
     os << "(" << bias.first << "/" << bias.second << ")";

--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -72,7 +72,7 @@ class TiffPathItem {
   //@{
   //! Return the tag corresponding to the extended tag
   [[nodiscard]] uint16_t tag() const {
-    return static_cast<uint16_t>(extendedTag_ & 0xffff);
+    return static_cast<uint16_t>(extendedTag_);
   }
   //! Return the extended tag (32 bit so that it can contain special tags)
   [[nodiscard]] uint32_t extendedTag() const {
@@ -352,7 +352,7 @@ struct TiffMappingInfo {
   bool operator==(const Key& key) const;
   //! Return the tag corresponding to the extended tag
   [[nodiscard]] uint16_t tag() const {
-    return static_cast<uint16_t>(extendedTag_ & 0xffff);
+    return static_cast<uint16_t>(extendedTag_);
   }
 
   // DATA

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1995,7 +1995,7 @@ EncoderFct TiffMapping::findEncoder(std::string_view make, uint32_t extendedTag,
 }
 
 TiffComponent::UniquePtr TiffCreator::create(uint32_t extendedTag, IfdId group) {
-  auto tag = static_cast<uint16_t>(extendedTag & 0xffff);
+  auto tag = static_cast<uint16_t>(extendedTag);
   auto i = tiffGroupTable_.find(TiffGroupKey(extendedTag, group));
   // If the lookup failed then try again with Tag::all.
   if (i == tiffGroupTable_.end()) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -361,12 +361,12 @@ size_t ul2Data(byte* buf, uint32_t l, ByteOrder byteOrder) {
 size_t ull2Data(byte* buf, uint64_t l, ByteOrder byteOrder) {
   if (byteOrder == littleEndian) {
     for (size_t i = 0; i < 8; i++) {
-      buf[i] = static_cast<byte>(l & 0xff);
+      buf[i] = static_cast<byte>(l);
       l >>= 8;
     }
   } else {
     for (size_t i = 0; i < 8; i++) {
-      buf[8 - i - 1] = static_cast<byte>(l & 0xff);
+      buf[8 - i - 1] = static_cast<byte>(l);
       l >>= 8;
     }
   }


### PR DESCRIPTION
The original reason for these is because of a clang-tidy check that triggers on C style casts. However, {} initialization is C++. Better to have shorter code.