### PR TITLE
Optimize QuickTime Parsing by Skipping Ignored Tags

### DIFF
--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -612,6 +612,10 @@ void QuickTimeVideo::decodeBlock(size_t recursion_depth, std::string const& ente
 
   // std::cerr<<"Tag=>"<<buf.data()<<"     size=>"<<size-hdrsize << '\n';
   const auto newsize = static_cast<size_t>(size - hdrsize);
+  if (ignoreList(buf)) {
+    discard(newsize);
+    return;
+  }
   if (newsize > buf.size()) {
     buf.resize(newsize);
   }


### PR DESCRIPTION
### Problem
Previously, parsing QuickTime files allocated large memory blocks for tags that were later discarded, wasting resources.

### Solution
This change checks the `ignoreList` before resizing buffers, skipping unnecessary allocations for ignored tags.

### Testing
- Tested with sample QuickTime files containing large tags.
- Verified non-ignored tags are still processed correctly.
