### PR TITLE
Indicate no translation for Nikon lenses

### DIFF
--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -1689,6 +1689,57 @@ const TagInfo* Nikon3MakerNote::tagListLd3() {
   return tagInfoLd3_;
 }
 
+//! LensID, tag index 48
+// see https://github.com/exiftool/exiftool/blob/13.16/lib/Image/ExifTool/Nikon.pm#L5668
+constexpr TagDetails nikonZMountLensId[] = {
+    {0, N_("n/a")},
+    {1, "Nikon Nikkor Z 24-70mm f/4 S"},
+    {2, "Nikon Nikkor Z 14-30mm f/4 S"},
+    {4, "Nikon Nikkor Z 35mm f/1.8 S"},
+    {8, "Nikon Nikkor Z 58mm f/0.95 S Noct"},  // IB
+    {9, "Nikon Nikkor Z 50mm f/1.8 S"},
+    {11, "Nikon Nikkor Z DX 16-50mm f/3.5-6.3 VR"},
+    {12, "Nikon Nikkor Z DX 50-250mm f/4.5-6.3 VR"},
+    {13, "Nikon Nikkor Z 24-70mm f/2.8 S"},
+    {14, "Nikon Nikkor Z 85mm f/1.8 S"},
+    {15, "Nikon Nikkor Z 24mm f/1.8 S"},              // IB
+    {16, "Nikon Nikkor Z 70-200mm f/2.8 VR S"},       // IB
+    {17, "Nikon Nikkor Z 20mm f/1.8 S"},              // IB
+    {18, "Nikon Nikkor Z 24-200mm f/4-6.3 VR"},       // IB
+    {21, "Nikon Nikkor Z 50mm f/1.2 S"},              // IB
+    {22, "Nikon Nikkor Z 24-50mm f/4-6.3"},           // IB
+    {23, "Nikon Nikkor Z 14-24mm f/2.8 S"},           // IB
+    {24, "Nikon Nikkor Z MC 105mm f/2.8 VR S"},       // IB
+    {25, "Nikon Nikkor Z 40mm f/2"},                  // 28
+    {26, "Nikon Nikkor Z DX 18-140mm f/3.5-6.3 VR"},  // IB
+    {27, "Nikon Nikkor Z MC 50mm f/2.8"},             // IB
+    {28, "Nikon Nikkor Z 100-400mm f/4.5-5.6 VR S"},  // 28
+    {29, "Nikon Nikkor Z 28mm f/2.8"},                // IB
+    {30, "Nikon Nikkor Z 400mm f/2.8 TC VR S"},       // 28
+    {31, "Nikon Nikkor Z 24-120mm f/4 S"},            // 28
+    {32, "Nikon Nikkor Z 800mm f/6.3 VR S"},          // 28
+    {35, "Nikon Nikkor Z 28-75mm f/2.8"},             // IB
+    {36, "Nikon Nikkor Z 400mm f/4.5 VR S"},          // IB
+    {37, "Nikon Nikkor Z 600mm f/4 TC VR S"},         // 28
+    {38, "Nikon Nikkor Z 85mm f/1.2 S"},              // 28
+    {39, "Nikon Nikkor Z 17-28mm f/2.8"},             // IB
+    {40, "Nikon Nikkor Z 26mm f/2.8"},
+    {41, "Nikon Nikkor Z DX 12-28mm f/3.5-5.6 PZ VR"},
+    {42, "Nikon Nikkor Z 180-600mm f/5.6-6.3 VR"},
+    {43, "Nikon Nikkor Z DX 24mm f/1.7"},
+    {44, "Nikon Nikkor Z 70-180mm f/2.8"},
+    {45, "Nikon Nikkor Z 600mm f/6.3 VR S"},
+    {46, "Nikon Nikkor Z 135mm f/1.8 S Plena"},
+    {47, "Nikon Nikkor Z 35mm f/1.2 S"},
+    {48, "Nikon Nikkor Z 28-400mm f/4-8 VR"},
+    {49, "Nikon Nikkor Z 28-135mm f/4 PZ"},
+    {51, "Nikon Nikkor Z 35mm f/1.4"},
+    {52, "Nikon Nikkor Z 50mm f/1.4"},
+    {2305, "Laowa FFII 10mm F2.8 C&D Dreamer"},
+    {53251, "Sigma 56mm F1.4 DC DN | C"},
+    {57346, "Tamron 35-150mm F/2-2.8 Di III VXD"},
+};
+
 // Nikon3 Lens Data 4 Tag Info
 // based on https://exiftool.org/TagNames/Nikon.html#LensData0800
 constexpr TagInfo Nikon3MakerNote::tagInfoLd4_[] = {
@@ -1721,7 +1772,7 @@ constexpr TagInfo Nikon3MakerNote::tagInfoLd4_[] = {
     {20, "EffectiveMaxAperture", N_("Effective Max Aperture"), N_("Effective max aperture"), IfdId::nikonLd4Id,
      SectionId::makerTags, unsignedByte, 1, printAperture},
     {48, "LensID", N_("LensID"), N_("Lens ID"), IfdId::nikonLd4Id, SectionId::makerTags, unsignedShort, 1,
-     printLensId4ZMount},
+     EXV_PRINT_TAG(nikonZMountLensId)},
     {54, "MaxAperture", N_("Max Aperture"), N_("Max aperture"), IfdId::nikonLd4Id, SectionId::makerTags, unsignedShort,
      1, printApertureLd4},
     {56, "FNumber", N_("F-Number"), N_("F-Number"), IfdId::nikonLd4Id, SectionId::makerTags, unsignedShort, 1,
@@ -3847,67 +3898,6 @@ std::ostream& Nikon3MakerNote::print0x009e(std::ostream& os, const Value& value,
     }
   }
   return os << s;
-}
-
-std::ostream& Nikon3MakerNote::printLensId4ZMount(std::ostream& os, const Value& value, const ExifData*) {
-  if (value.count() != 1 || value.typeId() != unsignedShort) {
-    return os << "(" << value << ")";
-  }
-
-  // cf. https://github.com/exiftool/exiftool/blob/13.16/lib/Image/ExifTool/Nikon.pm#L5668
-  static constexpr std::tuple<uint16_t, const char*, const char*> zmountlens[] = {
-      {1, "Nikon", "Nikkor Z 24-70mm f/4 S"},
-      {2, "Nikon", "Nikkor Z 14-30mm f/4 S"},
-      {4, "Nikon", "Nikkor Z 35mm f/1.8 S"},
-      {8, "Nikon", "Nikkor Z 58mm f/0.95 S Noct"},  // IB
-      {9, "Nikon", "Nikkor Z 50mm f/1.8 S"},
-      {11, "Nikon", "Nikkor Z DX 16-50mm f/3.5-6.3 VR"},
-      {12, "Nikon", "Nikkor Z DX 50-250mm f/4.5-6.3 VR"},
-      {13, "Nikon", "Nikkor Z 24-70mm f/2.8 S"},
-      {14, "Nikon", "Nikkor Z 85mm f/1.8 S"},
-      {15, "Nikon", "Nikkor Z 24mm f/1.8 S"},              // IB
-      {16, "Nikon", "Nikkor Z 70-200mm f/2.8 VR S"},       // IB
-      {17, "Nikon", "Nikkor Z 20mm f/1.8 S"},              // IB
-      {18, "Nikon", "Nikkor Z 24-200mm f/4-6.3 VR"},       // IB
-      {21, "Nikon", "Nikkor Z 50mm f/1.2 S"},              // IB
-      {22, "Nikon", "Nikkor Z 24-50mm f/4-6.3"},           // IB
-      {23, "Nikon", "Nikkor Z 14-24mm f/2.8 S"},           // IB
-      {24, "Nikon", "Nikkor Z MC 105mm f/2.8 VR S"},       // IB
-      {25, "Nikon", "Nikkor Z 40mm f/2"},                  // 28
-      {26, "Nikon", "Nikkor Z DX 18-140mm f/3.5-6.3 VR"},  // IB
-      {27, "Nikon", "Nikkor Z MC 50mm f/2.8"},             // IB
-      {28, "Nikon", "Nikkor Z 100-400mm f/4.5-5.6 VR S"},  // 28
-      {29, "Nikon", "Nikkor Z 28mm f/2.8"},                // IB
-      {30, "Nikon", "Nikkor Z 400mm f/2.8 TC VR S"},       // 28
-      {31, "Nikon", "Nikkor Z 24-120mm f/4 S"},            // 28
-      {32, "Nikon", "Nikkor Z 800mm f/6.3 VR S"},          // 28
-      {35, "Nikon", "Nikkor Z 28-75mm f/2.8"},             // IB
-      {36, "Nikon", "Nikkor Z 400mm f/4.5 VR S"},          // IB
-      {37, "Nikon", "Nikkor Z 600mm f/4 TC VR S"},         // 28
-      {38, "Nikon", "Nikkor Z 85mm f/1.2 S"},              // 28
-      {39, "Nikon", "Nikkor Z 17-28mm f/2.8"},             // IB
-      {40, "Nikon", "Nikkor Z 26mm f/2.8"},
-      {41, "Nikon", "Nikkor Z DX 12-28mm f/3.5-5.6 PZ VR"},
-      {42, "Nikon", "Nikkor Z 180-600mm f/5.6-6.3 VR"},
-      {43, "Nikon", "Nikkor Z DX 24mm f/1.7"},
-      {44, "Nikon", "Nikkor Z 70-180mm f/2.8"},
-      {45, "Nikon", "Nikkor Z 600mm f/6.3 VR S"},
-      {46, "Nikon", "Nikkor Z 135mm f/1.8 S Plena"},
-      {47, "Nikon", "Nikkor Z 35mm f/1.2 S"},
-      {48, "Nikon", "Nikkor Z 28-400mm f/4-8 VR"},
-      {49, "Nikon", "Nikkor Z 28-135mm f/4 PZ"},
-      {51, "Nikon", "Nikkor Z 35mm f/1.4"},
-      {52, "Nikon", "Nikkor Z 50mm f/1.4"},
-      {2305, "Laowa", "FFII 10mm F2.8 C&D Dreamer"},
-      {53251, "Sigma", "56mm F1.4 DC DN | C"},
-      {57346, "Tamron", "35-150mm F/2-2.8 Di III VXD"},
-  };
-
-  auto lid = static_cast<uint16_t>(value.toInt64());
-  for (auto&& [l, manuf, lensname] : zmountlens)
-    if (l == lid)
-      return os << manuf << " " << lensname;
-  return os << "(" << value << ")";
 }
 
 std::ostream& Nikon3MakerNote::printApertureLd4(std::ostream& os, const Value& value, const ExifData*) {

--- a/src/nikonmn_int.cpp
+++ b/src/nikonmn_int.cpp
@@ -3236,7 +3236,7 @@ std::ostream& Nikon3MakerNote::printLensId(std::ostream& os, const Value& value,
      */
     if (auto pf = Exiv2::find(fmountlens, vid))
       return os << pf->manuf << " " << pf->lensname;
-    return os << value;
+    return os << "(" << value << ")";
   }
 
   byte raw[] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
@@ -3251,14 +3251,14 @@ std::ostream& Nikon3MakerNote::printLensId(std::ostream& os, const Value& value,
     ExifKey key(pre + std::string(tags[i]));
     auto md = metadata->findKey(key);
     if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
-      return os << value;
+      return os << "(" << value << ")";
     }
     raw[i] = static_cast<byte>(md->toInt64());
   }
 
   auto md = metadata->findKey(ExifKey("Exif.Nikon3.LensType"));
   if (md == metadata->end() || md->typeId() != unsignedByte || md->count() == 0) {
-    return os << value;
+    return os << "(" << value << ")";
   }
   raw[7] = static_cast<byte>(md->toInt64());
 
@@ -3282,9 +3282,9 @@ std::ostream& Nikon3MakerNote::printLensId(std::ostream& os, const Value& value,
     }
   }
   // Lens not found in database
-  return os << value;
+  return os << "(" << value << ")";
 #else
-  return os << value;
+  return os << "(" << value << ")";
 #endif  // EXV_HAVE_LENSDATA
 }
 
@@ -3907,7 +3907,7 @@ std::ostream& Nikon3MakerNote::printLensId4ZMount(std::ostream& os, const Value&
   for (auto&& [l, manuf, lensname] : zmountlens)
     if (l == lid)
       return os << manuf << " " << lensname;
-  return os << lid;
+  return os << "(" << value << ")";
 }
 
 std::ostream& Nikon3MakerNote::printApertureLd4(std::ostream& os, const Value& value, const ExifData*) {

--- a/src/nikonmn_int.hpp
+++ b/src/nikonmn_int.hpp
@@ -177,8 +177,6 @@ class Nikon3MakerNote {
   static std::ostream& printLensId2(std::ostream& os, const Value& value, const ExifData* metadata);
   static std::ostream& printLensId3(std::ostream& os, const Value& value, const ExifData* metadata);
   static std::ostream& printLensId4(std::ostream& os, const Value& value, const ExifData* metadata);
-  //! Print lensname for ZMount Lens in new LensData as used for e.g. Nikon Z 6/7
-  static std::ostream& printLensId4ZMount(std::ostream& os, const Value& value, const ExifData*);
   //! Print focus distance
   static std::ostream& printFocusDistance(std::ostream& os, const Value& value, const ExifData*);
   //! Print focus distance for new LensData as used for e.g. Nikon Z 6/7

--- a/test/data/test_reference_files/CH0_0174.exv.out
+++ b/test/data/test_reference_files/CH0_0174.exv.out
@@ -112,7 +112,7 @@ Exif.NikonLd4.MaxApertureAtMinFocal          Byte        1  36  F2.8
 Exif.NikonLd4.MaxApertureAtMaxFocal          Byte        1  36  F2.8
 Exif.NikonLd4.MCUVersion                     Byte        1  123  123
 Exif.NikonLd4.EffectiveMaxAperture           Byte        1  36  F2.8
-Exif.NikonLd4.LensID                         Short       1  0  0
+Exif.NikonLd4.LensID                         Short       1  0  n/a
 Exif.NikonLd4.MaxAperture                    Short       1  0  n/a
 Exif.NikonLd4.FNumber                        Short       1  0  n/a
 Exif.NikonLd4.FocalLength2                   Short       1  0  n/a

--- a/test/data/test_reference_files/NikonZ6.exv.out
+++ b/test/data/test_reference_files/NikonZ6.exv.out
@@ -90,7 +90,7 @@ Exif.NikonLd4.AFAperture                     Byte        1  0  n/a
 Exif.NikonLd4.FocusPosition                  Byte        1  0  0
 Exif.NikonLd4.FocusDistance                  Byte        1  0  n/a
 Exif.NikonLd4.FocalLength                    Byte        1  0  n/a
-Exif.NikonLd4.LensIDNumber                   Byte        1  0  0
+Exif.NikonLd4.LensIDNumber                   Byte        1  0  (0)
 Exif.NikonLd4.LensFStops                     Byte        1  0  F0.0
 Exif.NikonLd4.MinFocalLength                 Byte        1  0  n/a
 Exif.NikonLd4.MaxFocalLength                 Byte        1  0  n/a

--- a/tests/bugfixes/github/test_pr_1437.py
+++ b/tests/bugfixes/github/test_pr_1437.py
@@ -21,7 +21,7 @@ Exif.NikonLd4.LensFStops                     Byte        1  F6.0
 Exif.NikonLd4.MaxApertureAtMinFocal          Byte        1  F2.8
 Exif.NikonLd4.MaxApertureAtMaxFocal          Byte        1  F2.8
 Exif.NikonLd4.EffectiveMaxAperture           Byte        1  F2.8
-Exif.NikonLd4.LensID                         Short       1  0
+Exif.NikonLd4.LensID                         Short       1  n/a
 Exif.NikonLd4.MaxAperture                    Short       1  n/a
 Exif.Nikon3.ShutterCount                     Long        1  174
 Exif.Photo.LensSpecification                 Rational    4  70-200mm F2.8


### PR DESCRIPTION
The "(xyz)" notation is used in some other makernotes like Minolta, Sony, Pentax... For Canon we even print "Unknown Lens (xyz)". The parentheses are sometimes used by apps to detect if the pretty printing of the lens model was not successful.

This is also the fallback behavior of `EXV_PRINT_TAG()` which is used for some lens tables (e.g. Canon RF mount), so also switching Nikon Z mount lenses to that.