### PR TITLE
remove old and outdated pragma

### DIFF
--- a/include/exiv2/config.h
+++ b/include/exiv2/config.h
@@ -7,7 +7,6 @@
 #ifdef _MSC_VER
 
 #pragma warning(disable : 4996)  // Disable warnings about 'deprecated' standard functions
-#pragma warning(disable : 4251)  // Disable warnings from std templates about exporting interfaces
 
 #endif  // _MSC_VER
 ///// End of Visual Studio Support /////


### PR DESCRIPTION
It looks like this is no longer an issue. There are no classes that inherit from std.