### PR TITLE
remove cbegin/cend

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -1013,7 +1013,7 @@ int Insert::insertXmpPacket(const std::string& path, const std::string& xmpPath)
 }  // Insert::insertXmpPacket
 
 int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket) {
-  std::string xmpPacket(xmpBlob.cbegin(), xmpBlob.cend());
+  std::string xmpPacket(xmpBlob.begin(), xmpBlob.end());
   auto image = Exiv2::ImageFactory::open(path);
   image->readMetadata();
   image->clearXmpData();

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -165,14 +165,6 @@ struct EXIV2API DataBuf {
     return pData_.end();
   }
 
-  [[nodiscard]] auto cbegin() const noexcept {
-    return pData_.cbegin();
-  }
-
-  [[nodiscard]] auto cend() const noexcept {
-    return pData_.cend();
-  }
-
   [[nodiscard]] size_t size() const {
     return pData_.size();
   }

--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -149,20 +149,28 @@ struct EXIV2API DataBuf {
   void reset();
   //@}
 
-  using iterator = std::vector<byte>::iterator;
-  using const_iterator = std::vector<byte>::const_iterator;
-
-  iterator begin() noexcept {
+  [[nodiscard]] auto begin() noexcept {
     return pData_.begin();
   }
-  [[nodiscard]] const_iterator cbegin() const noexcept {
+
+  [[nodiscard]] auto end() noexcept {
+    return pData_.end();
+  }
+
+  [[nodiscard]] auto begin() const noexcept {
+    return pData_.begin();
+  }
+
+  [[nodiscard]] auto end() const noexcept {
+    return pData_.end();
+  }
+
+  [[nodiscard]] auto cbegin() const noexcept {
     return pData_.cbegin();
   }
-  iterator end() noexcept {
-    return pData_.end();
-  }
-  [[nodiscard]] const_iterator cend() const noexcept {
-    return pData_.end();
+
+  [[nodiscard]] auto cend() const noexcept {
+    return pData_.cend();
   }
 
   [[nodiscard]] size_t size() const {

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1197,10 +1197,6 @@ class ValueType : public Value {
 
   //! Container for values
   using ValueList = std::vector<T>;
-  //! Iterator type defined for convenience.
-  using iterator = typename std::vector<T>::iterator;
-  //! Const iterator type defined for convenience.
-  using const_iterator = typename std::vector<T>::const_iterator;
 
   // DATA
   /*!

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -649,7 +649,7 @@ void Jp2Image::encodeJp2Header(const DataBuf& boxBuf, DataBuf& outBuf) {
       }
     } else {
       Internal::enforce(newlen <= output.size() - outlen, ErrorCode::kerCorruptedMetadata);
-      std::copy_n(boxBuf.cbegin() + inlen, subBox.length, output.begin() + outlen);
+      std::copy_n(boxBuf.begin() + inlen, subBox.length, output.begin() + outlen);
     }
 
     outlen += newlen;

--- a/src/pngchunk_int.cpp
+++ b/src/pngchunk_int.cpp
@@ -74,11 +74,11 @@ DataBuf PngChunk::keyTXTChunk(const DataBuf& data, bool stripHeader) {
   if (data.size() <= offset)
     throw Error(ErrorCode::kerFailedToReadImageData);
 
-  auto it = std::find(data.cbegin() + offset, data.cend(), 0);
-  if (it == data.cend())
+  auto it = std::find(data.begin() + offset, data.end(), 0);
+  if (it == data.end())
     throw Error(ErrorCode::kerFailedToReadImageData);
 
-  return {data.c_data() + offset, std::distance(data.cbegin(), it) - offset};
+  return {data.c_data() + offset, std::distance(data.begin(), it) - offset};
 }
 
 DataBuf PngChunk::parseTXTChunk(const DataBuf& data, size_t keysize, TxtChunkType type) {
@@ -478,7 +478,7 @@ DataBuf PngChunk::readRawProfile(const DataBuf& text, bool iTXt) {
 
   if (iTXt) {
     info.alloc(text.size());
-    std::copy(text.cbegin(), text.cend(), info.begin());
+    std::copy(text.begin(), text.end(), info.begin());
     return info;
   }
 

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -946,7 +946,7 @@ DataBuf makePnm(size_t width, size_t height, const DataBuf& rgb) {
 
   dest = DataBuf(header.size() + rgb.size());
   std::copy(header.begin(), header.end(), dest.begin());
-  std::copy(rgb.cbegin(), rgb.cend(), dest.begin() + header.size());
+  std::copy(rgb.begin(), rgb.end(), dest.begin() + header.size());
   return dest;
 }
 


### PR DESCRIPTION
Artifact from before C++11. Not necessary now.