### PR TITLE
CI: add big endian CI

### DIFF
--- a/.github/workflows/on_PR_linux_matrix.yml
+++ b/.github/workflows/on_PR_linux_matrix.yml
@@ -55,3 +55,34 @@ jobs:
         run: |
           cd build-base_linux
           ctest --output-on-failure
+  Alpine:
+    name: 'Alpine Edge - GCC, BuildType:${{matrix.build_type}}, SHARED:${{matrix.shared_libraries}} ARCH:${{matrix.arch}}'
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['riscv64', 's390x']
+        build_type: [Release, Debug]
+        shared_libraries: [ON, OFF]
+
+    defaults:
+      run:
+        shell: alpine.sh {0}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jirutka/setup-alpine@v1
+        with:
+          arch: ${{matrix.arch}}
+          branch: edge
+          packages: >
+            build-base cmake samurai brotli-dev curl-dev expat-dev inih-inireader-dev gtest-dev python3-dev zlib-dev
+      - name: Build
+        run: |
+          cmake --preset base_linux -S . -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.shared_libraries}} -DCONAN_AUTO_INSTALL=OFF
+          cmake --build build-base_linux --parallel
+      - name: Test
+        run: |
+          cd build-base_linux
+          ctest --output-on-failure


### PR DESCRIPTION
Alpine supports more platforms bug many are redundant. riscv64 is included as it's very new and s390x is big endian.