### PR TITLE
metadatum: remove deleted move operations

### DIFF
--- a/include/exiv2/metadatum.hpp
+++ b/include/exiv2/metadatum.hpp
@@ -33,8 +33,6 @@ class EXIV2API Key {
   //! Destructor
   virtual ~Key();
   //@}
-  Key(Key&&) = delete;
-  Key& operator=(Key&&) = delete;
   //! @name Accessors
   //@{
   /*!


### PR DESCRIPTION
These are already deleted. No need to be explicit.