### PR TITLE
Fix several gcc warnings about `-Wformat=`

### DIFF
--- a/xmpsdk/src/XMPMeta.cpp
+++ b/xmpsdk/src/XMPMeta.cpp
@@ -87,7 +87,7 @@ static const char * kTenSpaces = "          ";
 #define OutProcHexInt(num)	{ snprintf ( buffer, sizeof(buffer), "%X", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */	\
 							  status = (*outProc) ( refCon, buffer, strlen(buffer) );  if ( status != 0 ) goto EXIT; }
 #else
-#define OutProcHexInt(num)	{ snprintf ( buffer, sizeof(buffer), "%lX", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */	\
+#define OutProcHexInt(num)	{ snprintf ( buffer, sizeof(buffer), "%X", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */	\
 							  status = (*outProc) ( refCon, buffer, strlen(buffer) );  if ( status != 0 ) goto EXIT; }
 #endif
 

--- a/xmpsdk/src/XMPUtils.cpp
+++ b/xmpsdk/src/XMPUtils.cpp
@@ -1218,9 +1218,9 @@ XMPUtils::ConvertToInt64 ( XMP_StringPtr strValue )
 	XMP_Int64 result;
 
 	if ( ! XMP_LitNMatch ( strValue, "0x", 2 ) ) {
-		count = sscanf ( strValue, "%lld%c", &result, &nextCh );
+		count = sscanf ( strValue, "%ld%c", &result, &nextCh );
 	} else {
-		count = sscanf ( strValue, "%llx%c", &result, &nextCh );
+		count = sscanf ( strValue, "%lx%c", &result, &nextCh );
 	}
 
 	if ( count != 1 ) XMP_Throw ( "Invalid integer string", kXMPErr_BadParam );


### PR DESCRIPTION
```
Error: COMPILER_WARNING: [#def25]
exiv2-0.28.5/xmpsdk/src/XMPMeta.cpp: scope_hint: In function ‘XMP_Status DumpNodeOptions(XMP_OptionBits, XMP_TextOutputProc, void*)’
exiv2-0.28.5/xmpsdk/src/XMPMeta.cpp:90:70: warning[-Wformat=]: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 4 has type ‘XMP_OptionBits’ {aka ‘unsigned int’}
   90 | #define OutProcHexInt(num)      { snprintf ( buffer, sizeof(buffer), "%lX", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */      \
      |                                                                      ^~~~~  ~~~~~
exiv2-0.28.5/xmpsdk/src/XMPMeta.cpp:241:17: note: in expansion of macro ‘OutProcHexInt’
  241 |                 OutProcHexInt ( options );
      |                 ^~~~~~~~~~~~~
exiv2-0.28.5/xmpsdk/src/XMPMeta.cpp:90:73: note: format string is defined here
   90 | #define OutProcHexInt(num)      { snprintf ( buffer, sizeof(buffer), "%lX", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */      \
      |                                                                       ~~^
      |                                                                         |
      |                                                                         long unsigned int
      |                                                                       %X
   88|   							  status = (*outProc) ( refCon, buffer, strlen(buffer) );  if ( status != 0 ) goto EXIT; }
   89|   #else
   90|-> #define OutProcHexInt(num)	{ snprintf ( buffer, sizeof(buffer), "%lX", (num) ); /* AUDIT: Using sizeof for snprintf length is safe */	\
   91|   							  status = (*outProc) ( refCon, buffer, strlen(buffer) );  if ( status != 0 ) goto EXIT; }
   92|   #endif

Error: COMPILER_WARNING: [#def26]
exiv2-0.28.5/xmpsdk/src/XMPUtils.cpp: scope_hint: In static member function ‘static XMP_Int64 XMPUtils::ConvertToInt64(XMP_StringPtr)’
exiv2-0.28.5/xmpsdk/src/XMPUtils.cpp:1221:48: warning[-Wformat=]: format ‘%lld’ expects argument of type ‘long long int*’, but argument 3 has type ‘XMP_Int64*’ {aka ‘long int*’}
 1221 |                 count = sscanf ( strValue, "%lld%c", &result, &nextCh );
      |                                             ~~~^     ~~~~~~~
      |                                                |     |
      |                                                |     XMP_Int64* {aka long int*}
      |                                                long long int*
      |                                             %ld
 1219|
 1220|   	if ( ! XMP_LitNMatch ( strValue, "0x", 2 ) ) {
 1221|-> 		count = sscanf ( strValue, "%lld%c", &result, &nextCh );
 1222|   	} else {
 1223|   		count = sscanf ( strValue, "%llx%c", &result, &nextCh );

Error: COMPILER_WARNING: [#def27]
exiv2-0.28.5/xmpsdk/src/XMPUtils.cpp:1223:48: warning[-Wformat=]: format ‘%llx’ expects argument of type ‘long long unsigned int*’, but argument 3 has type ‘XMP_Int64*’ {aka ‘long int*’}
 1223 |                 count = sscanf ( strValue, "%llx%c", &result, &nextCh );
      |                                             ~~~^     ~~~~~~~
      |                                                |     |
      |                                                |     XMP_Int64* {aka long int*}
      |                                                long long unsigned int*
      |                                             %lx
 1221|   		count = sscanf ( strValue, "%lld%c", &result, &nextCh );
 1222|   	} else {
 1223|-> 		count = sscanf ( strValue, "%llx%c", &result, &nextCh );
 1224|   	}
 1225|
```

Resolves: https://openscanhub.fedoraproject.org/task/51946/log/exiv2-0.28.5-1.fc43/scan-results.html#def25