### PR TITLE
clang-tidy: avoid promotion warning

### DIFF
--- a/src/fujimn_int.cpp
+++ b/src/fujimn_int.cpp
@@ -295,7 +295,7 @@ static std::ostream& printFujiDriveSetting(std::ostream& os, const Value& value,
   if (auto setting = Exiv2::find(fujiDriveSettingByte1, byte1)) {
     os << exvGettext(setting->label_);
   } else {
-    os << "(" << byte1 << ")";
+    os << "(" << +byte1 << ")";
   }
 
   if (fps != 0) {
@@ -303,7 +303,7 @@ static std::ostream& printFujiDriveSetting(std::ostream& os, const Value& value,
   }
 
   if (byte1 != 0) {
-    os << ", (" << byte2 << ", " << byte3 << ")";  // unknown values
+    os << ", (" << +byte2 << ", " << +byte3 << ")";  // unknown values
   }
   return os;
 }

--- a/src/pentaxmn_int.cpp
+++ b/src/pentaxmn_int.cpp
@@ -983,7 +983,7 @@ std::ostream& PentaxMakerNote::printBracketing(std::ostream& os, const Value& va
           os << _("Unknown ") << type;
           break;
       }
-      os << " " << range;
+      os << " " << +range;
     }
     os << ")";
   }


### PR DESCRIPTION
This prints the ASCII value, not the number. Adding a + avoids the warning.