### PR TITLE
basicio: delete base class member funcs

### DIFF
--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -36,8 +36,11 @@ class EXIV2API BasicIo {
 
   //! @name Creators
   //@{
+  BasicIo() = default;
   //! Destructor
   virtual ~BasicIo();
+  BasicIo(const BasicIo&) = delete;
+  BasicIo& operator=(const BasicIo&) = delete;
   //@}
 
   //! @name Manipulators
@@ -262,12 +265,6 @@ class EXIV2API IoCloser {
   // DATA
   //! The BasicIo reference
   BasicIo& bio_;
-
-  // Not implemented
-  //! Copy constructor
-  IoCloser(const IoCloser&) = delete;
-  //! Assignment operator
-  IoCloser& operator=(const IoCloser&) = delete;
 };  // class IoCloser
 
 #ifdef EXV_ENABLE_FILESYSTEM
@@ -468,12 +465,6 @@ class EXIV2API FileIo : public BasicIo {
   void populateFakeData() override;
   //@}
 
-  // NOT IMPLEMENTED
-  //! Copy constructor
-  FileIo(const FileIo&) = delete;
-  //! Assignment operator
-  FileIo& operator=(const FileIo&) = delete;
-
  private:
   // Pimpl idiom
   class Impl;
@@ -651,12 +642,6 @@ class EXIV2API MemIo : public BasicIo {
 
   //@}
 
-  // NOT IMPLEMENTED
-  //! Copy constructor
-  MemIo(const MemIo&) = delete;
-  //! Assignment operator
-  MemIo& operator=(const MemIo&) = delete;
-
  private:
   // Pimpl idiom
   class Impl;
@@ -689,9 +674,6 @@ class EXIV2API XPathIo : public FileIo {
   //! Destructor. Releases all managed memory and removes the temp file.
   ~XPathIo() override;
   //@}
-
-  XPathIo(const XPathIo&) = delete;
-  XPathIo& operator=(const XPathIo&) = delete;
 
   //! @name Manipulators
   //@{
@@ -732,9 +714,6 @@ class EXIV2API RemoteIo : public BasicIo {
   RemoteIo();
   ~RemoteIo() override;
   //@}
-
-  RemoteIo(const RemoteIo&) = delete;
-  RemoteIo& operator=(const RemoteIo&) = delete;
 
   //! @name Manipulators
   //@{


### PR DESCRIPTION
Instead of deleting all the subclasses, delete the base.