### PR TITLE
meson: remove cmake config and fix pkgconfig

### DIFF
--- a/src/makernote_int.hpp
+++ b/src/makernote_int.hpp
@@ -80,8 +80,8 @@ class TiffMnCreator {
 
   ~TiffMnCreator() = default;
   //! Prevent destruction (needed if used as a policy class)
-  TiffMnCreator(const TiffComponent&) = delete;
-  TiffMnCreator& operator=(const TiffComponent&) = delete;
+  TiffMnCreator(const TiffMnCreator&) = delete;
+  TiffMnCreator& operator=(const TiffMnCreator&) = delete;
 
  private:
   static const TiffMnRegistry registry_[];  //!< List of makernotes


### PR DESCRIPTION
exiv2lib_export.h in meson is implemented as an empty file and the EXIVAPI definitions are handled by passing -D to the compiler. Add it to the pkgconf file to make it work.

For cmake configuration, there's no easy way to handle this. Because meson's support is limited, a full blown cmake configuration file needs to be written for this purpose.

Instead of trying to make it work, simpler to remove and tell people to use pkgconfig.