### PR TITLE
i18n: don't export _exvGettext

### DIFF
--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -35,6 +35,10 @@ namespace fs = std::filesystem;
 #define _strdup strdup
 #endif
 
+#ifdef EXV_ENABLE_NLS
+#include <libintl.h>
+#endif
+
 // *****************************************************************************
 // local declarations
 namespace {

--- a/src/i18n.h
+++ b/src/i18n.h
@@ -30,12 +30,12 @@
 
 /* NLS can be disabled through the configure --disable-nls option. */
 #ifdef EXV_ENABLE_NLS
-#include <libintl.h>
+#include "types.hpp"
 
 // Definition is in types.cpp
-EXIV2API const char* _exvGettext(const char* str);
+const char* _exvGettext(const char* str);
 
-#define _(String) _exvGettext(String)
+#define _(String) Exiv2::exvGettext(String)
 #define N_(String) String
 
 #else /* NLS is disabled */

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -19,6 +19,10 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
+#ifdef EXV_ENABLE_NLS
+#include <libintl.h>
+#endif
+
 // *****************************************************************************
 namespace {
 //! Information pertaining to the defined %Exiv2 value type identifiers.


### PR DESCRIPTION
All EXIV2API declarations are in include except for this one, which is meant to be internal anyway.

Fixes: https://github.com/Exiv2/exiv2/issues/3308