### PR TITLE
Add new fuzz target

### DIFF
--- a/.github/workflows/on_PR_linux_fuzz.yml
+++ b/.github/workflows/on_PR_linux_fuzz.yml
@@ -19,6 +19,11 @@ jobs:
     name: 'Ubuntu 24.04 - clang/libFuzzer'
     runs-on: ubuntu-24.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzz_target: [fuzz-read-write, fuzz-read-print-write]
+
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -37,4 +42,4 @@ jobs:
       run: |
         cd build
         mkdir corpus
-        LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/fuzz-read-print-write corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_len=4096 -max_total_time=120
+        LSAN_OPTIONS=suppressions=../fuzz/knownleaks.txt ./bin/${{matrix.fuzz_target}} corpus ../test/data/ -dict=../fuzz/exiv2.dict -jobs=$(nproc) -workers=$(nproc) -max_len=4096 -max_total_time=120

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -13,3 +13,4 @@ macro(FUZZER name)
 endmacro()
 
 FUZZER(fuzz-read-print-write)
+FUZZER(fuzz-read-write)

--- a/fuzz/fuzz-read-write.cpp
+++ b/fuzz/fuzz-read-write.cpp
@@ -1,0 +1,27 @@
+#include <exiv2/exiv2.hpp>
+
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // Invalid files generate a lot of warnings, so switch off logging.
+  Exiv2::LogMsg::setLevel(Exiv2::LogMsg::mute);
+
+  Exiv2::XmpParser::initialize();
+  ::atexit(Exiv2::XmpParser::terminate);
+
+  try {
+    Exiv2::DataBuf data_copy(data, size);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(data_copy.c_data(), size);
+    assert(image.get() != 0);
+
+    image->readMetadata();
+    image->writeMetadata();
+
+  } catch (...) {
+    // Exiv2 throws an exception if the metadata is invalid.
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Some bugs are not getting caught by our existing fuzz target (`fuzz-read-print-write`). The reason is that an error occurs during the "print" stage so the "write" stage isn't called, and that's where the bug is. So this fuzz target only calls `readMetadata` immediately followed by `writeMetadata`.

After this is merged, I'll add the new fuzz target to OSS-Fuzz.