### PR TITLE
Copy correct number of bytes

### DIFF
--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -179,7 +179,7 @@ void PgfImage::doWriteMetadata(BasicIo& outIo) {
   // Write new Header size.
   auto newHeaderSize = static_cast<uint32_t>(header.size() + imgSize);
   DataBuf buffer(4);
-  std::copy_n(&newHeaderSize, 4, buffer.data());
+  std::copy_n(&newHeaderSize, 1, buffer.data());
   byteSwap_(buffer, 0, bSwap_);
   if (outIo.write(buffer.c_data(), 4) != 4)
     throw Error(ErrorCode::kerImageWriteFailed);

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -179,7 +179,7 @@ void PgfImage::doWriteMetadata(BasicIo& outIo) {
   // Write new Header size.
   auto newHeaderSize = static_cast<uint32_t>(header.size() + imgSize);
   DataBuf buffer(4);
-  std::copy_n(&newHeaderSize, 1, buffer.data());
+  std::memcpy(buffer.data(), &newHeaderSize, sizeof(uint32_t));
   byteSwap_(buffer, 0, bSwap_);
   if (outIo.write(buffer.c_data(), 4) != 4)
     throw Error(ErrorCode::kerImageWriteFailed);


### PR DESCRIPTION
I found this bug when running the new fuzz target (#3313 ). This call to `std::copy_n` copies 4x `uint32_t` values, but it's only supposed to copy 4 bytes.

This bug causes an ASAN failure, but it doesn't copy enough bytes to be harmful, so I'm not treating it as a security issue.

The code on the main branch is different, so I think this only needs to be fixed on `0.28.x`.