### PR TITLE
remove C++11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | **CI Status:**    |      |      |     |
 |:--                |:--   |:--   |:--  |
-| [![Release](https://github.com/Exiv2/exiv2/actions/workflows/release.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/release.yml) | [![Basic jobs for all platforms](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![Nightly jobs for Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) | [![On PUSH - Linux Special Builds for main branch](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml) | 
+| [![Release](https://github.com/Exiv2/exiv2/actions/workflows/release.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/release.yml) | [![Basic jobs for all platforms](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_BasicWinLinMac.yml) |  [![Nightly jobs for Linux distributions](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml/badge.svg?branch=main)](https://github.com/Exiv2/exiv2/actions/workflows/nightly_Linux_distributions.yml) | [![On PUSH - Linux Special Builds for main branch](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml/badge.svg)](https://github.com/Exiv2/exiv2/actions/workflows/on_push_ExtraJobsForMain.yml) |
 
 <div id="Welcome">
 
@@ -313,7 +313,7 @@ where `platform: { CYGWIN | Darwin | Linux | MinGW | msvc | Unix }`
 
 In general you need to do the following:
 
-1) Application code should be written in C++98 and include exiv2 headers:
+1) Application code should be written in at least C++14 and include exiv2 headers:
 
 ```cpp
 #include <exiv2/exiv2.hpp>

--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -96,7 +96,7 @@ struct ConstSliceBase : SliceBase {
    *
    * @throw std::out_of_range when index is out of bounds of the slice
    */
-  [[nodiscard]] const value_type& at(size_t index) const {
+  [[nodiscard]] const auto& at(size_t index) const {
     rangeCheck(index);
     // we know: begin_ < end <= size() <= SIZE_T_MAX
     // and: index < end - begin
@@ -247,11 +247,7 @@ struct MutableSliceBase : public ConstSliceBase<storage_type, data_type> {
  */
 template <typename container>
 struct ContainerStorage {
-#ifdef __cpp_lib_type_trait_variable_templates
   using value_type = std::remove_cv_t<typename container::value_type>;
-#else
-  using value_type = typename std::remove_cv<typename container::value_type>::type;
-#endif
 
   /*!
    * @throw std::out_of_range when end is larger than the container's
@@ -269,11 +265,11 @@ struct ContainerStorage {
    *
    * @throw whatever container::at() throws
    */
-  [[nodiscard]] const value_type& unsafeAt(size_t index) const {
+  [[nodiscard]] const auto& unsafeAt(size_t index) const {
     return data_.at(index);
   }
 
-  [[nodiscard]] value_type& unsafeAt(size_t index) {
+  [[nodiscard]] auto& unsafeAt(size_t index) {
     return data_.at(index);
   }
 
@@ -312,11 +308,7 @@ struct ContainerStorage {
  */
 template <typename storage_type>
 struct PtrSliceStorage {
-#ifdef __cpp_lib_type_trait_variable_templates
   using value_type = std::remove_cv_t<std::remove_pointer_t<storage_type>>;
-#else
-  using value_type = typename std::remove_cv<typename std::remove_pointer<storage_type>::type>::type;
-#endif
 
   /*!
    * Stores ptr and checks that it is not `NULL`. The slice's bounds

--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1248,11 +1248,7 @@ class ValueType : public Value {
     } else if (std::is_signed<I>::value) {
 #endif
       // conversion is from unsigned to signed
-#ifdef __cpp_lib_type_trait_variable_templates
       const auto imax = static_cast<std::make_unsigned_t<I>>(std::numeric_limits<I>::max());
-#else
-      const auto imax = static_cast<typename std::make_unsigned<I>::type>(std::numeric_limits<I>::max());
-#endif
       if (imax < b || imax < a) {
         return 0;
       }
@@ -1263,13 +1259,8 @@ class ValueType : public Value {
         return 0;
       }
       // Inputs are not negative so convert them to unsigned.
-#ifdef __cpp_lib_type_trait_variable_templates
       const auto a_u = static_cast<std::make_unsigned_t<decltype(a)>>(a);
       const auto b_u = static_cast<std::make_unsigned_t<decltype(b)>>(b);
-#else
-      const auto a_u = static_cast<typename std::make_unsigned<decltype(a)>::type>(a);
-      const auto b_u = static_cast<typename std::make_unsigned<decltype(b)>::type>(b);
-#endif
       if (imax < b_u || imax < a_u) {
         return 0;
       }


### PR DESCRIPTION
Modern compilers have moved to defaulting to C++14 for various reasons. No need to keep pre-C++14 compatibility.