### PR TITLE
Add new method appendIccProfile to fix quadratic performance issue

### DIFF
--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -196,6 +196,16 @@ class EXIV2API Image {
    */
   virtual void setIccProfile(DataBuf&& iccProfile, bool bTestValid = true);
   /*!
+    @brief Append more bytes to the iccProfile.
+    @param iccProfile DataBuf containing profile (binary)
+    @param bTestValid - tests that iccProfile contains credible data
+   */
+  virtual void appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid);
+  /*!
+    @brief Throw an exception if the size at the beginning of the iccProfile isn't correct.
+   */
+  virtual void checkIccProfile();
+  /*!
     @brief Erase iccProfile. the profile is not removed from
         the actual image until the writeMetadata() method is called.
    */

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -197,7 +197,8 @@ class EXIV2API Image {
   virtual void setIccProfile(DataBuf&& iccProfile, bool bTestValid = true);
   /*!
     @brief Append more bytes to the iccProfile.
-    @param iccProfile DataBuf containing profile (binary)
+    @param bytes array of bytes to append
+    @param size number of bytes to append
     @param bTestValid - tests that iccProfile contains credible data
    */
   virtual void appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -629,16 +629,29 @@ void Image::setComment(const std::string& comment) {
 }
 
 void Image::setIccProfile(Exiv2::DataBuf&& iccProfile, bool bTestValid) {
-  if (bTestValid) {
-    if (iccProfile.size() < sizeof(long)) {
-      throw Error(ErrorCode::kerInvalidIccProfile);
-    }
-    const size_t size = iccProfile.read_uint32(0, bigEndian);
-    if (size != iccProfile.size()) {
-      throw Error(ErrorCode::kerInvalidIccProfile);
-    }
-  }
   iccProfile_ = std::move(iccProfile);
+  if (bTestValid) {
+    checkIccProfile();
+  }
+}
+
+void Image::appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid) {
+  const size_t start = iccProfile_.size();
+  iccProfile_.resize(Safe::add(start, size));
+  memcpy(iccProfile_.data(start), bytes, size);
+  if (bTestValid) {
+    checkIccProfile();
+  }
+}
+
+void Image::checkIccProfile() {
+  if (iccProfile_.size() < sizeof(long)) {
+    throw Error(ErrorCode::kerInvalidIccProfile);
+  }
+  const size_t size = iccProfile_.read_uint32(0, bigEndian);
+  if (size != iccProfile_.size()) {
+    throw Error(ErrorCode::kerInvalidIccProfile);
+  }
 }
 
 void Image::clearIccProfile() {

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -263,12 +263,7 @@ void JpegBase::readMetadata() {
         icc_size = s;
       }
 
-      DataBuf profile(Safe::add(iccProfile_.size(), icc_size));
-      if (!iccProfile_.empty()) {
-        std::copy(iccProfile_.begin(), iccProfile_.end(), profile.begin());
-      }
-      std::copy_n(buf.begin() + 2 + 14, icc_size, profile.begin() + iccProfile_.size());
-      setIccProfile(std::move(profile), chunk == chunks);
+      appendIccProfile(buf.c_data(2 + 14), icc_size, chunk == chunks);
     } else if (pixelHeight_ == 0 && inRange2(marker, sof0_, sof3_, sof5_, sof15_)) {
       // We hit a SOFn (start-of-frame) marker
       if (size < 8) {


### PR DESCRIPTION
Fixes: #3333 

The code in jpgimage.cpp was quadratic because it was appending bytes to the end of the iccProfile by copying the entire array every time. This PR adds an `appendIccProfile` method so that the bytes can be appended efficiently.