### PR TITLE
make more constructors constexpr

### DIFF
--- a/src/tiffcomposite_int.hpp
+++ b/src/tiffcomposite_int.hpp
@@ -592,7 +592,9 @@ class TiffDataEntryBase : public TiffEntryBase {
   //! @name Creators
   //@{
   //! Constructor
-  TiffDataEntryBase(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup);
+  constexpr TiffDataEntryBase(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup) :
+      TiffEntryBase(tag, group), szTag_(szTag), szGroup_(szGroup) {
+  }
   //@}
 
   ~TiffDataEntryBase() override;

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -344,10 +344,6 @@ static const TagInfo* findTag(const TagInfo* pList, uint16_t tag) {
   return pList->tag_ != 0xffff ? pList : nullptr;
 }
 
-TiffDataEntryBase::TiffDataEntryBase(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup) :
-    TiffEntryBase(tag, group), szTag_(szTag), szGroup_(szGroup) {
-}
-
 TiffDataEntryBase::~TiffDataEntryBase() = default;
 
 void TiffDecoder::decodeCanonAFInfo(const TiffEntryBase* object) {


### PR DESCRIPTION
@kevinbackhouse I'm not sure these constructors should even be constexpr.

Should they all be out of line?

```
src/tiffcomposite_int.hpp:  constexpr TiffPathItem(uint32_t extendedTag, IfdId group) : extendedTag_(extendedTag), group_(group) {
src/tiffcomposite_int.hpp:  constexpr TiffComponent(uint16_t tag, IfdId group) : tag_(tag), group_(group) {
src/tiffcomposite_int.hpp:  constexpr TiffEntryBase(uint16_t tag, IfdId group, TiffType tiffType = ttUndefined) :
src/tiffcomposite_int.hpp:  constexpr TiffDataEntryBase(uint16_t tag, IfdId group, uint16_t szTag, IfdId szGroup) :
src/tiffcomposite_int.hpp:  constexpr TiffSizeEntry(uint16_t tag, IfdId group, uint16_t dtTag, IfdId dtGroup) :
src/tiffcomposite_int.hpp:  constexpr TiffMnEntry(uint16_t tag, IfdId group, IfdId mnGroup) :
src/tiffvisitor_int.hpp:  constexpr TiffFinder(uint16_t tag, IfdId group) : tag_(tag), group_(group) {
src/tiffvisitor_int.hpp:  constexpr TiffRwState(ByteOrder byteOrder, size_t baseOffset) : byteOrder_(byteOrder), baseOffset_(baseOffset) **{**
```