### PR TITLE
Low quality workaround for https://github.com/Exiv2/exiv2/issues/3225

### DIFF
--- a/include/exiv2/value.hpp
+++ b/include/exiv2/value.hpp
@@ -1535,11 +1535,13 @@ template <typename T>
 std::ostream& ValueType<T>::write(std::ostream& os) const {
   auto end = value_.end();
   auto i = value_.begin();
+  auto oldlocale = std::locale::global(std::locale::classic());
   while (i != end) {
     os << std::setprecision(15) << *i;
     if (++i != end)
       os << " ";
   }
+  std::locale::global(oldlocale);
   return os;
 }
 


### PR DESCRIPTION
Fixes: #3225

Note: I don't want to merge this. It's for testing purposes only, so that we can confirm that #3225 is caused by a `setlocale` [bug](https://github.com/Exiv2/exiv2/issues/3225#issuecomment-2878458778) on Windows.