### PR TITLE
Fix test failure

### DIFF
--- a/tests/bugfixes/github/test_issue_ghsa_496f_x7cq_cq39.py
+++ b/tests/bugfixes/github/test_issue_ghsa_496f_x7cq_cq39.py
@@ -15,6 +15,6 @@ class EpsImageDeleteSegV(metaclass=CaseMeta):
     stdout = [""]
     stderr = [
         """$exception_in_erase """ + filename + """:
-$kerCorruptedMetadata
+$kerFailedToReadImageData
 """]
     retval = [1]


### PR DESCRIPTION
Fix test failure that was introduced by the fix for https://github.com/Exiv2/exiv2/security/advisories/GHSA-496f-x7cq-cq39. (The fix was developed on a temporary private fork, where the checks don't run, which is how this error managed to slip through.)