### PR TITLE
Make methods non-virtual

### DIFF
--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -197,11 +197,11 @@ class EXIV2API Image {
     @param size number of bytes to append
     @param bTestValid - tests that iccProfile contains credible data
    */
-  virtual void appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid);
+  void appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid);
   /*!
     @brief Throw an exception if the size at the beginning of the iccProfile isn't correct.
    */
-  virtual void checkIccProfile();
+  void checkIccProfile();
   /*!
     @brief Erase iccProfile. the profile is not removed from
         the actual image until the writeMetadata() method is called.


### PR DESCRIPTION
Fixes: #3376 

These methods were added in #3335 and accidentally introduced an ABI incompatibility because they're virtual. They don't actually need to be virtual, so this PR shouldn't break anything.