### PR TITLE
clang-tidy: use ifdef

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -29,7 +29,7 @@
 #include <unistd.h>  // for stat()
 #endif
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
 #include <sys/utime.h>
@@ -1659,7 +1659,7 @@ std::string temporaryPath() {
   static int count = 0;
   auto guard = std::scoped_lock(cs);
 
-#if defined(_WIN32)
+#ifdef _WIN32
   DWORD pid = ::GetCurrentProcessId();
 #else
   pid_t pid = ::getpid();
@@ -1843,7 +1843,7 @@ int renameFile(std::string& newPath, const tm* tm, Exiv2::ExifData& exifData) {
   // is done after calling setting date/time: the value retrieved from tag might include something like %Y, which then
   // should not be replaced by year
   std::regex format_regex(":{1}?(Exif\\..*?):{1}?");
-#if defined(_WIN32)
+#ifdef _WIN32
   std::string illegalChars = "\\/:*?\"<>|";
 #else
   std::string illegalChars = "/:";

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -25,7 +25,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
 #include <windows.h>
@@ -960,7 +960,7 @@ static size_t readFileToBuf(FILE* f, Exiv2::DataBuf& buf) {
 void Params::getStdin(Exiv2::DataBuf& buf) {
   // copy stdin to stdinBuf
   if (stdinBuf.empty()) {
-#if defined(_WIN32)
+#ifdef _WIN32
     DWORD fdwMode;
     _setmode(_fileno(stdin), O_BINARY);
     Sleep(300);

--- a/include/exiv2/basicio.hpp
+++ b/include/exiv2/basicio.hpp
@@ -655,7 +655,7 @@ class EXIV2API MemIo : public BasicIo {
 /*!
   @brief Provides binary IO for the data from stdin and data uri path.
  */
-#if defined(EXV_ENABLE_FILESYSTEM)
+#ifdef EXV_ENABLE_FILESYSTEM
 class EXIV2API XPathIo : public FileIo {
  public:
   /*!

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -85,7 +85,7 @@ class FileIo::Impl {
   FILE* fp_{};             //!< File stream pointer
   OpMode opMode_{opSeek};  //!< File open mode
 
-#if defined _WIN32
+#ifdef _WIN32
   HANDLE hFile_{};  //!< Duplicated fd
   HANDLE hMap_{};   //!< Handle from CreateFileMapping
 #endif
@@ -218,7 +218,7 @@ FileIo::~FileIo() {
 int FileIo::munmap() {
   int rc = 0;
   if (p_->pMappedArea_) {
-#if defined _WIN32
+#ifdef _WIN32
     UnmapViewOfFile(p_->pMappedArea_);
     CloseHandle(p_->hMap_);
     p_->hMap_ = nullptr;
@@ -878,7 +878,7 @@ const std::string& MemIo::path() const noexcept {
 void MemIo::populateFakeData() {
 }
 
-#if defined(EXV_ENABLE_FILESYSTEM)
+#ifdef EXV_ENABLE_FILESYSTEM
 XPathIo::XPathIo(const std::string& orgPath) : FileIo(XPathIo::writeDataToFile(orgPath)), tempFilePath_(path()) {
 }
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -44,7 +44,7 @@
 // *****************************************************************************
 // local declarations
 namespace {
-#if defined EXV_HAVE_ICONV
+#ifdef EXV_HAVE_ICONV
 // Convert string charset with iconv.
 bool convertStringCharsetIconv(std::string& str, std::string_view from, std::string_view to);
 #elif defined _WIN32
@@ -1377,7 +1377,7 @@ void moveXmpToIptc(XmpData& xmpData, IptcData& iptcData) {
 bool convertStringCharset([[maybe_unused]] std::string& str, const char* from, const char* to) {
   if (0 == strcmp(from, to))
     return true;  // nothing to do
-#if defined EXV_HAVE_ICONV
+#ifdef EXV_HAVE_ICONV
   return convertStringCharsetIconv(str, from, to);
 #elif defined _WIN32
   return convertStringCharsetWindows(str, from, to);
@@ -1395,7 +1395,7 @@ bool convertStringCharset([[maybe_unused]] std::string& str, const char* from, c
 namespace {
 using namespace Exiv2;
 
-#if defined EXV_HAVE_ICONV
+#ifdef EXV_HAVE_ICONV
 bool convertStringCharsetIconv(std::string& str, std::string_view from, std::string_view to) {
   if (from == to)
     return true;  // nothing to do

--- a/src/futils.cpp
+++ b/src/futils.cpp
@@ -20,7 +20,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#if defined(_WIN32)
+#ifdef _WIN32
 // clang-format off
 #include <windows.h>
 #include <psapi.h>  // For access to GetModuleFileName
@@ -39,7 +39,7 @@ namespace fs = std::filesystem;
 #include <mach-o/dyld.h>  // for _NSGetExecutablePath()
 #endif
 
-#if defined(__FreeBSD__)
+#ifdef __FreeBSD__
 // clang-format off
 #include <sys/mount.h>
 #include <sys/param.h>
@@ -355,7 +355,7 @@ Uri Uri::Parse(const std::string& uri) {
 
 std::string getProcessPath() {
 #ifdef EXV_ENABLE_FILESYSTEM
-#if defined(__FreeBSD__)
+#ifdef __FreeBSD__
   std::string ret("unknown");
   unsigned int n;
   char buffer[PATH_MAX] = {};
@@ -375,7 +375,7 @@ std::string getProcessPath() {
   return ret.substr(0, idxLastSeparator);
 #else
   try {
-#if defined(_WIN32)
+#ifdef _WIN32
     TCHAR pathbuf[MAX_PATH];
     GetModuleFileName(nullptr, pathbuf, MAX_PATH);
     auto path = fs::path(pathbuf);

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -124,7 +124,7 @@ int Exiv2::http(Exiv2::Dictionary& request, Exiv2::Dictionary& response, std::st
 
   ////////////////////////////////////
   // Windows specific code
-#if defined(_WIN32)
+#ifdef _WIN32
   WSADATA wsaData;
   if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
     return error(errors, "could not start WinSock");

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -21,7 +21,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#if !defined(_WIN32)
+#ifndef _WIN32
 #include <pwd.h>
 #include <unistd.h>
 #else

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -214,7 +214,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os, const std::vector<std::regex>& key
 #endif
 
   const char* compiler =
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
       "MSVC";
 
 #ifndef __VERSION__
@@ -266,7 +266,7 @@ void Exiv2::dumpLibraryInfo(std::ostream& os, const std::vector<std::regex>& key
 #endif
 
   const char* platform =
-#if defined(__MSYS__)
+#ifdef __MSYS__
       "msys";
 #elif defined(__CYGWIN__)
       "cygwin";


### PR DESCRIPTION
Found with readability-use-concise-preprocessor-directives