### PR TITLE
CI: fix inih install for CentOS

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -62,8 +62,8 @@ case "$distro_id" in
 
     'centos')
         dnf clean all
-        dnf -y install gcc-c++ clang cmake expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel inih-devel
-        dnf -y --enablerepo=crb install ninja-build
+        dnf -y install gcc-c++ clang cmake expat-devel zlib-devel brotli-devel libssh-devel libcurl-devel
+        dnf -y --enablerepo=crb install ninja-build inih-devel
         ;;
 
     'opensuse-tumbleweed')


### PR DESCRIPTION
Turns out -devel is in CRB, while libs are in BaseOS+AppStream...