### PR TITLE
fix reading mp4 url box nested in non video/audio track (#3425)

### DIFF
--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -687,6 +687,8 @@ void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursi
       xmpData_["Xmp.video.URL"] = readString(*io_, size);
     else if (currentStream_ == Audio)
       xmpData_["Xmp.audio.URL"] = readString(*io_, size);
+    else
+      discard(size);
   }
 
   else if (equalsQTimeTag(buf, "urn ")) {
@@ -694,6 +696,8 @@ void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursi
       xmpData_["Xmp.video.URN"] = readString(*io_, size);
     else if (currentStream_ == Audio)
       xmpData_["Xmp.audio.URN"] = readString(*io_, size);
+    else
+      discard(size);
   }
 
   else if (equalsQTimeTag(buf, "dcom")) {


### PR DESCRIPTION
This will seek the io ptr correctly to the next box, fixing #3425