### PR TITLE
simplify fmt/std format define

### DIFF
--- a/src/image_int.hpp
+++ b/src/image_int.hpp
@@ -14,16 +14,14 @@
 #include <ostream>  // for ostream, basic_ostream::put
 #include <string>
 
-#if __has_include(<format>)
+#ifdef EXV_HAVE_STD_FORMAT
 #include <format>
-#endif
-#ifndef EXV_HAVE_STD_FORMAT
+#define stringFormat std::format
+#define stringFormatTo std::format_to
+#else
 #include <fmt/format.h>
 #define stringFormat fmt::format
 #define stringFormatTo fmt::format_to
-#else
-#define stringFormat std::format
-#define stringFormatTo std::format_to
 #endif
 
 // *****************************************************************************


### PR DESCRIPTION
Don't use __has_include. Doesn't work with ccache.