### PR TITLE
CMake: use alternative exported config naming scheme

### DIFF
--- a/cmake/exiv2-config.cmake.in
+++ b/cmake/exiv2-config.cmake.in
@@ -53,7 +53,7 @@ if(NOT @BUILD_SHARED_LIBS@) # if(NOT BUILD_SHARED_LIBS)
   endif()
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/exiv2Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/exiv2-targets.cmake")
 
 check_required_components(exiv2)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -311,23 +311,23 @@ set(requires_private_for_pc_file
     PARENT_SCOPE
 )
 
-write_basic_package_version_file(exiv2ConfigVersion.cmake COMPATIBILITY ExactVersion)
+write_basic_package_version_file(exiv2-config-version.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS exiv2lib EXPORT exiv2Targets)
+install(TARGETS exiv2lib EXPORT exiv2-targets)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-  ../cmake/exiv2Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
+  ../cmake/exiv2-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/exiv2-config.cmake INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )
 
 install(FILES ${PUBLIC_HEADERS} ${CMAKE_BINARY_DIR}/exv_conf.h ${CMAKE_BINARY_DIR}/exiv2lib_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/exiv2)
 
 install(
-  EXPORT exiv2Targets
+  EXPORT exiv2-targets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
   NAMESPACE Exiv2::
 )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exiv2ConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/exiv2Config.cmake
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/exiv2-config-version.cmake ${CMAKE_CURRENT_BINARY_DIR}/exiv2-config.cmake
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/exiv2"
 )


### PR DESCRIPTION
This [case insensitive scheme](https://cmake.org/cmake/help/latest/command/find_package.html#search-modes) allows for `find_package(exiv2 ...)` and `find_package(EXIV2 ...)`, or even `find_package(Exiv2 ...)`.