### PR TITLE
Fix leak

### DIFF
--- a/src/crwimage_int.cpp
+++ b/src/crwimage_int.cpp
@@ -603,8 +603,10 @@ void CiffDirectory::doRemove(CrwDirs& crwDirs, uint16_t crwTagId) {
     if (it != components_.end()) {
       // Recursive call to next lower level directory
       (*it)->remove(crwDirs, crwTagId);
-      if ((*it)->empty())
+      if ((*it)->empty()) {
+        delete *it;
         components_.erase(it);
+      }
     }
   } else {
     // Find the tag


### PR DESCRIPTION
This code is causing the CIFuzz test to [fail](https://github.com/Exiv2/exiv2/actions/runs/21795630681/job/62882630129?pr=3463), with this error:

```
=================================================================
==22==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x555a05fbb98d in operator new(unsigned long) /src/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:109:35
    #1 0x555a063864a6 in make_unique<Exiv2::Internal::CiffDirectory, 0> /usr/local/bin/../include/c++/v1/__memory/unique_ptr.h:759:26
    #2 0x555a063864a6 in operator() /src/exiv2/src/crwimage_int.cpp:255:16
    #3 0x555a063864a6 in Exiv2::Internal::CiffDirectory::readDirectory(unsigned char const*, unsigned long, Exiv2::ByteOrder) /src/exiv2/src/crwimage_int.cpp:253:14
2026-02-08 09:18:08,474 - root - INFO - Fuzzer: fuzz-read-write. Detected bug.
2026-02-08 09:18:08,475 - root - INFO - Trying to reproduce crash using: /tmp/tmpaqo18i14/leak-020e45fe85e7730485365d2c0334b5e71a7ef085.
    #4 0x555a062b3999 in Exiv2::CrwParser::encode(std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>&, unsigned char const*, unsigned long, Exiv2::CrwImage const*) /src/exiv2/src/crwimage.cpp:120:12
    #5 0x555a062b30ad in Exiv2::CrwImage::writeMetadata() /src/exiv2/src/crwimage.cpp:92:3
    #6 0x555a05fbcf0b in LLVMFuzzerTestOneInput /src/exiv2/fuzz/fuzz-read-write.cpp:20:12
    #7 0x555a05e5a65d in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:619:13
    #8 0x555a05e59c95 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:516:7
    #9 0x555a05e5bfd2 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:834:7
    #10 0x555a05e5c2d8 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile>>&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:872:3
    #11 0x555a05e4b165 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:917:6
    #12 0x555a05e76dd2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #13 0x7f8a4208a082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 5792732f783158c66fb4f3756458ca24e46e827d)

DEDUP_TOKEN: operator new(unsigned long)--make_unique<Exiv2::Internal::CiffDirectory, 0>--operator()
SUMMARY: AddressSanitizer: 96 byte(s) leaked in 1 allocation(s).

INFO: a leak has been found in the initial corpus.
```

It's because `components_` is a vector of raw pointers, and we forgot to call `delete` on the element before erasing it. It's done correctly a few lines below.

This bug doesn't exist on the main branch because we switched to using `std::unique_ptr` in #3155.