### PR TITLE
CI: update mac runner for 0.28.x branch

### DIFF
--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -177,6 +177,7 @@ jobs:
             -DEXIV2_BUILD_SAMPLES=OFF \
             -DEXIV2_BUILD_UNIT_TESTS=OFF \
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=OFF \
+            -DPython3_EXECUTABLE=/usr/bin/python3 \
             -S . -B build && \
           cmake --build build --parallel
 

--- a/.github/workflows/on_push_BasicWinLinMac.yml
+++ b/.github/workflows/on_push_BasicWinLinMac.yml
@@ -86,15 +86,15 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-13,     arch: X64   }
-          - { os: macos-latest, arch: ARM64 }
+          - { os: macos-15-intel, arch: X64   }
+          - { os: macos-latest,   arch: ARM64 }
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
-          brew install ninja inih googletest
+          brew install inih googletest
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,19 +64,14 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-13, arch: x64   }
-          - { os: macos-14, arch: arm64 }
+          - { os: macos-15-intel, arch: x64   }
+          - { os: macos-14,       arch: arm64 }
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
-          brew install ninja
-          brew install inih
-          brew install tree
-          brew install gettext
-          brew install doxygen
-          brew install graphviz
+          brew install inih tree doxygen graphviz
 
       - name: Build packaged release
         run: |

--- a/unitTests/test_DateValue.cpp
+++ b/unitTests/test_DateValue.cpp
@@ -151,7 +151,7 @@ TEST(ADateValue, copiesToByteBufferWithBasicFormat) {
   std::array<byte, 8> buf = {};
 
   const byte expectedDate[10] = {'2', '0', '2', '1', '1', '2', '0', '1'};
-  ASSERT_EQ(8, dateValue.copy(buf.data()));
+  ASSERT_EQ(8u, dateValue.copy(buf.data()));
   ASSERT_TRUE(std::equal(buf.begin(), buf.end(), expectedDate));
 }
 

--- a/unitTests/test_FileIo.cpp
+++ b/unitTests/test_FileIo.cpp
@@ -54,7 +54,7 @@ TEST(AFileIO, returnsFileSizeEvenWhenFileItIsNotOpened) {
 TEST(AFileIO, isOpenedAtPosition0) {
   FileIo file(imagePath);
   file.open();
-  ASSERT_EQ(0, file.tell());
+  ASSERT_EQ(0u, file.tell());
 }
 
 TEST(AFileIO, canSeekToExistingPositions) {

--- a/unitTests/test_Photoshop.cpp
+++ b/unitTests/test_Photoshop.cpp
@@ -76,8 +76,8 @@ TEST(PhotoshopLocateIrb, returns0withGoodIptcIrb) {
   uint32_t sizeData = 0;
 
   ASSERT_EQ(0, Photoshop::locateIrb(data.data(), data.size(), Photoshop::iptc_, &record, sizeHdr, sizeData));
-  ASSERT_EQ(12, sizeHdr);
-  ASSERT_EQ(27, sizeData);
+  ASSERT_EQ(12u, sizeHdr);
+  ASSERT_EQ(27u, sizeData);
 }
 
 TEST(PhotoshopLocateIptcIrb, returns0withGoodIptcIrb) {
@@ -94,8 +94,8 @@ TEST(PhotoshopLocateIptcIrb, returns0withGoodIptcIrb) {
   uint32_t sizeData = 0;
 
   ASSERT_EQ(0, Photoshop::locateIptcIrb(data.data(), data.size(), &record, sizeHdr, sizeData));
-  ASSERT_EQ(12, sizeHdr);
-  ASSERT_EQ(27, sizeData);
+  ASSERT_EQ(12u, sizeHdr);
+  ASSERT_EQ(27u, sizeData);
 }
 
 TEST(PhotoshopLocateIptcIrb, returns3withoutIptcMarker) {
@@ -128,8 +128,8 @@ TEST(PhotoshopLocatePreviewIrb, returns0withGoodPreviewIrb) {
   uint32_t sizeData = 0;
 
   ASSERT_EQ(0, Photoshop::locatePreviewIrb(data.data(), data.size(), &record, sizeHdr, sizeData));
-  ASSERT_EQ(12, sizeHdr);
-  ASSERT_EQ(27, sizeData);
+  ASSERT_EQ(12u, sizeHdr);
+  ASSERT_EQ(27u, sizeData);
 }
 
 // --------------------------------

--- a/unitTests/test_TimeValue.cpp
+++ b/unitTests/test_TimeValue.cpp
@@ -151,7 +151,7 @@ TEST(ATimeValue, cannotReadFromStringWithBadFormat) {
 TEST(ATimeValue, isCopiedToBuffer) {
   const TimeValue value(23, 55, 2);
   byte buffer[11];
-  ASSERT_EQ(11, value.copy(buffer));
+  ASSERT_EQ(11u, value.copy(buffer));
 
   const byte expectedDate[11] = {'2', '3', '5', '5', '0', '2', '+', '0', '0', '0', '0'};
   for (int i = 0; i < 11; ++i) {

--- a/unitTests/test_asfvideo.cpp
+++ b/unitTests/test_asfvideo.cpp
@@ -51,5 +51,5 @@ TEST(AsfVideo, readMetadata) {
   ASSERT_NO_THROW(asf.setXmpData(xmpData));
   auto data = asf.xmpData();
   ASSERT_FALSE(data.empty());
-  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4);
+  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4u);
 }

--- a/unitTests/test_basicio.cpp
+++ b/unitTests/test_basicio.cpp
@@ -10,7 +10,7 @@ using namespace Exiv2;
 TEST(MemIoDefault, readEReturns0) {
   std::array<byte, 10> buf;
   MemIo io;
-  ASSERT_EQ(0, io.read(buf.data(), buf.size()));
+  ASSERT_EQ(0u, io.read(buf.data(), buf.size()));
 }
 
 TEST(MemIoDefault, isNotAtEof) {
@@ -32,19 +32,19 @@ TEST(MemIoDefault, seekBefore0Returns1ButItDoesNotSetEofToTrue) {
 
 TEST(MemIoDefault, seekToEndPositionDoesNotTriggerEof) {
   MemIo io;
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
   ASSERT_EQ(0, io.seek(0, BasicIo::end));
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
   ASSERT_FALSE(io.eof());
 }
 
 TEST(MemIoDefault, seekToEndPositionAndReadTriggersEof) {
   MemIo io;
   ASSERT_EQ(0, io.seek(0, BasicIo::end));
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
 
   std::array<byte, 64> buf2 = {};
-  ASSERT_EQ(0, io.read(buf2.data(), 1));  // Note that we cannot even read 1 byte being at the end
+  ASSERT_EQ(0u, io.read(buf2.data(), 1));  // Note that we cannot even read 1 byte being at the end
   ASSERT_TRUE(io.eof());
 }
 
@@ -78,25 +78,25 @@ TEST(MemIo, seekBeyondBoundsDoesNotMoveThePosition) {
   buf.fill(0);
 
   MemIo io(buf.data(), buf.size());
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
   ASSERT_EQ(1, io.seek(65, BasicIo::beg));
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
 }
 
 TEST(MemIo, seekInsideBoundsMoveThePosition) {
   std::array<byte, 64> buf = {};
 
   MemIo io(buf.data(), buf.size());
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
   ASSERT_EQ(0, io.seek(32, BasicIo::beg));
-  ASSERT_EQ(32, io.tell());
+  ASSERT_EQ(32u, io.tell());
 }
 
 TEST(MemIo, seekInsideBoundsUsingBegResetsThePosition) {
   std::array<byte, 64> buf = {};
 
   MemIo io(buf.data(), buf.size());
-  std::vector<std::int64_t> positions{0, 8, 16, 32, 64};
+  std::vector<std::uint64_t> positions{0, 8, 16, 32, 64};
   for (auto pos : positions) {
     ASSERT_EQ(0, io.seek(pos, BasicIo::beg));
     ASSERT_EQ(pos, io.tell());
@@ -108,7 +108,7 @@ TEST(MemIo, seekInsideBoundsUsingCurShiftThePosition) {
 
   MemIo io(buf.data(), buf.size());
   std::vector<std::int64_t> shifts{4, 4, 8, 16, 32};
-  std::vector<std::int64_t> positions{4, 8, 16, 32, 64};
+  std::vector<std::uint64_t> positions{4, 8, 16, 32, 64};
   for (size_t i = 0; i < shifts.size(); ++i) {
     ASSERT_EQ(0, io.seek(shifts[i], BasicIo::cur));
     ASSERT_EQ(positions[i], io.tell());
@@ -119,9 +119,9 @@ TEST(MemIo, seekToEndPositionDoesNotTriggerEof) {
   std::array<byte, 64> buf = {};
 
   MemIo io(buf.data(), buf.size());
-  ASSERT_EQ(0, io.tell());
+  ASSERT_EQ(0u, io.tell());
   ASSERT_EQ(0, io.seek(0, BasicIo::end));
-  ASSERT_EQ(64, io.tell());
+  ASSERT_EQ(64u, io.tell());
   ASSERT_FALSE(io.eof());
 }
 
@@ -130,17 +130,17 @@ TEST(MemIo, seekToEndPositionAndReadTriggersEof) {
 
   MemIo io(buf.data(), buf.size());
   ASSERT_EQ(0, io.seek(0, BasicIo::end));
-  ASSERT_EQ(64, io.tell());
+  ASSERT_EQ(64u, io.tell());
 
   std::array<byte, 64> buf2 = {};
-  ASSERT_EQ(0, io.read(buf2.data(), 1));  // Note that we cannot even read 1 byte being at the end
+  ASSERT_EQ(0u, io.read(buf2.data(), 1));  // Note that we cannot even read 1 byte being at the end
   ASSERT_TRUE(io.eof());
 }
 
 TEST(MemIo, readEmptyIoReturns0) {
   std::array<byte, 10> buf;
   MemIo io;
-  ASSERT_EQ(0, io.read(buf.data(), buf.size()));
+  ASSERT_EQ(0u, io.read(buf.data(), buf.size()));
 }
 
 TEST(MemIo, readLessBytesThanAvailableReturnsRequestedBytes) {
@@ -149,7 +149,7 @@ TEST(MemIo, readLessBytesThanAvailableReturnsRequestedBytes) {
   buf1.fill(1);
 
   MemIo io(buf1.data(), buf1.size());
-  ASSERT_EQ(5, io.read(buf2.data(), 5));
+  ASSERT_EQ(5u, io.read(buf2.data(), 5));
 }
 
 TEST(MemIo, readSameBytesThanAvailableReturnsRequestedBytes) {
@@ -158,7 +158,7 @@ TEST(MemIo, readSameBytesThanAvailableReturnsRequestedBytes) {
   buf1.fill(1);
 
   MemIo io(buf1.data(), buf1.size());
-  ASSERT_EQ(10, io.read(buf2.data(), 10));
+  ASSERT_EQ(10u, io.read(buf2.data(), 10));
 }
 
 TEST(MemIo, readMoreBytesThanAvailableReturnsAvailableBytes) {
@@ -167,5 +167,5 @@ TEST(MemIo, readMoreBytesThanAvailableReturnsAvailableBytes) {
   buf1.fill(1);
 
   MemIo io(buf1.data(), buf1.size());
-  ASSERT_EQ(10, io.read(buf2.data(), 15));
+  ASSERT_EQ(10u, io.read(buf2.data(), 15));
 }

--- a/unitTests/test_bmpimage.cpp
+++ b/unitTests/test_bmpimage.cpp
@@ -88,8 +88,8 @@ TEST(BmpImage, readMetadataReadsImageDimensionsWhenDataIsAvailable) {
   auto memIo = std::make_unique<MemIo>(header.data(), header.size());
   BmpImage bmp(std::move(memIo));
   ASSERT_NO_THROW(bmp.readMetadata());
-  ASSERT_EQ(1280, bmp.pixelWidth());
-  ASSERT_EQ(800, bmp.pixelHeight());
+  ASSERT_EQ(1280u, bmp.pixelWidth());
+  ASSERT_EQ(800u, bmp.pixelHeight());
 }
 
 TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {

--- a/unitTests/test_futils.cpp
+++ b/unitTests/test_futils.cpp
@@ -108,7 +108,7 @@ TEST(base64decode, decodesValidString) {
   const std::string original("VGhpcyBpcyBhIHVuaXQgdGVzdA==");
   const std::string expected("This is a unit test");
   std::vector<char> result(original.size());
-  ASSERT_EQ(static_cast<long>(expected.size()), base64decode(original.c_str(), result.data(), original.size()));
+  ASSERT_EQ(expected.size(), base64decode(original.c_str(), result.data(), original.size()));
   ASSERT_STREQ(expected.c_str(), result.data());
 }
 

--- a/unitTests/test_matroskavideo.cpp
+++ b/unitTests/test_matroskavideo.cpp
@@ -51,5 +51,5 @@ TEST(MatroskaVideo, readMetadata) {
   ASSERT_NO_THROW(mkv.setXmpData(xmpData));
   auto data = mkv.xmpData();
   ASSERT_FALSE(data.empty());
-  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4);
+  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4u);
 }

--- a/unitTests/test_pngimage.cpp
+++ b/unitTests/test_pngimage.cpp
@@ -20,7 +20,7 @@ TEST(PngChunk, keyTxtChunkExtractsKeywordCorrectlyInPresenceOfNullChar) {
 
   DataBuf chunkBuf(data.data(), data.size());
   DataBuf key = Internal::PngChunk::keyTXTChunk(chunkBuf, true);
-  ASSERT_EQ(21, key.size());
+  ASSERT_EQ(21u, key.size());
 
   ASSERT_TRUE(std::equal(key.data(), key.data() + key.size(), data.data() + 8));
 }

--- a/unitTests/test_riffVideo.cpp
+++ b/unitTests/test_riffVideo.cpp
@@ -51,5 +51,5 @@ TEST(RiffVideo, readMetadata) {
   ASSERT_NO_THROW(riff.setXmpData(xmpData));
   auto data = riff.xmpData();
   ASSERT_FALSE(data.empty());
-  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4);
+  ASSERT_EQ(xmpData["Xmp.video.TotalStream"].count(), 4u);
 }

--- a/unitTests/test_types.cpp
+++ b/unitTests/test_types.cpp
@@ -37,7 +37,7 @@ TEST(DataBuf, defaultInstanceIsEmpty) {
 TEST(DataBuf, allocatesDataWithNonEmptyConstructor) {
   DataBuf instance(5);
   ASSERT_NE(nullptr, instance.c_data());
-  ASSERT_EQ(5, instance.size());
+  ASSERT_EQ(5u, instance.size());
 }
 
 TEST(DataBuf, canBeConstructedFromExistingData) {
@@ -58,8 +58,8 @@ TEST(DataBuf, readUintFunctionsWorksOnExistingData) {
   DataBuf instance(data.data(), data.size());
   ASSERT_EQ(data[0], instance.read_uint8(0));
   ASSERT_EQ(data[1], instance.read_uint16(0, bigEndian));
-  ASSERT_EQ(0x00010203, instance.read_uint32(0, bigEndian));
-  ASSERT_EQ(0x0001020304050607, instance.read_uint64(0, bigEndian));
+  ASSERT_EQ(0x00010203u, instance.read_uint32(0, bigEndian));
+  ASSERT_EQ(0x0001020304050607u, instance.read_uint64(0, bigEndian));
 }
 
 TEST(DataBuf, readUintFunctionsThrowsOnTooFarElements) {
@@ -78,10 +78,10 @@ TEST(DataBuf, writeUintFunctionsWorksWhenThereIsEnoughData) {
   ASSERT_EQ(0x01, instance.read_uint8(0));
 
   ASSERT_NO_THROW(instance.write_uint16(0, (val >> 48), bigEndian));
-  ASSERT_EQ(0x0102, instance.read_uint16(0, bigEndian));
+  ASSERT_EQ(0x0102u, instance.read_uint16(0, bigEndian));
 
   ASSERT_NO_THROW(instance.write_uint32(0, (val >> 32), bigEndian));
-  ASSERT_EQ(0x01020304, instance.read_uint32(0, bigEndian));
+  ASSERT_EQ(0x01020304u, instance.read_uint32(0, bigEndian));
 
   ASSERT_NO_THROW(instance.write_uint64(0, val, bigEndian));
   ASSERT_EQ(val, instance.read_uint64(0, bigEndian));
@@ -110,7 +110,7 @@ TEST(DataBuf, readWriteEndianess) {
   ASSERT_EQ(0, buf.cmpBytes(0, expected_le, buf.size()));
   ASSERT_EQ(buf.read_uint8(4), 0x01);
   ASSERT_EQ(buf.read_uint16(4 + 1, bigEndian), 0x0203);
-  ASSERT_EQ(buf.read_uint32(4 + 1 + 2, bigEndian), 0x04050607);
+  ASSERT_EQ(buf.read_uint32(4 + 1 + 2, bigEndian), 0x04050607u);
   ASSERT_EQ(buf.read_uint64(4 + 1 + 2 + 4, bigEndian), 0x08090a0b0c0d0e0fULL);
 
   // Little endian.
@@ -123,7 +123,7 @@ TEST(DataBuf, readWriteEndianess) {
   ASSERT_EQ(0, buf.cmpBytes(0, expected_be, buf.size()));
   ASSERT_EQ(buf.read_uint8(4), 0x01);
   ASSERT_EQ(buf.read_uint16(4 + 1, littleEndian), 0x0203);
-  ASSERT_EQ(buf.read_uint32(4 + 1 + 2, littleEndian), 0x04050607);
+  ASSERT_EQ(buf.read_uint32(4 + 1 + 2, littleEndian), 0x04050607u);
   ASSERT_EQ(buf.read_uint64(4 + 1 + 2 + 4, littleEndian), 0x08090a0b0c0d0e0fULL);
 }
 
@@ -227,20 +227,20 @@ TEST(URational, readRationalFromStream) {
   URational r;
   std::istringstream input("1/2");
   input >> r;
-  ASSERT_EQ(1, r.first);
-  ASSERT_EQ(2, r.second);
+  ASSERT_EQ(1u, r.first);
+  ASSERT_EQ(2u, r.second);
 }
 
 // --------------------
 
 TEST(parseUint32, withNumberInRangeReturnsOK) {
   bool ok{false};
-  ASSERT_EQ(123456, parseUint32("123456", ok));
+  ASSERT_EQ(123456u, parseUint32("123456", ok));
   ASSERT_TRUE(ok);
 }
 
 TEST(parseUint32, withNumberOutOfRangeReturnsFalse) {
   bool ok{false};
-  ASSERT_EQ(0, parseUint32("4333333333", ok));
+  ASSERT_EQ(0u, parseUint32("4333333333", ok));
   ASSERT_FALSE(ok);
 }


### PR DESCRIPTION
macos-13 (Intel) has been deprecated since, macos-15-intel is the only available option.