### PR TITLE
CI: ensure Cygwin Python is used

### DIFF
--- a/.github/workflows/on_PR_windows_matrix.yml
+++ b/.github/workflows/on_PR_windows_matrix.yml
@@ -184,6 +184,7 @@ jobs:
             -DEXIV2_BUILD_SAMPLES=OFF \
             -DEXIV2_BUILD_UNIT_TESTS=OFF \
             -DEXIV2_TEAM_WARNINGS_AS_ERRORS=OFF \
+            -DPython3_EXECUTABLE=/usr/bin/python3 \
             -S . -B build && \
           cmake --build build --parallel
 


### PR DESCRIPTION
Forwarding from 0.28.x branch and #3470 

(cherry picked from commit 90fe698d1837fc17f08a12a75e234a4ae9e234f4)