### PR TITLE
Fix UBSAN false positive

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -646,6 +646,9 @@ void Image::setIccProfile(Exiv2::DataBuf&& iccProfile, bool bTestValid) {
 }
 
 void Image::appendIccProfile(const uint8_t* bytes, size_t size, bool bTestValid) {
+  if (size == 0) {
+    return;
+  }
   const size_t start = iccProfile_.size();
   iccProfile_.resize(Safe::add(start, size));
   memcpy(iccProfile_.data(start), bytes, size);


### PR DESCRIPTION
This fixes a (false positive) error from UBSAN:

```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3590403533
INFO: Loaded 2 modules   (184486 inline 8-bit counters): 183894 [0x76d8651991c0, 0x76d8651c6016), 592 [0x62495a70b448, 0x62495a70b698), 
INFO: Loaded 2 PC tables (184486 PCs): 183894 [0x76d8651c6018,0x76d865494578), 592 [0x62495a70b698,0x62495a70db98), 
./bin/fuzz-read-print-write: Running 1 inputs 1 time(s) each.
Running: crash-01c9e1813f47c45ee6be5c976f16641176e51982
/home/kev/work/exiv2/src/image.cpp:651:10: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/kev/work/exiv2/src/image.cpp:651:10 
```

It's a false positive because `size` is zero, so it doesn't matter that `bytes` is `NULL`. But it's easy to fix by returning early if `size == 0`.