### PR TITLE
Add Lens ID for Meike 85mm f/1.8 (DCM)

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -1929,6 +1929,7 @@ constexpr TagDetails canonCsLensType[] = {
     {754, "Canon EF 70-200mm f/4L IS II USM"},
     {757, "Canon EF 400mm f/2.8L IS III USM"},
     {758, "Canon EF 600mm f/4L IS III USM"},
+    {923, "Meike 85mm f/1.8 DCM"},
     {1136, "Sigma 24-70mm f/2.8 DG OS HSM | Art 017"},
     {4142, "Canon EF-S 18-135mm f/3.5-5.6 IS STM"},
     {4143, "Canon EF-M 18-55mm f/3.5-5.6 IS STM"},


### PR DESCRIPTION
Oddly, LensModel is "SKY85mm f/1.8 DCM" + the firmware date. I wasn't sure how to fix that or if it should be fixed, hence why this is a draft.

Output with this change:
```txt
before_update.CR2  Exif.CanonCs.LensType                        Short       1  Meike 85mm f/1.8 DCM
before_update.CR2  Exif.CanonCs.Lens                            Short       3  85.0 mm
before_update.CR2  Exif.Canon.LensModel                         Ascii      74  SKY85mm f/1.8 DCM Mar  7
before_update.CR2  Exif.CanonLe.LensSerialNumber                Byte        5  0000d51700
before_update.CR2  Exif.Photo.LensSpecification                 Rational    4  85mm
before_update.CR2  Exif.Photo.LensModel                         Ascii      25  SKY85mm f/1.8 DCM Mar  7
before_update.CR2  Exif.Photo.LensSerialNumber                  Ascii      11  0000d51700


after_update.CR2  Exif.CanonCs.LensType                        Short       1  Meike 85mm f/1.8 DCM
after_update.CR2  Exif.CanonCs.Lens                            Short       3  85.0 mm
after_update.CR2  Exif.Canon.LensModel                         Ascii      74  SKY85mm f/1.8 DCM Jun  1
after_update.CR2  Exif.CanonLe.LensSerialNumber                Byte        5  0000d51700
after_update.CR2  Exif.Photo.LensSpecification                 Rational    4  85mm
after_update.CR2  Exif.Photo.LensModel                         Ascii      25  SKY85mm f/1.8 DCM Jun  1
after_update.CR2  Exif.Photo.LensSerialNumber                  Ascii      11  0000d51700
```