### PR TITLE
Add build provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           - { os: ubuntu-22.04-arm, arch: arm64 }
     permissions:
       id-token: write  # For sigstore
+      attestations: write  # For artifact attestation
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,16 +51,15 @@ jobs:
           cmake --build build -t doc
           cmake --build build -t package
 
-      - name: Sign with sigstore
-        uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
-          inputs: >-
-            ./build/exiv2-*.tar.gz
+          subject-path: ./build/exiv2-*.tar.gz
 
       - uses: actions/upload-artifact@v6
         with:
           name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
-          path: ./build/exiv2-*.tar.gz*
+          path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -73,6 +73,7 @@ jobs:
           - { os: macos-14,       arch: arm64 }
     permissions:
       id-token: write  # For sigstore
+      attestations: write  # For artifact attestation
     steps:
       - uses: actions/checkout@v6
         with:
@@ -96,16 +97,15 @@ jobs:
           cmake --build build -t doc
           cmake --build build -t package
 
-      - name: Sign with sigstore
-        uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
-          inputs: >-
-            ./build/exiv2-*.tar.gz
+          subject-path: ./build/exiv2-*.tar.gz
 
       - uses: actions/upload-artifact@v6
         with:
           name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
-          path: ./build/exiv2-*.tar.gz*
+          path: ./build/exiv2-*.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -118,6 +118,7 @@ jobs:
           - { os: windows-2022, arch: x64   }
     permissions:
       id-token: write  # For sigstore
+      attestations: write  # For artifact attestation
     steps:
       - uses: actions/checkout@v6
         with:
@@ -160,16 +161,15 @@ jobs:
           cmake --build build --parallel -t doc
           cmake --build build --parallel -t package
 
-      - name: Sign with sigstore
-        uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
-          inputs: >-
-            ./build/exiv2-*.zip
+          subject-path: ./build/exiv2-*.zip
 
       - uses: actions/upload-artifact@v6
         with:
           name: exiv2-${{ matrix.runner.arch }}-${{ matrix.runner.os }}
-          path: ./build/exiv2-*.zip*
+          path: ./build/exiv2-*.zip
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
I added a sigstore step in #3479, but I've since discovered that it's better to use https://github.com/actions/attest-build-provenance, because then it's easy for users to verify the artifacts by running https://cli.github.com/manual/gh_attestation_verify. Apologies for the churn.

I've tested that this works on my fork: https://github.com/kevinbackhouse/exiv2/actions/runs/22243471920