### PR TITLE
Add fuzz target for previews

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -14,3 +14,4 @@ endmacro()
 
 FUZZER(fuzz-read-print-write)
 FUZZER(fuzz-read-write)
+FUZZER(fuzz-preview)

--- a/fuzz/fuzz-preview.cpp
+++ b/fuzz/fuzz-preview.cpp
@@ -1,0 +1,35 @@
+#include <exiv2/exiv2.hpp>
+
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // Invalid files generate a lot of warnings, so switch off logging.
+  Exiv2::LogMsg::setLevel(Exiv2::LogMsg::mute);
+
+  try {
+    Exiv2::DataBuf data_copy(data, size);
+    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(data_copy.c_data(), size);
+    assert(image.get() != 0);
+
+    image->readMetadata();
+
+    Exiv2::PreviewManager pm(*image);
+    std::ostringstream os;
+    Exiv2::PreviewPropertiesList list = pm.getPreviewProperties();
+    for (const auto& pos : list) {
+      os << pos.mimeType_ << "\n";
+
+      if (pos.width_ != 0 && pos.height_ != 0)
+        os << pos.width_ << " " << pos.height_ << " ";
+
+      os << pos.size_ << "\n";
+    }
+
+  } catch (...) {
+    // Exiv2 throws an exception if the metadata is invalid.
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This fuzz target mimics this code:

https://github.com/Exiv2/exiv2/blob/45c8b18c024518494baf8d7cde121fae3eced004/app/actions.cpp#L584-L616

I'll add it to OSS-Fuzz once it's merged.