### PR TITLE
Fix wrong variable in findXmp XMP trailer search loop

### DIFF
--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -179,7 +179,7 @@ void findXmp(size_t& xmpPos, size_t& xmpSize, const byte* data, size_t startPos,
 
       // search for valid XMP trailer
       for (size_t trailerPos = xmpPos + header.size(); trailerPos < size; trailerPos++) {
-        if (data[xmpPos] != '\x00' && data[xmpPos] != '<')
+        if (data[trailerPos] != '\x00' && data[trailerPos] != '<')
           continue;
         for (const auto& [trailer, readOnly] : xmpTrailers) {
           if (trailerPos + trailer.size() > size)


### PR DESCRIPTION
Fix #9283:

Line 182 checks data[xmpPos] instead of data[trailerPos]. The variable xmpPos is constant at this point, so the early-exit condition is never true. The loop checks every byte position against all XMP trailer patterns unnecessarily.

Use data[trailerPos] to restore the intended early-exit behavior.