### PR TITLE
Use integer division in TiffBinaryArray::doCount

### DIFF
--- a/src/tiffcomposite_int.cpp
+++ b/src/tiffcomposite_int.cpp
@@ -795,7 +795,7 @@ size_t TiffBinaryArray::doCount() const {
     typeSize = 1;
   }
 
-  return std::lround(static_cast<double>(size()) / typeSize);
+  return size() / typeSize;
 }
 
 size_t TiffBinaryElement::doCount() const {


### PR DESCRIPTION
Fix https://github.com/Exiv2/exiv2/issues/9287:

doCount() uses std::lround(double(size) / typeSize) which rounds to the nearest integer. When size is not a multiple of typeSize, this can round up and report more elements than the data holds. On re-read, the inflated count causes the parser to expect more data than exists.

Use integer division instead, which truncates and is consistent with how readTiffEntry computes size from count and typeSize.