### PR TITLE
fix out-of-bounds iterator in readStringWcharTag

### DIFF
--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -38,7 +38,7 @@ uint16_t readWORDTag(const BasicIo::UniquePtr& io) {
 }
 
 std::string readStringWcharTag(const BasicIo::UniquePtr& io, size_t length) {
-  Internal::enforce(length <= io->size() - io->tell(), Exiv2::ErrorCode::kerCorruptedMetadata);
+  Internal::enforce(length >= 2 && length <= io->size() - io->tell(), Exiv2::ErrorCode::kerCorruptedMetadata);
   DataBuf FieldBuf(length + 1);
   io->readOrThrow(FieldBuf.data(), length, ErrorCode::kerFailedToReadImageData);
   std::string wst(FieldBuf.begin(), FieldBuf.end() - 3);


### PR DESCRIPTION
readStringWcharTag() builds its result from FieldBuf.end() - 3, which points before the start of the buffer when length < 2, so the std::string is constructed from an inverted iterator range. A crafted ASF Content_Description with a 1-byte string length reaches it through contentDescription(). Require length >= 2.