### PR TITLE
catch stoi exceptions in TimeValue::read

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -916,57 +916,63 @@ int TimeValue::read(const std::string& buf) {
     spos = 4;
   }
 
-  auto hi = std::stoi(buf.substr(0, 2));
-  if (hi < 0 || hi > 23)
-    return printWarning();
-  time_.hour = hi;
-  if (buf.size() > 3) {
-    auto mi = std::stoi(buf.substr(mpos, 2));
-    if (mi < 0 || mi > 59)
+  try {
+    auto hi = std::stoi(buf.substr(0, 2));
+    if (hi < 0 || hi > 23)
       return printWarning();
-    time_.minute = std::stoi(buf.substr(mpos, 2));
-  } else {
-    time_.minute = 0;
-  }
-  if (buf.size() > 5) {
-    auto si = std::stoi(buf.substr(spos, 2));
-    if (si < 0 || si > 60)
-      return printWarning();
-    time_.second = std::stoi(buf.substr(spos, 2));
-  } else {
-    time_.second = 0;
-  }
-
-  auto fpos = buf.find('+');
-  if (fpos == std::string::npos)
-    fpos = buf.find('-');
-
-  if (fpos != std::string::npos) {
-    auto format = buf.substr(fpos, buf.size());
-    auto posColon = format.find(':');
-    if (posColon == std::string::npos) {
-      // Extended format
-      auto tzhi = std::stoi(format.substr(0, 3));
-      if (tzhi < -23 || tzhi > 23)
+    time_.hour = hi;
+    if (buf.size() > 3) {
+      auto mi = std::stoi(buf.substr(mpos, 2));
+      if (mi < 0 || mi > 59)
         return printWarning();
-      time_.tzHour = tzhi;
-      if (format.size() > 3) {
-        int minute = std::stoi(format.substr(3));
+      time_.minute = std::stoi(buf.substr(mpos, 2));
+    } else {
+      time_.minute = 0;
+    }
+    if (buf.size() > 5) {
+      auto si = std::stoi(buf.substr(spos, 2));
+      if (si < 0 || si > 60)
+        return printWarning();
+      time_.second = std::stoi(buf.substr(spos, 2));
+    } else {
+      time_.second = 0;
+    }
+
+    auto fpos = buf.find('+');
+    if (fpos == std::string::npos)
+      fpos = buf.find('-');
+
+    if (fpos != std::string::npos) {
+      auto format = buf.substr(fpos, buf.size());
+      auto posColon = format.find(':');
+      if (posColon == std::string::npos) {
+        // Extended format
+        auto tzhi = std::stoi(format.substr(0, 3));
+        if (tzhi < -23 || tzhi > 23)
+          return printWarning();
+        time_.tzHour = tzhi;
+        if (format.size() > 3) {
+          int minute = std::stoi(format.substr(3));
+          if (minute < 0 || minute > 59)
+            return printWarning();
+          time_.tzMinute = time_.tzHour < 0 ? -minute : minute;
+        }
+      } else {
+        // Basic format
+        auto tzhi = std::stoi(format.substr(0, posColon));
+        if (tzhi < -23 || tzhi > 23)
+          return printWarning();
+        time_.tzHour = tzhi;
+        int minute = std::stoi(format.substr(posColon + 1));
         if (minute < 0 || minute > 59)
           return printWarning();
         time_.tzMinute = time_.tzHour < 0 ? -minute : minute;
       }
-    } else {
-      // Basic format
-      auto tzhi = std::stoi(format.substr(0, posColon));
-      if (tzhi < -23 || tzhi > 23)
-        return printWarning();
-      time_.tzHour = tzhi;
-      int minute = std::stoi(format.substr(posColon + 1));
-      if (minute < 0 || minute > 59)
-        return printWarning();
-      time_.tzMinute = time_.tzHour < 0 ? -minute : minute;
     }
+  } catch (const std::invalid_argument&) {
+    return printWarning();
+  } catch (const std::out_of_range&) {
+    return printWarning();
   }
   return 0;
 }


### PR DESCRIPTION
On a crafted IPTC Envelope.TimeSent like `"12:34:56+"`:

    libc++abi: terminating due to uncaught exception of type
      std::invalid_argument: stoi: no conversion

The char whitelist passes the trailing sign so `std::stoi("+")` aborts through `IptcParser::decode`. Catch invalid_argument/out_of_range and fall through to the existing `printWarning()`.