### PR TITLE
enforce minimum FileTypeBox length in Jp2Image::readMetadata

### DIFF
--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -184,6 +184,7 @@ void Jp2Image::readMetadata() {
           throw Error(ErrorCode::kerCorruptedMetadata);
         }
         boxFileTypeFound = true;
+        Internal::enforce(box.length >= boxHSize, ErrorCode::kerCorruptedMetadata);
         Blob boxData(box.length - boxHSize);
         io_->readOrThrow(boxData.data(), boxData.size(), ErrorCode::kerCorruptedMetadata);
         if (!Internal::isValidBoxFileType(boxData))


### PR DESCRIPTION
A crafted FileTypeBox with length < 8 underflows box.length - boxHSize:

    Blob boxData(box.length - boxHSize);  // 2 - 8 -> 18446744073709551610

so the vector ctor throws std::length_error instead of the contracted Exiv2 error. The uuid boxes below already guard this.