### PR TITLE
enforce minimum FileTypeBox length in Jp2Image::printStructure

### DIFF
--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -444,6 +444,7 @@ void Jp2Image::printStructure(std::ostream& out, PrintStructureOption option, si
         case kJp2BoxType::FileTypeBox: {
           // This box shall immediately follow the JPEG 2000 Signature box
           /// \todo  All files shall contain one and only one File Type box.
+          Internal::enforce(box.length >= boxHSize, ErrorCode::kerCorruptedMetadata);
           Blob boxData(box.length - boxHSize);
           io_->readOrThrow(boxData.data(), boxData.size(), ErrorCode::kerCorruptedMetadata);
           if (!Internal::isValidBoxFileType(boxData))


### PR DESCRIPTION
`exiv2 -pS` on a JP2 whose FileTypeBox sets its length below the 8-byte box header:

       12 |        2 | ftyp      | Uncaught exception: vector

`box.length - boxHSize` underflows, so `Blob` is sized to near SIZE_MAX and `std::vector` throws `std::length_error` rather than an `Exiv2::Error`. The sibling sub-box and uuid cases already guard `length`; this adds the same check before the FileTypeBox allocation.
