### PR TITLE
Fix/xmp namespace uri leak

### DIFF
--- a/include/exiv2/properties.hpp
+++ b/include/exiv2/properties.hpp
@@ -100,6 +100,13 @@ class EXIV2API XmpProperties {
   // Unlocked versions of public methods (Caller MUST hold the lock obtained via XmpProperties::XmpLock)
   static std::string nsUnlocked(const std::string& prefix, const XmpLock&);
   static std::string prefixUnlocked(const std::string& ns, const XmpLock&);
+  /*!
+    @brief Return true if \em prefix already has a canonical built-in binding or
+           an existing registered binding, i.e. some URI is already globally
+           associated with it. Non-throwing; used to stop a parsed packet from
+           silently rebinding an established prefix to a different URI.
+   */
+  static bool prefixIsBoundUnlocked(const std::string& prefix, const XmpLock&);
   static void registerNsUnlocked(const std::string& ns, const std::string& prefix, const XmpLock&);
   static void unregisterNsUnlocked(const XmpLock&);
   static void registeredNamespacesUnlocked(Exiv2::Dictionary& nsDict, const XmpLock&);

--- a/include/exiv2/xmp_exiv2.hpp
+++ b/include/exiv2/xmp_exiv2.hpp
@@ -12,6 +12,7 @@
 #include "properties.hpp"
 
 #include <atomic>
+#include <map>
 
 // *****************************************************************************
 // namespace extensions
@@ -239,6 +240,26 @@ class EXIV2API XmpData {
   XmpMetadata xmpMetadata_;
   std::string xmpPacket_;
   bool usePacket_{};
+  //! Per-instance prefix-to-URI namespace bindings, see nsBindings().
+  std::map<std::string, std::string> nsBindings_;
+
+  /*!
+    @brief Namespace prefix-to-URI bindings captured from this object's own
+           source packet at decode time.
+
+    XMP namespace prefixes are document-scoped: two images may legitimately
+    bind the same prefix to different URIs.  Exiv2 keys are prefix-based and
+    the URI is otherwise re-derived from a process-global registry at encode
+    time, which lets one image's binding (including a corrupted one) leak into
+    another.  These per-instance bindings let encode() resolve each property's
+    URI from the data it actually came from, falling back to the global
+    registry only for keys that were added without a source packet.
+
+    @note Internal: read by XmpParser::resolveNamespace() during encode().
+   */
+  [[nodiscard]] const std::map<std::string, std::string>& nsBindings() const {
+    return nsBindings_;
+  }
 
   int addUnlocked(const XmpKey& key, const Value* value, const XmpProperties::XmpLock&);
   int addUnlocked(const Xmpdatum& xmpDatum, const XmpProperties::XmpLock&);
@@ -355,6 +376,14 @@ class EXIV2API XmpParser {
 
   static std::unique_ptr<XmpKey> makeXmpKey(const std::string& schemaNs, const std::string& propPath,
                                             const XmpProperties::XmpLock&);
+
+  /*!
+    @brief Resolve a namespace prefix to its URI for serialization, preferring the
+           binding declared by \em xmpData's own source packet and falling back to
+           the process-global registry for keys added without one.
+           Assumes the lock obtained via XmpProperties::XmpLock is held by caller.
+   */
+  static std::string resolveNamespace(const XmpData& xmpData, const std::string& prefix, const XmpProperties::XmpLock&);
 
 };  // class XmpParser
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -5078,6 +5078,11 @@ std::string XmpProperties::nsUnlocked(const std::string& prefix, const XmpLock& 
   return nsInfoUnlocked(prefix, lock)->ns_;
 }
 
+bool XmpProperties::prefixIsBoundUnlocked(const std::string& prefix, const XmpLock& lock) {
+  const auto pf = XmpNsInfo::Prefix{prefix};
+  return lookupNsRegistryUnlocked(pf, lock) != nullptr || Exiv2::find(xmpNsInfo, pf) != nullptr;
+}
+
 const char* XmpProperties::propertyTitle(const XmpKey& key) {
   XmpLock lock;
   return propertyTitleUnlocked(key, lock);

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -438,6 +438,7 @@ void XmpData::clear() {
 
 void XmpData::clearUnlocked(const XmpProperties::XmpLock&) {
   xmpMetadata_.clear();
+  nsBindings_.clear();
 }
 
 void XmpData::sortByKey() {
@@ -698,13 +699,26 @@ int XmpParser::decode(XmpData& xmpData, const std::string& xmpPacket) {
       if (XMP_NodeIsSchema(opt)) {
         // Register unknown namespaces with Exiv2
         // (Namespaces are automatically registered with the XMP Toolkit)
-        if (XmpProperties::prefixUnlocked(schemaNs, lock).empty()) {
-          std::string prefix;
+        std::string prefix = XmpProperties::prefixUnlocked(schemaNs, lock);
+        if (prefix.empty()) {
           if (!SXMPMeta::GetNamespacePrefix(schemaNs.c_str(), &prefix))
             throw Error(ErrorCode::kerSchemaNamespaceNotRegistered, schemaNs);
           prefix.pop_back();
-          XmpProperties::registerNsUnlocked(schemaNs, prefix, lock);
+          // Hardening: a parsed packet must not silently rebind a prefix that is
+          // already globally bound -- a built-in standard prefix, or one a prior
+          // explicit registerNs() established -- to a different URI.  Letting it
+          // would poison every later write and lookup in this process (the
+          // namespace-leak bug).  The packet's own binding is still captured
+          // per-instance below, so this object round-trips faithfully; we just
+          // don't pollute the global registry on a read.
+          if (!XmpProperties::prefixIsBoundUnlocked(prefix, lock))
+            XmpProperties::registerNsUnlocked(schemaNs, prefix, lock);
         }
+        // Record the prefix->URI binding exactly as declared by THIS packet so
+        // encode() can resolve each property's URI from the data it came from,
+        // rather than from the process-global registry which another image may
+        // have rebound (e.g. to a corrupted URI).  See XmpData::nsBindings().
+        xmpData.nsBindings_[prefix] = schemaNs;
         continue;
       }
       auto key = makeXmpKey(schemaNs, propPath, lock);
@@ -839,10 +853,16 @@ int XmpParser::encode(std::string& xmpPacket, const XmpData& xmpData, uint16_t f
       registerNsImpl(xmp, uri.prefix_);
     }
 
+    // Note: we deliberately do NOT re-register the per-instance bindings with
+    // the toolkit here.  Every URI they contain was already registered while its
+    // packet was parsed in decode() (custom ones are also in nsRegistry_, handled
+    // above), so SetProperty resolves them.  Re-registering would overwrite the
+    // toolkit's URI->prefix mapping whenever our preferred prefix differs from the
+    // one the file used for that URI (e.g. iptc vs Iptc4xmpCore), which breaks
+    // serialization of struct fields that still carry the file's prefix.
     SXMPMeta meta;
     for (const auto& xmp : xmpData) {
-      // Must use Unlocked version of ns() because we hold the lock!
-      const std::string ns = XmpProperties::nsUnlocked(xmp.groupName(), lock);
+      const std::string ns = resolveNamespace(xmpData, xmp.groupName(), lock);
       XMP_OptionBits options = 0;
 
       if (xmp.typeId() == langAlt) {
@@ -1083,8 +1103,26 @@ Exiv2::XmpKey::UniquePtr Exiv2::XmpParser::makeXmpKey(const std::string& schemaN
   property = propPath.substr(idx + 1);
   std::string prefix = Exiv2::XmpProperties::prefixUnlocked(schemaNs, lock);
   if (prefix.empty()) {
+    // The namespace was intentionally not registered globally (e.g. a packet
+    // that rebinds an already-bound prefix to a different URI -- see the
+    // hardening in decode()).  Fall back to the prefix the toolkit parsed so
+    // the property still gets a key; its URI is preserved per-instance.
+    std::string toolkitPrefix;
+    if (SXMPMeta::GetNamespacePrefix(schemaNs.c_str(), &toolkitPrefix)) {
+      toolkitPrefix.pop_back();
+      prefix = std::move(toolkitPrefix);
+    }
+  }
+  if (prefix.empty()) {
     throw Exiv2::Error(Exiv2::ErrorCode::kerNoPrefixForNamespace, propPath, schemaNs);
   }
   return Exiv2::XmpKey::UniquePtr(new Exiv2::XmpKey(prefix, property, lock));
 }  // makeXmpKey
+
+std::string Exiv2::XmpParser::resolveNamespace(const XmpData& xmpData, const std::string& prefix,
+                                               const XmpProperties::XmpLock& lock) {
+  const auto& nsBindings = xmpData.nsBindings();
+  const auto binding = nsBindings.find(prefix);
+  return binding != nsBindings.end() ? binding->second : XmpProperties::nsUnlocked(prefix, lock);
+}  // resolveNamespace
 #endif  // EXV_HAVE_XMP_TOOLKIT

--- a/tests/bugfixes/redmine/test_issue_751.py
+++ b/tests/bugfixes/redmine/test_issue_751.py
@@ -66,7 +66,8 @@ Set Xmp.imageapp.uuid "abcd" (XmpText)
         "",
         """Warning: Updating namespace URI for imageapp from orig/ to dest/
 """,
-        """Warning: Updating namespace URI for imageapp from dest/ to orig/
-""",
+        # Command 4 only *reads* the file; with per-instance namespace bindings a
+        # read no longer rebinds the global registry, so no warning is emitted.
+        "",
     ]
     retval = [0] * 4

--- a/tests/bugfixes/redmine/test_issue_937.py
+++ b/tests/bugfixes/redmine/test_issue_937.py
@@ -196,11 +196,11 @@ Xmp.photoshop.DateCreated                    Date Created                   XmpT
 Xmp.xmp.MetadataDate                         Metadata Date                  XmpText    29  2013-02-07T21:56:33.820-06:00
 Xmp.xmp.CreateDate                           Create Date                    XmpText    24  2008-03-14T20:59:26.535Z
 Xmp.xmp.ModifyDate                           Modify Date                    XmpText    25  2013-01-27T14:02:29-06:00
-Xmp.dwc.Event/dwc:earliestDate               Event/dwc:earliestDate         XmpText    25  2012-09-03T00:00:00-06:00
-Xmp.dwc.Event/dwc:latestDate                 Event/dwc:latestDate           XmpText    25  2013-01-27T00:00:00-06:00
-Xmp.dwc.Event/dwc:verbatimEventDate          Event/dwc:verbatimEventDate    XmpText    11  spring 1910
-Xmp.dwc.ResourceRelationship/dwc:relationshipEstablishedDate ResourceRelationship/dwc:relationshipEstablishedDate XmpText    25  2013-01-27T00:00:00-06:00
-Xmp.dwc.MeasurementOrFact/dwc:measurementDeterminedDate MeasurementOrFact/dwc:measurementDeterminedDate XmpText    25  2013-01-27T00:00:00-06:00
+Xmp.dwc.Event/dwc:earliestDate               Event Earliest Date            XmpText    25  2012-09-03T00:00:00-06:00
+Xmp.dwc.Event/dwc:latestDate                 Event Latest Date              XmpText    25  2013-01-27T00:00:00-06:00
+Xmp.dwc.Event/dwc:verbatimEventDate          Verbatim Event Date            XmpText    11  spring 1910
+Xmp.dwc.ResourceRelationship/dwc:relationshipEstablishedDate Relationship Established Date  XmpText    25  2013-01-27T00:00:00-06:00
+Xmp.dwc.MeasurementOrFact/dwc:measurementDeterminedDate Measurement Determined Date    XmpText    25  2013-01-27T00:00:00-06:00
 """
     ]
 

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   test_utils.cpp
   test_XmpKey.cpp
   test_xmp_concurrent.cpp
+  test_xmp_ns_leak.cpp
   test_xmp_lifecycle.cpp
   test_xmp_race_encode_decode.cpp
   test_xmp_concurrent_registry.cpp

--- a/unitTests/test_xmp_ns_leak.cpp
+++ b/unitTests/test_xmp_ns_leak.cpp
@@ -98,3 +98,98 @@ TEST(XmpNsLeak, ReporterPoisonedFileDoesNotLeakIntoCleanFile) {
   EXPECT_EQ(std::string::npos, packet.find("abobe")) << "corrupted 'abobe' leaked: " << packet;
   EXPECT_EQ(std::string::npos, packet.find("(ttp")) << "corrupted '(ttp' leaked: " << packet;
 }
+
+// ---------------------------------------------------------------------------
+// A read must not rebind a prefix that is already globally bound (here, an
+// explicitly registered one) to a different URI. After decoding a packet that
+// rebinds the prefix to a corrupted URI, XmpProperties::ns() must still return
+// the original, canonical URI.
+// ---------------------------------------------------------------------------
+TEST(XmpNsLeak, PoisonedReadDoesNotRebindRegisteredPrefix) {
+  using Exiv2::XmpProperties;
+
+  // Unique prefix so this test is independent of other tests' global state.
+  const std::string good = "http://ns.adobe.com/xleak/1.0/";
+  XmpProperties::registerNs(good, "xleak");
+  ASSERT_EQ(good, XmpProperties::ns("xleak"));
+
+  // Decode a packet that binds the SAME prefix to a corrupted URI.
+  const std::string poison = R"(<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>)"
+                             R"(<x:xmpmeta xmlns:x="adobe:ns:meta/">)"
+                             R"(<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">)"
+                             R"(<rdf:Description rdf:about="")"
+                             R"( xmlns:xleak="http://ns.abobe.com/xleak/1.0/")"
+                             R"( xleak:Foo="bar"/>)"
+                             R"(</rdf:RDF></x:xmpmeta><?xpacket end="w"?>)";
+  Exiv2::XmpData d;
+  Exiv2::XmpParser::decode(d, poison);
+
+  EXPECT_EQ(good, XmpProperties::ns("xleak"))
+      << "decode() of a poisoned packet rebound prefix 'xleak' in the global registry";
+}
+
+// ---------------------------------------------------------------------------
+// The legitimate case behind the bug: two DIFFERENT images each bind the SAME
+// custom prefix to a DIFFERENT (valid) URI. Exiv2 keys are prefix-based, so the
+// global registry can only hold one binding at a time -- but with per-instance
+// bindings each image must still serialize its own URI, even when both are read
+// in the same process before either is written.
+// ---------------------------------------------------------------------------
+TEST(XmpNsLeak, PerImageNamespaceBindingsAreIndependent) {
+  auto packetFor = [](const std::string& uri) {
+    return std::string(R"(<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>)") +
+           R"(<x:xmpmeta xmlns:x="adobe:ns:meta/">)"
+           R"(<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">)"
+           R"(<rdf:Description rdf:about="")"
+           R"( xmlns:shared=")" +
+           uri +
+           R"(")"
+           R"( shared:Tag="v"/>)"
+           R"(</rdf:RDF></x:xmpmeta><?xpacket end="w"?>)";
+  };
+  const std::string uriA = "http://example.com/A/1.0/";
+  const std::string uriB = "http://example.com/B/1.0/";
+
+  // Read both images (same prefix, different valid URIs) before writing either.
+  Exiv2::XmpData a;
+  ASSERT_EQ(0, Exiv2::XmpParser::decode(a, packetFor(uriA)));
+  Exiv2::XmpData b;
+  ASSERT_EQ(0, Exiv2::XmpParser::decode(b, packetFor(uriB)));
+
+  std::string pa, pb;
+  ASSERT_EQ(0, Exiv2::XmpParser::encode(pa, a, Exiv2::XmpParser::omitPacketWrapper));
+  ASSERT_EQ(0, Exiv2::XmpParser::encode(pb, b, Exiv2::XmpParser::omitPacketWrapper));
+
+  EXPECT_EQ(uriA, uriForPrefix(pa, "shared")) << "image A serialized the wrong URI for 'shared'";
+  EXPECT_EQ(uriB, uriForPrefix(pb, "shared")) << "image B serialized the wrong URI for 'shared'";
+}
+
+// ---------------------------------------------------------------------------
+// A property added PROGRAMMATICALLY in a namespace the source packet never
+// declared has no per-instance binding, so encode() falls back to the global
+// registry. After a poisoned read, that fallback must still resolve the
+// canonical URI for a standard prefix (the global hardening in decode()).
+// ---------------------------------------------------------------------------
+TEST(XmpNsLeak, ProgrammaticAddUsesCanonicalUriAfterPoison) {
+  const std::string poison = R"(<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>)"
+                             R"(<x:xmpmeta xmlns:x="adobe:ns:meta/">)"
+                             R"(<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">)"
+                             R"(<rdf:Description rdf:about="")"
+                             R"( xmlns:xmpMM="(ttp://ns.adobe.com/xap/1.0/mm/")"
+                             R"( xmpMM:DocumentID="uuid:original"/>)"
+                             R"(</rdf:RDF></x:xmpmeta><?xpacket end="w"?>)";
+  {
+    Exiv2::XmpData p;
+    Exiv2::XmpParser::decode(p, poison);
+  }
+
+  // Victim never declared xmpMM; we add it programmatically.
+  Exiv2::XmpData d;
+  d["Xmp.dc.creator"] = "Alice";
+  d["Xmp.xmpMM.DocumentID"] = "xmp.did:fresh";
+  std::string packet;
+  ASSERT_EQ(0, Exiv2::XmpParser::encode(packet, d, Exiv2::XmpParser::omitPacketWrapper));
+
+  EXPECT_EQ("http://ns.adobe.com/xap/1.0/mm/", uriForPrefix(packet, "xmpMM"))
+      << "programmatic add fell back to the poisoned global binding";
+}

--- a/unitTests/test_xmp_ns_leak.cpp
+++ b/unitTests/test_xmp_ns_leak.cpp
@@ -1,0 +1,100 @@
+// Regression tests for the XMP namespace-leak bug.
+//
+// Symptom (as originally reported): once exiv2 reads an image whose XMP packet
+// binds a namespace prefix to a particular URI, that URI starts appearing in
+// every subsequently written file -- even unrelated ones. The trigger in the
+// wild is a *corrupted* URI: a packet that binds a standard prefix (e.g. xmp,
+// xmpMM) to a typo'd URI poisons exiv2's process-global namespace registry, and
+// because the URI is re-derived from that registry at encode() time, the
+// corruption leaks into later writes.
+//
+// Reporter's reproduction sketch (downloads a NASA image, flips bytes in its
+// XMP to corrupt the xmp/xmpMM namespace URIs, then writes a *different* clean
+// image and observes the corruption in its output):
+//   https://gist.github.com/mrled/4c9e0ac820fd47d697138689f7474d90
+//
+// Root cause and fix:
+//   - decode() captures each prefix->URI binding from the packet onto the
+//     XmpData itself (XmpData::nsBindings), and refuses to let a read rebind a
+//     prefix that is already globally bound (built-in or explicitly registered)
+//     to a different URI.
+//   - encode() resolves each property's URI from its own XmpData's bindings
+//     first, falling back to the global registry only for keys added without a
+//     source packet.
+//
+// gtest runs every TEST in one process, so the cross-call global-state effects
+// these tests exercise are real. Where ordering matters the whole sequence is
+// packed into one TEST.
+
+#include <gtest/gtest.h>
+#include <exiv2/exiv2.hpp>
+
+#include <regex>
+#include <string>
+
+namespace {
+
+// Return the URI bound to a given xmlns prefix in a serialized packet.
+std::string uriForPrefix(const std::string& packet, const std::string& prefix) {
+  std::regex re("xmlns:" + prefix + R"RE(\s*=\s*"([^"]*)")RE");
+  std::smatch m;
+  if (std::regex_search(packet, m, re))
+    return m[1].str();
+  return "<none>";
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The reporter's exact pipeline, distilled: read a poisoned file that binds the
+// standard xmp/xmpMM prefixes to corrupted URIs, then read a CLEAN victim file,
+// set two properties, and re-encode. The clean file's output must NOT contain
+// the corrupted URIs from the poisoned file.
+// ---------------------------------------------------------------------------
+TEST(XmpNsLeak, ReporterPoisonedFileDoesNotLeakIntoCleanFile) {
+  const std::string poisoned = R"(<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>)"
+                               R"(<x:xmpmeta xmlns:x="adobe:ns:meta/">)"
+                               R"(<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">)"
+                               R"(<rdf:Description rdf:about="")"
+                               R"( xmlns:xmp="http://ns.abobe.com/xap/1.0/")"       // adobe -> abobe
+                               R"( xmlns:xmpMM="(ttp://ns.adobe.com/xap/1.0/mm/")"  // http  -> (ttp
+                               R"( xmp:Rating="3")"
+                               R"( xmpMM:DocumentID="uuid:original"/>)"
+                               R"(</rdf:RDF></x:xmpmeta><?xpacket end="w"?>)";
+
+  // Faithful victim: like the real NASA image, it carries xmp AND xmpMM with
+  // their correct URIs (the DocumentID below is overwritten by the reporter).
+  const std::string victim = R"(<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>)"
+                             R"(<x:xmpmeta xmlns:x="adobe:ns:meta/">)"
+                             R"(<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">)"
+                             R"(<rdf:Description rdf:about="")"
+                             R"( xmlns:xmp="http://ns.adobe.com/xap/1.0/")"       // correct
+                             R"( xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/")"  // correct
+                             R"( xmlns:dc="http://purl.org/dc/elements/1.1/")"
+                             R"( xmp:CreatorTool="cleantool")"
+                             R"( xmpMM:InstanceID="uuid:clean-instance")"
+                             R"( dc:format="image/jpeg"/>)"
+                             R"(</rdf:RDF></x:xmpmeta><?xpacket end="w"?>)";
+
+  // Read the poisoned file first (discard its data; keep global side-effects).
+  {
+    Exiv2::XmpData poisonedXmp;
+    Exiv2::XmpParser::decode(poisonedXmp, poisoned);
+  }
+
+  // Read the clean victim file second, set the two properties the reporter sets.
+  Exiv2::XmpData xmp;
+  ASSERT_EQ(0, Exiv2::XmpParser::decode(xmp, victim));
+  xmp["Xmp.xmp.Rating"] = "1";
+  xmp["Xmp.xmpMM.DocumentID"] = "xmp.did:exiv2-namespace-poison-repro";
+
+  std::string packet;
+  ASSERT_EQ(0, Exiv2::XmpParser::encode(packet, xmp, Exiv2::XmpParser::omitPacketWrapper));
+
+  EXPECT_EQ("http://ns.adobe.com/xap/1.0/", uriForPrefix(packet, "xmp"))
+      << "xmp prefix bound to corrupted URI in the clean file's output";
+  EXPECT_EQ("http://ns.adobe.com/xap/1.0/mm/", uriForPrefix(packet, "xmpMM"))
+      << "xmpMM prefix bound to corrupted URI in the clean file's output";
+  EXPECT_EQ(std::string::npos, packet.find("abobe")) << "corrupted 'abobe' leaked: " << packet;
+  EXPECT_EQ(std::string::npos, packet.find("(ttp")) << "corrupted '(ttp' leaked: " << packet;
+}


### PR DESCRIPTION
If exiv2 ever read an image whose XMP packet bound a namespace prefix to a particular URI, that URI would quietly resurface in every file written afterwards, as reported by #9323.

The issue happened because exiv2 did not keep track of which object registered which URI, and just relied on a global map.

This pull request adds an XmpData local map, essentially giving each object its own URI storage. We fall back to the global table only for keys added without the source packet.

Decoding was also changed, and now does not override default/built-in URIs. We still keep track of the new URI in the object itself, but don't pollute the global registry.

This is still a partial fix. Ideally, each XMP key would carry its own URI or prefix information instead of relying on dedicated lookup tables. However, that would be a much more invasive change and would likely require API breaks.