### PR TITLE
Remove array from some locations

### DIFF
--- a/app/exiv2app.hpp
+++ b/app/exiv2app.hpp
@@ -15,6 +15,7 @@
 #include "getopt.hpp"
 
 // + standard includes
+#include <array>
 #include <iostream>
 #include <regex>
 #include <set>

--- a/include/exiv2/photoshop.hpp
+++ b/include/exiv2/photoshop.hpp
@@ -7,7 +7,8 @@
 
 #include "types.hpp"
 
-#include <array>
+#include <cstddef>
+#include <cstdint>
 
 namespace Exiv2 {
 // Forward declarations
@@ -16,10 +17,10 @@ class IptcData;
 /// @brief Helper class, has methods to deal with %Photoshop "Information Resource Blocks" (IRBs).
 struct EXIV2API Photoshop {
   // Todo: Public for now
-  static constexpr std::array<const char*, 4> irbId_{"8BIM", "AgHg", "DCSR", "PHUT"};  //!< %Photoshop IRB markers
-  static constexpr auto ps3Id_ = "Photoshop 3.0\0";                                    //!< %Photoshop marker
-  static constexpr uint16_t iptc_ = 0x0404;                                            //!< %Photoshop IPTC marker
-  static constexpr uint16_t preview_ = 0x040c;                                         //!< %Photoshop preview marker
+  static const char irbId_[4][4];               //!< %Photoshop IRB markers
+  static const char ps3Id_[14];                 //!< %Photoshop marker
+  static constexpr uint16_t iptc_ = 0x0404;     //!< %Photoshop IPTC marker
+  static constexpr uint16_t preview_ = 0x040c;  //!< %Photoshop preview marker
 
   /// @brief Checks an IRB
   /// @param pPsData  Existing IRB buffer. It is expected to be of size 4.

--- a/src/cr2header_int.cpp
+++ b/src/cr2header_int.cpp
@@ -29,7 +29,7 @@ bool Cr2Header::read(const byte* pData, size_t size) {
   if (tag() != getUShort(pData + 2, byteOrder()))
     return false;
   setOffset(getULong(pData + 4, byteOrder()));
-  if (0 != memcmp(pData + 8, cr2sig_.data(), 4))
+  if (!std::equal(cr2sig_, cr2sig_ + 4, pData + 8))
     return false;
   offset2_ = getULong(pData + 12, byteOrder());
 
@@ -52,7 +52,7 @@ DataBuf Cr2Header::write() const {
 
   buf.write_uint16(2, tag(), byteOrder());
   buf.write_uint32(4, 0x00000010, byteOrder());
-  std::copy(cr2sig_.begin(), cr2sig_.end(), buf.begin() + 8);
+  std::copy(cr2sig_, cr2sig_ + 4, buf.begin() + 8);
   // Write a dummy value for the RAW IFD offset. The offset-writer is used to set this offset in a second pass.
   buf.write_uint32(12, 0x00000000, byteOrder());
   return buf;

--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -17,7 +17,6 @@
 #include "tifffwd_int.hpp"
 #include "tiffimage_int.hpp"
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 
@@ -56,8 +55,8 @@ class Cr2Header : public TiffHeaderBase {
 
  private:
   // DATA
-  uint32_t offset2_{0x00000000};                                          //!< Bytes 12-15 from the header
-  static constexpr std::array<byte, 4> cr2sig_ = {0x43, 0x52, 0x2, 0x0};  //!< Signature for CR2 type TIFF
+  uint32_t offset2_{0x00000000};                              //!< Bytes 12-15 from the header
+  static constexpr byte cr2sig_[4] = {0x43, 0x52, 0x2, 0x0};  //!< Signature for CR2 type TIFF
 };
 
 }  // namespace Internal

--- a/src/photoshop.cpp
+++ b/src/photoshop.cpp
@@ -6,6 +6,7 @@
 #include "image.hpp"
 #include "safe_op.hpp"
 
+#include <array>
 #include <cstring>
 
 #ifdef EXIV2_DEBUG_MESSAGES
@@ -14,11 +15,24 @@
 
 namespace Exiv2 {
 
+const char Photoshop::irbId_[4][4] = {
+    {'8', 'B', 'I', 'M'},
+    {'A', 'g', 'H', 'g'},
+    {'D', 'C', 'S', 'R'},
+    {'P', 'H', 'U', 'T'},
+};
+
+const char Photoshop::ps3Id_[14] = {'P', 'h', 'o', 't', 'o', 's', 'h', 'o', 'p', ' ', '3', '.', '0', '\0'};
+
 bool Photoshop::isIrb(const byte* pPsData) {
-  if (pPsData == nullptr) {
+  if (pPsData == nullptr)
     return false;
-  }
-  return std::any_of(irbId_.begin(), irbId_.end(), [pPsData](auto id) { return memcmp(pPsData, id, 4) == 0; });
+
+  for (auto id : irbId_)
+    if (std::equal(id, id + 4, pPsData))
+      return true;
+
+  return false;
 }
 
 bool Photoshop::valid(const byte* pPsData, size_t sizePsData) {
@@ -144,7 +158,7 @@ DataBuf Photoshop::setIptcIrb(const byte* pPsData, size_t sizePsData, const Iptc
   // Write new iptc record if we have it
   if (DataBuf rawIptc = IptcParser::encode(iptcData); !rawIptc.empty()) {
     std::array<byte, 12> tmpBuf;
-    std::copy_n(Photoshop::irbId_.front(), 4, tmpBuf.begin());
+    std::copy_n(Photoshop::irbId_[0], 4, tmpBuf.begin());
     us2Data(tmpBuf.data() + 4, iptc_, bigEndian);
     tmpBuf[6] = 0;
     tmpBuf[7] = 0;

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -16,6 +16,7 @@
 #include "value.hpp"
 
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <cstring>
 

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -15,6 +15,8 @@
 #include <iostream>
 #endif
 
+#include <array>
+
 // Todo: Consolidate with existing code in struct Photoshop (jpgimage.hpp):
 //       Extend this helper to a proper class with all required functionality,
 //       then move it here or into a separate file?
@@ -549,7 +551,7 @@ uint32_t PsdImage::writeIptcData(const IptcData& iptcData, BasicIo& out) {
       std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::IPTC_NAA << "\n";
       std::cerr << std::dec << "Writing IPTC_NAA: size: " << rawIptc.size() << "\n";
 #endif
-      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
+      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, kPhotoshopResourceID::IPTC_NAA, bigEndian);
       if (out.write(buf, 2) != 2)
@@ -594,7 +596,7 @@ uint32_t PsdImage::writeExifData(ExifData& exifData, BasicIo& out) {
       std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::ExifInfo << "\n";
       std::cerr << std::dec << "Writing ExifInfo: size: " << blob.size() << "\n";
 #endif
-      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
+      if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
         throw Error(ErrorCode::kerImageWriteFailed);
       us2Data(buf, kPhotoshopResourceID::ExifInfo, bigEndian);
       if (out.write(buf, 2) != 2)
@@ -641,7 +643,7 @@ uint32_t PsdImage::writeXmpData(const XmpData& xmpData, BasicIo& out) const {
     std::cerr << std::hex << "write: resourceId: " << kPhotoshopResourceID::XMPPacket << "\n";
     std::cerr << std::dec << "Writing XMPPacket: size: " << xmpPacket.size() << "\n";
 #endif
-    if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_.front()), 4) != 4)
+    if (out.write(reinterpret_cast<const byte*>(Photoshop::irbId_[0]), 4) != 4)
       throw Error(ErrorCode::kerImageWriteFailed);
     us2Data(buf, kPhotoshopResourceID::XMPPacket, bigEndian);
     if (out.write(buf, 2) != 2)

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -635,10 +635,7 @@ void TiffEncoder::visitIfdMakernote(TiffIfdMakernote* object) {
   }
   if (del_) {
     // Remove remaining synthesized tags
-    static constexpr auto synthesizedTags = std::array{
-        "Exif.MakerNote.Offset",
-    };
-    for (auto synthesizedTag : synthesizedTags) {
+    for (auto synthesizedTag : {"Exif.MakerNote.Offset"}) {
       pos = exifData_.findKey(ExifKey(synthesizedTag));
       if (pos != exifData_.end())
         exifData_.erase(pos);

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -10,7 +10,6 @@
 
 #include "tiffcomposite_int.hpp"
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -54,8 +53,8 @@ class TiffVisitor {
   };
 
  private:
-  static const int events_ = 2;               //!< The number of stop/go flags.
-  std::array<bool, events_> go_{true, true};  //!< Array of stop/go flags. See setGo().
+  static const int events_ = 2;   //!< The number of stop/go flags.
+  bool go_[events_]{true, true};  //!< Array of stop/go flags. See setGo().
 
  public:
   //! @name Creators

--- a/unitTests/test_Photoshop.cpp
+++ b/unitTests/test_Photoshop.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace Exiv2;
 
 TEST(PhotoshopIsIrb, returnsTrueWithValidMarkers) {


### PR DESCRIPTION
Instead of having array as an implicit include, remove it from public headers where it makes sense.