### PR TITLE
Revert "Bound setMediaStream search to the trak atom size"

### DIFF
--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -184,10 +184,8 @@ class EXIV2API QuickTimeVideo : public Image {
   /*!
     @brief Recognizes which stream is currently under processing,
         and save its information in currentStream_ .
-    @param atom_size Full size of the atom currently being processed, in bytes,
-        including both the atom header and its payload.
    */
-  void setMediaStream(size_t atom_size);
+  void setMediaStream();
   /*!
     @brief Used to discard a tag along with its data. The Tag will
         be skipped and not decoded.

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -643,7 +643,7 @@ void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursi
     fileTypeDecoder(size);
 
   else if (equalsQTimeTag(buf, "trak"))
-    setMediaStream(size);
+    setMediaStream();
 
   else if (equalsQTimeTag(buf, "mvhd"))
     movieHeaderDecoder(size);
@@ -1131,18 +1131,13 @@ void QuickTimeVideo::NikonTagsDecoder(size_t size_external) {
   io_->seek(cur_pos + size_external, BasicIo::beg);
 }  // QuickTimeVideo::NikonTagsDecoder
 
-void QuickTimeVideo::setMediaStream(size_t atom_size) {
+void QuickTimeVideo::setMediaStream() {
   size_t current_position = io_->tell();
-  size_t search_end = Safe::add(current_position, atom_size);
-  if (search_end > io_->size())
-    search_end = io_->size();
   DataBuf buf(4 + 1);
 
-  while (!io_->eof() && Safe::add(io_->tell(), size_t{4}) <= search_end) {
+  while (!io_->eof()) {
     io_->readOrThrow(buf.data(), 4);
     if (equalsQTimeTag(buf, "hdlr")) {
-      if (Safe::add(io_->tell(), size_t{12}) > search_end)
-        break;
       io_->readOrThrow(buf.data(), 4);
       io_->readOrThrow(buf.data(), 4);
       io_->readOrThrow(buf.data(), 4);


### PR DESCRIPTION
Reverts #9319 because of API change.