### PR TITLE
Fix/issue 3318 dx tiff xmp

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -601,6 +601,11 @@ void Image::setIptcData(const IptcData& iptcData) {
 
 void Image::clearXmpPacket() {
   xmpPacket_.clear();
+  // Also clear the packet cached inside xmpData_. Some formats (e.g. TIFF, where
+  // XMP is stored in the Exif.Image.XMLPacket tag) write XMP from xmpData_'s
+  // packet when writeXmpFromPacket() is set. Without this, a stale packet would
+  // survive and the XMP would not be erased (e.g. "exiv2 -dx" on a TIFF).
+  xmpData_.setPacket(std::string());
   writeXmpFromPacket(true);
 }
 

--- a/tests/bugfixes/github/test_issue_3318.py
+++ b/tests/bugfixes/github/test_issue_3318.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, CopyTmpFiles, path
+
+
+@CopyTmpFiles("$data_path/exiv2-bug1044.tif")
+class DeleteXmpFromTiff(metaclass=CaseMeta):
+    """
+    Regression test: "exiv2 -dx" must actually erase XMP from a TIFF.
+
+    In a TIFF the XMP is stored in the Exif.Image.XMLPacket tag. Deleting it
+    used to leave a stale packet cached in xmpData_, which the TIFF encoder
+    wrote back on save, so the XMP survived "exiv2 -dx".
+
+    https://github.com/Exiv2/exiv2/issues/3318
+    """
+
+    url = "https://github.com/Exiv2/exiv2/issues/3318"
+
+    filename = path("$tmp_path/exiv2-bug1044.tif")
+    commands = [
+        # Add an XMP property to the TIFF.
+        '$exiv2 -M"set Xmp.dc.subject MyCustomXmpValue" $filename',
+        # It is present.
+        "$exiv2 -px $filename",
+        # Delete all XMP.
+        "$exiv2 -dx $filename",
+        # It must be gone (this printed the value again before the fix).
+        "$exiv2 -px $filename",
+    ]
+    stdout = [
+        "",
+        "Xmp.dc.subject                               XmpBag      1  MyCustomXmpValue\n",
+        "",
+        "",
+    ]
+    stderr = [""] * len(commands)
+    retval = [0] * len(commands)


### PR DESCRIPTION
In some formats like TIFF xmp data does not live in its own block, instead if lives inside Exif.Image.XMLPacket tag.

When you erase XMP, `clearXmpPacket()` emptied the image-level packet, but a second copy was quietly cached inside xmpData_. On save, the TIFF encoder reached for that stale copy and wrote the XMP right back. So the library could not effectively clear xmp data from the image.

This pr adds a small fix that clears the "stashed" packet as well.