### PR TITLE
Revert to Windows 2022 to fix build failure

### DIFF
--- a/.github/workflows/on_PR_meson.yaml
+++ b/.github/workflows/on_PR_meson.yaml
@@ -101,7 +101,7 @@ jobs:
           - platform: arm64
             runner: windows-11-arm
           - platform: x64
-            runner: windows-latest
+            runner: windows-2022
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The `clang-cl-forcefallback-x64` workflow started failing a few weeks ago after the `windows-latest` runner got [upgraded](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/). I can't figure out how to get the build to work with `windows-latest`, so the best solution that I can find is to revert it to `windows-2022`.