### PR TITLE
Avoid using destNode after deleting

### DIFF
--- a/xmpsdk/src/XMPUtils-FileInfo.cpp
+++ b/xmpsdk/src/XMPUtils-FileInfo.cpp
@@ -655,6 +655,7 @@ AppendSubtree ( const XMP_Node * sourceNode, XMP_Node * destParent, const bool r
 		if ( destNode != 0 ) {
 			delete ( destNode );
 			destParent->children.erase ( destPos );
+			return;
 		}
 	
 	} else if ( destNode == 0 ) {
@@ -695,6 +696,7 @@ AppendSubtree ( const XMP_Node * sourceNode, XMP_Node * destParent, const bool r
 				if ( deleteEmpty && destNode->children.empty() ) {
 					delete ( destNode );
 					destParent->children.erase ( destPos );
+					return;
 				}
 			}
 			
@@ -719,6 +721,7 @@ AppendSubtree ( const XMP_Node * sourceNode, XMP_Node * destParent, const bool r
 						if ( destNode->children.empty() ) {
 							delete ( destNode );
 							destParent->children.erase ( destPos );
+							return;
 						}
 					}
 


### PR DESCRIPTION
This function sometimes deletes `destNode` during a loop, which could cause a crash on the next iteration of the loop. To avoid that, the function should return after calling `delete`.

This was reported as a vulnerability, but the reporters couldn't find a way to trigger this from the Exiv2 command line app, and had to write a custom main function to reproduce the issue. So I'm treating this as a regular bug that doesn't need a CVE. I'll copy their full report below.