### PR TITLE
add test to improve code coverage of XmpTextValue::read

### DIFF
--- a/test/data/issue_9368_coverage.exv
+++ b/test/data/issue_9368_coverage.exv
@@ -1,0 +1,10 @@
+<?xpacket begin="﻿"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="3.1.2-113">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+   xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+   xmp:CreateDate="type=Oops">
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/tests/bugfixes/github/test_issue_9368.py
+++ b/tests/bugfixes/github/test_issue_9368.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import system_tests
+
+# This test was added to increase code coverage of XmpTextValue::read()
+class XmpTextValue_read_coverage(metaclass=system_tests.CaseMeta):
+    url = "https://github.com/Exiv2/exiv2/pull/9368"
+
+    filename = "$data_path/issue_9368_coverage.exv"
+    commands = ["$exiv2 $filename"]
+    retval = [1]
+    stderr = [
+        """$exiv2_exception_message $filename:
+Invalid XmpText type `Oops'
+"""
+    ]
+    stdout = [""]

--- a/tests/regression_tests/test_regression_allfiles.py
+++ b/tests/regression_tests/test_regression_allfiles.py
@@ -130,6 +130,7 @@ def get_valid_files(data_dir):
         "issue_3513_poc.psd",
         "crash-23eba73bb01cb01caa96a389eb12955c34b98a37.jpg",
         "issue_3511_poc.eps",
+        "issue_9368_coverage.exv",
         # large file that creates 11Mb of output so let's exclude it
         "ReaganLargeTiff.tiff",
         # files that don't create any output


### PR DESCRIPTION
Adding a test to add code coverage for this code:

https://github.com/Exiv2/exiv2/blob/57684e1489af041fc54be6fdaa0110c2b9861639/src/value.cpp#L479-L481

We got a vulnerability report which says (as far as I can understand it) that it's bad that we throw an exception when Exiv2 is run on an malformed input. The report is nonsense, but it did make me realize that we don't have any test coverage for this code. I'll copy the full report below.