### PR TITLE
Check for duplicates in RiffVideo::readInfoListChunk

### DIFF
--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -664,7 +664,7 @@ void RiffVideo::readInfoListChunk(uint64_t size_) {
     current_size += DWORD * 2 + size;
   }
   // Copy the elements from the temporary table to xmpData_.
-  for (auto it : table) {
+  for (const auto& it : table) {
     xmpData_[it.first] = it.second;
   }
 }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -648,13 +648,24 @@ void RiffVideo::StreamName(uint64_t size_) const {
 
 void RiffVideo::readInfoListChunk(uint64_t size_) {
   uint64_t current_size = DWORD;
+
+  // Add the elements to a temporary table first, so that we can check
+  // for duplicates before adding them to xmpData_.
+  std::map<std::string, std::string> table;
   while (current_size < size_) {
     std::string type = readStringTag(io_);
     size_t size = readDWORDTag(io_);
     std::string content = readStringTag(io_, size);
-    if (auto it = Internal::infoTags.find(type); it != Internal::infoTags.end())
-      xmpData_[it->second] = content;
+    if (auto it = Internal::infoTags.find(type); it != Internal::infoTags.end()) {
+      // Check that it isn't a duplicate.
+      Internal::enforce(table.find(it->second) == table.end(), ErrorCode::kerCorruptedMetadata);
+      table[it->second] = content;
+    }
     current_size += DWORD * 2 + size;
+  }
+  // Copy the elements from the temporary table to xmpData_.
+  for (auto it : table) {
+    xmpData_[it.first] = it.second;
   }
 }
 


### PR DESCRIPTION
We've had some security reports about `RiffVideo::readInfoListChunk()` because it's a bit slow when you give it a long list to process. The complexity of this code is linear but the constant factor cost of inserting an element into `xmpData_` is high. I got a 4x speedup by copying the elements into a `std::map` first (to eliminate duplicate keys). But duplicate keys probably only happen in malformed input files, so I've also added an `enforce` to disallow duplicates.

I don't think this is a security issue because it's just slow performance. It's not a quadratic algorithm, just constant factor slowness. 