### PR TITLE
Fix totalRead calculation

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1204,7 +1204,6 @@ DataBuf RemoteIo::read(size_t rcount) {
 size_t RemoteIo::read(byte* buf, size_t rcount) {
   if (p_->eof_)
     return 0;
-  p_->totalRead_ += rcount;
 
   auto allow = std::min<size_t>(rcount, (p_->size_ - p_->idx_));
   size_t lowBlock = p_->idx_ / p_->blockSize_;
@@ -1235,6 +1234,7 @@ size_t RemoteIo::read(byte* buf, size_t rcount) {
 
   p_->idx_ += totalRead;
   p_->eof_ = (p_->idx_ == p_->size_);
+  p_->totalRead_ += totalRead;
 
   return totalRead;
 }

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -983,7 +983,7 @@ class RemoteIo::Impl {
   size_t idx_{0};                          //!< Index into the memory area
   bool eof_{false};                        //!< EOF indicator
   Protocol protocol_;                      //!< the protocol of url
-  size_t totalRead_{0};                    //!< bytes requested from host
+  size_t totalRead_{0};                    //!< total number of bytes read from host
 
   // METHODS
   /*!


### PR DESCRIPTION
I noticed this while working on #9377. This calculation of `p_->totalRead_` should be done _after_ the `std::min`:

https://github.com/Exiv2/exiv2/blob/4d1d6568ea67b7c485a321d93924fd18555c17e1/src/basicio.cpp#L1207-L1209

Luckily `p_->totalRead_` is only used in debug messages, so it's only a very minor bug.