### PR TITLE
Fix missing throw

### DIFF
--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* const argv[]) {
       }
       FileIo output(f0);
       if (!output.open("wb")) {
-        Error(Exiv2::ErrorCode::kerFileOpenFailed, output.path(), "w+b", strError());
+        throw Error(Exiv2::ErrorCode::kerFileOpenFailed, output.path(), "w+b", strError());
       }
       size_t l = 0;
       if (!bytes.empty()) {

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* const argv[]) {
       // copy fileIn from a remote location.
       auto io = Exiv2::ImageFactory::createIo(fr);
       if (io->open() != 0) {
-        Error(Exiv2::ErrorCode::kerFileOpenFailed, io->path(), "rb", strError());
+        throw Error(Exiv2::ErrorCode::kerFileOpenFailed, io->path(), "rb", strError());
       }
       FileIo output(f0);
       if (output.open("wb") != 0) {

--- a/samples/iotest.cpp
+++ b/samples/iotest.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* const argv[]) {
         Error(Exiv2::ErrorCode::kerFileOpenFailed, io->path(), "rb", strError());
       }
       FileIo output(f0);
-      if (!output.open("wb")) {
+      if (output.open("wb") != 0) {
         throw Error(Exiv2::ErrorCode::kerFileOpenFailed, output.path(), "w+b", strError());
       }
       size_t l = 0;


### PR DESCRIPTION
There's a missing `throw` which means that it keeps running even though it couldn't open the file.

I'm trying to fix io_test which keeps failing. I don't think this is the root cause, but it is certainly causing confusion.