### PR TITLE
Add new class: ImageCtorParams

### DIFF
--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -37,11 +37,10 @@ class EXIV2API AsfVideo : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
-    @param max_recursion_depth An exception will be thrown if the file
-       contains headers that are nested more deeply than this number.
+    @param params Parameters that are passed through to Image's constructor.
   */
 
-  explicit AsfVideo(std::unique_ptr<BasicIo> io, size_t max_recursion_depth = 500);
+  explicit AsfVideo(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -187,7 +186,7 @@ class EXIV2API AsfVideo : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-EXIV2API Image::UniquePtr newAsfInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newAsfInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Windows Asf Video.
 EXIV2API bool isAsfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/bmffimage.hpp
+++ b/include/exiv2/bmffimage.hpp
@@ -52,10 +52,9 @@ class EXIV2API BmffImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  BmffImage(std::unique_ptr<BasicIo> io, bool create, size_t max_box_depth = 1000);
+  BmffImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //@{
@@ -168,7 +167,7 @@ class EXIV2API BmffImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newBmffInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newBmffInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a BMFF image.
 EXIV2API bool isBmffType(BasicIo& iIo, bool advance);

--- a/include/exiv2/bmpimage.hpp
+++ b/include/exiv2/bmpimage.hpp
@@ -39,8 +39,9 @@ class EXIV2API BmpImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit BmpImage(std::unique_ptr<BasicIo> io);
+  explicit BmpImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -80,7 +81,7 @@ class EXIV2API BmpImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newBmpInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newBmpInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Windows Bitmap image.
 EXIV2API bool isBmpType(BasicIo& iIo, bool advance);

--- a/include/exiv2/cr2image.hpp
+++ b/include/exiv2/cr2image.hpp
@@ -40,10 +40,9 @@ class EXIV2API Cr2Image : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  Cr2Image(std::unique_ptr<BasicIo> io, bool create);
+  Cr2Image(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -104,7 +103,7 @@ class EXIV2API Cr2Parser {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newCr2Instance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newCr2Instance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a CR2 image.
 EXIV2API bool isCr2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/crwimage.hpp
+++ b/include/exiv2/crwimage.hpp
@@ -49,10 +49,9 @@ class EXIV2API CrwImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  CrwImage(std::unique_ptr<BasicIo> io, bool create);
+  CrwImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -123,7 +122,7 @@ class EXIV2API CrwParser {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newCrwInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newCrwInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a CRW image.
 EXIV2API bool isCrwType(BasicIo& iIo, bool advance);

--- a/include/exiv2/epsimage.hpp
+++ b/include/exiv2/epsimage.hpp
@@ -51,10 +51,9 @@ class EXIV2API EpsImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  EpsImage(std::unique_ptr<BasicIo> io, bool create);
+  EpsImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -84,7 +83,7 @@ class EXIV2API EpsImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newEpsInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newEpsInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a EPS image.
 EXIV2API bool isEpsType(BasicIo& iIo, bool advance);

--- a/include/exiv2/gifimage.hpp
+++ b/include/exiv2/gifimage.hpp
@@ -34,8 +34,9 @@ class EXIV2API GifImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit GifImage(std::unique_ptr<BasicIo> io);
+  explicit GifImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -80,7 +81,7 @@ class EXIV2API GifImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newGifInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newGifInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a GIF image.
 EXIV2API bool isGifType(BasicIo& iIo, bool advance);

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -40,6 +40,30 @@ using NativePreviewList = std::vector<NativePreview>;
 enum PrintStructureOption { kpsNone, kpsBasic, kpsXMP, kpsRecursive, kpsIccProfile, kpsIptcErase };
 
 /*!
+  @brief Parameters for the Image constructor. A large number of classes
+  inherit from Image, and they all have a builder function that matches
+  the NewInstanceFct signature. This class makes it easier to add new
+  parameters to Image's constructor when we need to, because they can
+  be added as fields of this class.
+ */
+class EXIV2API ImageCtorParams {
+ public:
+  ImageCtorParams(bool create, size_t max_recursion_depth);
+
+  bool create() const {
+    return create_;
+  }
+
+  size_t max_recursion_depth() const {
+    return max_recursion_depth_;
+  }
+
+ private:
+  const bool create_;
+  const size_t max_recursion_depth_;
+};
+
+/*!
   @brief Abstract base class defining the interface for an image. This is
      the top-level interface to the Exiv2 library.
 
@@ -60,8 +84,9 @@ class EXIV2API Image {
     @brief Constructor taking the image type, a bitmap of the supported
         metadata types and an auto-pointer that owns an IO instance.
         See subclass constructor doc.
+    @param params Parameters that are passed through to Image's constructor.
    */
-  Image(ImageType type, uint16_t supportedMetadata, std::unique_ptr<BasicIo> io);
+  Image(ImageType type, uint16_t supportedMetadata, std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //! Virtual Destructor
   virtual ~Image();
   //@}
@@ -507,7 +532,7 @@ class EXIV2API Image {
 };  // class Image
 
 //! Type for function pointer that creates new Image instances
-using NewInstanceFct = Image::UniquePtr (*)(std::unique_ptr<BasicIo> io, bool create);
+using NewInstanceFct = Image::UniquePtr (*)(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 //! Type for function pointer that checks image types
 using IsThisTypeFct = bool (*)(BasicIo& iIo, bool advance);
 

--- a/include/exiv2/jp2image.hpp
+++ b/include/exiv2/jp2image.hpp
@@ -33,10 +33,9 @@ class EXIV2API Jp2Image : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  Jp2Image(std::unique_ptr<BasicIo> io, bool create);
+  Jp2Image(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -97,7 +96,7 @@ class EXIV2API Jp2Image : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newJp2Instance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newJp2Instance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a JPEG-2000 image.
 EXIV2API bool isJp2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/jpgimage.hpp
+++ b/include/exiv2/jpgimage.hpp
@@ -41,14 +41,14 @@ class EXIV2API JpegBase : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new image should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
     @param initData Data to initialize newly created images. Only used
-        when \em create is true. Should contain data for the smallest
+        when params specify creation. Should contain data for the smallest
         valid image of the calling subclass.
     @param dataSize Size of initData in bytes.
    */
-  JpegBase(ImageType type, std::unique_ptr<BasicIo> io, bool create, const byte initData[], size_t dataSize);
+  JpegBase(ImageType type, std::unique_ptr<BasicIo> io, const ImageCtorParams& params, const byte initData[],
+           size_t dataSize);
   //@}
 
   //! @name Accessors
@@ -148,10 +148,9 @@ class EXIV2API JpegImage : public JpegBase {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  JpegImage(std::unique_ptr<BasicIo> io, bool create);
+  JpegImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
   //! @name Accessors
   //@{
@@ -212,10 +211,9 @@ class EXIV2API ExvImage : public JpegBase {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-           or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  ExvImage(std::unique_ptr<BasicIo> io, bool create);
+  ExvImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
   //! @name Accessors
   //@{
@@ -249,7 +247,7 @@ class EXIV2API ExvImage : public JpegBase {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newJpegInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newJpegInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 //! Check if the file iIo is a JPEG image.
 EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
 /*!
@@ -257,7 +255,7 @@ EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newExvInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newExvInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 //! Check if the file iIo is an EXV file
 EXIV2API bool isExvType(BasicIo& iIo, bool advance);
 

--- a/include/exiv2/matroskavideo.hpp
+++ b/include/exiv2/matroskavideo.hpp
@@ -111,8 +111,9 @@ class EXIV2API MatroskaVideo : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit MatroskaVideo(std::unique_ptr<BasicIo> io);
+  explicit MatroskaVideo(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -180,7 +181,7 @@ class EXIV2API MatroskaVideo : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-EXIV2API Image::UniquePtr newMkvInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newMkvInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Matroska Video.
 EXIV2API bool isMkvType(BasicIo& iIo, bool advance);

--- a/include/exiv2/mrwimage.hpp
+++ b/include/exiv2/mrwimage.hpp
@@ -35,10 +35,9 @@ class EXIV2API MrwImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  MrwImage(std::unique_ptr<BasicIo> io, bool create);
+  MrwImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -84,7 +83,7 @@ class EXIV2API MrwImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newMrwInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newMrwInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a MRW image.
 EXIV2API bool isMrwType(BasicIo& iIo, bool advance);

--- a/include/exiv2/orfimage.hpp
+++ b/include/exiv2/orfimage.hpp
@@ -35,10 +35,9 @@ class EXIV2API OrfImage : public TiffImage {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  OrfImage(std::unique_ptr<BasicIo> io, bool create);
+  OrfImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -92,7 +91,7 @@ class EXIV2API OrfParser {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newOrfInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newOrfInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is an ORF image.
 EXIV2API bool isOrfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/pgfimage.hpp
+++ b/include/exiv2/pgfimage.hpp
@@ -35,10 +35,9 @@ class EXIV2API PgfImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  PgfImage(std::unique_ptr<BasicIo> io, bool create);
+  PgfImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -84,7 +83,7 @@ class EXIV2API PgfImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newPgfInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newPgfInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a PGF image.
 EXIV2API bool isPgfType(BasicIo& iIo, bool advance);

--- a/include/exiv2/pngimage.hpp
+++ b/include/exiv2/pngimage.hpp
@@ -35,10 +35,9 @@ class EXIV2API PngImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  PngImage(std::unique_ptr<BasicIo> io, bool create);
+  PngImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -85,7 +84,7 @@ class EXIV2API PngImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newPngInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newPngInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a PNG image.
 EXIV2API bool isPngType(BasicIo& iIo, bool advance);

--- a/include/exiv2/psdimage.hpp
+++ b/include/exiv2/psdimage.hpp
@@ -33,8 +33,9 @@ class EXIV2API PsdImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit PsdImage(std::unique_ptr<BasicIo> io);
+  explicit PsdImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -96,7 +97,7 @@ class EXIV2API PsdImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newPsdInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newPsdInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Photoshop image.
 EXIV2API bool isPsdType(BasicIo& iIo, bool advance);

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -50,8 +50,9 @@ class EXIV2API QuickTimeVideo : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit QuickTimeVideo(std::unique_ptr<BasicIo> io, size_t max_recursion_depth = 1000);
+  explicit QuickTimeVideo(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -220,7 +221,7 @@ class EXIV2API QuickTimeVideo : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-EXIV2API Image::UniquePtr newQTimeInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newQTimeInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Quick Time Video.
 EXIV2API bool isQTimeType(BasicIo& iIo, bool advance);

--- a/include/exiv2/rafimage.hpp
+++ b/include/exiv2/rafimage.hpp
@@ -35,10 +35,9 @@ class EXIV2API RafImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  RafImage(std::unique_ptr<BasicIo> io, bool create);
+  RafImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -85,7 +84,7 @@ class EXIV2API RafImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newRafInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newRafInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a RAF image.
 EXIV2API bool isRafType(BasicIo& iIo, bool advance);

--- a/include/exiv2/riffvideo.hpp
+++ b/include/exiv2/riffvideo.hpp
@@ -28,8 +28,9 @@ class EXIV2API RiffVideo : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit RiffVideo(std::unique_ptr<BasicIo> io);
+  explicit RiffVideo(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -178,7 +179,7 @@ class EXIV2API RiffVideo : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-EXIV2API Image::UniquePtr newRiffInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newRiffInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Riff Video.
 EXIV2API bool isRiffType(BasicIo& iIo, bool advance);

--- a/include/exiv2/rw2image.hpp
+++ b/include/exiv2/rw2image.hpp
@@ -35,8 +35,9 @@ class EXIV2API Rw2Image : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit Rw2Image(std::unique_ptr<BasicIo> io);
+  explicit Rw2Image(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -99,7 +100,7 @@ class EXIV2API Rw2Parser {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newRw2Instance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newRw2Instance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a RW2 image.
 EXIV2API bool isRw2Type(BasicIo& iIo, bool advance);

--- a/include/exiv2/tgaimage.hpp
+++ b/include/exiv2/tgaimage.hpp
@@ -33,8 +33,9 @@ class EXIV2API TgaImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit TgaImage(std::unique_ptr<BasicIo> io);
+  explicit TgaImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -79,7 +80,7 @@ class EXIV2API TgaImage : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newTgaInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newTgaInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a Targa v2 image.
 EXIV2API bool isTgaType(BasicIo& iIo, bool advance);

--- a/include/exiv2/tiffimage.hpp
+++ b/include/exiv2/tiffimage.hpp
@@ -36,10 +36,9 @@ class EXIV2API TiffImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method.  Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new file should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  TiffImage(std::unique_ptr<BasicIo> io, bool create);
+  TiffImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -153,7 +152,7 @@ class EXIV2API TiffParser {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newTiffInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newTiffInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a TIFF image.
 EXIV2API bool isTiffType(BasicIo& iIo, bool advance);

--- a/include/exiv2/webpimage.hpp
+++ b/include/exiv2/webpimage.hpp
@@ -32,8 +32,9 @@ class EXIV2API WebPImage : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
+      @param params Parameters that are passed through to Image's constructor.
    */
-  explicit WebPImage(std::unique_ptr<BasicIo> io);
+  explicit WebPImage(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -94,7 +95,7 @@ class EXIV2API WebPImage : public Image {
       Caller owns the returned object and the auto-pointer ensures that
       it will be deleted.
  */
-EXIV2API Image::UniquePtr newWebPInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newWebPInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is a WebP Video.
 EXIV2API bool isWebPType(BasicIo& iIo, bool advance);

--- a/include/exiv2/xmpsidecar.hpp
+++ b/include/exiv2/xmpsidecar.hpp
@@ -32,10 +32,9 @@ class EXIV2API XmpSidecar : public Image {
         auto-pointer. Callers should not continue to use the BasicIo
         instance after it is passed to this method. Use the Image::io()
         method to get a temporary reference.
-    @param create Specifies if an existing image should be read (false)
-        or if a new image should be created (true).
+    @param params Parameters that are passed through to Image's constructor.
    */
-  XmpSidecar(std::unique_ptr<BasicIo> io, bool create);
+  XmpSidecar(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
   //@}
 
   //! @name Manipulators
@@ -67,7 +66,7 @@ class EXIV2API XmpSidecar : public Image {
          Caller owns the returned object and the auto-pointer ensures that
          it will be deleted.
  */
-EXIV2API Image::UniquePtr newXmpInstance(std::unique_ptr<BasicIo> io, bool create);
+EXIV2API Image::UniquePtr newXmpInstance(std::unique_ptr<BasicIo> io, const ImageCtorParams& params);
 
 //! Check if the file iIo is an XMP sidecar file.
 EXIV2API bool isXmpType(BasicIo& iIo, bool advance);

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -61,7 +61,8 @@ void mini1(const char* path) {
 }
 
 void mini9(const char* path) {
-  TiffImage tiffImage(std::make_unique<FileIo>(path), false);
+  const Exiv2::ImageCtorParams params(false, 500);
+  TiffImage tiffImage(std::make_unique<FileIo>(path), params);
   tiffImage.readMetadata();
 
   std::cout << "MIME type:  " << tiffImage.mimeType() << "\n";

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -179,8 +179,8 @@ static bool isASFType(const byte buf[]) {
   return Header == AsfVideo::GUIDTag(buf);
 }
 
-AsfVideo::AsfVideo(BasicIo::UniquePtr io, size_t max_recursion_depth) :
-    Image(ImageType::asf, mdNone, std::move(io)), max_recursion_depth_(max_recursion_depth) {
+AsfVideo::AsfVideo(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::asf, mdNone, std::move(io), params), max_recursion_depth_(params.max_recursion_depth()) {
 }  // AsfVideo::AsfVideo
 
 std::string AsfVideo::mimeType() const {
@@ -469,8 +469,8 @@ void AsfVideo::fileProperties() {
   xmpData()["Xmp.video.MaxBitRate"] = readDWORDTag(io_);
 }  // AsfVideo::fileProperties
 
-Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<AsfVideo>(std::move(io));
+Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<AsfVideo>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -83,8 +83,9 @@ std::string Iloc::toString() const {
   return stringFormat("ID = {} from,length = {},{}", ID_, start_, length_);
 }
 
-BmffImage::BmffImage(BasicIo::UniquePtr io, bool /* create */, size_t max_box_depth) :
-    Image(ImageType::bmff, mdExif | mdIptc | mdXmp, std::move(io)), max_box_depth_(max_box_depth) {
+BmffImage::BmffImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::bmff, mdExif | mdIptc | mdXmp, std::move(io), params),
+    max_box_depth_(params.max_recursion_depth()) {
 }  // BmffImage::BmffImage
 
 std::string BmffImage::toAscii(uint32_t n) {
@@ -765,8 +766,8 @@ void BmffImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<BmffImage>(std::move(io), create);
+Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<BmffImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -23,7 +23,8 @@
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-BmpImage::BmpImage(BasicIo::UniquePtr io) : Image(ImageType::bmp, mdNone, std::move(io)) {
+BmpImage::BmpImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::bmp, mdNone, std::move(io), params) {
 }
 
 std::string BmpImage::mimeType() const {
@@ -93,8 +94,8 @@ void BmpImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<BmpImage>(std::move(io));
+Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<BmpImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -20,8 +20,8 @@
 // class member definitions
 namespace Exiv2 {
 
-Cr2Image::Cr2Image(BasicIo::UniquePtr io, bool /*create*/) :
-    Image(ImageType::cr2, mdExif | mdIptc | mdXmp, std::move(io)) {
+Cr2Image::Cr2Image(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::cr2, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }  // Cr2Image::Cr2Image
 
 std::string Cr2Image::mimeType() const {
@@ -128,8 +128,8 @@ WriteMethod Cr2Parser::encode(BasicIo& io, const byte* pData, size_t size, ByteO
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<Cr2Image>(std::move(io), create);
+Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<Cr2Image>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/crwimage.cpp
+++ b/src/crwimage.cpp
@@ -23,7 +23,8 @@
 // class member definitions
 namespace Exiv2 {
 
-CrwImage::CrwImage(BasicIo::UniquePtr io, bool /*create*/) : Image(ImageType::crw, mdExif | mdComment, std::move(io)) {
+CrwImage::CrwImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::crw, mdExif | mdComment, std::move(io), params) {
 }  // CrwImage::CrwImage
 
 std::string CrwImage::mimeType() const {
@@ -131,8 +132,8 @@ void CrwParser::encode(Blob& blob, const byte* pData, size_t size, const CrwImag
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<CrwImage>(std::move(io), create);
+Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<CrwImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1023,9 +1023,10 @@ void readWriteEpsMetadata(BasicIo& io, std::string& xmpPacket, NativePreviewList
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-EpsImage::EpsImage(BasicIo::UniquePtr io, bool create) : Image(ImageType::eps, mdXmp, std::move(io)) {
+EpsImage::EpsImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::eps, mdXmp, std::move(io), params) {
   // LogMsg::setLevel(LogMsg::debug);
-  if (create && io_->open() == 0) {
+  if (params.create() && io_->open() == 0) {
 #ifdef DEBUG
     EXV_DEBUG << "Exiv2::EpsImage:: Creating blank EPS image\n";
 #endif
@@ -1091,8 +1092,8 @@ void EpsImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<EpsImage>(std::move(io), create);
+Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<EpsImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/gifimage.cpp
+++ b/src/gifimage.cpp
@@ -16,7 +16,8 @@
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-GifImage::GifImage(BasicIo::UniquePtr io) : Image(ImageType::gif, mdNone, std::move(io)) {
+GifImage::GifImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::gif, mdNone, std::move(io), params) {
 }
 
 std::string GifImage::mimeType() const {
@@ -68,8 +69,8 @@ void GifImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<GifImage>(std::move(io));
+Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<GifImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -136,7 +136,12 @@ std::string pathOfFileUrl(const std::string& url) {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-Image::Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io) :
+
+ImageCtorParams::ImageCtorParams(bool create, size_t max_recursion_depth) :
+    create_(create), max_recursion_depth_(max_recursion_depth) {
+}
+
+Image::Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io, const ImageCtorParams& /*params*/) :
     io_(std::move(io)), imageType_(type), supportedMetadata_(supportedMetadata) {
 }
 
@@ -878,7 +883,7 @@ Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io) {
   }
   for (const auto& r : registry) {
     if (r.isThisType_(*io, false)) {
-      return r.newInstance_(std::move(io), false);
+      return r.newInstance_(std::move(io), ImageCtorParams(false, 1000));
     }
   }
   return nullptr;
@@ -913,7 +918,7 @@ Image::UniquePtr ImageFactory::create(ImageType type, BasicIo::UniquePtr io) {
   if (type == ImageType::none)
     return {};
   if (auto r = Exiv2::find(registry, type))
-    return r->newInstance_(std::move(io), true);
+    return r->newInstance_(std::move(io), ImageCtorParams(true, 1000));
   return {};
 }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -97,8 +97,9 @@ void boxes_check(size_t b, size_t m) {
 
 }  // namespace
 
-Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create) : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, std::move(io)) {
-  if (create && io_->open() == 0) {
+Jp2Image::Jp2Image(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::jp2, mdExif | mdIptc | mdXmp, std::move(io), params) {
+  if (params.create() && io_->open() == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
     std::cerr << "Exiv2::Jp2Image:: Creating JPEG2000 image to memory" << '\n';
 #endif
@@ -866,8 +867,8 @@ void Jp2Image::doWriteMetadata(BasicIo& outIo) {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<Jp2Image>(std::move(io), create);
+Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<Jp2Image>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -112,9 +112,10 @@ std::pair<std::array<byte, 2>, uint16_t> readSegmentSize(const byte marker, Basi
 }
 }  // namespace
 
-JpegBase::JpegBase(ImageType type, BasicIo::UniquePtr io, bool create, const byte initData[], size_t dataSize) :
-    Image(type, mdExif | mdIptc | mdXmp | mdComment, std::move(io)) {
-  if (create) {
+JpegBase::JpegBase(ImageType type, BasicIo::UniquePtr io, const ImageCtorParams& params, const byte initData[],
+                   size_t dataSize) :
+    Image(type, mdExif | mdIptc | mdXmp | mdComment, std::move(io), params) {
+  if (params.create()) {
     initImage(initData, dataSize);
   }
 }
@@ -964,8 +965,8 @@ const byte JpegImage::blank_[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xDA,
     0x00, 0x0C, 0x03, 0x01, 0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3F, 0x00, 0xA0, 0x00, 0x0F, 0xFF, 0xD9};
 
-JpegImage::JpegImage(BasicIo::UniquePtr io, bool create) :
-    JpegBase(ImageType::jpeg, std::move(io), create, blank_, sizeof(blank_)) {
+JpegImage::JpegImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    JpegBase(ImageType::jpeg, std::move(io), params, blank_, sizeof(blank_)) {
 }
 
 std::string JpegImage::mimeType() const {
@@ -988,8 +989,8 @@ bool JpegImage::isThisType(BasicIo& iIo, bool advance) const {
   return isJpegType(iIo, advance);
 }
 
-Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<JpegImage>(std::move(io), create);
+Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<JpegImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }
@@ -1011,8 +1012,8 @@ bool isJpegType(BasicIo& iIo, bool advance) {
   return result;
 }
 
-ExvImage::ExvImage(BasicIo::UniquePtr io, bool create) :
-    JpegBase(ImageType::exv, std::move(io), create, blank_, sizeof(blank_)) {
+ExvImage::ExvImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    JpegBase(ImageType::exv, std::move(io), params, blank_, sizeof(blank_)) {
 }
 
 std::string ExvImage::mimeType() const {
@@ -1034,8 +1035,8 @@ bool ExvImage::isThisType(BasicIo& iIo, bool advance) const {
   return isExvType(iIo, advance);
 }
 
-Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<ExvImage>(std::move(io), create);
+Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<ExvImage>(std::move(io), params);
   if (!image->good())
     return nullptr;
   return image;

--- a/src/matroskavideo.cpp
+++ b/src/matroskavideo.cpp
@@ -596,7 +596,8 @@ namespace Exiv2 {
 
 using namespace Exiv2::Internal;
 
-MatroskaVideo::MatroskaVideo(BasicIo::UniquePtr io) : Image(ImageType::mkv, mdNone, std::move(io)) {
+MatroskaVideo::MatroskaVideo(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::mkv, mdNone, std::move(io), params) {
 }  // MatroskaVideo::MatroskaVideo
 
 std::string MatroskaVideo::mimeType() const {
@@ -913,8 +914,8 @@ uint32_t MatroskaVideo::findBlockSize(byte b) {
   return 0;
 }
 
-Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<MatroskaVideo>(std::move(io));
+Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<MatroskaVideo>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -20,8 +20,8 @@
 #endif
 
 namespace Exiv2 {
-MrwImage::MrwImage(BasicIo::UniquePtr io, bool /*create*/) :
-    Image(ImageType::mrw, mdExif | mdIptc | mdXmp, std::move(io)) {
+MrwImage::MrwImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::mrw, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }
 
 std::string MrwImage::mimeType() const {
@@ -123,8 +123,8 @@ void MrwImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<MrwImage>(std::move(io), create);
+Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<MrwImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -21,8 +21,8 @@
 namespace Exiv2 {
 using namespace Internal;
 
-OrfImage::OrfImage(BasicIo::UniquePtr io, bool create) :
-    TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ std::move(io), create) {
+OrfImage::OrfImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ std::move(io), params) {
   setTypeSupported(ImageType::orf, mdExif | mdIptc | mdXmp);
 }  // OrfImage::OrfImage
 
@@ -136,8 +136,8 @@ WriteMethod OrfParser::encode(BasicIo& io, const byte* pData, size_t size, ByteO
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<OrfImage>(std::move(io), create);
+Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<OrfImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -49,9 +49,9 @@ static uint32_t byteSwap_(Exiv2::DataBuf& buf, size_t offset, bool bSwap) {
   return result;
 }
 
-PgfImage::PgfImage(BasicIo::UniquePtr io, bool create) :
-    Image(ImageType::pgf, mdExif | mdIptc | mdXmp | mdComment, std::move(io)), bSwap_(isBigEndianPlatform()) {
-  if (create && io_->open() == 0) {
+PgfImage::PgfImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::pgf, mdExif | mdIptc | mdXmp | mdComment, std::move(io), params), bSwap_(isBigEndianPlatform()) {
+  if (params.create() && io_->open() == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
     std::cerr << "Exiv2::PgfImage:: Creating PGF image to memory\n";
 #endif
@@ -285,8 +285,8 @@ DataBuf PgfImage::readPgfHeaderStructure(BasicIo& iIo, uint32_t& width, uint32_t
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<PgfImage>(std::move(io), create);
+Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<PgfImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -52,9 +52,9 @@ bool compare(std::string_view str, const Exiv2::DataBuf& buf) {
 namespace Exiv2 {
 using namespace Internal;
 
-PngImage::PngImage(BasicIo::UniquePtr io, bool create) :
-    Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, std::move(io)) {
-  if (create && io_->open() == 0) {
+PngImage::PngImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, std::move(io), params) {
+  if (params.create() && io_->open() == 0) {
 #ifdef EXIV2_DEBUG_MESSAGES
     std::cerr << "Exiv2::PngImage:: Creating PNG image to memory\n";
 #endif
@@ -681,8 +681,8 @@ void PngImage::doWriteMetadata(BasicIo& outIo) {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<PngImage>(std::move(io), create);
+Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<PngImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -99,7 +99,8 @@ enum kPhotoshopResourceID {
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-PsdImage::PsdImage(BasicIo::UniquePtr io) : Image(ImageType::psd, mdExif | mdIptc | mdXmp, std::move(io)) {
+PsdImage::PsdImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::psd, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }  // PsdImage::PsdImage
 
 std::string PsdImage::mimeType() const {
@@ -673,8 +674,8 @@ uint32_t PsdImage::writeXmpData(const XmpData& xmpData, BasicIo& out) const {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<PsdImage>(std::move(io));
+Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<PsdImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -536,12 +536,12 @@ namespace Exiv2 {
 
 using namespace Exiv2::Internal;
 
-QuickTimeVideo::QuickTimeVideo(BasicIo::UniquePtr io, size_t max_recursion_depth) :
-    Image(ImageType::qtime, mdNone, std::move(io)),
+QuickTimeVideo::QuickTimeVideo(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::qtime, mdNone, std::move(io), params),
     mvhdTimeScale_(1),
     mdhdTimeScale_(1),
     currentStream_(Null),
-    max_recursion_depth_(max_recursion_depth) {
+    max_recursion_depth_(params.max_recursion_depth()) {
 }  // QuickTimeVideo::QuickTimeVideo
 
 std::string QuickTimeVideo::mimeType() const {
@@ -1602,8 +1602,8 @@ void QuickTimeVideo::movieHeaderDecoder(size_t size) {
   io_->readOrThrow(buf.data(), size % 4);
 }  // QuickTimeVideo::movieHeaderDecoder
 
-Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<QuickTimeVideo>(std::move(io));
+Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<QuickTimeVideo>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -21,8 +21,8 @@
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-RafImage::RafImage(BasicIo::UniquePtr io, bool /*create*/) :
-    Image(ImageType::raf, mdExif | mdIptc | mdXmp, std::move(io)) {
+RafImage::RafImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::raf, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }  // RafImage::RafImage
 
 std::string RafImage::mimeType() const {
@@ -296,7 +296,7 @@ void RafImage::readMetadata() {
   // Retrieve metadata from embedded JPEG preview image.
   try {
     auto jpg_io = std::make_unique<Exiv2::MemIo>(jpg_buf.data(), jpg_buf.size());
-    auto jpg_img = JpegImage(std::move(jpg_io), false);
+    auto jpg_img = JpegImage(std::move(jpg_io), ImageCtorParams(false, 0));
     jpg_img.readMetadata();
     setByteOrder(jpg_img.byteOrder());
     xmpData_ = jpg_img.xmpData();
@@ -358,8 +358,8 @@ void RafImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<RafImage>(std::move(io), create);
+Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<RafImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/riffvideo.cpp
+++ b/src/riffvideo.cpp
@@ -361,7 +361,8 @@ namespace Exiv2 {
 
 enum streamTypeInfo { Audio = 1, MIDI, Text, Video };
 
-RiffVideo::RiffVideo(BasicIo::UniquePtr io) : Image(ImageType::riff, mdNone, std::move(io)) {
+RiffVideo::RiffVideo(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::riff, mdNone, std::move(io), params) {
 }  // RiffVideo::RiffVideo
 
 std::string RiffVideo::mimeType() const {
@@ -757,8 +758,8 @@ void RiffVideo::fillDuration(double frame_rate, size_t frame_count) {
   xmpData_["Xmp.video.Duration"] = duration;  // Duration in number of seconds
 }  // RiffVideo::fillDuration
 
-Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<RiffVideo>(std::move(io));
+Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<RiffVideo>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -26,7 +26,8 @@
 namespace Exiv2 {
 using namespace Internal;
 
-Rw2Image::Rw2Image(BasicIo::UniquePtr io) : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, std::move(io)) {
+Rw2Image::Rw2Image(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::rw2, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }  // Rw2Image::Rw2Image
 
 std::string Rw2Image::mimeType() const {
@@ -195,8 +196,8 @@ ByteOrder Rw2Parser::decode(ExifData& exifData, IptcData& iptcData, XmpData& xmp
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<Rw2Image>(std::move(io));
+Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<Rw2Image>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/tgaimage.cpp
+++ b/src/tgaimage.cpp
@@ -18,7 +18,8 @@
 // *****************************************************************************
 // class member definitions
 namespace Exiv2 {
-TgaImage::TgaImage(BasicIo::UniquePtr io) : Image(ImageType::tga, mdNone, std::move(io)) {
+TgaImage::TgaImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::tga, mdNone, std::move(io), params) {
 }
 
 std::string TgaImage::mimeType() const {
@@ -92,8 +93,8 @@ void TgaImage::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<TgaImage>(std::move(io));
+Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<TgaImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -40,8 +40,8 @@
 namespace Exiv2 {
 using namespace Internal;
 
-TiffImage::TiffImage(BasicIo::UniquePtr io, bool /*create*/) :
-    Image(ImageType::tiff, mdExif | mdIptc | mdXmp, std::move(io)) {
+TiffImage::TiffImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::tiff, mdExif | mdIptc | mdXmp, std::move(io), params) {
 }  // TiffImage::TiffImage
 
 //! List of TIFF compression to MIME type mappings
@@ -238,8 +238,8 @@ WriteMethod TiffParser::encode(BasicIo& io, const byte* pData, size_t size, Byte
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<TiffImage>(std::move(io), create);
+Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<TiffImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -74,7 +74,8 @@ std::string binaryToHex(const uint8_t* data, size_t size) {
 // class member definitions
 namespace Exiv2 {
 
-WebPImage::WebPImage(BasicIo::UniquePtr io) : Image(ImageType::webp, mdNone, std::move(io)) {
+WebPImage::WebPImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::webp, mdNone, std::move(io), params) {
 }  // WebPImage::WebPImage
 
 std::string WebPImage::mimeType() const {
@@ -691,8 +692,8 @@ void WebPImage::decodeChunks(uint32_t filesize) {
 
 /* =========================================== */
 
-Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool /*create*/) {
-  auto image = std::make_unique<WebPImage>(std::move(io));
+Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<WebPImage>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -26,8 +26,9 @@ constexpr auto xmlFooter = "<?xpacket end=\"w\"?>";
 
 // class member definitions
 namespace Exiv2 {
-XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, bool create) : Image(ImageType::xmp, mdXmp, std::move(io)) {
-  if (create && io_->open() == 0) {
+XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, const ImageCtorParams& params) :
+    Image(ImageType::xmp, mdXmp, std::move(io), params) {
+  if (params.create() && io_->open() == 0) {
     IoCloser closer(*io_);
     io_->write(reinterpret_cast<const byte*>(xmlHeader), xmlHdrCnt);
   }
@@ -149,8 +150,8 @@ void XmpSidecar::writeMetadata() {
 
 // *************************************************************************
 // free functions
-Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create) {
-  auto image = std::make_unique<XmpSidecar>(std::move(io), create);
+Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, const ImageCtorParams& params) {
+  auto image = std::make_unique<XmpSidecar>(std::move(io), params);
   if (!image->good()) {
     return nullptr;
   }

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(
   test_xmp_lifecycle.cpp
   test_xmp_race_encode_decode.cpp
   test_xmp_concurrent_registry.cpp
+  unittest_utils.hpp
+  unittest_utils.cpp
   ${VIDEO_SUPPORT}
   $<TARGET_OBJECTS:exiv2lib_int>
 )

--- a/unitTests/meson.build
+++ b/unitTests/meson.build
@@ -31,6 +31,7 @@ test_sources = files(
   'test_xmp_concurrent.cpp',
   'test_xmp_concurrent_registry.cpp',
   'test_xmp_race_encode_decode.cpp',
+  'unittest_utils.cpp',
 )
 
 if get_option('video')

--- a/unitTests/test_asfvideo.cpp
+++ b/unitTests/test_asfvideo.cpp
@@ -4,17 +4,18 @@
 
 #include <exiv2/asfvideo.hpp>
 #include <exiv2/basicio.hpp>
+#include "unittest_utils.hpp"
 
 using namespace Exiv2;
 
 TEST(AsfVideo, canBeOpenedWithEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  ASSERT_NO_THROW(AsfVideo asf(std::move(memIo)));
+  ASSERT_NO_THROW(AsfVideo asf(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(AsfVideo, mimeTypeIsAsf) {
   auto memIo = std::make_unique<MemIo>();
-  AsfVideo asf(std::move(memIo));
+  AsfVideo asf(std::move(memIo), defaultImageCtorParams(false));
 
   ASSERT_EQ("video/asf", asf.mimeType());
 }
@@ -26,13 +27,13 @@ TEST(AsfVideo, isAsfTypewithEmptyDataReturnsFalse) {
 
 TEST(AsfVideo, emptyThrowError) {
   auto memIo = std::make_unique<MemIo>();
-  AsfVideo asf(std::move(memIo));
+  AsfVideo asf(std::move(memIo), defaultImageCtorParams(false));
   ASSERT_THROW(asf.readMetadata(), Exiv2::Error);
 }
 
 TEST(AsfVideo, printStructurePrintsNothingAndthrowError) {
   auto memIo = std::make_unique<MemIo>();
-  AsfVideo asf(std::move(memIo));
+  AsfVideo asf(std::move(memIo), defaultImageCtorParams(false));
 
   std::ostringstream stream;
 
@@ -43,7 +44,7 @@ TEST(AsfVideo, printStructurePrintsNothingAndthrowError) {
 
 TEST(AsfVideo, readMetadata) {
   auto memIo = std::make_unique<MemIo>();
-  AsfVideo asf(std::move(memIo));
+  AsfVideo asf(std::move(memIo), defaultImageCtorParams(false));
   XmpData xmpData;
   xmpData["Xmp.video.TotalStream"] = 1000;
   xmpData["Xmp.video.TimecodeScale"] = 10001;

--- a/unitTests/test_bmpimage.cpp
+++ b/unitTests/test_bmpimage.cpp
@@ -5,24 +5,25 @@
 #include <array>
 #include <exiv2/basicio.hpp>
 #include <exiv2/bmpimage.hpp>
+#include "unittest_utils.hpp"
 
 using namespace Exiv2;
 
 TEST(BmpImage, canBeOpenedWithEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  ASSERT_NO_THROW(BmpImage bmp(std::move(memIo)));
+  ASSERT_NO_THROW(BmpImage bmp(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(BmpImage, mimeTypeIsBmp) {
   auto memIo = std::make_unique<MemIo>();
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
 
   ASSERT_EQ("image/x-ms-bmp", bmp.mimeType());
 }
 
 TEST(BmpImage, writeMetadataIsNotImplemented) {
   auto memIo = std::make_unique<MemIo>();
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     bmp.writeMetadata();
@@ -35,7 +36,7 @@ TEST(BmpImage, writeMetadataIsNotImplemented) {
 
 TEST(BmpImage, setExitDataIsNotImplemented) {
   auto memIo = std::make_unique<MemIo>();
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     ExifData data;
@@ -49,7 +50,7 @@ TEST(BmpImage, setExitDataIsNotImplemented) {
 
 TEST(BmpImage, setIptcDataIsNotImplemented) {
   auto memIo = std::make_unique<MemIo>();
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     IptcData data;
@@ -63,7 +64,7 @@ TEST(BmpImage, setIptcDataIsNotImplemented) {
 
 TEST(BmpImage, setCommentIsNotImplemented) {
   auto memIo = std::make_unique<MemIo>();
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     bmp.setComment("random comment");
@@ -87,7 +88,7 @@ TEST(BmpImage, readMetadataReadsImageDimensionsWhenDataIsAvailable) {
   };
 
   auto memIo = std::make_unique<MemIo>(header.data(), header.size());
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
   ASSERT_NO_THROW(bmp.readMetadata());
   ASSERT_EQ(1280u, bmp.pixelWidth());
   ASSERT_EQ(800u, bmp.pixelHeight());
@@ -106,7 +107,7 @@ TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {
   };
 
   auto memIo = std::make_unique<MemIo>(header.data(), header.size());
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
   try {
     bmp.readMetadata();
     FAIL();
@@ -119,7 +120,7 @@ TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {
 TEST(BmpImage, readMetadataThrowsWhenThereIsNotEnoughInfoToRead) {
   const std::array<unsigned char, 1> header{'B'};
   auto memIo = std::make_unique<MemIo>(header.data(), header.size());
-  BmpImage bmp(std::move(memIo));
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
   try {
     bmp.readMetadata();
     FAIL();
@@ -131,7 +132,7 @@ TEST(BmpImage, readMetadataThrowsWhenThereIsNotEnoughInfoToRead) {
 
 TEST(BmpImage, readMetadataThrowsWhenIoCannotBeOpened) {
   auto fileIo = std::make_unique<FileIo>("NonExistingPath.png");
-  BmpImage bmp(std::move(fileIo));
+  BmpImage bmp(std::move(fileIo), defaultImageCtorParams(false));
   try {
     bmp.readMetadata();
     FAIL();
@@ -149,13 +150,13 @@ TEST(newBmpInstance, createsValidInstace) {
       0x00, 0x00, 0x00, 0x00   // Offset of the byte where the bitmap image data can be found
   };
   auto memIo = std::make_unique<MemIo>(bitmapHeader.data(), bitmapHeader.size());
-  auto img = newBmpInstance(std::move(memIo), false);
+  auto img = newBmpInstance(std::move(memIo), defaultImageCtorParams(false));
   ASSERT_TRUE(img->good());
 }
 
 TEST(newBmpInstance, createsInvalidInstaceWithNonExistingFilePath) {
   auto fileIo = std::make_unique<FileIo>("NonExistingPath.png");
-  auto img = newBmpInstance(std::move(fileIo), false);
+  auto img = newBmpInstance(std::move(fileIo), defaultImageCtorParams(false));
   ASSERT_FALSE(img);
 }
 

--- a/unitTests/test_jp2image.cpp
+++ b/unitTests/test_jp2image.cpp
@@ -2,6 +2,7 @@
 
 #include <exiv2/basicio.hpp>
 #include <exiv2/jp2image.hpp>
+#include "unittest_utils.hpp"
 
 #include <gtest/gtest.h>
 
@@ -9,28 +10,24 @@ using namespace Exiv2;
 
 TEST(Jp2Image, canBeCreatedFromScratch) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  ASSERT_NO_THROW(Jp2Image image(std::move(memIo), create));
+  ASSERT_NO_THROW(Jp2Image image(std::move(memIo), defaultImageCtorParams(true)));
 }
 
 TEST(Jp2Image, canBeOpenedEvenWithAnEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  ASSERT_NO_THROW(Jp2Image image(std::move(memIo), create));
+  ASSERT_NO_THROW(Jp2Image image(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(Jp2Image, mimeTypeIsPng) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(true));
 
   ASSERT_EQ("image/jp2", image.mimeType());
 }
 
 TEST(Jp2Image, printStructurePrintsNothingWithKpsNone) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(true));
 
   std::ostringstream stream;
   image.printStructure(stream, Exiv2::kpsNone, 1);
@@ -40,8 +37,7 @@ TEST(Jp2Image, printStructurePrintsNothingWithKpsNone) {
 
 TEST(Jp2Image, printStructurePrintsDataWithKpsBasic) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(true));
 
   std::ostringstream stream;
   image.printStructure(stream, Exiv2::kpsBasic, 1);
@@ -51,8 +47,7 @@ TEST(Jp2Image, printStructurePrintsDataWithKpsBasic) {
 
 TEST(Jp2Image, cannotReadMetadataFromEmptyIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     image.readMetadata();
@@ -65,8 +60,7 @@ TEST(Jp2Image, cannotReadMetadataFromEmptyIo) {
 
 TEST(Jp2Image, cannotReadMetadataFromIoWhichCannotBeOpened) {
   auto memIo = std::make_unique<FileIo>("NonExistingPath.jp2");
-  const bool create{false};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     image.readMetadata();
@@ -78,8 +72,7 @@ TEST(Jp2Image, cannotReadMetadataFromIoWhichCannotBeOpened) {
 
 TEST(Jp2Image, cannotWriteMetadataToEmptyIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     image.writeMetadata();
@@ -91,15 +84,13 @@ TEST(Jp2Image, cannotWriteMetadataToEmptyIo) {
 
 TEST(Jp2Image, canWriteMetadataFromCreatedJp2Image) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(true));
   ASSERT_NO_THROW(image.writeMetadata());
 }
 
 TEST(Jp2Image, cannotWriteMetadataToIoWhichCannotBeOpened) {
   auto memIo = std::make_unique<FileIo>("NonExistingPath.jp2");
-  const bool create{false};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     image.readMetadata();
@@ -111,8 +102,7 @@ TEST(Jp2Image, cannotWriteMetadataToIoWhichCannotBeOpened) {
 
 TEST(Jp2Image, canWriteMetadataAndReadAfterwards) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  Jp2Image image(std::move(memIo), create);
+  Jp2Image image(std::move(memIo), defaultImageCtorParams(true));
   ASSERT_NO_THROW(image.writeMetadata());
   ASSERT_NO_THROW(image.readMetadata());
 }

--- a/unitTests/test_matroskavideo.cpp
+++ b/unitTests/test_matroskavideo.cpp
@@ -4,17 +4,18 @@
 
 #include <exiv2/basicio.hpp>
 #include <exiv2/matroskavideo.hpp>
+#include "unittest_utils.hpp"
 
 using namespace Exiv2;
 
 TEST(MatroskaVideo, canBeOpenedWithEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  ASSERT_NO_THROW(MatroskaVideo mkv(std::move(memIo)));
+  ASSERT_NO_THROW(MatroskaVideo mkv(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(MatroskaVideo, mimeTypeIsMkv) {
   auto memIo = std::make_unique<MemIo>();
-  MatroskaVideo mkv(std::move(memIo));
+  MatroskaVideo mkv(std::move(memIo), defaultImageCtorParams(false));
 
   ASSERT_EQ("video/matroska", mkv.mimeType());
 }
@@ -26,13 +27,13 @@ TEST(MatroskaVideo, isMkvTypewithEmptyDataReturnsFalse) {
 
 TEST(MatroskaVideo, emptyThrowError) {
   auto memIo = std::make_unique<MemIo>();
-  MatroskaVideo mkv(std::move(memIo));
+  MatroskaVideo mkv(std::move(memIo), defaultImageCtorParams(false));
   ASSERT_THROW(mkv.readMetadata(), Exiv2::Error);
 }
 
 TEST(MatroskaVideo, printStructurePrintsNothingAndthrowError) {
   auto memIo = std::make_unique<MemIo>();
-  MatroskaVideo mkv(std::move(memIo));
+  MatroskaVideo mkv(std::move(memIo), defaultImageCtorParams(false));
 
   std::ostringstream stream;
 
@@ -43,7 +44,7 @@ TEST(MatroskaVideo, printStructurePrintsNothingAndthrowError) {
 
 TEST(MatroskaVideo, readMetadata) {
   auto memIo = std::make_unique<MemIo>();
-  MatroskaVideo mkv(std::move(memIo));
+  MatroskaVideo mkv(std::move(memIo), defaultImageCtorParams(false));
   XmpData xmpData;
   xmpData["Xmp.video.TotalStream"] = 1000;
   xmpData["Xmp.video.TimecodeScale"] = 10001;

--- a/unitTests/test_pngimage.cpp
+++ b/unitTests/test_pngimage.cpp
@@ -3,6 +3,7 @@
 #include <exiv2/basicio.hpp>
 #include <exiv2/pngimage.hpp>
 #include "pngchunk_int.hpp"  // This is not part of the public API
+#include "unittest_utils.hpp"
 
 #include <gtest/gtest.h>
 
@@ -47,28 +48,24 @@ TEST(PngChunk, keyTxtChunkThrowsIfSizeIsNotEnough) {
 
 TEST(PngImage, canBeCreatedFromScratch) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  ASSERT_NO_THROW(PngImage png(std::move(memIo), create));
+  ASSERT_NO_THROW(PngImage png(std::move(memIo), defaultImageCtorParams(true)));
 }
 
 TEST(PngImage, canBeOpenedEvenWithAnEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  ASSERT_NO_THROW(PngImage png(std::move(memIo), create));
+  ASSERT_NO_THROW(PngImage png(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(PngImage, mimeTypeIsPng) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(true));
 
   ASSERT_EQ("image/png", png.mimeType());
 }
 
 TEST(PngImage, printStructurePrintsNothingWithKpsNone) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(true));
 
   std::ostringstream stream;
   png.printStructure(stream, Exiv2::kpsNone, 1);
@@ -78,8 +75,7 @@ TEST(PngImage, printStructurePrintsNothingWithKpsNone) {
 
 TEST(PngImage, printStructurePrintsDataWithKpsBasic) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(true));
 
   std::ostringstream stream;
   png.printStructure(stream, Exiv2::kpsBasic, 1);
@@ -89,8 +85,7 @@ TEST(PngImage, printStructurePrintsDataWithKpsBasic) {
 
 TEST(PngImage, cannotReadMetadataFromEmptyIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     png.readMetadata();
@@ -103,8 +98,7 @@ TEST(PngImage, cannotReadMetadataFromEmptyIo) {
 
 TEST(PngImage, cannotReadMetadataFromIoWhichCannotBeOpened) {
   auto memIo = std::make_unique<FileIo>("NonExistingPath.png");
-  const bool create{false};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     png.readMetadata();
@@ -116,8 +110,7 @@ TEST(PngImage, cannotReadMetadataFromIoWhichCannotBeOpened) {
 
 TEST(PngImage, cannotWriteMetadataToEmptyIo) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{false};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     png.writeMetadata();
@@ -129,15 +122,13 @@ TEST(PngImage, cannotWriteMetadataToEmptyIo) {
 
 TEST(PngImage, canWriteMetadataFromCreatedPngImage) {
   auto memIo = std::make_unique<MemIo>();
-  const bool create{true};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(true));
   ASSERT_NO_THROW(png.writeMetadata());
 }
 
 TEST(PngImage, cannotWriteMetadataToIoWhichCannotBeOpened) {
   auto memIo = std::make_unique<FileIo>("NonExistingPath.png");
-  const bool create{false};
-  PngImage png(std::move(memIo), create);
+  PngImage png(std::move(memIo), defaultImageCtorParams(false));
 
   try {
     png.readMetadata();

--- a/unitTests/test_riffVideo.cpp
+++ b/unitTests/test_riffVideo.cpp
@@ -4,17 +4,18 @@
 
 #include <exiv2/basicio.hpp>
 #include <exiv2/riffvideo.hpp>
+#include "unittest_utils.hpp"
 
 using namespace Exiv2;
 
 TEST(RiffVideo, canBeOpenedWithEmptyMemIo) {
   auto memIo = std::make_unique<MemIo>();
-  ASSERT_NO_THROW(RiffVideo riff(std::move(memIo)));
+  ASSERT_NO_THROW(RiffVideo riff(std::move(memIo), defaultImageCtorParams(false)));
 }
 
 TEST(RiffVideo, mimeTypeIsRiff) {
   auto memIo = std::make_unique<MemIo>();
-  RiffVideo riff(std::move(memIo));
+  RiffVideo riff(std::move(memIo), defaultImageCtorParams(false));
 
   ASSERT_EQ("video/riff", riff.mimeType());
 }
@@ -26,13 +27,13 @@ TEST(RiffVideo, isRiffTypewithEmptyDataReturnsFalse) {
 
 TEST(RiffVideo, emptyThrowError) {
   auto memIo = std::make_unique<MemIo>();
-  RiffVideo riff(std::move(memIo));
+  RiffVideo riff(std::move(memIo), defaultImageCtorParams(false));
   ASSERT_THROW(riff.readMetadata(), Exiv2::Error);
 }
 
 TEST(RiffVideo, printStructurePrintsNothingAndthrowError) {
   auto memIo = std::make_unique<MemIo>();
-  RiffVideo riff(std::move(memIo));
+  RiffVideo riff(std::move(memIo), defaultImageCtorParams(false));
 
   std::ostringstream stream;
 
@@ -43,7 +44,7 @@ TEST(RiffVideo, printStructurePrintsNothingAndthrowError) {
 
 TEST(RiffVideo, readMetadata) {
   auto memIo = std::make_unique<MemIo>();
-  RiffVideo riff(std::move(memIo));
+  RiffVideo riff(std::move(memIo), defaultImageCtorParams(false));
   XmpData xmpData;
   xmpData["Xmp.video.TotalStream"] = 1000;
   xmpData["Xmp.video.TimecodeScale"] = 10001;

--- a/unitTests/unittest_utils.cpp
+++ b/unitTests/unittest_utils.cpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "unittest_utils.hpp"
+
+Exiv2::ImageCtorParams defaultImageCtorParams(bool create) {
+  return Exiv2::ImageCtorParams(create, 500);
+}

--- a/unitTests/unittest_utils.hpp
+++ b/unitTests/unittest_utils.hpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef UNITTEST_UTILS_HPP_
+#define UNITTEST_UTILS_HPP_
+
+#include <exiv2/image.hpp>
+
+Exiv2::ImageCtorParams defaultImageCtorParams(bool create);
+
+#endif  // #ifndef UNITTEST_UTILS_HPP_


### PR DESCRIPTION
This PR adds a new parameter to the constructor of the `Image` class and refactors the constructors of all the classes that inherit from `Image` so that they pass that parameter through. This is an initial refactoring step. The end goal is to add a `max_recursion_depth` limit to all of the image parsers so that we can stop people from sending us security reports about deep recursions. (An alternative solution is #9347, but that only works on Linux.) Rather than adding a `max_recursion_depth` to every constructor, I thought it would be better to a new class named `ImageCtorParams`. That way, it will be much easier to add new parameters like this in the future, because we can just add a new field to the class.

There are a few classes that already have a `max_recursion_depth_` field. I will move that field into the `Image` base class in a follow-up PR. I will also follow up with PRs that add recursion depth tracking to each of the image parsers that need it.

This PR changes the public interface, so it should _not_ be backported to 0.28.x.