### PR TITLE
Replace lowblock/highBlock with startBlock/stopBlock and add more error checking

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1062,7 +1062,7 @@ size_t RemoteIo::Impl::populateBlocks(size_t startBlock, size_t stopBlock) {
   // optimize: ignore all true blocks on left & right sides.
   while (startBlock < stopBlock && !blocksMap_.at(startBlock).isNone())
     startBlock++;
-  while (startBlock < stopBlock && !blocksMap_.at(stopBlock-1).isNone())
+  while (startBlock < stopBlock && !blocksMap_.at(stopBlock - 1).isNone())
     stopBlock--;
   if (startBlock >= stopBlock) {
     return 0;
@@ -1301,7 +1301,7 @@ int RemoteIo::getb() {
 
   size_t expectedBlock = p_->idx_ / p_->blockSize_;
   // connect to the remote machine & populate the blocks just in time.
-  p_->populateBlocks(expectedBlock, expectedBlock+1);
+  p_->populateBlocks(expectedBlock, expectedBlock + 1);
 
   auto data = p_->blocksMap_.at(expectedBlock).getData();
   return data[p_->idx_++ - expectedBlock * p_->blockSize_];

--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -52,6 +52,12 @@ namespace fs = std::experimental::filesystem;
 #endif
 #endif
 
+// When RemoteIo is used to access a file, the remote server can claim
+// that the file is ludicrously large, which will cause a large allocation
+// on the client side (Exiv2). To avoid this, we will throw an exception if
+// the file size is larger than this limit.
+static constexpr int MAX_REMOTE_FILE_SIZE = 0x8000000;
+
 namespace Exiv2 {
 void BasicIo::readOrThrow(byte* buf, size_t rcount, ErrorCode err) {
   const size_t nread = read(buf, rcount);
@@ -1019,13 +1025,13 @@ class RemoteIo::Impl {
   virtual int64_t getFileLength() = 0;
   /*!
     @brief Get the data by range.
-    @param lowBlock The start block index.
-    @param highBlock The end block index.
+    @param startBlock The start block index.
+    @param stopBlock The stop block index.
     @param response The data from the server.
     @throw Error if the server returns the error code.
-    @note Set lowBlock = -1 and highBlock = -1 to get the whole file content.
+    @note Set startBlock = -1 and stopBlock = -1 to get the whole file content.
    */
-  virtual void getDataByRange(size_t lowBlock, size_t highBlock, std::string& response) = 0;
+  virtual void getDataByRange(size_t startBlock, size_t stopBlock, std::string& response) = 0;
   /*!
     @brief Submit the data to the remote machine. The data replace a part of the remote file.
           The replaced part of remote file is indicated by from and to parameters.
@@ -1040,45 +1046,57 @@ class RemoteIo::Impl {
   virtual void writeRemote(const byte* data, size_t size, size_t from, size_t to) = 0;
   /*!
     @brief Get the data from the remote machine and write them to the memory blocks.
-    @param lowBlock The start block index.
-    @param highBlock The end block index.
+    @param startBlock The start block index.
+    @param stopBlock The stop block index.
     @return Number of bytes written to the memory block successfully
     @throw Error if it fails.
    */
-  virtual size_t populateBlocks(size_t lowBlock, size_t highBlock);
+  virtual size_t populateBlocks(size_t startBlock, size_t stopBlock);
 };
 
 RemoteIo::Impl::Impl(const std::string& url, size_t blockSize) :
     path_(url), blockSize_(blockSize), protocol_(fileProtocol(url)) {
 }
 
-size_t RemoteIo::Impl::populateBlocks(size_t lowBlock, size_t highBlock) {
+size_t RemoteIo::Impl::populateBlocks(size_t startBlock, size_t stopBlock) {
   // optimize: ignore all true blocks on left & right sides.
-  while (!blocksMap_.at(lowBlock).isNone() && lowBlock < highBlock)
-    lowBlock++;
-  while (!blocksMap_.at(highBlock).isNone() && highBlock > lowBlock)
-    highBlock--;
+  while (startBlock < stopBlock && !blocksMap_.at(startBlock).isNone())
+    startBlock++;
+  while (startBlock < stopBlock && !blocksMap_.at(stopBlock-1).isNone())
+    stopBlock--;
+  if (startBlock >= stopBlock) {
+    return 0;
+  }
 
   size_t rcount = 0;
-  if (blocksMap_.at(highBlock).isNone()) {
-    std::string data;
-    getDataByRange(lowBlock, highBlock, data);
-    rcount = data.length();
-    if (rcount == 0) {
-      throw Error(ErrorCode::kerErrorMessage, "Data By Range is empty. Please check the permission.");
-    }
-    auto source = reinterpret_cast<byte*>(const_cast<char*>(data.c_str()));
-    size_t remain = rcount;
-    size_t totalRead = 0;
-    size_t iBlock = (rcount == size_) ? 0 : lowBlock;
+  std::string data;
+  getDataByRange(startBlock, stopBlock, data);
+  rcount = data.length();
+  size_t iBlock;
+  size_t iStop;
+  if (rcount == 0) {
+    throw Error(ErrorCode::kerErrorMessage, "Data By Range is empty. Please check the permission.");
+  } else if (rcount > size_) {
+    throw Error(ErrorCode::kerErrorMessage, "Remote server returned more bytes than the specified file size.");
+  } else if (rcount == size_) {
+    // The remote server is returning the entire file, rather than the subset that we asked for.
+    iBlock = 0;
+    iStop = (size_ + blockSize_ - 1) / blockSize_;
+  } else {
+    iBlock = startBlock;
+    iStop = stopBlock;
+  }
 
-    while (remain) {
-      auto allow = std::min<size_t>(remain, blockSize_);
-      blocksMap_.at(iBlock).populate(&source[totalRead], allow);
-      remain -= allow;
-      totalRead += allow;
-      iBlock++;
-    }
+  auto source = reinterpret_cast<byte*>(const_cast<char*>(data.c_str()));
+  size_t remain = rcount;
+  size_t totalRead = 0;
+
+  while (iBlock < iStop && remain) {
+    auto allow = std::min<size_t>(remain, blockSize_);
+    blocksMap_.at(iBlock).populate(&source[totalRead], allow);
+    remain -= allow;
+    totalRead += allow;
+    iBlock++;
   }
 
   return rcount;
@@ -1120,6 +1138,8 @@ int RemoteIo::open() {
       }
     } else if (length == 0) {  // file is empty
       throw Error(ErrorCode::kerErrorMessage, "the file length is 0");
+    } else if (length > MAX_REMOTE_FILE_SIZE) {
+      throw Error(ErrorCode::kerErrorMessage, "the remote file is too large");
     } else {
       p_->size_ = static_cast<size_t>(length);
       size_t nBlocks = (p_->size_ + p_->blockSize_ - 1) / p_->blockSize_;
@@ -1240,18 +1260,18 @@ size_t RemoteIo::read(byte* buf, size_t rcount) {
   if (allow == 0) {
     return 0;
   }
-  size_t lowBlock = p_->idx_ / p_->blockSize_;
-  size_t highBlock = (p_->idx_ + allow - 1) / p_->blockSize_;
+  size_t startBlock = p_->idx_ / p_->blockSize_;
+  size_t stopBlock = (p_->idx_ + allow + p_->blockSize_ - 1) / p_->blockSize_;
 
   // connect to the remote machine & populate the blocks just in time.
-  p_->populateBlocks(lowBlock, highBlock);
+  p_->populateBlocks(startBlock, stopBlock);
   auto fakeData = static_cast<byte*>(std::calloc(p_->blockSize_, sizeof(byte)));
   if (!fakeData) {
     throw Error(ErrorCode::kerErrorMessage, "Unable to allocate data");
   }
 
-  size_t iBlock = lowBlock;
-  size_t startPos = p_->idx_ - lowBlock * p_->blockSize_;
+  size_t iBlock = startBlock;
+  size_t startPos = p_->idx_ - startBlock * p_->blockSize_;
   size_t totalRead = 0;
   do {
     auto data = p_->blocksMap_.at(iBlock++).getData();
@@ -1281,7 +1301,7 @@ int RemoteIo::getb() {
 
   size_t expectedBlock = p_->idx_ / p_->blockSize_;
   // connect to the remote machine & populate the blocks just in time.
-  p_->populateBlocks(expectedBlock, expectedBlock);
+  p_->populateBlocks(expectedBlock, expectedBlock+1);
 
   auto data = p_->blocksMap_.at(expectedBlock).getData();
   return data[p_->idx_++ - expectedBlock * p_->blockSize_];
@@ -1394,13 +1414,13 @@ class HttpIo::HttpImpl : public Impl {
   int64_t getFileLength() override;
   /*!
     @brief Get the data by range.
-    @param lowBlock The start block index.
-    @param highBlock The end block index.
+    @param startBlock The start block index.
+    @param stopBlock The stop block index.
     @param response The data from the server.
     @throw Error if the server returns the error code.
-    @note Set lowBlock = -1 and highBlock = -1 to get the whole file content.
+    @note Set startBlock = -1 and stopBlock = -1 to get the whole file content.
    */
-  void getDataByRange(size_t lowBlock, size_t highBlock, std::string& response) override;
+  void getDataByRange(size_t startBlock, size_t stopBlock, std::string& response) override;
   /*!
     @brief Submit the data to the remote machine. The data replace a part of the remote file.
           The replaced part of remote file is indicated by from and to parameters.
@@ -1440,7 +1460,7 @@ int64_t HttpIo::HttpImpl::getFileLength() {
   return (lengthIter == response.end()) ? -1 : atol((lengthIter->second).c_str());
 }
 
-void HttpIo::HttpImpl::getDataByRange(size_t lowBlock, size_t highBlock, std::string& response) {
+void HttpIo::HttpImpl::getDataByRange(size_t startBlock, size_t stopBlock, std::string& response) {
   Exiv2::Dictionary responseDic;
   Exiv2::Dictionary request;
   request["server"] = hostInfo_.Host;
@@ -1449,9 +1469,9 @@ void HttpIo::HttpImpl::getDataByRange(size_t lowBlock, size_t highBlock, std::st
     request["port"] = hostInfo_.Port;
   request["verb"] = "GET";
   std::string errors;
-  if (lowBlock != std::numeric_limits<size_t>::max() && highBlock != std::numeric_limits<size_t>::max()) {
+  if (startBlock != std::numeric_limits<size_t>::max() && stopBlock != std::numeric_limits<size_t>::max()) {
     std::stringstream ss;
-    ss << "Range: bytes=" << lowBlock * blockSize_ << "-" << ((highBlock + 1) * blockSize_ - 1) << "\r\n";
+    ss << "Range: bytes=" << startBlock * blockSize_ << "-" << (stopBlock * blockSize_ - 1) << "\r\n";
     request["header"] = ss.str();
   }
 
@@ -1539,13 +1559,13 @@ class CurlIo::CurlImpl : public Impl {
   int64_t getFileLength() override;
   /*!
     @brief Get the data by range.
-    @param lowBlock The start block index.
-    @param highBlock The end block index.
+    @param startBlock The start block index.
+    @param stopBlock The stop block index.
     @param response The data from the server.
     @throw Error if the server returns the error code.
-    @note Set lowBlock = -1 and highBlock = -1 to get the whole file content.
+    @note Set startBlock = -1 and stopBlock = -1 to get the whole file content.
    */
-  void getDataByRange(size_t lowBlock, size_t highBlock, std::string& response) override;
+  void getDataByRange(size_t startBlock, size_t stopBlock, std::string& response) override;
   /*!
     @brief Submit the data to the remote machine. The data replace a part of the remote file.
           The replaced part of remote file is indicated by from and to parameters.
@@ -1616,7 +1636,7 @@ int64_t CurlIo::CurlImpl::getFileLength() {
   return temp;
 }
 
-void CurlIo::CurlImpl::getDataByRange(size_t lowBlock, size_t highBlock, std::string& response) {
+void CurlIo::CurlImpl::getDataByRange(size_t startBlock, size_t stopBlock, std::string& response) {
   curl_easy_reset(curl_);  // reset all options
   curl_easy_setopt(curl_, CURLOPT_URL, path_.c_str());
   curl_easy_setopt(curl_, CURLOPT_NOPROGRESS, 1L);  // no progress meter please
@@ -1628,9 +1648,9 @@ void CurlIo::CurlImpl::getDataByRange(size_t lowBlock, size_t highBlock, std::st
 
   // curl_easy_setopt(curl_, CURLOPT_VERBOSE, 1); // debugging mode
 
-  if (lowBlock != std::numeric_limits<size_t>::max() && highBlock != std::numeric_limits<size_t>::max()) {
+  if (startBlock != std::numeric_limits<size_t>::max() && stopBlock != std::numeric_limits<size_t>::max()) {
     std::stringstream ss;
-    ss << lowBlock * blockSize_ << "-" << ((highBlock + 1) * blockSize_ - 1);
+    ss << startBlock * blockSize_ << "-" << (stopBlock * blockSize_ - 1);
     std::string range = ss.str();
     curl_easy_setopt(curl_, CURLOPT_RANGE, range.c_str());
   }


### PR DESCRIPTION
This is the follow-up to #9392 which completes the fix for #9391. I said in #9392 that I would do two follow-up PRs but it ended up being more convenient to include both changes in one PR.

The first change is to replace lowblock/highBlock with startBlock/stopBlock. The lowblock/highBlock logic didn't follow the normal C convention where loop ranges look like `for (i = start; i < stop; i++)`. That caused confusion which led to an off-by-one error, which we fixed in #9377. So this PR replaces `highBlock` with `stopBlock`, such that `stopBlock == highBlock + 1`.

The second change is to add better error checking to detect if the remote server returns a bogus file size. 