### PR TITLE
Check snprintf result to avoid out-of-bounds access

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -87,7 +87,7 @@ static int error(std::string& errors, const char* msg, const char* x = nullptr, 
   return -1;
 }
 
-static void flushBuffer(const char* buffer, size_t start, int& end, std::string& file) {
+static void flushBuffer(const char* buffer, size_t start, size_t& end, std::string& file) {
   file += std::string(buffer + start, end - start);
   end = 0;
 }
@@ -226,18 +226,21 @@ int Exiv2::http(Exiv2::Dictionary& request, Exiv2::Dictionary& response, std::st
   }
 
   char buffer[32 * 1024 + 1];
-  size_t buff_l = sizeof buffer - 1;
+  constexpr size_t buff_l = sizeof buffer - 1;
 
   ////////////////////////////////////
   // format the request
-  int n = snprintf(buffer, buff_l, httpTemplate, verb, page, version, servername, header);
-  buffer[n] = 0;
-  response["requestheaders"] = std::string(buffer, n);
+  const int response_len = snprintf(buffer, sizeof(buffer), httpTemplate, verb, page, version, servername, header);
+  if (response_len < 0 || static_cast<size_t>(response_len) > buff_l) {
+    closesocket(sockfd);
+    return error(errors, "HTTP request is too large");
+  }
+  response["requestheaders"] = std::string(buffer, response_len);
 
   ////////////////////////////////////
   // send the header (we'll have to wait for the connection by the non-blocking socket)
   while (sleep_ >= std::chrono::milliseconds::zero() &&
-         send(sockfd, buffer, n, 0) == SOCKET_ERROR /* && WSAGetLastError() == WSAENOTCONN */) {
+         send(sockfd, buffer, response_len, 0) == SOCKET_ERROR /* && WSAGetLastError() == WSAENOTCONN */) {
     std::this_thread::sleep_for(snooze);
     sleep_ -= snooze;
   }
@@ -248,14 +251,14 @@ int Exiv2::http(Exiv2::Dictionary& request, Exiv2::Dictionary& response, std::st
                  WSAGetLastError());
   }
 
-  int end = 0;             // write position in buffer
+  size_t end = 0;          // write position in buffer
   bool bSearching = true;  // looking for headers in the response
   int status = 200;        // assume happiness
 
   ////////////////////////////////////
   // read and process the response
   int err = 0;
-  n = forgive(recv(sockfd, buffer, static_cast<int>(buff_l), 0), err);
+  int n = forgive(recv(sockfd, buffer, static_cast<int>(buff_l), 0), err);
   while (n >= 0 && OK(status)) {
     if (n) {
       end += n;


### PR DESCRIPTION
Fixes: #9408 

If the buffer is too small, `snprintf` returns the length that it _would have_ written. This PR adds a check for that case. I've also cleaned up some of the types in the surrounding code: `recv` uses `ssize_t`, not `int`.