### PR TITLE
Install params.hpp when building with CMake and meson

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -22,6 +22,7 @@ headers = files(
   'exiv2/metadatum.hpp',
   'exiv2/mrwimage.hpp',
   'exiv2/orfimage.hpp',
+  'exiv2/params.hpp',
   'exiv2/pgfimage.hpp',
   'exiv2/photoshop.hpp',
   'exiv2/pngimage.hpp',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,7 @@ set(PUBLIC_HEADERS
     ../include/exiv2/metadatum.hpp
     ../include/exiv2/mrwimage.hpp
     ../include/exiv2/orfimage.hpp
+    ../include/exiv2/params.hpp
     ../include/exiv2/pgfimage.hpp
     ../include/exiv2/photoshop.hpp
     ../include/exiv2/preview.hpp


### PR DESCRIPTION
Fixes: 33061941

Closes #9425

---

### Testing
- I tested the CMake change with gexiv2 and was able to get past the initial build failure
- The meson change is untested