### PR TITLE
Remove nRealData variable

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -1340,22 +1340,16 @@ int RemoteIo::seek(int64_t offset, Position pos) {
 }
 
 byte* RemoteIo::mmap(bool /*isWriteable*/) {
-  size_t nRealData = 0;
   if (!bigBlock_) {
     size_t blockSize = p_->blockSize_;
     size_t blocks = (p_->size_ + blockSize - 1) / blockSize;
-    bigBlock_ = new byte[blocks * blockSize];
+    bigBlock_ = new byte[blocks * blockSize]{};
     for (size_t block = 0; block < blocks; block++) {
-      auto p = p_->blocksMap_.at(block).getData();
-      if (p) {
-        size_t nRead = block == (blocks - 1) ? p_->size_ - nRealData : blockSize;
-        memcpy(bigBlock_ + (block * blockSize), p, nRead);
-        nRealData += nRead;
+      auto& b = p_->blocksMap_.at(block);
+      if (!b.isNone()) {
+        memcpy(bigBlock_ + (block * blockSize), b.getData(), b.getSize());
       }
     }
-#ifdef EXIV2_DEBUG_MESSAGES
-    std::cerr << "RemoteIo::mmap nRealData = " << nRealData << std::endl;
-#endif
   }
 
   return bigBlock_;


### PR DESCRIPTION
Fixes: #9427

`nRealData` is a flawed attempt at tracking the number of bytes in the current block. Much better to just call the `getSize()` method.