### PR TITLE
Call CreateFileMapping correctly on Windows

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -270,7 +270,10 @@ byte* FileIo::mmap(bool isWriteable) {
   if (!DuplicateHandle(hPh, hFd, hPh, &p_->hFile_, 0, false, DUPLICATE_SAME_ACCESS)) {
     throw Error(ErrorCode::kerCallFailed, path(), "MSG2", "DuplicateHandle");
   }
-  p_->hMap_ = CreateFileMapping(p_->hFile_, nullptr, flProtect, 0, static_cast<DWORD>(p_->mappedLength_), nullptr);
+  // For the call to CreateFileMapping(), p_->mappedLength_ needs to be split into high and low parts:
+  ULARGE_INTEGER mappedLength{};
+  mappedLength.QuadPart = p_->mappedLength_;
+  p_->hMap_ = CreateFileMapping(p_->hFile_, nullptr, flProtect, mappedLength.HighPart, mappedLength.LowPart, nullptr);
   if (p_->hMap_ == nullptr) {
     throw Error(ErrorCode::kerCallFailed, path(), "MSG3", "CreateFileMapping");
   }


### PR DESCRIPTION
Fixing a security report that we received from @grulja. The same bug was also independently reported by @gb1dev. On Windows, there's an integer overflow if you run Exiv2 on a file larger than 4GB. It causes Exiv2 to crash. I'm treating this as a regular bug due to the unrealistic size of the input file.

`CreateFileMapping` has a weird interface where the size has to be broken into a high part and a low part. There's an example of how to call it [here](https://learn.microsoft.com/en-us/answers/questions/2200464/createfilemapping-size-constraints).