### PR TITLE
Delete default methods to avoid accidental copying of DataBufs

### DIFF
--- a/include/exiv2/types.hpp
+++ b/include/exiv2/types.hpp
@@ -128,6 +128,14 @@ struct EXIV2API DataBuf {
   explicit DataBuf(size_t size);
   //! Constructor, copies an existing buffer
   DataBuf(const byte* pData, size_t size);
+  //! Move constructor
+  DataBuf(DataBuf&&) = default;
+  //! Move assignment operator
+  DataBuf& operator=(DataBuf&& other) = default;
+  //! Copy constructor (deleted to avoid accidental copying)
+  DataBuf(const DataBuf&) = delete;
+  //! Assignment operator (deleted to avoid accidental copying)
+  DataBuf& operator=(const DataBuf&) = delete;
   //@}
 
   //! @name Manipulators
@@ -165,6 +173,11 @@ struct EXIV2API DataBuf {
 
   [[nodiscard]] size_t size() const {
     return pData_.size();
+  }
+
+  //! Returns a copy
+  [[nodiscard]] DataBuf clone() const {
+    return DataBuf(c_data(), size());
   }
 
   [[nodiscard]] uint8_t read_uint8(size_t offset) const;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -580,7 +580,7 @@ void Image::setMetadata(const Image& image) {
     setIptcData(image.iptcData());
   }
   if (checkMode(mdIccProfile) & amWrite) {
-    setIccProfile(DataBuf(image.iccProfile()));
+    setIccProfile(image.iccProfile().clone());
   }
   if (checkMode(mdXmp) & amWrite) {
     setXmpPacket(image.xmpPacket());


### PR DESCRIPTION
A `DataBuf` can be large, so we don't want to copy them by accident. This deletes the copy constructor and assignment operator which copy silently. A new `clone()` method is added for explicit copying.

This is an API change, so won't be backported to 0.28.x.