### PR TITLE
Remove TaskFactory

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -608,10 +608,6 @@ int Print::printPreviewList() {
   return 0;
 }  // Print::printPreviewList
 
-Task::UniquePtr Print::clone() const {
-  return std::make_unique<Print>(*this);
-}
-
 int Rename::run(const std::string& path) {
   try {
     if (!Exiv2::fileExists(path)) {
@@ -670,10 +666,6 @@ int Rename::run(const std::string& path) {
     std::cerr << "Exiv2 exception in rename action for file " << path << ":\n" << e << "\n";
     return 1;
   }
-}
-
-Task::UniquePtr Rename::clone() const {
-  return std::make_unique<Rename>(*this);
 }
 
 int Erase::run(const std::string& path) {
@@ -778,10 +770,6 @@ int Erase::eraseIccProfile(Exiv2::Image* image) {
   }
   image->clearIccProfile();
   return 0;
-}
-
-Task::UniquePtr Erase::clone() const {
-  return std::make_unique<Erase>(*this);
 }
 
 int Extract::run(const std::string& path) {
@@ -950,10 +938,6 @@ void Extract::writePreviewFile(const Exiv2::PreviewImage& pvImg, size_t num) con
   }
 }
 
-Task::UniquePtr Extract::clone() const {
-  return std::make_unique<Extract>(*this);
-}
-
 int Insert::run(const std::string& path) try {
   // -i{tgt}-  reading from stdin?
   bool bStdin = (Params::instance().target_ & Params::ctStdInOut) != 0;
@@ -1100,10 +1084,6 @@ int Insert::insertThumbnail(const std::string& path) {
 
   return 0;
 }  // Insert::insertThumbnail
-
-Task::UniquePtr Insert::clone() const {
-  return std::make_unique<Insert>(*this);
-}
 
 int Modify::run(const std::string& path) {
   try {
@@ -1306,10 +1286,6 @@ void Modify::regNamespace(const ModifyCmd& modifyCmd) {
   Exiv2::XmpProperties::registerNs(modifyCmd.value_, modifyCmd.key_);
 }
 
-Task::UniquePtr Modify::clone() const {
-  return std::make_unique<Modify>(*this);
-}
-
 int Adjust::run(const std::string& path) try {
   adjustment_ = Params::instance().adjustment_;
   yearAdjustment_ = Params::instance().yodAdjust_[Params::yodYear].adjustment_;
@@ -1346,10 +1322,6 @@ int Adjust::run(const std::string& path) try {
   std::cerr << "Exiv2 exception in adjust action for file " << path << ":\n" << e << "\n";
   return 1;
 }  // Adjust::run
-
-Task::UniquePtr Adjust::clone() const {
-  return std::make_unique<Adjust>(*this);
-}
 
 int Adjust::adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, const std::string& path) const {
   Exiv2::ExifKey ek(key);
@@ -1505,10 +1477,6 @@ int FixIso::run(const std::string& path) {
   }
 }  // FixIso::run
 
-Task::UniquePtr FixIso::clone() const {
-  return std::make_unique<FixIso>(*this);
-}
-
 int FixCom::run(const std::string& path) {
   try {
     if (!Exiv2::fileExists(path)) {
@@ -1565,10 +1533,6 @@ int FixCom::run(const std::string& path) {
     return 1;
   }
 }  // FixCom::run
-
-Task::UniquePtr FixCom::clone() const {
-  return std::make_unique<FixCom>(*this);
-}
 
 }  // namespace Action
 

--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -134,33 +134,30 @@ int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const 
 // *****************************************************************************
 // class member definitions
 namespace Action {
-TaskFactory& TaskFactory::instance() {
-  static TaskFactory instance_;
-  return instance_;
-}
 
-void TaskFactory::cleanup() {
-  registry_.clear();
-}
-
-TaskFactory::TaskFactory() {
-  registry_.emplace(adjust, std::make_unique<Adjust>());
-  registry_.emplace(print, std::make_unique<Print>());
-  registry_.emplace(rename, std::make_unique<Rename>());
-  registry_.emplace(erase, std::make_unique<Erase>());
-  registry_.emplace(extract, std::make_unique<Extract>());
-  registry_.emplace(insert, std::make_unique<Insert>());
-  registry_.emplace(modify, std::make_unique<Modify>());
-  registry_.emplace(fixiso, std::make_unique<FixIso>());
-  registry_.emplace(fixcom, std::make_unique<FixCom>());
-}
-
-Task::UniquePtr TaskFactory::create(TaskType type) {
-  auto i = registry_.find(type);
-  if (i != registry_.end() && i->second) {
-    return i->second->clone();
+Task::UniquePtr Task::create(TaskType type) {
+  switch (type) {
+    case adjust:
+      return std::make_unique<Adjust>();
+    case print:
+      return std::make_unique<Print>();
+    case rename:
+      return std::make_unique<Rename>();
+    case erase:
+      return std::make_unique<Erase>();
+    case extract:
+      return std::make_unique<Extract>();
+    case insert:
+      return std::make_unique<Insert>();
+    case modify:
+      return std::make_unique<Modify>();
+    case fixiso:
+      return std::make_unique<FixIso>();
+    case fixcom:
+      return std::make_unique<FixCom>();
+    default:
+      return nullptr;
   }
-  return nullptr;
 }
 
 static int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::string& path, bool binary) {

--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -82,34 +82,6 @@ class Task {
     return binary_;
   }
 
- private:
-  //! copy binary_ from command-line params to task
-  bool binary_{false};
-};  // class Task
-
-/*!
-  @brief Task factory.
-
-  Creates an instance of the task of the requested type.  The factory is
-  implemented as a singleton, which can be accessed only through the static
-  member function instance().
-*/
-class TaskFactory {
- public:
-  /*!
-    @brief Get access to the task factory.
-    Clients access the task factory exclusively through this method. (SINGLETON)
-  */
-  static TaskFactory& instance();
-
-  ~TaskFactory() = default;
-  //! Prevent copy construction: not implemented.
-  TaskFactory(const TaskFactory&) = delete;
-  TaskFactory& operator=(const TaskFactory&) = delete;
-
-  //! Destructor
-  void cleanup();
-
   /*!
     @brief  Create a task.
 
@@ -120,15 +92,12 @@ class TaskFactory {
             returned auto pointer and take appropriate action (e.g., throw
             an exception) if it is 0.
    */
-  Task::UniquePtr create(TaskType type);
+  static Task::UniquePtr create(TaskType type);
 
  private:
-  //! Prevent construction other than through instance().
-  TaskFactory();
-
-  //! List of task types and corresponding prototypes.
-  std::unordered_map<TaskType, Task::UniquePtr> registry_;
-};
+  //! copy binary_ from command-line params to task
+  bool binary_{false};
+};  // class Task
 
 //! %Print the Exif (or other metadata) of a file to stdout
 class Print : public Task {

--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -64,9 +64,6 @@ class Task {
   Task(const Task&) = default;
   Task& operator=(const Task&) = default;
 
-  //! Virtual copy construction.
-  [[nodiscard]] virtual UniquePtr clone() const = 0;
-
   /// @brief Application interface to perform a task.
   /// @param path Path of the file to process.
   /// @return 0 if successful.
@@ -103,7 +100,6 @@ class Task {
 class Print : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
   //! Print the Jpeg comment
   int printComment();
@@ -148,14 +144,12 @@ class Print : public Task {
 class Rename : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 };  // class Rename
 
 //! %Adjust the Exif (or other metadata) timestamps
 class Adjust : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
  private:
   int adjustDateTime(Exiv2::ExifData& exifData, const std::string& key, const std::string& path) const;
@@ -171,7 +165,6 @@ class Adjust : public Task {
 class Erase : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
   /// @brief Delete the thumbnail image, incl IFD1 metadata from the file.
   static int eraseThumbnail(Exiv2::Image* image);
@@ -199,7 +192,6 @@ class Erase : public Task {
 class Extract : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
   /*!
     @brief Write the thumbnail image to a file. The filename is composed by
@@ -228,7 +220,6 @@ class Extract : public Task {
 class Insert : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
   /*!
     @brief Insert a Jpeg thumbnail image from a file into file \em path.
@@ -254,7 +245,6 @@ class Insert : public Task {
 class Modify : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
   //! Apply modification commands to the \em pImage, return 0 if successful.
   static int applyCommands(Exiv2::Image* pImage);
 
@@ -273,7 +263,6 @@ class Modify : public Task {
 class FixIso : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
  private:
   std::string path_;
@@ -285,7 +274,6 @@ class FixIso : public Task {
 class FixCom : public Task {
  public:
   int run(const std::string& path) override;
-  [[nodiscard]] Task::UniquePtr clone() const override;
 
  private:
   std::string path_;

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* const argv[]) {
 
   try {
     // Create the required action class
-    auto task = Action::TaskFactory::instance().create(static_cast<Action::TaskType>(params.action_));
+    auto task = Action::Task::create(static_cast<Action::TaskType>(params.action_));
 
     // Process all files
     auto filesCount = params.files_.size();
@@ -180,8 +180,6 @@ int main(int argc, char* const argv[]) {
         if (returnCode == EXIT_SUCCESS)
           returnCode = ret;
       }
-
-      Action::TaskFactory::instance().cleanup();
     }
   } catch (const std::exception& exc) {
     std::cerr << "Uncaught exception: " << exc.what() << '\n';


### PR DESCRIPTION
`TaskFactory` is a bit weird. I don't understand why it needs to be a singleton that constructs Tasks by cloning them from a registry. This PR replaces it with a static method in the `Task` class.

This is a significant API change to `app/actions.hpp`, but it doesn't change our public API in the `include` sub-directory. Below is a before/after of how to create and use a task:

## before

```c
auto task = Action::TaskFactory::instance().create(actiontype);
...
task->run(...)
...
Action::TaskFactory::instance().cleanup();
```

## after

```c
auto task = Action::Task::create(actiontype);
...
task->run(...)
...
// no need for any cleanup
```