### PR TITLE
Fix incorrect image size for OS/2 1.x / Windows 2.x BMP files

### DIFF
--- a/src/bmpimage.cpp
+++ b/src/bmpimage.cpp
@@ -79,11 +79,30 @@ void BmpImage::readMetadata() {
     4 = JPEG; 5 = PNG 34      4 bytes  image size             size of the raw bitmap data, in bytes 38      4
     bytes  horizontal resolution  (in pixels per meter) 42      4 bytes  vertical resolution    (in pixels per
     meter) 46      4 bytes  color count 50      4 bytes  important colors       number of "important" colors
+
+    The layout above describes the BITMAPINFOHEADER (and later) variants, identified by a header size
+    of 40 bytes or more. The older OS/2 1.x / Windows 2.x format uses the shorter, 12-byte
+    BITMAPCOREHEADER instead, in which the width and height fields are only 2 bytes wide:
+
+    offset  length   name                   description
+    ======  =======  =====================  =======
+    14      4 bytes  header size            always 12 for BITMAPCOREHEADER
+    18      2 bytes  bitmap width
+    20      2 bytes  bitmap height
+    22      2 bytes  plane count
+    24      2 bytes  depth
   */
   byte buf[26];
   if (io_->read(buf, sizeof(buf)) == sizeof(buf)) {
-    pixelWidth_ = getULong(buf + 18, littleEndian);
-    pixelHeight_ = getULong(buf + 22, littleEndian);
+    const uint32_t headerSize = getULong(buf + 14, littleEndian);
+    if (headerSize == 12) {
+      // OS/2 1.x / Windows 2.x BITMAPCOREHEADER: width and height are 16-bit fields.
+      pixelWidth_ = getUShort(buf + 18, littleEndian);
+      pixelHeight_ = getUShort(buf + 20, littleEndian);
+    } else {
+      pixelWidth_ = getULong(buf + 18, littleEndian);
+      pixelHeight_ = getULong(buf + 22, littleEndian);
+    }
   }
 }
 

--- a/unitTests/test_bmpimage.cpp
+++ b/unitTests/test_bmpimage.cpp
@@ -94,6 +94,28 @@ TEST(BmpImage, readMetadataReadsImageDimensionsWhenDataIsAvailable) {
   ASSERT_EQ(800u, bmp.pixelHeight());
 }
 
+TEST(BmpImage, readMetadataReadsImageDimensionsForOs2V1Header) {
+  // OS/2 1.x / Windows 2.x BMP uses the 12-byte BITMAPCOREHEADER, whose width and height
+  // fields are 16-bit instead of the 32-bit fields used by BITMAPINFOHEADER. Regression test
+  // for https://github.com/Exiv2/exiv2/issues/3304
+  const std::array<unsigned char, 26> header{
+      'B',  'M',               // Signature                                                         off:0   size:2
+      0x1A, 0x0E, 0x0E, 0x00,  // Size of the BMP file in bytes                                     off:2,  size:4
+      0x00, 0x00,              // Reserved                                                          off:6,  size:2
+      0x00, 0x00,              // Reserved                                                          off:8,  size:2
+      0x1A, 0x00, 0x00, 0x00,  // Offset of the byte where the bitmap image data can be found       off:10, size:4
+      0x0C, 0x00, 0x00, 0x00,  // Size of this header (12 => BITMAPCOREHEADER)                      off:14, size:4
+      0x80, 0x02,              // The bitmap width in pixels (unsigned 16 bit): 640                 off:18, size:2
+      0xE0, 0x01,              // The bitmap height in pixels (unsigned 16 bit): 480                off:20, size:2
+  };
+
+  auto memIo = std::make_unique<MemIo>(header.data(), header.size());
+  BmpImage bmp(std::move(memIo), defaultImageCtorParams(false));
+  ASSERT_NO_THROW(bmp.readMetadata());
+  ASSERT_EQ(640u, bmp.pixelWidth());
+  ASSERT_EQ(480u, bmp.pixelHeight());
+}
+
 TEST(BmpImage, readMetadataThrowsWhenImageIsNotBMP) {
   const std::array<unsigned char, 26> header{
       'B',  'A',               // Signature                                                         off:0   size:2


### PR DESCRIPTION
## Summary

Fixes #3304.

`BmpImage::readMetadata()` always read the bitmap width and height as two
32-bit fields at offsets 18 and 22 in the file header. That layout is only
correct for `BITMAPINFOHEADER` (and later) files. The older OS/2 1.x /
Windows 2.x format uses the shorter, 12-byte `BITMAPCOREHEADER`, where
width and height are 16-bit fields at offsets 18 and 20.

Reading the 16-bit width/height pair as a single 32-bit value merges the
width, height, and part of the following plane-count field into two bogus
numbers. For the 640x480 sample attached to the issue, this produced
`31457920 x 1572865` instead of `640 x 480` — reproduced exactly against a
reconstructed sample file matching the issue's dimensions and file size
(921626 bytes).

The header-size field at offset 14 already tells us which layout is in
use (12 for `BITMAPCOREHEADER`, 40+ for `BITMAPINFOHEADER`/newer), so the
fix branches on it and reads the correct field widths for each case.

## Changes

- `src/bmpimage.cpp`: branch on the header-size field to read either the
  16-bit `BITMAPCOREHEADER` width/height or the existing 32-bit
  `BITMAPINFOHEADER` width/height.
- `unitTests/test_bmpimage.cpp`: added a regression test constructing a
  minimal `BITMAPCOREHEADER` (OS/2 1.x) BMP header and asserting the
  correct 640x480 dimensions are read.

## AI assistance disclosure

This change was developed with AI assistance (Claude). The root cause was
verified by reconstructing a sample BMP matching the exact dimensions and
file size reported in #3304, confirming the CLI reproduced the exact bogus
output (`31457920 x 1572865`) before the fix and the correct `640 x 480`
after. Code and commit message were reviewed by hand before submission.

## Test plan

- [x] `cmake -S . -B build -DEXIV2_BUILD_UNIT_TESTS=ON && cmake --build build`
- [x] Full unit test suite: `bin/unit_tests` — 370/370 passed (previously 369, +1 new regression test)
- [x] Manual repro: built a `BITMAPCOREHEADER` (OS/2 1.x) BMP matching the issue's exact width/height/file size, confirmed `bin/exiv2` reports the wrong size before this patch and `640 x 480` after