### PR TITLE
Remove unused argument useCurl

### DIFF
--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -560,7 +560,7 @@ class EXIV2API ImageFactory {
     @throw Error If the file is not found or it is unable to connect to the server to
           read the remote file.
    */
-  static std::unique_ptr<BasicIo> createIo(const std::string& path, bool useCurl = true);
+  static std::unique_ptr<BasicIo> createIo(const std::string& path);
 #ifdef _WIN32
   static std::unique_ptr<BasicIo> createIo(const std::wstring& path);
 #endif
@@ -577,7 +577,7 @@ class EXIV2API ImageFactory {
     @throw Error If opening the file fails or it contains data of an
         unknown image type.
    */
-  static Image::UniquePtr open(const std::string& path, bool useCurl = true);
+  static Image::UniquePtr open(const std::string& path);
 #ifdef _WIN32
   static Image::UniquePtr open(const std::wstring& path);
 #endif

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -10,17 +10,8 @@
 int main(int argc, char* const argv[]) {
   try {
     if (argc < 2) {
-      std::cout << "Usage: " << argv[0] << " file {--nocurl | --curl}\n\n";
+      std::cout << "Usage: " << argv[0] << " file\n\n";
       return EXIT_FAILURE;
-    }
-
-    bool useCurlFromExiv2TestApps = true;
-    for (int a = 1; a < argc; a++) {
-      std::string arg(argv[a]);
-      if (arg == "--nocurl")
-        useCurlFromExiv2TestApps = false;
-      else if (arg == "--curl")
-        useCurlFromExiv2TestApps = true;
     }
 
     std::string file(argv[1]);
@@ -39,13 +30,13 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifKey key("Exif.Image.DateTime");
     exifData.add(key, v.get());
 
-    auto writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    auto writeTest = Exiv2::ImageFactory::open(file);
     writeTest->setExifData(exifData);
     writeTest->writeMetadata();
 
     // read the result to make sure everything fine
     std::cout << "Print out the new metadata ...\n";
-    auto readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    auto readTest = Exiv2::ImageFactory::open(file);
     readTest->readMetadata();
     Exiv2::ExifData& exifReadData = readTest->exifData();
     if (exifReadData.empty()) {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -820,7 +820,7 @@ ImageType ImageFactory::getType(BasicIo& io) {
   return ImageType::none;
 }
 
-BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, [[maybe_unused]] bool useCurl) {
+BasicIo::UniquePtr ImageFactory::createIo(const std::string& path) {
   [[maybe_unused]] Protocol fProt = fileProtocol(path);
 
 #ifdef EXV_USE_CURL
@@ -855,8 +855,8 @@ BasicIo::UniquePtr ImageFactory::createIo(const std::wstring& path) {
 }
 #endif
 
-Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl) {
-  auto image = open(ImageFactory::createIo(path, useCurl));  // may throw
+Image::UniquePtr ImageFactory::open(const std::string& path) {
+  auto image = open(ImageFactory::createIo(path));  // may throw
   if (!image)
     throw Error(ErrorCode::kerFileContainsUnknownImageType, path);
   return image;

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -102,45 +102,45 @@ TEST(TheImageFactory, loadInstancesDifferentImageTypes) {
 
   std::string imagePath = (testData / "DSC_3079.jpg").string();
   EXPECT_EQ(ImageType::jpeg, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "exiv2-bug1108.exv").string();
   EXPECT_EQ(ImageType::exv, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "exiv2-canon-powershot-s40.crw").string();
   EXPECT_EQ(ImageType::crw, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "exiv2-bug1044.tif").string();
   EXPECT_EQ(ImageType::tiff, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
 #ifdef EXV_HAVE_LIBZ
   imagePath = (testData / "exiv2-bug1074.png").string();
   EXPECT_EQ(ImageType::png, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 #endif
 
   imagePath = (testData / "BlueSquare.xmp").string();
   EXPECT_EQ(ImageType::xmp, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "exiv2-photoshop.psd").string();
   EXPECT_EQ(ImageType::psd, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "cve_2017_1000126_stack-oob-read.webp").string();
   EXPECT_EQ(ImageType::webp, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "imagemagick.pgf").string();
   EXPECT_EQ(ImageType::pgf, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 
   imagePath = (testData / "Reagan.jp2").string();
   EXPECT_EQ(ImageType::jp2, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath));
 }
 
 TEST(TheImageFactory, getsExpectedModesForJp2Images) {


### PR DESCRIPTION
`ImageFactory::createIo()` and `ImageFactory::open()` both have an optional parameter named `useCurl` which is never used. This PR deletes it.

Note: this changes the public API.