### PR TITLE
Nul-terminate strings

### DIFF
--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -720,7 +720,7 @@ void QuickTimeVideo::discard(size_t size) {
 }  // QuickTimeVideo::discard
 
 void QuickTimeVideo::previewTagDecoder(size_t size) {
-  DataBuf buf(4);
+  DataBuf buf(5);
   size_t cur_pos = io_->tell();
   io_->readOrThrow(buf.data(), 4);
   xmpData_["Xmp.video.PreviewDate"] = buf.read_uint32(0, bigEndian);
@@ -728,16 +728,17 @@ void QuickTimeVideo::previewTagDecoder(size_t size) {
   xmpData_["Xmp.video.PreviewVersion"] = getShort(buf.data(), bigEndian);
 
   io_->readOrThrow(buf.data(), 4);
+  buf.write_uint8(4, 0);  // nul-terminate string
   if (equalsQTimeTag(buf, "PICT"))
     xmpData_["Xmp.video.PreviewAtomType"] = "QuickDraw Picture";
   else
-    xmpData_["Xmp.video.PreviewAtomType"] = std::string{buf.c_str(), 4};
+    xmpData_["Xmp.video.PreviewAtomType"] = Exiv2::toString(buf.data());
 
   io_->seek(cur_pos + size, BasicIo::beg);
 }  // QuickTimeVideo::previewTagDecoder
 
 void QuickTimeVideo::keysTagDecoder(size_t size) {
-  DataBuf buf(4);
+  DataBuf buf(5);
   size_t cur_pos = io_->tell();
   io_->readOrThrow(buf.data(), 4);
   xmpData_["Xmp.video.PreviewDate"] = buf.read_uint32(0, bigEndian);
@@ -745,10 +746,11 @@ void QuickTimeVideo::keysTagDecoder(size_t size) {
   xmpData_["Xmp.video.PreviewVersion"] = getShort(buf.data(), bigEndian);
 
   io_->readOrThrow(buf.data(), 4);
+  buf.write_uint8(4, 0);  // nul-terminate string
   if (equalsQTimeTag(buf, "PICT"))
     xmpData_["Xmp.video.PreviewAtomType"] = "QuickDraw Picture";
   else
-    xmpData_["Xmp.video.PreviewAtomType"] = std::string{buf.c_str(), 4};
+    xmpData_["Xmp.video.PreviewAtomType"] = Exiv2::toString(buf.data());
 
   io_->seek(cur_pos + size, BasicIo::beg);
 }  // QuickTimeVideo::keysTagDecoder
@@ -804,7 +806,7 @@ void QuickTimeVideo::trackApertureTagDecoder(size_t size) {
 
 void QuickTimeVideo::CameraTagsDecoder(size_t size_external) {
   size_t cur_pos = io_->tell();
-  DataBuf buf(50);
+  DataBuf buf(49);
   DataBuf buf2(4);
   const TagDetails* td;
 
@@ -813,8 +815,10 @@ void QuickTimeVideo::CameraTagsDecoder(size_t size_external) {
     io_->seek(cur_pos, BasicIo::beg);
 
     io_->readOrThrow(buf.data(), 24);
+    buf.write_uint8(24, 0);  // nul-terminate string
     xmpData_["Xmp.video.Make"] = Exiv2::toString(buf.data());
     io_->readOrThrow(buf.data(), 14);
+    buf.write_uint8(14, 0);  // nul-terminate string
     xmpData_["Xmp.video.Model"] = Exiv2::toString(buf.data());
     io_->readOrThrow(buf.data(), 4);
     xmpData_["Xmp.video.ExposureTime"] =
@@ -1245,6 +1249,7 @@ void QuickTimeVideo::imageDescDecoder() {
 
   for (int i = 0; size / 4 != 0; size -= 4, i++) {
     io_->readOrThrow(buf.data(), 4);
+    buf.write_uint8(4, 0);  // nul-terminate string
 
     switch (i) {
       case codec:
@@ -1329,7 +1334,7 @@ void QuickTimeVideo::videoHeaderDecoder(size_t size) {
 
 void QuickTimeVideo::handlerDecoder(size_t size) {
   size_t cur_pos = io_->tell();
-  DataBuf buf(100);
+  DataBuf buf(5);
   std::memset(buf.data(), 0x0, buf.size());
   buf.data()[4] = '\0';
 
@@ -1612,8 +1617,9 @@ Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool /*create*/) {
 }
 
 bool isQTimeType(BasicIo& iIo, bool advance) {
-  auto buf = DataBuf(12);
+  auto buf = DataBuf(12 + 1);
   iIo.read(buf.data(), 12);
+  buf.write_uint8(12, 0);  // nul-terminate string
 
   if (iIo.error() || iIo.eof()) {
     return false;
@@ -1628,7 +1634,7 @@ bool isQTimeType(BasicIo& iIo, bool advance) {
       // we only match if we actually know the video type. This is done
       // to avoid matching just on ftyp because bmffimage also has that
       // header.
-      if (Exiv2::find(qTimeFileType, std::string{buf.c_str(8), 4})) {
+      if (Exiv2::find(qTimeFileType, Exiv2::toString(buf.data(8)))) {
         matched = true;
       }
       break;


### PR DESCRIPTION
There are a few places where we're using this syntax to create a `std::string`:

https://github.com/Exiv2/exiv2/blob/3996d6602bb1c09aaa2fa0c1d6164afc81073fd3/src/quicktimevideo.cpp#L734

I think that'll create a string of length 4 even if it's actually shorter, so it's better to just make sure that there's always a nul byte.

I also noticed a few places where the `DataBuf` is bigger than it needs to be, so I've cleaned that up to make the code more accurate.