### PR TITLE
Remove unnecessary resize

### DIFF
--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -616,9 +616,6 @@ void QuickTimeVideo::decodeBlock(size_t recursion_depth, std::string const& ente
 
   // std::cerr<<"Tag=>"<<buf.data()<<"     size=>"<<size-hdrsize << std::endl;
   const auto newsize = static_cast<size_t>(size - hdrsize);
-  if (newsize > buf.size()) {
-    buf.resize(newsize);
-  }
   tagDecoder(buf, newsize, recursion_depth + 1);
 }  // QuickTimeVideo::decodeBlock
 


### PR DESCRIPTION
This resize is unnecessary because `tagDecoder` only uses the first 4 bytes of `buf`. I think the resize was originally necessary, but became obsolete after #2378.

This is related to a security report that we received from @bugmithlegend (see comment below). I think their report is mostly an AI hallucination because I cannot reproduce their claim that the poc causes 384MB of memory allocation. (And even if I could reproduce it, I would not consider it to be a vulnerability.) But I agree that the performance of the code can be improved by removing this resize.