### PR TITLE
Add RecursionGuard

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -88,7 +88,8 @@ std::string time2Str(time_t time);
                 be kept.
   @return 0 if successful, else an error code
 */
-int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType targetType, bool preserve);
+int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType targetType, bool preserve,
+             const Exiv2::ImageCtorParams& params);
 
 /*!
   @brief Rename a file according to a timestamp value.
@@ -128,12 +129,16 @@ int dontOverwrite(const std::string& path);
 std::ostream& operator<<(std::ostream& os, const std::pair<std::string, int>& strAndWidth);
 
 //! Print image Structure information
-int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const std::string& path);
+int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const std::string& path,
+                   const Exiv2::ImageCtorParams& params);
 }  // namespace
 
 // *****************************************************************************
 // class member definitions
 namespace Action {
+
+Task::Task() : imageCtorParams_(false, true, Exiv2::RecursionLimit(Params::instance().max_recursion_depth_)) {
+}
 
 Task::UniquePtr Task::create(TaskType type) {
   switch (type) {
@@ -160,11 +165,12 @@ Task::UniquePtr Task::create(TaskType type) {
   }
 }
 
-static int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::string& path, bool binary) {
+static int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const std::string& path, bool binary,
+                                    const Exiv2::ImageCtorParams& params) {
   int result = 0;
   if (binary && option == Exiv2::kpsIccProfile) {
     std::stringstream output(std::stringstream::out | std::stringstream::binary);
-    result = printStructure(output, option, path);
+    result = printStructure(output, option, path, params);
     std::string str = output.str();
     if (result == 0 && !str.empty()) {
       Exiv2::DataBuf iccProfile(str.size());
@@ -183,7 +189,7 @@ static int setModeAndPrintStructure(Exiv2::PrintStructureOption option, const st
     }
   } else {
     _setmode(_fileno(stdout), O_BINARY);
-    result = printStructure(std::cout, option, path);
+    result = printStructure(std::cout, option, path, params);
   }
 
   return result;
@@ -202,13 +208,13 @@ int Print::run(const std::string& path) {
       case Params::pmPreview:
         return printPreviewList();
       case Params::pmStructure:
-        return printStructure(std::cout, Exiv2::kpsBasic, path_);
+        return printStructure(std::cout, Exiv2::kpsBasic, path_, imageCtorParams_);
       case Params::pmRecursive:
-        return printStructure(std::cout, Exiv2::kpsRecursive, path_);
+        return printStructure(std::cout, Exiv2::kpsRecursive, path_, imageCtorParams_);
       case Params::pmXMP:
-        return setModeAndPrintStructure(Exiv2::kpsXMP, path_, binary());
+        return setModeAndPrintStructure(Exiv2::kpsXMP, path_, binary(), imageCtorParams_);
       case Params::pmIccProfile:
-        return setModeAndPrintStructure(Exiv2::kpsIccProfile, path_, binary());
+        return setModeAndPrintStructure(Exiv2::kpsIccProfile, path_, binary(), imageCtorParams_);
     }
     return 0;
   } catch (const Exiv2::Error& e) {
@@ -226,7 +232,7 @@ int Print::printSummary() {
     return -1;
   }
 
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
   const Exiv2::ExifData& exifData = image->exifData();
   align_ = 16;
@@ -345,7 +351,7 @@ int Print::printList() {
     return -1;
   }
 
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
   // Set defaults for metadata types and data columns
   if (Params::instance().printTags_ == MetadataId::invalid) {
@@ -569,7 +575,7 @@ int Print::printComment() {
     return -1;
   }
 
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
   if (Params::instance().verbose_) {
     std::cout << _("JPEG comment") << ": ";
@@ -584,7 +590,7 @@ int Print::printPreviewList() {
     return -1;
   }
 
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
   bool const manyFiles = Params::instance().files_.size() > 1;
   int cnt = 0;
@@ -618,7 +624,7 @@ int Rename::run(const std::string& path) {
     if (Params::instance().preserve_)
       ts.read(path);
 
-    auto image = Exiv2::ImageFactory::open(path);
+    auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -680,7 +686,7 @@ int Erase::run(const std::string& path) {
     if (Params::instance().preserve_)
       ts.read(path);
 
-    auto image = Exiv2::ImageFactory::open(path_);
+    auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
     image->readMetadata();
     // Thumbnail must be before Exif
     int rc = 0;
@@ -703,7 +709,7 @@ int Erase::run(const std::string& path) {
       rc = eraseIccProfile(image.get());
     }
     if (0 == rc && Params::instance().target_ & Params::ctIptcRaw) {
-      rc = printStructure(std::cout, Exiv2::kpsIptcErase, path_);
+      rc = printStructure(std::cout, Exiv2::kpsIptcErase, path_, imageCtorParams_);
     }
 
     if (0 == rc) {
@@ -792,7 +798,7 @@ int Extract::run(const std::string& path) {
       std::string xmpPath = bStdout ? "-" : newFilePath(path_, ".xmp");
       if (dontOverwrite(xmpPath))
         return 0;
-      rc = metacopy(path_, xmpPath, Exiv2::ImageType::xmp, false);
+      rc = metacopy(path_, xmpPath, Exiv2::ImageType::xmp, false, imageCtorParams_);
     }
     if (!rc && Params::instance().target_ & Params::ctIccProfile) {
       std::string iccPath = bStdout ? "-" : newFilePath(path_, ".icc");
@@ -804,7 +810,7 @@ int Extract::run(const std::string& path) {
       std::string exvPath = bStdout ? "-" : newFilePath(path_, ".exv");
       if (dontOverwrite(exvPath))
         return 0;
-      rc = metacopy(path_, exvPath, Exiv2::ImageType::exv, false);
+      rc = metacopy(path_, exvPath, Exiv2::ImageType::exv, false, imageCtorParams_);
     }
     return rc;
   } catch (const Exiv2::Error& e) {
@@ -818,7 +824,7 @@ int Extract::writeThumbnail() const {
     std::cerr << path_ << ": " << _("Failed to open the file") << "\n";
     return -1;
   }
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
   Exiv2::ExifData& exifData = image->exifData();
   if (exifData.empty()) {
@@ -862,7 +868,7 @@ int Extract::writePreviews() const {
     return -1;
   }
 
-  auto image = Exiv2::ImageFactory::open(path_);
+  auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
   image->readMetadata();
 
   Exiv2::PreviewManager pvMgr(*image);
@@ -898,7 +904,7 @@ int Extract::writeIccProfile(const std::string& target) const {
   bool bStdout = target == "-";
 
   if (rc == 0) {
-    auto image = Exiv2::ImageFactory::open(path_);
+    auto image = Exiv2::ImageFactory::open(path_, imageCtorParams_);
     image->readMetadata();
     if (!image->iccProfileDefined()) {
       std::cerr << _("No embedded iccProfile: ") << path_ << '\n';
@@ -965,7 +971,7 @@ int Insert::run(const std::string& path) try {
     if (Params::instance().target_ & Params::ctXmpSidecar)
       suffix = ".xmp";
     std::string exvPath = bStdin ? "-" : newFilePath(path, suffix);
-    rc = metacopy(exvPath, path, Exiv2::ImageType::none, true);
+    rc = metacopy(exvPath, path, Exiv2::ImageType::none, true, imageCtorParams_);
   }
 
   if (0 == rc && (Params::instance().target_ & (Params::ctXmpSidecar | Params::ctXmpRaw))) {
@@ -986,7 +992,7 @@ int Insert::run(const std::string& path) try {
   return 1;
 }  // Insert::run
 
-int Insert::insertXmpPacket(const std::string& path, const std::string& xmpPath) {
+int Insert::insertXmpPacket(const std::string& path, const std::string& xmpPath) const {
   int rc = 0;
   bool bStdin = xmpPath == "-";
   if (bStdin) {
@@ -1011,9 +1017,9 @@ int Insert::insertXmpPacket(const std::string& path, const std::string& xmpPath)
 
 }  // Insert::insertXmpPacket
 
-int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket) {
+int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket) const {
   std::string xmpPacket(xmpBlob.begin(), xmpBlob.end());
-  auto image = Exiv2::ImageFactory::open(path);
+  auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
   image->readMetadata();
   image->clearXmpData();
   image->setXmpPacket(xmpPacket);
@@ -1023,7 +1029,7 @@ int Insert::insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBl
   return 0;
 }
 
-int Insert::insertIccProfile(const std::string& path, const std::string& iccPath) {
+int Insert::insertIccProfile(const std::string& path, const std::string& iccPath) const {
   int rc = 0;
   // for path "foo.XXX", do a binary copy of "foo.icc"
   std::string iccProfilePath = newFilePath(path, ".icc");
@@ -1043,7 +1049,7 @@ int Insert::insertIccProfile(const std::string& path, const std::string& iccPath
   return rc;
 }  // Insert::insertIccProfile
 
-int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfileBlob) {
+int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfileBlob) const {
   int rc = 0;
   // test path exists
   if (!Exiv2::fileExists(path)) {
@@ -1053,7 +1059,7 @@ int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfil
 
   // read in the metadata
   if (rc == 0) {
-    auto image = Exiv2::ImageFactory::open(path);
+    auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
     image->readMetadata();
     // clear existing profile, assign the blob and rewrite image
     image->clearIccProfile();
@@ -1066,7 +1072,7 @@ int Insert::insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfil
   return rc;
 }  // Insert::insertIccProfile
 
-int Insert::insertThumbnail(const std::string& path) {
+int Insert::insertThumbnail(const std::string& path) const {
   std::string thumbPath = newFilePath(path, "-thumb.jpg");
   if (!Exiv2::fileExists(thumbPath)) {
     std::cerr << thumbPath << ": " << _("Failed to open the file") << "\n";
@@ -1076,7 +1082,7 @@ int Insert::insertThumbnail(const std::string& path) {
     std::cerr << path << ": " << _("Failed to open the file") << "\n";
     return -1;
   }
-  auto image = Exiv2::ImageFactory::open(path);
+  auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
   image->readMetadata();
   Exiv2::ExifThumb exifThumb(image->exifData());
   exifThumb.setJpegThumbnail(thumbPath);
@@ -1095,7 +1101,7 @@ int Modify::run(const std::string& path) {
     if (Params::instance().preserve_)
       ts.read(path);
 
-    auto image = Exiv2::ImageFactory::open(path);
+    auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
     image->readMetadata();
 
     int rc = applyCommands(image.get());
@@ -1300,7 +1306,7 @@ int Adjust::run(const std::string& path) try {
   if (Params::instance().preserve_)
     ts.read(path);
 
-  auto image = Exiv2::ImageFactory::open(path);
+  auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
   image->readMetadata();
   Exiv2::ExifData& exifData = image->exifData();
   if (exifData.empty()) {
@@ -1443,7 +1449,7 @@ int FixIso::run(const std::string& path) {
     if (Params::instance().preserve_)
       ts.read(path);
 
-    auto image = Exiv2::ImageFactory::open(path);
+    auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -1487,7 +1493,7 @@ int FixCom::run(const std::string& path) {
     if (Params::instance().preserve_)
       ts.read(path);
 
-    auto image = Exiv2::ImageFactory::open(path);
+    auto image = Exiv2::ImageFactory::open(path, imageCtorParams_);
     image->readMetadata();
     Exiv2::ExifData& exifData = image->exifData();
     if (exifData.empty()) {
@@ -1651,7 +1657,8 @@ std::string temporaryPath() {
   return p.string();
 }
 
-int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType targetType, bool preserve) {
+int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType targetType, bool preserve,
+             const Exiv2::ImageCtorParams& params) {
 #ifdef EXIV2_DEBUG_MESSAGES
   std::cerr << "actions.cpp::metacopy"
             << " source = " << source << " target = " << tgt << '\n';
@@ -1672,9 +1679,9 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
   if (bStdin) {
     Params::instance().getStdin(stdIn);
     auto ioStdin = std::make_unique<Exiv2::MemIo>(stdIn.c_data(), stdIn.size());
-    sourceImage = Exiv2::ImageFactory::open(std::move(ioStdin));
+    sourceImage = Exiv2::ImageFactory::open(std::move(ioStdin), params);
   } else {
-    sourceImage = Exiv2::ImageFactory::open(source);
+    sourceImage = Exiv2::ImageFactory::open(source, params);
   }
 
   sourceImage->readMetadata();
@@ -1687,10 +1694,10 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
 
   std::unique_ptr<Exiv2::Image> targetImage;
   if (Exiv2::fileExists(target)) {
-    targetImage = Exiv2::ImageFactory::open(target);
+    targetImage = Exiv2::ImageFactory::open(target, params);
     targetImage->readMetadata();
   } else {
-    targetImage = Exiv2::ImageFactory::create(targetType, target);
+    targetImage = Exiv2::ImageFactory::create(targetType, target, params);
   }
 
   // Copy each type of metadata
@@ -1943,12 +1950,13 @@ std::ostream& operator<<(std::ostream& os, const std::pair<std::string, int>& st
   return os << std::setw(minChCount) << str;
 }
 
-int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const std::string& path) {
+int printStructure(std::ostream& out, Exiv2::PrintStructureOption option, const std::string& path,
+                   const Exiv2::ImageCtorParams& params) {
   if (!Exiv2::fileExists(path)) {
     std::cerr << path << ": " << _("Failed to open the file") << "\n";
     return -1;
   }
-  Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+  Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path, params);
   image->printStructure(out, option);
   return 0;
 }

--- a/app/actions.hpp
+++ b/app/actions.hpp
@@ -60,9 +60,9 @@ class Task {
   //! Virtual destructor.
   virtual ~Task() = default;
 
-  Task() = default;
-  Task(const Task&) = default;
-  Task& operator=(const Task&) = default;
+  Task();
+  Task(const Task&) = delete;
+  Task& operator=(const Task&) = delete;
 
   /// @brief Application interface to perform a task.
   /// @param path Path of the file to process.
@@ -90,6 +90,9 @@ class Task {
             an exception) if it is 0.
    */
   static Task::UniquePtr create(TaskType type);
+
+ protected:
+  const Exiv2::ImageCtorParams imageCtorParams_;
 
  private:
   //! copy binary_ from command-line params to task
@@ -226,19 +229,19 @@ class Insert : public Task {
            The filename of the thumbnail is expected to be the image
            filename (\em path) minus its suffix plus "-thumb.jpg".
    */
-  static int insertThumbnail(const std::string& path);
+  int insertThumbnail(const std::string& path) const;
 
   /// @brief Insert an XMP packet from a xmpPath into file \em path.
-  static int insertXmpPacket(const std::string& path, const std::string& xmpPath);
+  int insertXmpPacket(const std::string& path, const std::string& xmpPath) const;
 
   /// @brief Insert xmp from a DataBuf into file \em path.
-  static int insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket = false);
+  int insertXmpPacket(const std::string& path, const Exiv2::DataBuf& xmpBlob, bool usePacket = false) const;
 
   /// @brief Insert an ICC profile from iccPath into file \em path.
-  static int insertIccProfile(const std::string& path, const std::string& iccPath);
+  int insertIccProfile(const std::string& path, const std::string& iccPath) const;
 
   /// @brief Insert an ICC profile from binary DataBuf into file \em path.
-  static int insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfileBlob);
+  int insertIccProfile(const std::string& path, Exiv2::DataBuf&& iccProfileBlob) const;
 };
 
 /// @brief %Modify the Exif data according to the commands in the modification table.

--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -194,10 +194,11 @@ int main(int argc, char* const argv[]) {
 // class Params
 
 Params::Params() :
-    optstring_(":hVvqfbuktTFa:Y:O:D:r:p:P:d:e:i:c:m:M:l:S:g:K:n:Q:"),
+    optstring_(":hVvqfbuktTFa:Y:O:D:r:p:P:d:e:i:c:m:M:l:S:g:K:n:Q:R:"),
     target_(ctExif | ctIptc | ctComment | ctXmp),
     yodAdjust_(emptyYodAdjust_),
-    format_("%Y%m%d_%H%M%S") {
+    format_("%Y%m%d_%H%M%S"),
+    max_recursion_depth_(1000) {
 }
 
 Params& Params::instance() {
@@ -264,6 +265,7 @@ void Params::help(std::ostream& os) const {
      << _("   -V      Show the program version and exit\n") << _("   -v      Be verbose during the program run\n")
      << _("   -q      Silence warnings and error messages (quiet)\n")
      << _("   -Q lvl  Set log-level to d(ebug), i(nfo), w(arning), e(rror) or m(ute)\n")
+     << _("   -R num  Set maximum recursion depth limit. 0 means no limit.\n")
      << _("   -b      Obsolete, reserved for use with the test suit\n")
      << _("   -u      Show unknown tags (e.g., Exif.SonyMisc3c.0x022b)\n")
      << _("   -g str  Only output where 'str' matches in output text (grep)\n"
@@ -365,6 +367,9 @@ int Params::option(int opt, const std::string& optArg, int optOpt) {
       break;
     case 'Q':
       rc = setLogLevel(optArg);
+      break;
+    case 'R':
+      rc = setRecursionLimit(optArg);
       break;
     case 'k':
       preserve_ = true;
@@ -491,6 +496,27 @@ int Params::setLogLevel(const std::string& optArg) {
   }
   return rc;
 }  // Params::setLogLevel
+
+int Params::setRecursionLimit(const std::string& optArg) {
+  int64_t n = 0;
+  if (!Util::strtol(optArg.c_str(), n)) {
+    std::cerr << progname() << ": " << _("Error parsing maximum recursion depth") << " "
+              << " `" << optArg << "'\n";
+    return 1;
+  }
+
+  if (n > 0) {
+    const uint64_t u = static_cast<uint64_t>(n);
+    if (u <= std::numeric_limits<size_t>::max()) {
+      max_recursion_depth_ = static_cast<size_t>(u);
+      return 0;
+    }
+  }
+
+  // Zero or negative means no limit.
+  max_recursion_depth_ = std::numeric_limits<size_t>::max();
+  return 0;
+}  // Params::setRecursionLimit
 
 int Params::evalGrep(const std::string& optArg) {
   // check that string ends in "/i"

--- a/app/exiv2app.hpp
+++ b/app/exiv2app.hpp
@@ -222,6 +222,7 @@ class Params : public Util::Getopt {
   std::vector<std::regex> greps_;       //!< List of keys to 'grep' from the metadata
   Keys keys_;                           //!< List of keys to match from the metadata
   std::string charset_;                 //!< Charset to use for UNICODE Exif user comment
+  size_t max_recursion_depth_;          //!< Guards against very deeply nested files
 
   Exiv2::DataBuf stdinBuf;  //!< DataBuf with the binary bytes from stdin
 
@@ -233,6 +234,7 @@ class Params : public Util::Getopt {
   //! @name Helpers
   //@{
   int setLogLevel(const std::string& optarg);
+  int setRecursionLimit(const std::string& optarg);
   int evalGrep(const std::string& optarg);
   int evalKey(const std::string& optarg);
   int evalRename(int opt, const std::string& optarg);

--- a/include/exiv2/asfvideo.hpp
+++ b/include/exiv2/asfvideo.hpp
@@ -119,15 +119,13 @@ class EXIV2API AsfVideo : public Image {
   /*!
     @brief Check for a valid tag and decode the block at the current IO
     position. Calls tagDecoder() or skips to next tag, if required.
-    @param depth Current recursion depth, to detect files with excessive nesting.
    */
-  void decodeBlock(size_t depth);
+  void decodeBlock();
 
   /*!
     @brief Parse the header
-    @param depth Current recursion depth, to detect files with excessive nesting.
    */
-  void decodeHeader(size_t depth);
+  void decodeHeader();
   /*!
     @brief Interpret File_Properties tag information, and save it in
         the respective XMP container.

--- a/include/exiv2/error.hpp
+++ b/include/exiv2/error.hpp
@@ -223,6 +223,7 @@ enum class ErrorCode {
   kerMallocFailed,
   kerInvalidIconvEncoding,
   kerFileAccessDisabled,
+  kerMaxRecursionDepth,
 
   kerErrorCount,
 };

--- a/include/exiv2/image.hpp
+++ b/include/exiv2/image.hpp
@@ -12,6 +12,7 @@
 #include "exif.hpp"
 #include "image_types.hpp"
 #include "iptc.hpp"
+#include "recursion_guard.hpp"
 #include "xmp_exiv2.hpp"
 
 // *****************************************************************************
@@ -48,19 +49,31 @@ enum PrintStructureOption { kpsNone, kpsBasic, kpsXMP, kpsRecursive, kpsIccProfi
  */
 class EXIV2API ImageCtorParams {
  public:
-  ImageCtorParams(bool create, size_t max_recursion_depth);
+  ImageCtorParams(bool create, bool useCurl, RecursionLimit max_recursion_depth);
 
   bool create() const {
     return create_;
   }
 
-  size_t max_recursion_depth() const {
+  bool useCurl() const {
+    return useCurl_;
+  }
+
+  RecursionLimit max_recursion_depth() const {
     return max_recursion_depth_;
   }
 
+  //! Return a new version of the params with an updated value
+  //! for the create field.
+  ImageCtorParams withCreate(bool create) const;
+
+  // Default settings, useful for things like the applications in the samples directory.
+  static ImageCtorParams defaultSettings();
+
  private:
   const bool create_;
-  const size_t max_recursion_depth_;
+  const bool useCurl_;
+  const RecursionLimit max_recursion_depth_;
 };
 
 /*!
@@ -475,6 +488,10 @@ class EXIV2API Image {
   [[nodiscard]] bool writeXmpFromPacket() const;
   //! Return list of native previews. This is meant to be used only by the PreviewManager.
   [[nodiscard]] const NativePreviewList& nativePreviews() const;
+  //! Get the current recursion limit.
+  [[nodiscard]] RecursionLimit recursion_limit() const {
+    return recursion_limit_;
+  };
   //@}
 
   //! set type support for this image format
@@ -508,7 +525,7 @@ class EXIV2API Image {
   uint32_t pixelWidth_{0};            //!< image pixel width
   uint32_t pixelHeight_{0};           //!< image pixel height
   NativePreviewList nativePreviews_;  //!< list of native previews
-  const size_t max_recursion_depth_;  //!< don't allow recursion deeper than this
+  RecursionLimit recursion_limit_;    //!< don't allow recursion deeper than this
 
   //! Return tag name for given tag id.
   const std::string& tagName(uint16_t tag);
@@ -577,9 +594,11 @@ class EXIV2API ImageFactory {
     @throw Error If opening the file fails or it contains data of an
         unknown image type.
    */
-  static Image::UniquePtr open(const std::string& path, bool useCurl = true);
+  static Image::UniquePtr open(const std::string& path,
+                               const ImageCtorParams& params = ImageCtorParams::defaultSettings());
 #ifdef _WIN32
-  static Image::UniquePtr open(const std::wstring& path);
+  static Image::UniquePtr open(const std::wstring& path,
+                               const ImageCtorParams& params = ImageCtorParams::defaultSettings());
 #endif
   /*!
     @brief Create an Image subclass of the appropriate type by reading
@@ -592,7 +611,8 @@ class EXIV2API ImageFactory {
         matches that of the data buffer.
     @throw Error If the memory contains data of an unknown image type.
    */
-  static Image::UniquePtr open(const byte* data, size_t size);
+  static Image::UniquePtr open(const byte* data, size_t size,
+                               const ImageCtorParams& params = ImageCtorParams::defaultSettings());
   /*!
     @brief Create an Image subclass of the appropriate type by reading
         the provided BasicIo instance. %Image type is derived from the
@@ -610,7 +630,8 @@ class EXIV2API ImageFactory {
         determined, the pointer is 0.
     @throw Error If opening the BasicIo fails
    */
-  static Image::UniquePtr open(std::unique_ptr<BasicIo> io);
+  static Image::UniquePtr open(std::unique_ptr<BasicIo> io,
+                               const ImageCtorParams& params = ImageCtorParams::defaultSettings());
   /*!
     @brief Create an Image subclass of the requested type by creating a
         new image file. If the file already exists, it will be overwritten.
@@ -620,7 +641,8 @@ class EXIV2API ImageFactory {
         type.
     @throw Error If the image type is not supported.
    */
-  static Image::UniquePtr create(ImageType type, const std::string& path);
+  static Image::UniquePtr create(ImageType type, const std::string& path,
+                                 const ImageCtorParams& params = ImageCtorParams::defaultSettings());
   /*!
     @brief Create an Image subclass of the requested type by creating a
         new image in memory.
@@ -629,7 +651,7 @@ class EXIV2API ImageFactory {
         type.
     @throw Error If the image type is not supported
    */
-  static Image::UniquePtr create(ImageType type);
+  static Image::UniquePtr create(ImageType type, const ImageCtorParams& params = ImageCtorParams::defaultSettings());
 
   /*!
     @brief Create an Image subclass of the requested type by writing a
@@ -646,7 +668,8 @@ class EXIV2API ImageFactory {
         type. If the image type is not supported, the pointer is 0.
    */
 
-  static Image::UniquePtr create(ImageType type, std::unique_ptr<BasicIo> io);
+  static Image::UniquePtr create(ImageType type, std::unique_ptr<BasicIo> io,
+                                 const ImageCtorParams& params = ImageCtorParams::defaultSettings());
   /*!
     @brief Returns the image type of the provided file.
     @param path %Image file. The contents of the file are tested to

--- a/include/exiv2/params.hpp
+++ b/include/exiv2/params.hpp
@@ -5,6 +5,7 @@
 
 // *****************************************************************************
 #include "exiv2lib_export.h"
+#include "recursion_guard.hpp"
 
 // *****************************************************************************
 // namespace extensions
@@ -20,14 +21,14 @@ namespace Exiv2 {
  */
 class EXIV2API DecodeParams {
  public:
-  explicit DecodeParams(size_t max_recursion_depth);
+  explicit DecodeParams(RecursionLimit max_recursion_depth);
 
-  size_t max_recursion_depth() const {
+  RecursionLimit max_recursion_depth() const {
     return max_recursion_depth_;
   }
 
  private:
-  const size_t max_recursion_depth_;
+  const RecursionLimit max_recursion_depth_;
 };
 
 }  // namespace Exiv2

--- a/include/exiv2/quicktimevideo.hpp
+++ b/include/exiv2/quicktimevideo.hpp
@@ -71,7 +71,7 @@ class EXIV2API QuickTimeVideo : public Image {
     @brief Check for a valid tag and decode the block at the current IO
     position. Calls tagDecoder() or skips to next tag, if required.
    */
-  void decodeBlock(size_t recursion_depth, std::string const& entered_from = "");
+  void decodeBlock(std::string const& entered_from = "");
   /*!
     @brief Interpret tag information, and call the respective function
         to save it in the respective XMP container. Decodes a Tag
@@ -80,7 +80,7 @@ class EXIV2API QuickTimeVideo : public Image {
     @param buf Data buffer which contains tag ID.
     @param size Size of the data block used to store Tag Information.
    */
-  void tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursion_depth);
+  void tagDecoder(Exiv2::DataBuf& buf, size_t size);
 
  private:
   /*!
@@ -123,7 +123,7 @@ class EXIV2API QuickTimeVideo : public Image {
     @brief Interpret Tag which contain other sub-tags,
         and save it in the respective XMP container.
    */
-  void multipleEntriesDecoder(size_t recursion_depth);
+  void multipleEntriesDecoder();
   /*!
     @brief Interpret Sample Description Tag, and save it
         in the respective XMP container.
@@ -140,7 +140,7 @@ class EXIV2API QuickTimeVideo : public Image {
         in the respective XMP container.
     @param outer_size Size of the data block used to store Tag Information.
    */
-  void userDataDecoder(size_t outer_size, size_t recursion_depth);
+  void userDataDecoder(size_t outer_size);
   /*!
     @brief Interpret Preview Tag, and save it
         in the respective XMP container.

--- a/include/exiv2/recursion_guard.hpp
+++ b/include/exiv2/recursion_guard.hpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef EXIV2_RECURSION_GUARD_HPP
+#define EXIV2_RECURSION_GUARD_HPP
+
+// *****************************************************************************
+#include <cstddef>
+#include "error.hpp"
+
+// *****************************************************************************
+// namespace extensions
+namespace Exiv2 {
+
+/*!
+  @brief RecursionLimit is used in combination with RecursionGuard
+  (below) to prevent excessively deep recursion (which could cause
+  stack exhaustion if Exiv2 is run on a very deeply nested file.
+  The Image class has a field of type RecursionLimit which tracks
+  the remaining number of recursions allowed. It is decremented at
+  the beginning of every recursive function and incremented on exit.
+  An exception is thrown if the zero is reached. The incrementing
+  and decrementing is done by RecursionGuard.
+ */
+class EXIV2API RecursionLimit final {
+  friend class RecursionGuard;
+
+ public:
+  explicit RecursionLimit(size_t limit) : remaining_(limit) {
+  }
+
+  size_t remaining() const {
+    return remaining_;
+  }
+
+ private:
+  //! Remaining quota of recursive calls. Gets decremented at the
+  //! beginning of a recursive function and incremented at the end. An
+  //! exception will be thrown if this number hits zero.
+  size_t remaining_;
+};  // class RecursionLimit
+
+/*!
+  @brief Used to prevent excessively deep recursion (which could
+  cause stack exhaustion if Exiv2 is run on a very deeply nested file.
+
+  This class is intended to be declared as a local variable at the
+  beginning of a recursive method. Its constructor is given a
+  reference to a variable of type RecursionLimit. The RecursionLimit
+  reference is decremented by RecursionGuard's constructor and
+  incremented back to its original value by RecursionGuard's destructor.
+  An exception is thrown if the limit drops to zero.
+
+  Usage: add this statement to the beginning of every recursive
+  method of an Image class:
+
+  RECURSION_GUARD(recursion_limit_);
+*/
+class EXIV2API RecursionGuard final {
+ public:
+  explicit RecursionGuard(RecursionLimit& limit) : limit_(limit) {
+    if (limit_.remaining_ == 0) {
+      throw Error(ErrorCode::kerMaxRecursionDepth);
+    }
+    limit_.remaining_--;
+  }
+
+  ~RecursionGuard() {
+    limit_.remaining_++;
+  }
+
+  // Prevent copying
+  RecursionGuard() = delete;
+  RecursionGuard(const RecursionGuard&) = delete;
+  RecursionGuard& operator=(const RecursionGuard&) = delete;
+  RecursionGuard(RecursionGuard&&) = delete;
+  RecursionGuard& operator=(RecursionGuard&&) = delete;
+
+ private:
+  RecursionLimit& limit_;
+};  // class RecursionGuard
+
+}  // namespace Exiv2
+
+#define RECURSION_GUARD(limit) Exiv2::RecursionGuard _recursion_guard(limit)
+
+#endif  // EXIV2_RECURSION_GUARD_HPP

--- a/include/meson.build
+++ b/include/meson.build
@@ -30,6 +30,7 @@ headers = files(
   'exiv2/properties.hpp',
   'exiv2/psdimage.hpp',
   'exiv2/rafimage.hpp',
+  'exiv2/recursion_guard.hpp',
   'exiv2/rw2image.hpp',
   'exiv2/slice.hpp',
   'exiv2/tags.hpp',

--- a/samples/remotetest.cpp
+++ b/samples/remotetest.cpp
@@ -23,6 +23,8 @@ int main(int argc, char* const argv[]) {
         useCurlFromExiv2TestApps = true;
     }
 
+    Exiv2::ImageCtorParams params(false, useCurlFromExiv2TestApps, Exiv2::RecursionLimit(500));
+
     std::string file(argv[1]);
 
     // set/add metadata
@@ -39,13 +41,13 @@ int main(int argc, char* const argv[]) {
     Exiv2::ExifKey key("Exif.Image.DateTime");
     exifData.add(key, v.get());
 
-    auto writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    auto writeTest = Exiv2::ImageFactory::open(file, params);
     writeTest->setExifData(exifData);
     writeTest->writeMetadata();
 
     // read the result to make sure everything fine
     std::cout << "Print out the new metadata ...\n";
-    auto readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+    auto readTest = Exiv2::ImageFactory::open(file, params);
     readTest->readMetadata();
     Exiv2::ExifData& exifReadData = readTest->exifData();
     if (exifReadData.empty()) {

--- a/samples/tiff-test.cpp
+++ b/samples/tiff-test.cpp
@@ -55,15 +55,14 @@ void mini1(const char* path) {
   Internal::enforce(wm == wmIntrusive, Exiv2::ErrorCode::kerErrorMessage, "encode returned an unexpected value");
   std::cout << "Test 3: Wrote non-empty Exif data without original binary data:\n";
   exifData.clear();
-  const DecodeParams dp(500);
+  const DecodeParams dp(Exiv2::RecursionLimit(500));
   ByteOrder bo = ExifParser::decode(exifData, blob.data(), blob.size(), dp);
   Internal::enforce(bo == bigEndian, Exiv2::ErrorCode::kerErrorMessage, "decode returned an unexpected value");
   print(exifData);
 }
 
 void mini9(const char* path) {
-  const Exiv2::ImageCtorParams params(false, 500);
-  TiffImage tiffImage(std::make_unique<FileIo>(path), params);
+  TiffImage tiffImage(std::make_unique<FileIo>(path), Exiv2::ImageCtorParams::defaultSettings());
   tiffImage.readMetadata();
 
   std::cout << "MIME type:  " << tiffImage.mimeType() << "\n";

--- a/samples/xmpparse.cpp
+++ b/samples/xmpparse.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* const argv[]) try {
   std::string xmpPacket;
   xmpPacket.assign(buf.c_str(), buf.size());
   Exiv2::XmpData xmpData;
-  const Exiv2::DecodeParams dp(500);
+  const Exiv2::DecodeParams dp(Exiv2::RecursionLimit(500));
   if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket, dp)) {
     std::string error(argv[1]);
     error += ": Failed to parse file contents (XMP packet)";

--- a/samples/xmpparser-test.cpp
+++ b/samples/xmpparser-test.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* const argv[]) try {
   xmpPacket.assign(buf.c_str(), buf.size());
   std::cerr << "-----> Decoding XMP data read from " << filename << " <-----\n";
   Exiv2::XmpData xmpData;
-  const Exiv2::DecodeParams dp(500);
+  const Exiv2::DecodeParams dp(Exiv2::RecursionLimit(500));
   if (0 != Exiv2::XmpParser::decode(xmpData, xmpPacket, dp)) {
     std::string error(argv[1]);
     error += ": Failed to parse file contents (XMP packet)";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,7 @@ set(PUBLIC_HEADERS
     ../include/exiv2/properties.hpp
     ../include/exiv2/psdimage.hpp
     ../include/exiv2/rafimage.hpp
+    ../include/exiv2/recursion_guard.hpp
     ../include/exiv2/rw2image.hpp
     ../include/exiv2/slice.hpp
     ../include/exiv2/tags.hpp

--- a/src/asfvideo.cpp
+++ b/src/asfvideo.cpp
@@ -209,7 +209,7 @@ void AsfVideo::readMetadata() {
   xmpData()["Xmp.video.FileSize"] = io_->size() / 1048576.;
   xmpData()["Xmp.video.MimeType"] = mimeType();
 
-  decodeBlock(0);
+  decodeBlock();
 
   xmpData_["Xmp.video.AspectRatio"] = getAspectRatio(width_, height_);
 }  // AsfVideo::readMetadata
@@ -224,7 +224,7 @@ AsfVideo::HeaderReader::HeaderReader(const BasicIo::UniquePtr& io) : IdBuf_(GUID
   }
 }
 
-void AsfVideo::decodeBlock(size_t depth) {
+void AsfVideo::decodeBlock() {
   Internal::enforce(GUID + QWORD <= io_->size() - io_->tell(), Exiv2::ErrorCode::kerCorruptedMetadata);
   HeaderReader objectHeader(io_);
 #ifdef EXIV2_DEBUG_MESSAGES
@@ -236,7 +236,7 @@ void AsfVideo::decodeBlock(size_t depth) {
 
   if (tag != GUIDReferenceTags.end()) {
     if (tag->second == "Header")
-      decodeHeader(depth + 1);
+      decodeHeader();
     else if (tag->second == "File_Properties")
       fileProperties();
     else if (tag->second == "Stream_Properties")
@@ -270,8 +270,8 @@ void AsfVideo::decodeBlock(size_t depth) {
 
 }  // AsfVideo::decodeBlock
 
-void AsfVideo::decodeHeader(size_t depth) {
-  Internal::enforce(depth <= max_recursion_depth_, Exiv2::ErrorCode::kerCorruptedMetadata);
+void AsfVideo::decodeHeader() {
+  RECURSION_GUARD(recursion_limit_);
   DataBuf nbHeadersBuf(DWORD + 1);
   io_->readOrThrow(nbHeadersBuf.data(), DWORD, Exiv2::ErrorCode::kerCorruptedMetadata);
 
@@ -280,7 +280,7 @@ void AsfVideo::decodeHeader(size_t depth) {
   io_->seekOrThrow(io_->tell() + (BYTE * 2), BasicIo::beg,
                    ErrorCode::kerFailedToReadImageData);  // skip two reserved tags
   for (uint32_t i = 0; i < nb_headers; i++) {
-    decodeBlock(depth);
+    decodeBlock();
   }
 }
 

--- a/src/bmffimage.cpp
+++ b/src/bmffimage.cpp
@@ -225,11 +225,12 @@ void BmffImage::brotliUncompress(const byte* compressedBuf, size_t compressedBuf
 
 uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintStructureOption option /* = kpsNone */,
                                uint64_t pbox_end, size_t depth) {
+  RECURSION_GUARD(recursion_limit_);
   const size_t address = io_->tell();
   // never visit a box twice!
   if (depth == 0)
     visits_.clear();
-  if (visits_.contains(address) || visits_.size() > visits_max_ || depth >= max_recursion_depth_) {
+  if (visits_.contains(address) || visits_.size() > visits_max_) {
     throw Error(ErrorCode::kerCorruptedMetadata);
   }
   visits_.insert(address);
@@ -532,7 +533,7 @@ uint64_t BmffImage::boxHandler(std::ostream& out /* = std::cout*/, Exiv2::PrintS
 #ifdef EXV_HAVE_BROTLI
       DataBuf arr;
       brotliUncompress(data.c_data(4), data.size() - 4, arr);
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       if (realType == TAG::exif) {
         uint32_t offset = Safe::add(arr.read_uint32(0, endian_), 4u);
         Internal::enforce(Safe::add(offset, 4u) < arr.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
@@ -602,7 +603,7 @@ void BmffImage::parseTiff(uint32_t root_tag, uint64_t length, uint64_t start) {
         punt = i;
     }
     if (punt != eof) {
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(), exif.c_data(punt), exif.size() - punt,
                                          root_tag, Internal::TiffMapping::findDecoder, dp);
     }
@@ -622,7 +623,7 @@ void BmffImage::parseTiff(uint32_t root_tag, uint64_t length) {
     if (bufRead != data.size())
       throw Error(ErrorCode::kerInputDataReadFailed);
 
-    const DecodeParams dp(max_recursion_depth_);
+    const DecodeParams dp(recursion_limit());
     Internal::TiffParserWorker::decode(exifData(), iptcData(), xmpData(), data.c_data(), data.size(), root_tag,
                                        Internal::TiffMapping::findDecoder, dp);
   }
@@ -643,7 +644,7 @@ void BmffImage::parseXmp(uint64_t length, uint64_t start) {
   if (io_->error())
     throw Error(ErrorCode::kerFailedToReadImageData);
   try {
-    const DecodeParams dp(max_recursion_depth_);
+    const DecodeParams dp(recursion_limit());
     Exiv2::XmpParser::decode(xmpData(), std::string(xmp.c_str()), dp);
   } catch (...) {
     throw Error(ErrorCode::kerFailedToReadImageData);

--- a/src/cr2image.cpp
+++ b/src/cr2image.cpp
@@ -71,7 +71,7 @@ void Cr2Image::readMetadata() {
     throw Error(ErrorCode::kerNotAnImage, "CR2");
   }
   clearMetadata();
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   ByteOrder bo = Cr2Parser::decode(exifData_, iptcData_, xmpData_, io_->mmap(), io_->size(), dp);
   setByteOrder(bo);
 }  // Cr2Image::readMetadata

--- a/src/epsimage.cpp
+++ b/src/epsimage.cpp
@@ -1057,7 +1057,7 @@ void EpsImage::readMetadata() {
   readWriteEpsMetadata(*io_, xmpPacket_, nativePreviews_, /* write = */ false);
 
   // decode XMP metadata
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp) > 1) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Failed to decode XMP metadata.\n";

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -92,6 +92,7 @@ constexpr std::array errList{
     N_("Memory allocation failed"),                              // kerMallocFailed
     N_("Cannot convert text encoding from '%1' to '%2'"),        // kerInvalidIconvEncoding
     N_("%1: File access disabled in exiv2 build options"),       // kerFileAccessDisabled %1=path
+    N_("File is too deeply nested"),                             // kerMaxRecursionDepth
 };
 static_assert(errList.size() == static_cast<size_t>(Exiv2::ErrorCode::kerErrorCount),
               "errList needs to contain a error msg for every ErrorCode defined in error.hpp");

--- a/src/exif.cpp
+++ b/src/exif.cpp
@@ -490,7 +490,7 @@ ExifData::iterator ExifData::erase(ExifData::iterator pos) {
   return exifMetadata_.erase(pos);
 }
 
-DecodeParams::DecodeParams(size_t max_recursion_depth) : max_recursion_depth_(max_recursion_depth) {
+DecodeParams::DecodeParams(RecursionLimit max_recursion_depth) : max_recursion_depth_(max_recursion_depth) {
 }
 
 ByteOrder ExifParser::decode(ExifData& exifData, const byte* pData, size_t size, const DecodeParams& dp) {

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -137,13 +137,21 @@ std::string pathOfFileUrl(const std::string& url) {
 // class member definitions
 namespace Exiv2 {
 
-ImageCtorParams::ImageCtorParams(bool create, size_t max_recursion_depth) :
-    create_(create), max_recursion_depth_(max_recursion_depth) {
+ImageCtorParams::ImageCtorParams(bool create, bool useCurl, RecursionLimit max_recursion_depth) :
+    create_(create), useCurl_(useCurl), max_recursion_depth_(max_recursion_depth) {
+}
+
+ImageCtorParams ImageCtorParams::withCreate(bool create) const {
+  return ImageCtorParams(create, useCurl_, max_recursion_depth_);
+}
+
+ImageCtorParams ImageCtorParams::defaultSettings() {
+  return Exiv2::ImageCtorParams(false, true, Exiv2::RecursionLimit(1000));
 }
 
 Image::Image(ImageType type, uint16_t supportedMetadata, BasicIo::UniquePtr io, const ImageCtorParams& params) :
     io_(std::move(io)),
-    max_recursion_depth_(params.max_recursion_depth()),
+    recursion_limit_(params.max_recursion_depth()),
     imageType_(type),
     supportedMetadata_(supportedMetadata) {
 }
@@ -618,7 +626,7 @@ void Image::clearXmpPacket() {
 }
 
 void Image::setXmpPacket(const std::string& xmpPacket) {
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   if (XmpParser::decode(xmpData_, xmpPacket, dp)) {
     throw Error(ErrorCode::kerInvalidXMP);
   }
@@ -855,16 +863,16 @@ BasicIo::UniquePtr ImageFactory::createIo(const std::wstring& path) {
 }
 #endif
 
-Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl) {
-  auto image = open(ImageFactory::createIo(path, useCurl));  // may throw
+Image::UniquePtr ImageFactory::open(const std::string& path, const ImageCtorParams& params) {
+  auto image = open(ImageFactory::createIo(path, params.useCurl()), params);  // may throw
   if (!image)
     throw Error(ErrorCode::kerFileContainsUnknownImageType, path);
   return image;
 }
 
 #ifdef _WIN32
-Image::UniquePtr ImageFactory::open(const std::wstring& path) {
-  auto image = open(ImageFactory::createIo(path));  // may throw
+Image::UniquePtr ImageFactory::open(const std::wstring& path, const ImageCtorParams& params) {
+  auto image = open(ImageFactory::createIo(path), params);  // may throw
   if (!image) {
     char t[1024];
     WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, t, 1024, nullptr, nullptr);
@@ -874,27 +882,27 @@ Image::UniquePtr ImageFactory::open(const std::wstring& path) {
 }
 #endif
 
-Image::UniquePtr ImageFactory::open(const byte* data, size_t size) {
-  auto image = open(std::make_unique<MemIo>(data, size));  // may throw
+Image::UniquePtr ImageFactory::open(const byte* data, size_t size, const ImageCtorParams& params) {
+  auto image = open(std::make_unique<MemIo>(data, size), params);  // may throw
   if (!image)
     throw Error(ErrorCode::kerMemoryContainsUnknownImageType);
   return image;
 }
 
-Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io) {
+Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io, const ImageCtorParams& params) {
   if (io->open() != 0) {
     throw Error(ErrorCode::kerDataSourceOpenFailed, io->path(), strError());
   }
   for (const auto& r : registry) {
     if (r.isThisType_(*io, false)) {
-      return r.newInstance_(std::move(io), ImageCtorParams(false, 1000));
+      return r.newInstance_(std::move(io), params.withCreate(false));
     }
   }
   return nullptr;
 }
 
 #ifdef EXV_ENABLE_FILESYSTEM
-Image::UniquePtr ImageFactory::create(ImageType type, const std::string& path) {
+Image::UniquePtr ImageFactory::create(ImageType type, const std::string& path, const ImageCtorParams& params) {
   auto fileIo = std::make_unique<FileIo>(path);
   // Create or overwrite the file, then close it
   if (fileIo->open("w+b") != 0) {
@@ -903,26 +911,26 @@ Image::UniquePtr ImageFactory::create(ImageType type, const std::string& path) {
   fileIo->close();
 
   BasicIo::UniquePtr io(std::move(fileIo));
-  auto image = create(type, std::move(io));
+  auto image = create(type, std::move(io), params);
   if (!image)
     throw Error(ErrorCode::kerUnsupportedImageType, static_cast<int>(type));
   return image;
 }
 #endif
 
-Image::UniquePtr ImageFactory::create(ImageType type) {
-  auto image = create(type, std::make_unique<MemIo>());
+Image::UniquePtr ImageFactory::create(ImageType type, const ImageCtorParams& params) {
+  auto image = create(type, std::make_unique<MemIo>(), params);
   if (!image)
     throw Error(ErrorCode::kerUnsupportedImageType, static_cast<int>(type));
   return image;
 }
 
-Image::UniquePtr ImageFactory::create(ImageType type, BasicIo::UniquePtr io) {
+Image::UniquePtr ImageFactory::create(ImageType type, BasicIo::UniquePtr io, const ImageCtorParams& params) {
   // BasicIo instance does not need to be open
   if (type == ImageType::none)
     return {};
   if (auto r = Exiv2::find(registry, type))
-    return r->newInstance_(std::move(io), ImageCtorParams(true, 1000));
+    return r->newInstance_(std::move(io), params.withCreate(true));
   return {};
 }
 

--- a/src/jp2image.cpp
+++ b/src/jp2image.cpp
@@ -315,7 +315,7 @@ void Jp2Image::readMetadata() {
 #ifdef EXIV2_DEBUG_MESSAGES
                 std::cout << "Exiv2::Jp2Image::readMetadata: Exif header found at position " << pos << '\n';
 #endif
-                const DecodeParams dp(max_recursion_depth_);
+                const DecodeParams dp(recursion_limit());
                 ByteOrder bo = TiffParser::decode(exifData(), iptcData(), xmpData(), rawData.c_data(pos),
                                                   rawData.size() - pos, dp);
                 setByteOrder(bo);
@@ -369,7 +369,7 @@ void Jp2Image::readMetadata() {
               xmpPacket_ = xmpPacket_.substr(idx);
             }
 
-            const DecodeParams dp(max_recursion_depth_);
+            const DecodeParams dp(recursion_limit());
             if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp)) {
 #ifndef SUPPRESS_WARNINGS
               EXV_WARNING << "Failed to decode XMP metadata." << '\n';

--- a/src/jpgimage.cpp
+++ b/src/jpgimage.cpp
@@ -191,7 +191,7 @@ void JpegBase::readMetadata() {
 
     if (!foundExifData && marker == app1_ && size >= 8  // prevent out-of-bounds read in memcmp on next line
         && buf.cmpBytes(2, exifId_.data(), 6) == 0) {
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       ByteOrder bo = ExifParser::decode(exifData_, buf.c_data(8), size - 8, dp);
       setByteOrder(bo);
       if (size > 8 && byteOrder() == invalidByteOrder) {
@@ -205,7 +205,7 @@ void JpegBase::readMetadata() {
     } else if (!foundXmpData && marker == app1_ && size >= 31  // prevent out-of-bounds read in memcmp on next line
                && buf.cmpBytes(2, xmpId_.data(), 29) == 0) {
       xmpPacket_.assign(buf.c_str(31), size - 31);
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp)) {
 #ifndef SUPPRESS_WARNINGS
         EXV_WARNING << "Failed to decode XMP metadata.\n";

--- a/src/mrwimage.cpp
+++ b/src/mrwimage.cpp
@@ -112,7 +112,7 @@ void MrwImage::readMetadata() {
   io_->read(buf.data(), buf.size());
   Internal::enforce(!io_->error() && !io_->eof(), ErrorCode::kerFailedToReadImageData);
 
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   ByteOrder bo = TiffParser::decode(exifData_, iptcData_, xmpData_, buf.c_data(), buf.size(), dp);
   setByteOrder(bo);
 }  // MrwImage::readMetadata

--- a/src/orfimage.cpp
+++ b/src/orfimage.cpp
@@ -82,7 +82,7 @@ void OrfImage::readMetadata() {
     throw Error(ErrorCode::kerNotAnImage, "ORF");
   }
   clearMetadata();
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   ByteOrder bo = OrfParser::decode(exifData_, iptcData_, xmpData_, io_->mmap(), io_->size(), dp);
   setByteOrder(bo);
 }

--- a/src/pgfimage.cpp
+++ b/src/pgfimage.cpp
@@ -65,6 +65,7 @@ PgfImage::PgfImage(BasicIo::UniquePtr io, const ImageCtorParams& params) :
 }  // PgfImage::PgfImage
 
 void PgfImage::readMetadata() {
+  RECURSION_GUARD(recursion_limit_);
 #ifdef EXIV2_DEBUG_MESSAGES
   std::cerr << "Exiv2::PgfImage::readMetadata: Reading PGF file " << io_->path() << "\n";
 #endif
@@ -105,7 +106,8 @@ void PgfImage::readMetadata() {
   if (io_->error())
     throw Error(ErrorCode::kerFailedToReadImageData);
 
-  auto image = Exiv2::ImageFactory::open(base + offset, size);
+  ImageCtorParams params(false, false, recursion_limit());
+  auto image = Exiv2::ImageFactory::open(base + offset, size, params);
   image->readMetadata();
   exifData() = image->exifData();
   iptcData() = image->iptcData();
@@ -152,7 +154,8 @@ void PgfImage::doWriteMetadata(BasicIo& outIo) {
   uint32_t h = 0;
   DataBuf header = readPgfHeaderStructure(*io_, w, h);
 
-  auto img = ImageFactory::create(ImageType::png);
+  ImageCtorParams params(false, false, recursion_limit());
+  auto img = ImageFactory::create(ImageType::png, params);
 
   img->setExifData(exifData_);
   img->setIptcData(iptcData_);

--- a/src/pngimage.cpp
+++ b/src/pngimage.cpp
@@ -404,7 +404,7 @@ void PngImage::readMetadata() {
 
   const size_t imgSize = io_->size();
   DataBuf cheaderBuf(8);  // Chunk header: 4 bytes (data size) + 4 bytes (chunk type).
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
 
   while (!io_->eof()) {
     readChunk(cheaderBuf, *io_);  // Read chunk header.

--- a/src/preview.cpp
+++ b/src/preview.cpp
@@ -448,7 +448,8 @@ bool LoaderNative::readDimensions() {
     return false;
 
   try {
-    auto image = ImageFactory::open(data.c_data(), data.size());
+    ImageCtorParams params(false, false, image_.recursion_limit());
+    auto image = ImageFactory::open(data.c_data(), data.size(), params);
     if (!image)
       return false;
     image->readMetadata();
@@ -534,7 +535,8 @@ bool LoaderExifJpeg::readDimensions() {
   const Exiv2::byte* base = io.mmap();
 
   try {
-    auto image = ImageFactory::open(base + offset_, size_);
+    ImageCtorParams params(false, false, image_.recursion_limit());
+    auto image = ImageFactory::open(base + offset_, size_, params);
     if (!image)
       return false;
     image->readMetadata();
@@ -606,7 +608,8 @@ bool LoaderExifDataJpeg::readDimensions() {
     return false;
 
   try {
-    auto image = ImageFactory::open(buf.c_data(), buf.size());
+    ImageCtorParams params(false, false, image_.recursion_limit());
+    auto image = ImageFactory::open(buf.c_data(), buf.size(), params);
     if (!image)
       return false;
     image->readMetadata();

--- a/src/psdimage.cpp
+++ b/src/psdimage.cpp
@@ -231,7 +231,7 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       io_->read(rawExif.data(), rawExif.size());
       if (io_->error() || io_->eof())
         throw Error(ErrorCode::kerFailedToReadImageData);
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       ByteOrder bo = ExifParser::decode(exifData_, rawExif.c_data(), rawExif.size(), dp);
       setByteOrder(bo);
       if (!rawExif.empty() && byteOrder() == invalidByteOrder) {
@@ -249,7 +249,7 @@ void PsdImage::readResourceBlock(uint16_t resourceId, uint32_t resourceSize) {
       if (io_->error() || io_->eof())
         throw Error(ErrorCode::kerFailedToReadImageData);
       xmpPacket_.assign(xmpPacket.c_str(), xmpPacket.size());
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp)) {
 #ifndef SUPPRESS_WARNINGS
         EXV_WARNING << "Failed to decode XMP metadata.\n";

--- a/src/quicktimevideo.cpp
+++ b/src/quicktimevideo.cpp
@@ -567,13 +567,13 @@ void QuickTimeVideo::readMetadata() {
   xmpData_["Xmp.video.MimeType"] = mimeType();
 
   while (continueTraversing_)
-    decodeBlock(0);
+    decodeBlock();
 
   xmpData_["Xmp.video.AspectRatio"] = getAspectRatio(width_, height_);
 }  // QuickTimeVideo::readMetadata
 
-void QuickTimeVideo::decodeBlock(size_t recursion_depth, std::string const& entered_from) {
-  enforce(recursion_depth < max_recursion_depth_, Exiv2::ErrorCode::kerCorruptedMetadata);
+void QuickTimeVideo::decodeBlock(std::string const& entered_from) {
+  RECURSION_GUARD(recursion_limit_);
 
   const long bufMinSize = 4;
   DataBuf buf(bufMinSize + 1);
@@ -614,7 +614,7 @@ void QuickTimeVideo::decodeBlock(size_t recursion_depth, std::string const& ente
     discard(newsize);
     return;
   }
-  tagDecoder(buf, newsize, recursion_depth + 1);
+  tagDecoder(buf, newsize);
 }  // QuickTimeVideo::decodeBlock
 
 static std::string readString(BasicIo& io, size_t size) {
@@ -625,15 +625,15 @@ static std::string readString(BasicIo& io, size_t size) {
   return Exiv2::toString(str.data());
 }
 
-void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursion_depth) {
-  enforce(recursion_depth < max_recursion_depth_, Exiv2::ErrorCode::kerCorruptedMetadata);
+void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size) {
+  RECURSION_GUARD(recursion_limit_);
   assert(buf.size() > 4);
 
   if (ignoreList(buf))
     discard(size);
 
   else if (dataIgnoreList(buf)) {
-    decodeBlock(recursion_depth + 1, Exiv2::toString(buf.data()));
+    decodeBlock(Exiv2::toString(buf.data()));
   } else if (equalsQTimeTag(buf, "ftyp"))
     fileTypeDecoder(size);
 
@@ -656,10 +656,10 @@ void QuickTimeVideo::tagDecoder(Exiv2::DataBuf& buf, size_t size, size_t recursi
     videoHeaderDecoder(size);
 
   else if (equalsQTimeTag(buf, "udta"))
-    userDataDecoder(size, recursion_depth + 1);
+    userDataDecoder(size);
 
   else if (equalsQTimeTag(buf, "dref"))
-    multipleEntriesDecoder(recursion_depth + 1);
+    multipleEntriesDecoder();
 
   else if (equalsQTimeTag(buf, "stsd"))
     sampleDesc(size);
@@ -843,8 +843,8 @@ void QuickTimeVideo::CameraTagsDecoder(size_t size) {
   io_->seek(cur_pos + size, BasicIo::beg);
 }  // QuickTimeVideo::CameraTagsDecoder
 
-void QuickTimeVideo::userDataDecoder(size_t outer_size, size_t recursion_depth) {
-  enforce(recursion_depth < max_recursion_depth_, Exiv2::ErrorCode::kerCorruptedMetadata);
+void QuickTimeVideo::userDataDecoder(size_t outer_size) {
+  RECURSION_GUARD(recursion_limit_);
   const size_t start_pos = io_->tell();
   const TagVocabulary* td;
   const TagVocabulary* tv;
@@ -875,7 +875,7 @@ void QuickTimeVideo::userDataDecoder(size_t outer_size, size_t recursion_depth) 
       break;
 
     if (equalsQTimeTag(buf, "DcMD") || equalsQTimeTag(buf, "NCDT"))
-      userDataDecoder(size - 8, recursion_depth + 1);
+      userDataDecoder(size - 8);
 
     else if (equalsQTimeTag(buf, "NCTG"))
       NikonTagsDecoder(size - 8);
@@ -907,7 +907,7 @@ void QuickTimeVideo::userDataDecoder(size_t outer_size, size_t recursion_depth) 
     }
 
     else if (td)
-      tagDecoder(buf, size - 8, recursion_depth + 1);
+      tagDecoder(buf, size - 8);
 
     enforce(io_->tell() <= loop_start_pos + size, Exiv2::ErrorCode::kerCorruptedMetadata);
   }
@@ -1290,8 +1290,8 @@ void QuickTimeVideo::imageDescDecoder() {
   xmpData_["Xmp.video.BitDepth"] = static_cast<int>(buf.read_uint8(0));
 }  // QuickTimeVideo::imageDescDecoder
 
-void QuickTimeVideo::multipleEntriesDecoder(size_t recursion_depth) {
-  enforce(recursion_depth < max_recursion_depth_, Exiv2::ErrorCode::kerCorruptedMetadata);
+void QuickTimeVideo::multipleEntriesDecoder() {
+  RECURSION_GUARD(recursion_limit_);
   DataBuf buf(4 + 1);
   io_->readOrThrow(buf.data(), 4);
   io_->readOrThrow(buf.data(), 4);
@@ -1300,7 +1300,7 @@ void QuickTimeVideo::multipleEntriesDecoder(size_t recursion_depth) {
   noOfEntries = buf.read_uint32(0, bigEndian);
 
   for (uint32_t i = 0; i < noOfEntries && continueTraversing_; i++) {
-    decodeBlock(recursion_depth + 1);
+    decodeBlock();
   }
 }  // QuickTimeVideo::multipleEntriesDecoder
 

--- a/src/rafimage.cpp
+++ b/src/rafimage.cpp
@@ -296,7 +296,8 @@ void RafImage::readMetadata() {
   // Retrieve metadata from embedded JPEG preview image.
   try {
     auto jpg_io = std::make_unique<Exiv2::MemIo>(jpg_buf.data(), jpg_buf.size());
-    auto jpg_img = JpegImage(std::move(jpg_io), ImageCtorParams(false, 0));
+    ImageCtorParams params(false, false, recursion_limit());
+    auto jpg_img = JpegImage(std::move(jpg_io), params);
     jpg_img.readMetadata();
     setByteOrder(jpg_img.byteOrder());
     xmpData_ = jpg_img.xmpData();
@@ -346,7 +347,7 @@ void RafImage::readMetadata() {
     io_->read(tiff.data(), tiff.size());
 
     if (!io_->error() && !io_->eof()) {
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       TiffParser::decode(exifData_, iptcData_, xmpData_, tiff.c_data(), tiff.size(), dp);
     }
   }

--- a/src/rw2image.cpp
+++ b/src/rw2image.cpp
@@ -94,7 +94,7 @@ void Rw2Image::readMetadata() {
     throw Error(ErrorCode::kerNotAnImage, "RW2");
   }
   clearMetadata();
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   ByteOrder bo = Rw2Parser::decode(exifData_, iptcData_, xmpData_, io_->mmap(), io_->size(), dp);
   setByteOrder(bo);
 
@@ -112,7 +112,8 @@ void Rw2Image::readMetadata() {
     return;
   ExifData exifData;
   PreviewImage preview = loader.getPreviewImage(*list.begin());
-  auto image = ImageFactory::open(preview.pData(), preview.size());
+  ImageCtorParams params(false, false, recursion_limit());
+  auto image = ImageFactory::open(preview.pData(), preview.size(), params);
   if (!image) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Failed to open RW2 preview image.\n";

--- a/src/tiffimage.cpp
+++ b/src/tiffimage.cpp
@@ -147,7 +147,7 @@ void TiffImage::readMetadata() {
   }
   clearMetadata();
 
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   ByteOrder bo = TiffParser::decode(exifData_, iptcData_, xmpData_, io_->mmap(), io_->size(), dp);
   setByteOrder(bo);
 

--- a/src/tiffvisitor_int.cpp
+++ b/src/tiffvisitor_int.cpp
@@ -317,7 +317,8 @@ void TiffDecoder::decodeIptc(const TiffEntryBase* object) {
       return;
     }
 #ifndef SUPPRESS_WARNINGS
-    EXV_WARNING << "Failed to decode IPTC block found in " << "Directory Image, entry 0x83bb\n";
+    EXV_WARNING << "Failed to decode IPTC block found in "
+                << "Directory Image, entry 0x83bb\n";
 
 #endif
   }
@@ -338,7 +339,8 @@ void TiffDecoder::decodeIptc(const TiffEntryBase* object) {
       return;
     }
 #ifndef SUPPRESS_WARNINGS
-    EXV_WARNING << "Failed to decode IPTC block found in " << "Directory Image, entry 0x8649\n";
+    EXV_WARNING << "Failed to decode IPTC block found in "
+                << "Directory Image, entry 0x8649\n";
 
 #endif
   }
@@ -1236,7 +1238,8 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
     if (p + 12 > pLast_) {
 #ifndef SUPPRESS_WARNINGS
       EXV_ERROR << "Entry in directory " << groupName(object->group())
-                << "requests access to memory beyond the data buffer. " << "Skipping entry.\n";
+                << "requests access to memory beyond the data buffer. "
+                << "Skipping entry.\n";
 #endif
       return;
     }
@@ -1289,8 +1292,9 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
       } else {
 #ifndef SUPPRESS_WARNINGS
         EXV_ERROR << "Offset of directory " << groupName(object->group()) << ", entry 0x" << std::setw(4)
-                  << std::setfill('0') << std::hex << object->tag() << " is out of bounds: " << "Offset = 0x"
-                  << std::setw(8) << std::setfill('0') << std::hex << offset << "; truncating the entry\n";
+                  << std::setfill('0') << std::hex << object->tag() << " is out of bounds: "
+                  << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset
+                  << "; truncating the entry\n";
 #endif
       }
       size = 0;
@@ -1306,10 +1310,11 @@ void TiffReader::readTiffEntry(TiffEntryBase* object) {
       // check for size being invalid
       if (size > static_cast<size_t>(pLast_ - pData)) {
 #ifndef SUPPRESS_WARNINGS
-        EXV_ERROR << "Upper boundary of data for " << "directory " << groupName(object->group()) << ", entry 0x"
-                  << std::setw(4) << std::setfill('0') << std::hex << object->tag()
-                  << " is out of bounds: " << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset
-                  << ", size = " << std::dec << size
+        EXV_ERROR << "Upper boundary of data for "
+                  << "directory " << groupName(object->group()) << ", entry 0x" << std::setw(4) << std::setfill('0')
+                  << std::hex << object->tag() << " is out of bounds: "
+                  << "Offset = 0x" << std::setw(8) << std::setfill('0') << std::hex << offset << ", size = " << std::dec
+                  << size
                   << ", exceeds buffer size by "
                   // cast to make MSVC happy
                   << size - static_cast<size_t>(pLast_ - pData) << " Bytes; truncating the entry\n";

--- a/src/tiffvisitor_int.hpp
+++ b/src/tiffvisitor_int.hpp
@@ -311,14 +311,14 @@ class TiffDecoder : public TiffVisitor {
   //@}
 
   // DATA
-  ExifData& exifData_;                //!< Exif metadata container
-  IptcData& iptcData_;                //!< IPTC metadata container
-  XmpData& xmpData_;                  //!< XMP metadata container
-  TiffComponent* pRoot_;              //!< Root element of the composite
-  FindDecoderFct findDecoderFct_;     //!< Ptr to the function to find special decoding functions
-  const size_t max_recursion_depth_;  //!< don't allow recursion deeper than this
-  std::string make_;                  //!< Camera make, determined from the tags to decode
-  bool decodedIptc_{false};           //!< Indicates if IPTC has been decoded yet
+  ExifData& exifData_;                        //!< Exif metadata container
+  IptcData& iptcData_;                        //!< IPTC metadata container
+  XmpData& xmpData_;                          //!< XMP metadata container
+  TiffComponent* pRoot_;                      //!< Root element of the composite
+  FindDecoderFct findDecoderFct_;             //!< Ptr to the function to find special decoding functions
+  const RecursionLimit max_recursion_depth_;  //!< don't allow recursion deeper than this
+  std::string make_;                          //!< Camera make, determined from the tags to decode
+  bool decodedIptc_{false};                   //!< Indicates if IPTC has been decoded yet
 
 };  // class TiffDecoder
 

--- a/src/webpimage.cpp
+++ b/src/webpimage.cpp
@@ -660,7 +660,7 @@ void WebPImage::decodeChunks(uint32_t filesize) {
 
       if (pos != std::string::npos) {
         XmpData xmpData;
-        const DecodeParams dp(max_recursion_depth_);
+        const DecodeParams dp(recursion_limit());
         ByteOrder bo = ExifParser::decode(exifData_, payload.c_data(pos), payload.size() - pos, dp);
         setByteOrder(bo);
       } else {
@@ -672,7 +672,7 @@ void WebPImage::decodeChunks(uint32_t filesize) {
     } else if (equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_XMP)) {
       io_->readOrThrow(payload.data(), payload.size(), Exiv2::ErrorCode::kerCorruptedMetadata);
       xmpPacket_.assign(payload.c_str(), payload.size());
-      const DecodeParams dp(max_recursion_depth_);
+      const DecodeParams dp(recursion_limit());
       if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp)) {
 #ifndef SUPPRESS_WARNINGS
         EXV_WARNING << "Failed to decode XMP metadata." << '\n';

--- a/src/xmp.cpp
+++ b/src/xmp.cpp
@@ -75,8 +75,8 @@ class XMLValidator {
  private:
   // Private constructor, because this class is only constructed by
   // the (static) check method.
-  explicit XMLValidator(size_t max_recursion_depth) :
-      max_recursion_depth_(max_recursion_depth), parser_(XML_ParserCreateNS(nullptr, '@')) {
+  explicit XMLValidator(RecursionLimit max_recursion_depth) :
+      max_recursion_depth_(max_recursion_depth.remaining()), parser_(XML_ParserCreateNS(nullptr, '@')) {
     if (!parser_) {
       throw Error(ErrorCode::kerXMPToolkitError, "Could not create expat parser");
     }

--- a/src/xmpsidecar.cpp
+++ b/src/xmpsidecar.cpp
@@ -68,7 +68,7 @@ void XmpSidecar::readMetadata() {
     throw Error(ErrorCode::kerFailedToReadImageData);
   clearMetadata();
   xmpPacket_ = std::move(xmpPacket);
-  const DecodeParams dp(max_recursion_depth_);
+  const DecodeParams dp(recursion_limit());
   if (!xmpPacket_.empty() && XmpParser::decode(xmpData_, xmpPacket_, dp)) {
 #ifndef SUPPRESS_WARNINGS
     EXV_WARNING << "Failed to decode XMP metadata.\n";

--- a/test/data/test_reference_files/exiv2-test.out
+++ b/test/data/test_reference_files/exiv2-test.out
@@ -56,6 +56,7 @@ Options:
    -v      Be verbose during the program run
    -q      Silence warnings and error messages (quiet)
    -Q lvl  Set log-level to d(ebug), i(nfo), w(arning), e(rror) or m(ute)
+   -R num  Set maximum recursion depth limit. 0 means no limit.
    -b      Obsolete, reserved for use with the test suit
    -u      Show unknown tags (e.g., Exif.SonyMisc3c.0x022b)
    -g str  Only output where 'str' matches in output text (grep)

--- a/tests/bugfixes/github/test_issue_ghsa_crmj_qh74_2r36.py
+++ b/tests/bugfixes/github/test_issue_ghsa_crmj_qh74_2r36.py
@@ -16,7 +16,7 @@ class QuickTimeVideoNikonTagsDecoderOutOfBoundsRead(metaclass=CaseMeta):
     retval = [1]
     stderr = [
         """$exiv2_exception_message $filename:
-$kerCorruptedMetadata
+$kerMaxRecursionDepth
 """
     ]
     stdout = [""]

--- a/tests/suite.conf
+++ b/tests/suite.conf
@@ -46,6 +46,7 @@ kerInvalidTypeValue: invalid type in tiff structure
 kerNotAJpeg : This does not look like a JPEG image
 kerNoImageInInputData: Input data does not contain a valid image
 kerFileContainsUnknownImageType: The file contains data of an unknown image type
+kerMaxRecursionDepth: File is too deeply nested
 addition_overflow_message: Overflow in addition
 exiv2_exception_message: Exiv2 exception in print action for file
 exiv2_overflow_exception_message: std::overflow_error exception in print action for file

--- a/unitTests/test_ImageFactory.cpp
+++ b/unitTests/test_ImageFactory.cpp
@@ -8,64 +8,66 @@
 
 #include <gtest/gtest.h>
 
+#include "unittest_utils.hpp"
+
 namespace fs = std::filesystem;
 
 using namespace Exiv2;
 
 TEST(TheImageFactory, createsInstancesForFewSupportedTypesInMemory) {
   // Note that the constructor of these Image classes take an 'create' argument
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::exv));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, defaultImageCtorParams(false)));
 #ifdef EXV_HAVE_LIBZ
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::png));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::png, defaultImageCtorParams(false)));
 #endif
 }
 
 TEST(TheImageFactory, cannotCreateInstancesForMostTypesInMemory) {
   // Note that the constructor of these Image classes does not take an 'create' argument
 
-  EXPECT_THROW(ImageFactory::create(ImageType::bmp), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::cr2), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::crw), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::gif), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::mrw), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::orf), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::psd), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::raf), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::rw2), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::tga), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::webp), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::bmp, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::cr2, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::crw, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::gif, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::mrw, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::orf, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::psd, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::raf, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::rw2, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::tga, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::webp, defaultImageCtorParams(false)), Error);
 
   // TIFF
-  EXPECT_THROW(ImageFactory::create(ImageType::tiff), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::dng), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::nef), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::pef), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::arw), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::sr2), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::srw), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::tiff, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::dng, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::nef, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::pef, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::arw, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::sr2, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::srw, defaultImageCtorParams(false)), Error);
 }
 
 TEST(TheImageFactory, throwsWithImageTypeNone) {
-  EXPECT_THROW(ImageFactory::create(ImageType::none), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::none, defaultImageCtorParams(false)), Error);
 }
 
 TEST(TheImageFactory, throwsWithNonExistingImageTypes) {
-  EXPECT_THROW(ImageFactory::create(static_cast<ImageType>(666)), Error);
+  EXPECT_THROW(ImageFactory::create(static_cast<ImageType>(666), defaultImageCtorParams(false)), Error);
 }
 
 TEST(TheImageFactory, createsInstancesForFewSupportedTypesInFiles) {
   const std::string filePath("./here");
 
   // Note that the constructor of these Image classes take an 'create' argument
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2, filePath));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, filePath));
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::jp2, filePath, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::jpeg, filePath, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::exv, filePath, defaultImageCtorParams(false)));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::pgf, filePath, defaultImageCtorParams(false)));
 #ifdef EXV_HAVE_LIBZ
-  EXPECT_NO_THROW(ImageFactory::create(ImageType::png, filePath));
+  EXPECT_NO_THROW(ImageFactory::create(ImageType::png, filePath, defaultImageCtorParams(false)));
 #endif
 
   EXPECT_TRUE(fs::remove(filePath));
@@ -75,26 +77,26 @@ TEST(TheImageFactory, cannotCreateInstancesForSomeTypesInFiles) {
   const std::string filePath("./here");
 
   // Note that the constructor of these Image classes does not take an 'create' argument
-  EXPECT_THROW(ImageFactory::create(ImageType::bmp, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::cr2, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::crw, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::gif, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::mrw, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::orf, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::psd, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::raf, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::rw2, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::tga, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::webp, filePath), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::bmp, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::cr2, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::crw, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::gif, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::mrw, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::orf, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::psd, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::raf, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::rw2, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::tga, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::webp, filePath, defaultImageCtorParams(false)), Error);
 
   // TIFF
-  EXPECT_THROW(ImageFactory::create(ImageType::tiff, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::dng, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::nef, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::pef, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::arw, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::sr2, filePath), Error);
-  EXPECT_THROW(ImageFactory::create(ImageType::srw, filePath), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::tiff, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::dng, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::nef, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::pef, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::arw, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::sr2, filePath, defaultImageCtorParams(false)), Error);
+  EXPECT_THROW(ImageFactory::create(ImageType::srw, filePath, defaultImageCtorParams(false)), Error);
 }
 
 TEST(TheImageFactory, loadInstancesDifferentImageTypes) {
@@ -102,45 +104,45 @@ TEST(TheImageFactory, loadInstancesDifferentImageTypes) {
 
   std::string imagePath = (testData / "DSC_3079.jpg").string();
   EXPECT_EQ(ImageType::jpeg, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "exiv2-bug1108.exv").string();
   EXPECT_EQ(ImageType::exv, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "exiv2-canon-powershot-s40.crw").string();
   EXPECT_EQ(ImageType::crw, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "exiv2-bug1044.tif").string();
   EXPECT_EQ(ImageType::tiff, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
 #ifdef EXV_HAVE_LIBZ
   imagePath = (testData / "exiv2-bug1074.png").string();
   EXPECT_EQ(ImageType::png, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 #endif
 
   imagePath = (testData / "BlueSquare.xmp").string();
   EXPECT_EQ(ImageType::xmp, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "exiv2-photoshop.psd").string();
   EXPECT_EQ(ImageType::psd, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "cve_2017_1000126_stack-oob-read.webp").string();
   EXPECT_EQ(ImageType::webp, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "imagemagick.pgf").string();
   EXPECT_EQ(ImageType::pgf, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 
   imagePath = (testData / "Reagan.jp2").string();
   EXPECT_EQ(ImageType::jp2, ImageFactory::getType(imagePath));
-  EXPECT_NO_THROW(ImageFactory::open(imagePath, false));
+  EXPECT_NO_THROW(ImageFactory::open(imagePath, defaultImageCtorParams(false)));
 }
 
 TEST(TheImageFactory, getsExpectedModesForJp2Images) {

--- a/unitTests/unittest_utils.cpp
+++ b/unitTests/unittest_utils.cpp
@@ -3,9 +3,9 @@
 #include "unittest_utils.hpp"
 
 Exiv2::ImageCtorParams defaultImageCtorParams(bool create) {
-  return Exiv2::ImageCtorParams(create, MAX_RECURSION_DEPTH);
+  return Exiv2::ImageCtorParams(create, true, Exiv2::RecursionLimit(MAX_RECURSION_DEPTH));
 }
 
 Exiv2::DecodeParams defaultDecodeParams() {
-  return Exiv2::DecodeParams(MAX_RECURSION_DEPTH);
+  return Exiv2::DecodeParams(Exiv2::RecursionLimit(MAX_RECURSION_DEPTH));
 }


### PR DESCRIPTION
This is my proposed solution to #9414.  The idea is that we add this statement at the start of every recursive parsing function:

```c
RECURSION_GUARD(recursion_limit_);
```

In this PR, I haven't added it to all the parsing functions yet. I have only added it to the parsers that already had recursion depth tracking, for example bmffimage.

It works by decrementing `Image::recursion_limit_` at the beginning of the function and incrementing it back to it's original value on function exit. This is done by the `RecursionGuard` class. Function exit is handled automatically by `RecursionGuard`'s destructor. An exception is thrown if the limit is decremented all the way down to zero.

The default limit is 1000. I've also added a command-line parameter so that you can change it. For example:

```bash
exiv2 pic.jpg  # limit is 1000
exiv2 -R 20000 pic.jpg  # limit is 20000
exiv2 -R 0 pic.jpg  # no limit
```