### PR TITLE
Fix doxygen error

### DIFF
--- a/include/exiv2/slice.hpp
+++ b/include/exiv2/slice.hpp
@@ -208,7 +208,7 @@ struct MutableSliceBase : public ConstSliceBase<storage_type, data_type> {
    *
    * Now, `slice<T>` can call the `subSlice() const` method from its
    * base class, but that will return a mutable `slice<T>`! Instead we
-   * use this function to convert the ``slice<T>` into the parent of
+   * use this function to convert the `slice<T>` into the parent of
    * the appropriate `slice<const T>` and call its `subSlice() const`,
    * which returns the correct type.
    */


### PR DESCRIPTION
The release workflow is failing due to a doxygen error on macOS: https://github.com/Exiv2/exiv2/actions/runs/33306529235/job/99243948247. It looks like this extra backtick is the cause.