### PR TITLE
Remove macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
     strategy:
       matrix:
         runner:
-          - { os: macos-15-intel, arch: x64   }
           - { os: macos-14,       arch: arm64 }
     permissions:
       id-token: write  # For sigstore


### PR DESCRIPTION
doxygen is [crashing with a SEGV](https://github.com/Exiv2/exiv2/actions/runs/33318852417/job/99277134658) on macos-15-intel, which is preventing the release workflow from succeeding. I'd like to release 0.28.9 today, so I think the best solution is to temporarily remove this platform from the release workflow.

Error message:

```
/bin/sh: line 1:  9655 Segmentation fault: 11  /usr/local/bin/doxygen /Users/runner/work/exiv2/exiv2/build/doxy.config
```

Screenshot:

<img width="3160" height="2108" alt="Screenshot From 2026-08-30 16-39-28" src="https://github.com/user-attachments/assets/ecce2211-ad76-49d6-a421-525327d92ba6" />

