### PR TITLE
Revert temporary release.yml modification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     strategy:
       matrix:
         runner:
+          - { os: macos-15-intel, arch: x64   }
           - { os: macos-14,       arch: arm64 }
     permissions:
       id-token: write  # For sigstore


### PR DESCRIPTION
This reverts #9466, which was a temporary change so that we could publish v0.28.9 today. Hopefully the issue with doxygen crashing on macOS is a temporary problem that will get fixed soon.