### PR TITLE
sony: read the A580 family camera settings block as bytes

### DIFF
--- a/include/exiv2/tags.hpp
+++ b/include/exiv2/tags.hpp
@@ -161,6 +161,7 @@ enum class IfdId : uint32_t {
   sony1Cs2Id,
   sony2CsId,
   sony2Cs2Id,
+  sony2Cs3Id,
   sony2FpId,
   sonyMisc1Id,
   sonyMisc2bId,

--- a/src/makernote_int.cpp
+++ b/src/makernote_int.cpp
@@ -959,12 +959,22 @@ DataBuf nikonCrypt(uint16_t tag, const byte* pData, size_t size, TiffComponent* 
 }
 
 int sonyCsSelector(uint16_t /*tag*/, const byte* /*pData*/, size_t /*size*/, TiffComponent* pRoot) {
+  // Models whose camera settings block is an array of bytes rather than of
+  // shorts. Matched in full: "NEX-5" must not catch the NEX-5N, NEX-5R and
+  // NEX-5T, which use a different layout again.
+  static constexpr const char* byteModels[] = {
+      "DSLR-A450", "DSLR-A500", "DSLR-A550", "DSLR-A560",  "DSLR-A580", "NEX-3",
+      "NEX-5",     "NEX-C3",    "NEX-VG10E", "SLT-A33",    "SLT-A35",   "SLT-A55",
+      "SLT-A55V",
+  };
   std::string model = getExifModel(pRoot);
   if (model.empty())
     return -1;
   int idx = 0;
   if (Internal::contains(model, "DSLR-A330") || Internal::contains(model, "DSLR-A380")) {
     idx = 1;
+  } else if (Exiv2::find(byteModels, model)) {
+    idx = 2;
   }
   return idx;
 }

--- a/src/sonymn_int.cpp
+++ b/src/sonymn_int.cpp
@@ -1802,6 +1802,21 @@ constexpr TagInfo SonyMakerNote::tagInfoCs_[] = {
 
 // Warnings: Exiftool database give a list of tags shorted in decimal mode, not hexadecimal.
 
+//! Lookup table to translate Sony camera settings version 3 aspect ratio values
+constexpr TagDetails sonyCs3AspectRatio[] = {
+    {4, N_("3:2")},
+    {8, N_("16:9")},
+};
+
+//! Sony Standard Camera Settings version 3, a byte array
+constexpr TagInfo SonyMakerNote::tagInfoCs3_[] = {
+    {0x000a, "AspectRatio", N_("Aspect Ratio"), N_("Aspect ratio selected on the camera"), IfdId::sony2Cs3Id,
+     SectionId::makerTags, unsignedByte, 1, EXV_PRINT_TAG(sonyCs3AspectRatio)},
+    // End of list marker
+    {0xffff, "(UnknownSony2Cs3Tag)", "(UnknownSony2Cs3Tag)", N_("Unknown Sony Camera Settings 3 tag"),
+     IfdId::sony2Cs3Id, SectionId::makerTags, unsignedByte, 1, printValue},
+};
+
 constexpr TagInfo SonyMakerNote::tagInfoCs2_[] = {
     {0x0010, "FocusMode", N_("Focus Mode"), N_("Focus Mode"), IfdId::sony1Cs2Id, SectionId::makerTags, unsignedShort, 1,
      EXV_PRINT_TAG(sonyCSFocusMode)},

--- a/src/sonymn_int.hpp
+++ b/src/sonymn_int.hpp
@@ -37,6 +37,10 @@ class SonyMakerNote {
   static constexpr auto tagListCs2() {
     return tagInfoCs2_;
   }
+  //! Return read-only list of built-in Sony Standard Camera Settings version 3 tags
+  static constexpr auto tagListCs3() {
+    return tagInfoCs3_;
+  }
   //! Return read-only list of built-in Sony FocusPosition tags
   static constexpr auto tagListFp() {
     return tagInfoFp_;
@@ -140,6 +144,7 @@ class SonyMakerNote {
   static const TagInfo tagInfo_[];
   static const TagInfo tagInfoCs_[];
   static const TagInfo tagInfoCs2_[];
+  static const TagInfo tagInfoCs3_[];
   static const TagInfo tagInfoFp_[];
   static const TagInfo tagInfoSonyMisc1_[];
   static const TagInfo tagInfoSonyMisc2b_[];

--- a/src/tags_int.cpp
+++ b/src/tags_int.cpp
@@ -162,6 +162,7 @@ constexpr GroupInfo groupInfo[] = {
     {IfdId::sony1MltCsA100Id, "Makernote", "Sony1MltCsA100", &MinoltaMakerNote::tagListCsA100},
     {IfdId::sony2CsId, "Makernote", "Sony2Cs", &SonyMakerNote::tagListCs},
     {IfdId::sony2Cs2Id, "Makernote", "Sony2Cs2", &SonyMakerNote::tagListCs2},
+    {IfdId::sony2Cs3Id, "Makernote", "Sony2Cs3", &SonyMakerNote::tagListCs3},
     {IfdId::sony2FpId, "Makernote", "Sony2Fp", &SonyMakerNote::tagListFp},
     {IfdId::sonyMisc1Id, "Makernote", "SonyMisc1", &SonyMakerNote::tagListSonyMisc1},
     {IfdId::sonyMisc2bId, "Makernote", "SonyMisc2b", &SonyMakerNote::tagListSonyMisc2b},

--- a/src/tiffimage_int.cpp
+++ b/src/tiffimage_int.cpp
@@ -1186,6 +1186,22 @@ constexpr ArrayCfg sony2Cs2Cfg = {
 constexpr ArrayDef sonyCs2Def[] = {
     {44, ttUnsignedShort, 1},  // Exif.Sony[12]Cs2.FocusMode
 };
+//! Sony2 Camera Settings 3 binary array - configuration
+// Unlike the two above this block is an array of bytes, not of shorts.
+constexpr ArrayCfg sony2Cs3Cfg = {
+    IfdId::sony2Cs3Id,  // Group for the elements
+    bigEndian,          // Big endian
+    ttUndefined,        // Type for array entry and size element
+    notEncrypted,       // Not encrypted
+    false,              // No size element
+    false,              // No fillers
+    false,              // Don't concatenate gaps
+    {0, ttUnsignedByte, 1},
+};
+//! Sony2 Camera Settings 3 binary array - definition
+constexpr ArrayDef sonyCs3Def[] = {
+    {0x0a, ttUnsignedByte, 1},  // Exif.Sony2Cs3.AspectRatio
+};
 //! Sony1 Camera Settings configurations and definitions
 constexpr ArraySet sony1CsSet[] = {
     {sony1CsCfg, sonyCsDef, std::size(sonyCsDef)},
@@ -1195,6 +1211,7 @@ constexpr ArraySet sony1CsSet[] = {
 constexpr ArraySet sony2CsSet[] = {
     {sony2CsCfg, sonyCsDef, std::size(sonyCsDef)},
     {sony2Cs2Cfg, sonyCs2Def, std::size(sonyCs2Def)},
+    {sony2Cs3Cfg, sonyCs3Def, std::size(sonyCs3Def)},
 };
 
 //! Sony Minolta Camera Settings (old) binary array - configuration
@@ -1404,6 +1421,7 @@ const TiffTreeTable TiffCreator::tiffTreeTable_ = {
     {{Tag::root, IfdId::sonySInfo1Id}, {IfdId::sony2Id, 0x3000}},
     {{Tag::root, IfdId::sony2CsId}, {IfdId::sony2Id, 0x0114}},
     {{Tag::root, IfdId::sony2Cs2Id}, {IfdId::sony2Id, 0x0114}},
+    {{Tag::root, IfdId::sony2Cs3Id}, {IfdId::sony2Id, 0x0114}},
     {{Tag::root, IfdId::minoltaId}, {IfdId::exifId, 0x927c}},
     {{Tag::root, IfdId::minoltaCsOldId}, {IfdId::minoltaId, 0x0001}},
     {{Tag::root, IfdId::minoltaCsNewId}, {IfdId::minoltaId, 0x0003}},
@@ -1920,6 +1938,7 @@ const TiffGroupTable TiffCreator::tiffGroupTable_ = {
     // Sony2 camera settings
     {{Tag::all, IfdId::sony2CsId}, &newTiffBinaryElement},
     {{Tag::all, IfdId::sony2Cs2Id}, &newTiffBinaryElement},
+    {{Tag::all, IfdId::sony2Cs3Id}, &newTiffBinaryElement},
 
     // Sony1 Minolta makernote
     {{0x0001, IfdId::sonyMltId}, EXV_SIMPLE_BINARY_ARRAY(sony1MCsoCfg)},


### PR DESCRIPTION
Fixes #9469.

### The problem

The camera settings block of the A33/A55/A450/A580/NEX family is an array of
bytes, but `sonyCsSelector` has no byte oriented variant to offer, so these
models fall through to the short based `sonyCsCfg`. Every `Exif.Sony2Cs`
value for them is two unrelated bytes glued together.

On a DSLR-A580, `Sony2Cs.DriveMode` reports 4121. The block begins
`68 38 38 80 10 02 13 01 10 19 08 ...`, and 4121 is `0x1019`, bytes 8 and 9
read as a big endian short. `AspectRatio` really lives at byte `0x0a` and is
not reachable at all today.

### The change

- `sony2Cs3Cfg`, a third configuration whose default element is
  `ttUnsignedByte`, added to `sony2CsSet`
- `sonyCsSelector` selects it by model
- a new `Exif.Sony2Cs3` group naming `AspectRatio` at byte `0x0a`

Only `AspectRatio` is named, because it is the only tag I could verify. The
rest of the block is now reported with correct values under `Sony2Cs3` and
can be named by anyone with the samples to check them; ExifTool documents the
layout as `CameraSettings3`.

**The model list is matched in full, not by substring.** `contains(model,
"NEX-5")` would also catch the NEX-5N, NEX-5R and NEX-5T, which are a
different layout again and are parsed correctly today.

### Testing

CC0 samples from raw.pixls.us, comparing a pristine build of `main` against
this branch.

`AspectRatio` now agrees with ExifTool on all nine affected models available
there:

| Model | ExifTool | Exiv2 (this branch) |
| --- | --- | --- |
| DSLR-A580 | 16:9 | 16:9 |
| DSLR-A450, A500, A560 | 3:2 | 3:2 |
| NEX-5, NEX-C3 | 3:2 | 3:2 |
| SLT-A33, A35, A55 | 3:2 | 3:2 |

Before this change none of them reported an aspect ratio, and every other
`Sony2Cs` value was wrong.

Output is byte for byte unchanged for DSLR-A200, A330, A380, A700, A900,
NEX-5N, NEX-5R and ILCE-7M3. NEX-5N is the only model of any of these that
appears in `test/data/test_reference_files`, and it is deliberately not in
the list, so no reference output should move.

DSLR-A550, NEX-3 and NEX-VG10E are in the list on ExifTool's authority; I had
no sample to confirm them. They are currently misparsed either way, so
including them cannot be worse than leaving them out, but I am happy to drop
them if you would rather only ship what is verified.

Found while trying to read the in-camera aspect ratio for darktable, where
Canon and Olympus both work through Exiv2 and Sony was the odd one out.

I can add a test if you point me at a suitable sample to use.

*Disclosure: written with AI assistance (Claude Code with Claude Opus 5). I
have reviewed it and take responsibility for it.*
