### PR TITLE
Include previously implicit header

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -10,6 +10,7 @@
 #include "types.hpp"
 
 // + standard includes
+#include <ctime>
 #include <iterator>
 #include <sstream>
 


### PR DESCRIPTION
* Needed for std::mktime which previously worked via implicit headers. Libcxx-23 has pruned these so its needed explicitly now.

```
/home/ask/sources/exiv2/src/value.cpp:850:33: error: no member named 'mktime' in namespace 'std'; did
      you mean simply 'mktime'?
  850 |   auto l = static_cast<int64_t>(std::mktime(&tms));
      |                                 ^~~~~~~~~~~
      |                                 mktime
/usr/include/time.h:91:15: note: 'mktime' declared here
   91 | extern time_t mktime (struct tm *__tp) __THROW;
      |               ^
```

See also: https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157