### PR TITLE
canonmn_int: round converted focal lengths

### DIFF
--- a/src/canonmn_int.cpp
+++ b/src/canonmn_int.cpp
@@ -2866,8 +2866,9 @@ std::ostream& printCsLensTypeByMetadata(std::ostream& os, const Value& value, co
 
     auto tc = base_match[5].length() > 0 ? string_to_float(base_match[5].str()) : 1.f;
 
-    auto flMax = static_cast<int>(string_to_float(base_match[2].str()) * tc);
-    int flMin = base_match[1].length() > 0 ? static_cast<int>(string_to_float(base_match[1].str()) * tc) : flMax;
+    auto flMax = static_cast<int>(std::lround(string_to_float(base_match[2].str()) * tc));
+    int flMin =
+        base_match[1].length() > 0 ? static_cast<int>(std::lround(string_to_float(base_match[1].str()) * tc)) : flMax;
 
     auto aperMaxTele = string_to_float(base_match[4].str()) * tc;
     auto aperMaxShort = base_match[3].length() > 0 ? string_to_float(base_match[3].str()) * tc : aperMaxTele;


### PR DESCRIPTION
On i686, x87 excess floating-point precision can make products such as `100.0F * 1.4F` slightly lower than 140. Converting that value directly to `int` truncates it to 139, so teleconverter lens entries do not match the focal lengths decoded from metadata.

This rounds the focal lengths after applying the teleconverter factor and before converting them to `int`. The existing lens tests cover the affected cases.

Verification:

- i686: all 6 CTest suites pass (baseline: 28 lens-test failures)
- x86_64: all 6 CTest suites pass
