### PR TITLE
basicio: write through a temp file so the original survives an interrupted metadata write (#9482)

### DIFF
--- a/src/basicio.cpp
+++ b/src/basicio.cpp
@@ -444,15 +444,88 @@ void FileIo::transfer(BasicIo& src) {
     }
   }  // if (fileIo)
   else {
-    // Generic handling, reopen both to reset to start
-    if (open("w+b") != 0) {
-      throw Error(ErrorCode::kerFileOpenFailed, path(), "w+b", strError());
+    // Generic handling. Build the new bytes in a temporary file next to the
+    // target, then rename it into place, matching the durability of the
+    // FileIo branch above. Without this, a crash between the open("w+b")
+    // truncate and the write left a zero-byte file where the original image
+    // was (issue #9482).
+    bool statOk = true;
+    fs::perms origStMode{};
+    const auto& pf = path();
+
+    Impl::StructStat buf1;
+    if (p_->stat(buf1) == -1) {
+      statOk = false;
     }
-    if (src.open() != 0) {
-      throw Error(ErrorCode::kerDataSourceOpenFailed, src.path(), strError());
+    origStMode = buf1.st_mode;
+
+    // Close self before touching a temp file; we only reopen at the end.
+    close();
+
+    // Same directory as pf so fs::rename is atomic on POSIX and ReplaceFileA
+    // works on Windows.
+    fs::path tmp_path(pf);
+    tmp_path += ".exv-tmp-";
+    tmp_path += std::to_string(static_cast<long long>(
+#ifdef _WIN32
+        _getpid()
+#else
+        getpid()
+#endif
+        ));
+    if (fileExists(tmp_path.string())) {
+      auto base_tmp = tmp_path;
+      for (int i = 1; i <= 4096; ++i) {
+        auto candidate = base_tmp;
+        candidate += "-";
+        candidate += std::to_string(i);
+        if (!fileExists(candidate.string())) {
+          tmp_path = candidate;
+          break;
+        }
+      }
     }
-    write(src);
-    src.close();
+
+    {
+      FileIo tmp(tmp_path);
+      if (tmp.open("w+b") != 0) {
+        throw Error(ErrorCode::kerFileOpenFailed, tmp_path.string(), "w+b", strError());
+      }
+      if (src.open() != 0) {
+        tmp.close();
+        fs::remove(tmp_path);
+        throw Error(ErrorCode::kerDataSourceOpenFailed, src.path(), strError());
+      }
+      tmp.write(src);
+      src.close();
+      tmp.close();
+      if (tmp.error()) {
+        fs::remove(tmp_path);
+        throw Error(ErrorCode::kerTransferFailed, pf, strError());
+      }
+    }
+
+#if defined(_WIN32) && defined(REPLACEFILE_IGNORE_MERGE_ERRORS)
+    {
+      auto ret = ReplaceFileA(pf.c_str(), tmp_path.string().c_str(), nullptr,
+                              REPLACEFILE_IGNORE_MERGE_ERRORS, nullptr, nullptr);
+      if (ret == 0) {
+        if (GetLastError() != ERROR_FILE_NOT_FOUND) {
+          fs::remove(tmp_path);
+          throw Error(ErrorCode::kerFileRenameFailed, tmp_path.string(), pf, strError());
+        }
+        fs::rename(tmp_path, pf);
+      }
+    }
+#else
+    fs::rename(tmp_path, pf);
+#endif
+
+    // Preserve original permissions, mirroring the FileIo branch.
+    auto newStMode = fs::status(pf).permissions();
+    if (statOk && origStMode != newStMode) {
+      fs::permissions(pf, origStMode);
+    }
   }
 
   if (wasOpen) {

--- a/unitTests/test_FileIo.cpp
+++ b/unitTests/test_FileIo.cpp
@@ -77,3 +77,58 @@ TEST(AFileIO, canSeekBeyondEOF) {
   ASSERT_FALSE(file.error());
   ASSERT_FALSE(file.eof());
 }
+
+// ---------------------------------------------------------------------
+// Regression: issue #9482
+// FileIo::transfer's generic branch used to open the target with "w+b"
+// (which truncates) BEFORE writing the new content. If anything failed
+// between the truncate and the write, the original image was gone: a
+// zero-byte file with no backup. The fix writes the new bytes into a
+// temporary file next to the target and renames it in atomically.
+// ---------------------------------------------------------------------
+
+#include <fstream>
+#include <filesystem>
+
+namespace {
+// A source that behaves like a MemIo but refuses to open, simulating a
+// mid-transfer failure BEFORE any bytes could reach the target.
+class FailingOpenMemIo : public Exiv2::MemIo {
+ public:
+  int open() override { return -1; }
+};
+}  // namespace
+
+TEST(AFileIO, transferGenericBranchPreservesOriginalOnSourceOpenFailure_9482) {
+  namespace fs = std::filesystem;
+  auto dir = fs::temp_directory_path() / "exiv2_9482_repro";
+  std::error_code ec;
+  fs::remove_all(dir, ec);
+  fs::create_directories(dir);
+  auto orig = dir / "victim.bin";
+  const std::string original_bytes = "ORIGINAL_CONTENTS_9482";
+  {
+    std::ofstream ofs(orig, std::ios::binary);
+    ofs << original_bytes;
+  }
+  ASSERT_TRUE(fs::exists(orig));
+  ASSERT_EQ(fs::file_size(orig), original_bytes.size());
+
+  FailingOpenMemIo src;  // else branch: not a FileIo, open() will fail
+  Exiv2::FileIo victim(orig.string());
+  EXPECT_THROW(victim.transfer(src), Exiv2::Error);
+
+  // Regression invariant for #9482: the original file must still be readable
+  // and byte-identical after a failed transfer through the generic branch.
+  ASSERT_TRUE(fs::exists(orig));
+  EXPECT_EQ(fs::file_size(orig), original_bytes.size());
+  std::ifstream in(orig, std::ios::binary);
+  std::string got((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  EXPECT_EQ(got, original_bytes);
+
+  // No temp litter left behind.
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    EXPECT_EQ(entry.path().filename(), std::string("victim.bin"));
+  }
+  fs::remove_all(dir, ec);
+}


### PR DESCRIPTION
Fix for #9482.

### The bug

`FileIo::transfer` has two branches. When the source is another
`FileIo` (a temp file), it renames it into place. When the source is
not — which is the branch JPEG metadata writes reach through `MemIo`
— it opens the target with `"w+b"` first, and `"w+b"` truncates. If
anything between that truncate and the write completing goes wrong
(a crash, a failing `src.open()`, out of space during the write), the
original image is left as a zero-byte file with no backup.

The issue's syscall trace shows the same on the current `main`.

### The change

Route the generic branch through the same shape the `FileIo` branch
already uses:

- Build the new bytes in a temp file next to the target
  (`<path>.exv-tmp-<pid>[-<counter>]`, same directory so `fs::rename`
  is atomic on POSIX and `ReplaceFileA` works on Windows).
- Rename atomically only after the temp file closes cleanly.
- On any failure along the temp path — `tmp.open`, `src.open`,
  `write`, `close` — remove the temp file and throw. The original is
  never touched.
- Preserve the original file's permissions, the same way the `FileIo`
  branch already does.

### Test

`AFileIO.transferGenericBranchPreservesOriginalOnSourceOpenFailure_9482`
in `unitTests/test_FileIo.cpp`. It writes a fixture file, calls
`transfer` with a `MemIo` whose `open()` returns `-1`, and asserts the
fixture is still there with its original bytes. On `main` at
`dc9364b` it fails with the fixture reduced to 0 bytes; with this
change it passes.

Also checked the happy path: `exiv2 rm` on a real JPEG still strips
metadata (118 685 → 115 163 bytes, no `.exv-tmp` files left behind),
and the full `AFileIO.*` suite runs 11 / 11.

### Reporter

Thanks to @yottayoshida — the report has a syscall-level trace and
sets out the two possible responses; this PR is option 1.

### AI assistance

I used an AI assistant to help draft the patch, the test and this
description. I read every line, checked the invariants against the
fixed code, and ran the tests myself before opening this.

- [x] I have re-read every line and this description is in my own words.