### PR TITLE
Keep all values of repeatable IPTC datasets on insert

### DIFF
--- a/app/actions.cpp
+++ b/app/actions.cpp
@@ -1711,8 +1711,21 @@ int metacopy(const std::string& source, const std::string& tgt, Exiv2::ImageType
       std::cout << _("Writing IPTC data from") << " " << source << " " << _("to") << " " << target << '\n';
     }
     if (preserve) {
-      for (const auto& iptc : sourceImage->iptcData()) {
-        targetImage->iptcData()[iptc.key()] = iptc.value();
+      // IPTC datasets such as Iptc.Application2.Keywords may occur more than once. Assigning through
+      // IptcData::operator[] would collapse every source value of such a dataset onto the target's first
+      // matching entry, so instead drop the target's entries for the datasets the source provides and
+      // append all source entries in their original order.
+      const auto& sourceIptc = sourceImage->iptcData();
+      auto& targetIptc = targetImage->iptcData();
+      for (auto pos = targetIptc.begin(); pos != targetIptc.end();) {
+        if (sourceIptc.findId(pos->tag(), pos->record()) != sourceIptc.end()) {
+          pos = targetIptc.erase(pos);
+        } else {
+          ++pos;
+        }
+      }
+      for (const auto& iptc : sourceIptc) {
+        targetIptc.add(iptc);
       }
     } else {
       targetImage->setIptcData(sourceImage->iptcData());

--- a/test/data/test_reference_files/conversions.out
+++ b/test/data/test_reference_files/conversions.out
@@ -75,6 +75,8 @@ Xmp.dc.subject                               XmpBag      3  Sex, Drugs, Rock'n'r
 File 1/1: p.jpg
 p.jpg: No Exif data found in the file
 Iptc.Envelope.CharacterSet                   String      3  %G
+Iptc.Application2.Keywords                   String      3  Sex
+Iptc.Application2.Keywords                   String      5  Drugs
 Iptc.Application2.Keywords                   String     11  Rock'n'roll
 
 Testcase 10

--- a/test/data/test_reference_files/stdin-test.out
+++ b/test/data/test_reference_files/stdin-test.out
@@ -125,16 +125,16 @@ STRUCTURE OF JPEG FILE: girl.jpg
        2 | 0xffe0 APP0  |      16 | JFIF.........
       20 | 0xffe1 APP1  |    5704 | Exif..II*......................
     5726 | 0xffe1 APP1  |    5336 | http://ns.adobe.com/xap/1.0/.<?x
-   11064 | 0xffed APP13 |     784 | Photoshop 3.0.8BIM..........Z...
-   11850 | 0xffdb DQT   |      67 
-   11919 | 0xffdb DQT   |      67 
-   11988 | 0xffc0 SOF0  |      17 
-   12007 | 0xffc4 DHT   |      28 
-   12037 | 0xffc4 DHT   |      74 
-   12113 | 0xffc4 DHT   |      28 
-   12143 | 0xffc4 DHT   |      57 
-   12202 | 0xffe1 APP1  |    4602 | http://ns.adobe.com/xap/1.0/.<?x
-   16806 | 0xffda SOS  
+   11064 | 0xffed APP13 |     952 | Photoshop 3.0.8BIM..........Z...
+   12018 | 0xffdb DQT   |      67 
+   12087 | 0xffdb DQT   |      67 
+   12156 | 0xffc0 SOF0  |      17 
+   12175 | 0xffc4 DHT   |      28 
+   12205 | 0xffc4 DHT   |      74 
+   12281 | 0xffc4 DHT   |      28 
+   12311 | 0xffc4 DHT   |      57 
+   12370 | 0xffe1 APP1  |    4602 | http://ns.adobe.com/xap/1.0/.<?x
+   16974 | 0xffda SOS  
 STRUCTURE OF JPEG FILE: girl.jpg
  address | marker       |  length | data
        0 | 0xffd8 SOI  

--- a/tests/bugfixes/github/test_issue_3334.py
+++ b/tests/bugfixes/github/test_issue_3334.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, CopyTmpFiles, path
+
+
+@CopyTmpFiles("$data_path/exiv2-empty.jpg")
+class test_issue_3334Test(metaclass=CaseMeta):
+    """
+    Regression test for the bug described in:
+    https://github.com/Exiv2/exiv2/issues/3334
+
+    Insert (-i) has to keep every value of a repeatable IPTC dataset instead of
+    collapsing them onto the target's first matching entry.
+    """
+
+    url = "https://github.com/Exiv2/exiv2/issues/3334"
+
+    filename = path("$tmp_path/exiv2-empty.jpg")
+    commands = [
+        '$exiv2 -M"add Iptc.Application2.Keywords one"   $filename',
+        '$exiv2 -M"add Iptc.Application2.Keywords two"   $filename',
+        '$exiv2 -M"add Iptc.Application2.Keywords three" $filename',
+        "$exiv2 -ea --force $filename",
+        "$exiv2 -ia $filename",
+        "$exiv2 -PI -g Keywords $filename",
+    ]
+    stdout = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        """Iptc.Application2.Keywords                   String      3  one
+Iptc.Application2.Keywords                   String      3  two
+Iptc.Application2.Keywords                   String      5  three
+""",
+    ]
+    stderr = [""] * len(commands)
+    retval = [0] * len(commands)


### PR DESCRIPTION
Fixes #3334.

### Problem

Exporting IPTC to an `.exv` sidecar and inserting it again loses all but one value of a repeatable IPTC dataset:

```console
$ exiv2 -M"add Iptc.Application2.Keywords one"   e.jpg
$ exiv2 -M"add Iptc.Application2.Keywords two"   e.jpg
$ exiv2 -M"add Iptc.Application2.Keywords three" e.jpg
$ exiv2 -ea e.jpg
$ exiv2 -ia e.jpg
$ exiv2 -PI -g Keywords e.jpg
Iptc.Application2.Keywords                   String      5  three
Iptc.Application2.Keywords                   String      3  two
Iptc.Application2.Keywords                   String      5  three
```

The `.exv` itself is fine; the values are lost on insert.

### Cause

`metacopy()` copies IPTC in preserve mode (the mode used by the insert action) with:

```cpp
targetImage->iptcData()[iptc.key()] = iptc.value();
```

`IptcData::operator[]` looks up the *first* entry with that key. Datasets like `Iptc.Application2.Keywords`, `Iptc.Application2.Byline` and `Iptc.Application2.SuppCategory` are repeatable, so every source value is written onto the same first target entry and only the last one survives. Exif and XMP are unaffected: their keys are unique.

### Fix

Remove the target's entries for the datasets the source provides, then append all source entries in their original order. Non-repeatable datasets behave exactly as before: the source value replaces the target value, and target-only datasets are still preserved.

### Tests

New system test `tests/bugfixes/github/test_issue_3334.py` reproduces the report: it adds three keywords, exports with `-ea`, re-inserts with `-ia` and checks that all three come back in order. It fails before the change and passes after.

Two existing reference outputs change, both because keywords that used to be dropped are now kept:

- `conversions.out`: step 9 ("And back to IPTC") now returns all three keywords (`Sex`, `Drugs`, `Rock'n'roll`) instead of only the last one.
- `stdin-test.out`: piping `exiv2 -ea-` from `Reagan.jpg` into `exiv2 -ia-` now carries all 10 keywords and all 3 `SuppCategory` values, so the APP13 segment grows from 784 to 952 bytes and the following segment offsets shift.

Ran locally on macOS (arm64, Ninja, Release):

- `unit_tests`: 370/370 pass
- `tests/runner.py bugfixes`: 325 pass, 10 skipped
- `tests/runner.py regression_tests`: 329 pass
- `tests/runner.py bash_tests`: 66/67 pass; `io_test` fails both with and without this change because this build has webready/network support disabled
- `tests/runner.py tiff_test`: 1 pass

`clang-format` was not available on this machine, so the new code was matched to the surrounding style by hand rather than verified with the tool.