### PR TITLE
Address some doxygen warnings

### DIFF
--- a/src/cr2header_int.hpp
+++ b/src/cr2header_int.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /*!
-  @file    cr2image_int.hpp
+  @file    cr2header_int.hpp
   @brief   Internal classes to support CR2 image format
   @author  Andreas Huggel (ahu)
            <a href="mailto:ahuggel@gmx.net">ahuggel@gmx.net</a>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -5332,7 +5332,6 @@ std::string XmpKey::ns() const {
   return XmpProperties::nsUnlocked(p_->prefix_, lock);
 }
 
-//! @cond IGNORE
 void XmpKey::Impl::decomposeKey(const std::string& key) {
   XmpProperties::XmpLock lock;
   decomposeKeyUnlocked(key, lock);


### PR DESCRIPTION
I'm actually not sure what was behind https://github.com/Exiv2/exiv2/commit/192a2a83cf0cedd67b88aef61a86d402e74717c9 and whether another endcond should be added somewhere instead...