### PR TITLE
Fix the -d target letter for all IPTC data in --help

### DIFF
--- a/app/exiv2.cpp
+++ b/app/exiv2.cpp
@@ -310,7 +310,7 @@ void Params::help(std::ostream& os) const {
      << _("             a : All supported metadata (the default)\n") << _("             e : Exif tags\n")
      << _("             t : Exif thumbnail only\n") << _("             i : IPTC tags\n")
      << _("             x : XMP tags\n") << _("             c : JPEG comment\n") << _("             C : ICC Profile\n")
-     << _("             c : All IPTC data (any broken multiple IPTC blocks)\n")
+     << _("             I : All IPTC data (any broken multiple IPTC blocks)\n")
      << _("             - : Input from stdin\n")
      << _("   -i tgt2 Insert target(s) for the 'insert' action. Possible targets are\n")
      << _("             a : All supported metadata (the default)\n") << _("             e : Exif tags\n")

--- a/test/data/test_reference_files/exiv2-test.out
+++ b/test/data/test_reference_files/exiv2-test.out
@@ -112,7 +112,7 @@ Options:
              x : XMP tags
              c : JPEG comment
              C : ICC Profile
-             c : All IPTC data (any broken multiple IPTC blocks)
+             I : All IPTC data (any broken multiple IPTC blocks)
              - : Input from stdin
    -i tgt2 Insert target(s) for the 'insert' action. Possible targets are
              a : All supported metadata (the default)


### PR DESCRIPTION
The `-d` help prints `c` for two different targets, though the parser maps `c` to the JPEG comment and `I` to all IPTC data. Follow the second `c` line while clearing broken or duplicated IPTC blocks and `exiv2 -dc file.jpg` deletes the JPEG comment instead, wtih no warning, while leaving the IPTC blocks in place.

    x : XMP tags
    c : JPEG comment
    C : ICC Profile
    c : All IPTC data (any broken multiple IPTC blocks)
    - : Input from stdin

The manpage already lists `I` and agrees with the parser. The help reference was generated from the bad output, so `exiv2-test` has compared aginst that typo ever since. It's the golden file for this output, which is why the same character changes there too.
