### PR TITLE
Print nested XMP properties through their own print function

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -12,6 +12,8 @@
 #include "value.hpp"
 #include "xmp_exiv2.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <iostream>
 
 namespace {
@@ -25,6 +27,27 @@ struct XmpPrintInfo {
   std::string_view key_;      //!< XMP key
   Exiv2::PrintFct printFct_;  //!< Print function
 };
+
+/*!
+  @brief Return the key of the innermost element of a nested XMP property key.
+
+  For example, "Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1" yields
+  "Xmp.plus.LicensorTelephoneType1". Returns an empty string if \em key is not
+  the key of a nested property.
+ */
+std::string innermostElementKey(const std::string& key) {
+  const auto slash = key.find_last_of('/');
+  if (slash == std::string::npos)
+    return {};
+  // Skip the array index and any other non-alphabetic characters of the path element
+  const auto prefix = std::find_if(key.begin() + slash, key.end(), [](unsigned char c) { return std::isalpha(c) != 0; });
+  const auto colon = std::find(prefix, key.end(), ':');
+  if (colon == key.end() || colon + 1 == key.end())
+    return {};
+  std::string result = "Xmp.";
+  result.append(prefix, colon).append(1, '.').append(colon + 1, key.end());
+  return result;
+}
 
 }  // namespace
 
@@ -5213,7 +5236,13 @@ std::ostream& XmpProperties::printPropertyUnlocked(std::ostream& os, const std::
                                                    const XmpLock&) {
   PrintFct fct = printValue;
   if (value.count() != 0) {
-    if (auto info = Exiv2::find(xmpPrintInfo, key))
+    auto info = Exiv2::find(xmpPrintInfo, key);
+    if (!info) {
+      // A nested property is keyed by its path, look up the innermost element instead
+      if (auto nested = innermostElementKey(key); !nested.empty())
+        info = Exiv2::find(xmpPrintInfo, nested);
+    }
+    if (info)
       fct = info->printFct_;
   }
   return fct(os, value, nullptr);

--- a/test/data/test_reference_files/issue_1959_poc.xmp.out
+++ b/test/data/test_reference_files/issue_1959_poc.xmp.out
@@ -195,8 +195,8 @@ Xmp.plus.Licensor[1]/plus:LicensorRegion     XmpText    20  Test Licensor Region
 Xmp.plus.Licensor[1]/plus:LicensorStreetAddress XmpText    28  Test Licensor Street Address  Test Licensor Street Address
 Xmp.plus.Licensor[1]/plus:LicensorTelephone1 XmpText    15  +1 (234) 567890  +1 (234) 567890
 Xmp.plus.Licensor[1]/plus:LicensorTelephone2 XmpText    15  +1 (345) 678901  +1 (345) 678901
-Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1 XmpText    36  http://ns.useplus.org/ldf/vocab/work  http://ns.useplus.org/ldf/vocab/work
-Xmp.plus.Licensor[1]/plus:LicensorTelephoneType2 XmpText    36  http://ns.useplus.org/ldf/vocab/cell  http://ns.useplus.org/ldf/vocab/cell
+Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1 XmpText    36  http://ns.useplus.org/ldf/vocab/work  Work
+Xmp.plus.Licensor[1]/plus:LicensorTelephoneType2 XmpText    36  http://ns.useplus.org/ldf/vocab/cell  Cell
 Xmp.plus.Licensor[1]/plus:LicensorURL        XmpText    61  http://www.example.com/licensorurl/okng0934j9jkrg0430gjn0mn03  http://www.example.com/licensorurl/okng0934j9jkrg0430gjn0mn03
 Xmp.plus.ModelReleaseID                      XmpBag      1  http://www.example.com/modelreleaseid/jhgmw3m0932mg0943mh32  http://www.example.com/modelreleaseid/jhgmw3m0932mg0943mh32
 Xmp.plus.PropertyReleaseID                   XmpBag      1  http://www.example.com/propertyreleaseid/wii09mng290mg0b3mgb0ebebt  http://www.example.com/propertyreleaseid/wii09mng290mg0b3mgb0ebebt

--- a/tests/bugfixes/github/test_issue_3332.py
+++ b/tests/bugfixes/github/test_issue_3332.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from system_tests import CaseMeta, path
+
+
+class test_issue_3332Test(metaclass=CaseMeta):
+    """
+    Regression test for the bug described in:
+    https://github.com/Exiv2/exiv2/issues/3332
+
+    The value of a nested XMP property has to be printed through the print
+    function registered for that property, so the PLUS telephone types are
+    translated instead of shown as the raw vocabulary URL.
+    """
+
+    url = "https://github.com/Exiv2/exiv2/issues/3332"
+
+    filename = path("$data_path/issue_1959_poc.xmp")
+    commands = ["$exiv2 -px -g LicensorTelephoneType $filename"]
+    stdout = [
+        """Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1 XmpText    36  Work
+Xmp.plus.Licensor[1]/plus:LicensorTelephoneType2 XmpText    36  Cell
+"""
+    ]
+    stderr = [""]
+    retval = [0]


### PR DESCRIPTION
### Problem

`exiv2 -px` prints the raw value of a nested XMP property even when that property has a print function registered.

The report is about the two PLUS licensor telephone types, which are the only PLUS fields that are both subfields of a structure and use a controlled vocabulary:

```
$ exiv2 -px -g LicensorTelephoneType test/data/issue_1959_poc.xmp
Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1 XmpText    36  http://ns.useplus.org/ldf/vocab/work
Xmp.plus.Licensor[1]/plus:LicensorTelephoneType2 XmpText    36  http://ns.useplus.org/ldf/vocab/cell
```

### Cause

`XmpProperties::printPropertyUnlocked()` looks the print function up in `xmpPrintInfo` by the full key. A nested property is keyed by its path (`Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1`), and the table holds plain property keys (`Xmp.plus.LicensorTelephoneType1`), so the lookup never matches and `printValue` is used. Top level PLUS fields such as `Xmp.plus.ModelReleaseStatus` are unaffected and already print translated.

### Fix

If the direct lookup fails and the key is a path, retry with the key of the innermost path element. That is the same element `XmpProperties::propertyInfoUnlocked()` already resolves a nested key to when it looks up the property definition, so the print function and the property definition now agree on which element a nested key describes.

After the change:

```
Xmp.plus.Licensor[1]/plus:LicensorTelephoneType1 XmpText    36  Work
Xmp.plus.Licensor[1]/plus:LicensorTelephoneType2 XmpText    36  Cell
```

### Tests

New system test `tests/bugfixes/github/test_issue_3332.py`, using the existing sample `test/data/issue_1959_poc.xmp`, which already carries both values. It fails before the change and passes after (verified by reverting the source change, rebuilding and re-running).

One reference file changes, and the change is the fix itself: `test/data/test_reference_files/issue_1959_poc.xmp.out` lines 198 and 199 now show `Work` and `Cell` in the interpreted column. No other reference output in the tree changes, so no other nested key currently resolves to a property that has a print function.

Local results: `unit_tests` 370/370, `bugfixes` 325 pass and 10 skipped, `regression_tests` 329 pass, `tiff_test` 1 pass, `bash_tests` 66/67 and `lens_tests` 1/2. The two failures (`io_test`, `test_canon_lenses`) reproduce identically on unmodified `main` in this build, which has network support off. `clang-format` is not installed here, so the new code was hand matched to the surrounding style rather than tool checked.

Fixes #3332
