### PR TITLE
CMake: add missing include for inih find module

### DIFF
--- a/cmake/Findinih.cmake
+++ b/cmake/Findinih.cmake
@@ -1,3 +1,5 @@
+include(FindPackageHandleStandardArgs)
+
 set(inih_LIBRARY_NAMES "inih" "libinih")
 set(inih_inireader_LIBRARY_NAMES "INIReader" "libINIReader")
 


### PR DESCRIPTION
Is included from somewhere else, but should be formal about it.